### PR TITLE
Fix Pokedex form bitflags not saved in XY

### DIFF
--- a/SAV/SAV_PokedexXY.cs
+++ b/SAV/SAV_PokedexXY.cs
@@ -254,6 +254,8 @@ namespace PKHeX
                 ldata.CopyTo(sav, Main.SAV.PokeDexLanguageFlags);
             }
 
+            formbools.CopyTo(sav, Main.SAV.PokeDex + 0x368);
+
             // Return Foreign Array
             {
                 byte[] foreigndata = new byte[0x52];


### PR DESCRIPTION
Missing line copied from ORAS (offsets are the same).