### PR TITLE
Explicitly set InitialDirectory when creating new OpenFileDialog

### DIFF
--- a/PKX/f1-Main.cs
+++ b/PKX/f1-Main.cs
@@ -193,6 +193,7 @@ namespace PKHeX
                          "|EKX File|*.ek6;*.ekx" +
                          "|BIN File|*.bin" +
                          "|All Files|*.*",
+                InitialDirectory = Environment.CurrentDirectory,
                 RestoreDirectory = true,
                 FilterIndex = 4,
                 FileName = "main",

--- a/PKX/f1-Main.cs
+++ b/PKX/f1-Main.cs
@@ -193,11 +193,14 @@ namespace PKHeX
                          "|EKX File|*.ek6;*.ekx" +
                          "|BIN File|*.bin" +
                          "|All Files|*.*",
-                InitialDirectory = Environment.CurrentDirectory,
                 RestoreDirectory = true,
                 FilterIndex = 4,
                 FileName = "main",
             };
+
+            // Reset file dialog path if it no longer exists
+            if (!Directory.Exists(ofd.InitialDirectory))
+                ofd.InitialDirectory = Environment.CurrentDirectory;
 
             // Detect main
             string cyberpath = Util.GetTempFolder();


### PR DESCRIPTION
The OS seems to remember the last path used in file dialogs even between launches of the application.

This gets rid of the "no disk in drive" error if a user last performs any file operation on a removable drive, quits PKHeX, ejects the drive, re-launches the application and attempts to use the open file dialog.