### PR TITLE
Updating Inventory Editor width for Mono

### DIFF
--- a/SAV/SAV_Inventory.Designer.cs
+++ b/SAV/SAV_Inventory.Designer.cs
@@ -167,7 +167,7 @@
             this.Controls.Add(this.dataGridView1);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.MaximizeBox = false;
-            this.MaximumSize = new System.Drawing.Size(350, 750);
+            this.MaximumSize = new System.Drawing.Size(500, 750);
             this.MinimizeBox = false;
             this.MinimumSize = new System.Drawing.Size(350, 250);
             this.Name = "SAV_Inventory";


### PR DESCRIPTION
Hello again, I made a change to the inventory editor to fix an issue when using PKHeX in Mono in which the controls would get cut-off horizontally. The change was to increase the maximum width of inventory editor.
This change does not affect running on Windows as Windows is able to fit in the 350 pixel width.
This is how it looks on Windows before and after
![windows_maxwidth_350](https://cloud.githubusercontent.com/assets/9974424/6097962/70c97e62-af95-11e4-9336-93b7b0983348.png)
![windows_maxwidth_500](https://cloud.githubusercontent.com/assets/9974424/6097963/72f1b5b0-af95-11e4-8fe7-f3ff18f31717.png)

And this is how it looks on Linux before and after
![screenshot from 2015-02-08 12 59 15](https://cloud.githubusercontent.com/assets/9974424/6097967/98083c16-af95-11e4-829a-5d602bf70733.png)
![screenshot from 2015-02-08 12 54 40](https://cloud.githubusercontent.com/assets/9974424/6097968/9c18e24c-af95-11e4-90d6-f12af5ee64c8.png)

