### PR TITLE
Trim underscores in Util.ToInt32 and Util.ToUInt32

### DIFF
--- a/Misc/Util.cs
+++ b/Misc/Util.cs
@@ -184,11 +184,11 @@ namespace PKHeX
         // Data Retrieval
         internal static int ToInt32(string value)
         {
-            return string.IsNullOrWhiteSpace(value) ? 0 : int.Parse(value.Trim());
+            return string.IsNullOrWhiteSpace(value) ? 0 : int.Parse(value.Trim(new char[2] { ' ', '_' }));
         }
         internal static uint ToUInt32(string value)
         {
-            return string.IsNullOrWhiteSpace(value) ? 0 : uint.Parse(value.Trim());
+            return string.IsNullOrWhiteSpace(value) ? 0 : uint.Parse(value.Trim(new char[2] { ' ', '_' }));
         }
         internal static uint getHEXval(string s)
         {


### PR DESCRIPTION
This PR addresses a Mono-specific regression introduced in 8469d04.

Due to Mono bug [12241](https://bugzilla.xamarin.com/show_bug.cgi?id=12241), when run in a Mono environment, all MaskedTextBoxes return underscores in their Text property and causing FormatException to be thrown.

I am not sure about this approach to addressing upstream bugs, but Mono users are completely unable to launch the program without this workaround, and that bug doesn't look like it will be fixed any time soon.