### PR TITLE
ORAS: fix incorrect display if only daycare 1 is empty

### DIFF
--- a/PKX/f1-Main.cs
+++ b/PKX/f1-Main.cs
@@ -760,8 +760,6 @@ namespace PKHeX
             // Enable Secondary Tools
             GB_SAVtools.Enabled = B_JPEG.Enabled = true;
             Menu_ExportSAV.Enabled = B_VerifyCHK.Enabled = SAV.Exportable;
-
-            DaycareSlot = 0;
             
             setBoxNames();   // Display the Box Names
             setPKXBoxes();   // Reload all of the PKX Windows
@@ -2904,7 +2902,7 @@ namespace PKHeX
             if (slot < 42) // Battle Box Slot
                 return SAV.BattleBox + (slot - 36) * PK6.SIZE_STORED;
             if (slot < 44) // Daycare
-                return SAV.DaycareSlot[DaycareSlot] + 8 + (slot - 42) * (PK6.SIZE_STORED + 8);
+                return SAV.DaycareSlot[SAV.DaycareIndex] + 8 + (slot - 42) * (PK6.SIZE_STORED + 8);
             if (slot < 45) // GTS
                 return SAV.GTS;
             if (slot < 46) // Fused
@@ -2951,7 +2949,7 @@ namespace PKHeX
 
                 for (int i = 0; i < 2; i++)
                 {
-                    getSlotFiller(SAV.DaycareSlot[DaycareSlot] + PK6.SIZE_STORED * i + 8 * (i + 1), SlotPictureBoxes[i + 42]);
+                    getSlotFiller(SAV.DaycareSlot[SAV.DaycareIndex] + PK6.SIZE_STORED * i + 8 * (i + 1), SlotPictureBoxes[i + 42]);
                     dctexta[i].Text = exp[i].ToString();
                     if (occ[i])   // If Occupied
                         dclabela[i].Text = $"{i + 1}: ✓";
@@ -3055,14 +3053,13 @@ namespace PKHeX
             setPKXBoxes();
         }
 
-        private int DaycareSlot;
         private void switchDaycare(object sender, EventArgs e)
         {
             if (!SAV.ORAS) return;
             if (DialogResult.Yes == Util.Prompt(MessageBoxButtons.YesNo, "Would you like to switch the view to the other Daycare?",
-                $"Currently viewing daycare {DaycareSlot + 1}."))
+                $"Currently viewing daycare {SAV.DaycareIndex + 1}."))
                 // If ORAS, alter the daycare offset via toggle.
-                DaycareSlot ^= 1;
+                SAV.DaycareIndex ^= 1;
 
             // Refresh Boxes
             setPKXBoxes();


### PR DESCRIPTION
Toggling of the daycare display previously toggled DaycareIndex only in Main but not SAV. Deposited Pokemon in the Battle Resort daycare were still displayed correctly, but they would appear as unoccupied and with gained EXP 0.