### PR TITLE
Fixing a bug with the Country Sub Region selection

### DIFF
--- a/PKX/f1-Main.cs
+++ b/PKX/f1-Main.cs
@@ -1221,7 +1221,7 @@ namespace PKHeX
 
             CB.DataSource = Util.getCBList(type, cl);
 
-            if (index > 0 && index <= CB.Items.Count && init)
+            if (index > 0 && index < CB.Items.Count && init)
                 CB.SelectedIndex = index;
         }
         public void setForms(int species, ComboBox cb)


### PR DESCRIPTION
This bug occurred via switching from "Australia" to "Austria" while selecting "Vorarlberg".
It throws an ArgumentException and this is the fix I used while working on this: http://projectpokemon.org/forums/showthread.php?44994-Mass-Editor-for-all-PKHeX-supported-files