### PR TITLE
For Gen III & IV Pokemon, generate PIDs to ensure legal nature

### DIFF
--- a/Misc/PKX.cs
+++ b/Misc/PKX.cs
@@ -520,21 +520,42 @@ namespace PKHeX
         {
             return (TID ^ SID) >> 4;
         }
-        internal static uint getRandomPID(int species, int cg)
+        internal static uint getRandomPID(int species, int cg, int origin, int nature)
         {
             int gt = Personal[species].Gender;
-            if (gt == 255 || gt == 254 || gt == 0) // Set Gender(less)
-                return Util.rnd32(); // PID can be anything
-
-            do
+            if (origin <= 15) // Gen III/IV
             {
-                uint pid = Util.rnd32();
-                uint gv = pid & 0xFF;
-                if (cg == 1 && gv <= gt) // Female
-                    return pid;  // PID Passes
-                if (cg == 0 && gv > gt) // Male
-                    return pid;  // PID Passes
-            } while (true); // Loop until we find a suitable PID
+                do
+                {
+                    uint pid = Util.rnd32();
+                    uint gv = pid & 0xFF;
+                    if (pid % 25 == nature)
+                    {
+                        if (gt == 255 || gt == 254 || gt == 0) // Set Gender(less)
+                            return pid; // PID can be anything
+                        else
+                            if (cg == 1 && gv <= gt) // Female
+                            return pid;  // PID Passes
+                        if (cg == 0 && gv > gt) // Male
+                            return pid;  // PID Passes
+                    }
+                } while (true); // Loop until we find a suitable PID
+            }
+            else
+            {
+                if (gt == 255 || gt == 254 || gt == 0) // Set Gender(less)
+                    return Util.rnd32(); // PID can be anything
+
+                do
+                {
+                    uint pid = Util.rnd32();
+                    uint gv = pid & 0xFF;
+                    if (cg == 1 && gv <= gt) // Female
+                        return pid;  // PID Passes
+                    if (cg == 0 && gv > gt) // Male
+                        return pid;  // PID Passes
+                } while (true); // Loop until we find a suitable PID
+            }
         }
 
         // SAV Manipulation

--- a/PKX/f1-Main.cs
+++ b/PKX/f1-Main.cs
@@ -1603,7 +1603,7 @@ namespace PKHeX
         }
         private void updateRandomPID(object sender, EventArgs e)
         {
-            TB_PID.Text = PKX.getRandomPID(Util.getIndex(CB_Species), PKX.getGender(Label_Gender.Text)).ToString("X8");
+            TB_PID.Text = PKX.getRandomPID(Util.getIndex(CB_Species), PKX.getGender(Label_Gender.Text), Util.getIndex(CB_GameOrigin), Util.getIndex(CB_Nature)).ToString("X8");
             getQuickFiller(dragout);
         }
         private void updateRandomEC(object sender, EventArgs e)


### PR DESCRIPTION
Pokemon originating from Gen III & IV had their nature determined by their PID. Since there is no way in-game to modify a Pokemon's nature, Gen <=IV Pokemon PIDs should be generated to take nature into consideration, and not just any random value will may fail the mod 25 calculation.

Gen VI games will happily accept previous gen Pokemon will illegal PID/nature combination, but such a Pokemon theoretically does not exist.