### PR TITLE
Fix for uncaught numeric parse exception

### DIFF
--- a/SAV/SAV_Trainer.cs
+++ b/SAV/SAV_Trainer.cs
@@ -659,7 +659,7 @@ namespace PKHeX
         {
             MaskedTextBox box = sender as MaskedTextBox;
             if (box.Text == "") box.Text = "0";
-            if (int.Parse(box.Text) > 255) box.Text = "255";
+            if (Util.ToInt32(box.Text) > 255) box.Text = "255";
         }
         private int psssatoffset = 0x23800;
         private void changeStat(object sender, EventArgs e)


### PR DESCRIPTION
Hello kwsch, I have added a fix for an uncaught system format exception in the SAV_Trainer::change255 function due to the text box containing trailing underscores.