### PR TITLE
Fix for a Mono specific issue when editing the inventory. Also fixed a general issue with the Super Training dialog

### DIFF
--- a/SAV/SAV_Inventory.cs
+++ b/SAV/SAV_Inventory.cs
@@ -161,6 +161,7 @@ namespace PKHeX
             dataGridView1.Columns.Add(dgvIndex);
 
             dataGridView1.Rows.Add(itemcount);
+            dataGridView1.CancelEdit();
 
             string itemname = "";
             for (int i = 0; i < itemcount; i++)

--- a/SAV/SAV_SuperTrain.cs
+++ b/SAV/SAV_SuperTrain.cs
@@ -189,7 +189,7 @@ namespace PKHeX
             {
                 byte[] data = BitConverter.GetBytes(UInt16.Parse(TB_Unk.Text)); 
                 Array.Resize(ref data, 2);
-                Array.Copy(data, 0, sav, offsetVal + 4 * index, 4);
+                Array.Copy(data, 0, sav, offsetVal + 4 * index, 2);
             }
             catch { return; }
         }


### PR DESCRIPTION
Hello again, I have added a fix for an issue that occurs when using Mono in which calling add on a DataGridViewRowCollection would place the (zeroth row, zeroth cell) cell into edit mode and set it's Edited Value to empty string. Therefore later when the cell is populated with a value in this line
 `dataGridView1.Rows[i].Cells[0].Value = itemarr[itemarrayval];`
the Edited Value is not updated to point to the new value for the name of the item. The fix is to move the newly populated empty cell out of edit mode.

Long story short this change is to fix the issue with the first item name in the Inventory Item showing up as empty string on Mono.

I have fully tested this change on Windows and Linux and verified that it causes no issues especially on Windows.

The second change is to fix the issue with the changeRecordVal function in the Super Training dialog attempting to write 4 bytes from a 2 byte array.