### PR TITLE
Fix Legality Check for some Wonder Cards

### DIFF
--- a/Legality/Checks.cs
+++ b/Legality/Checks.cs
@@ -726,7 +726,7 @@ namespace PKHeX
                 if (CardMatch.Count > 1)
                     return res;
                 if (CardMatch.Count == 1)
-                { EncounterMatch = CardMatch[0]; RelearnBase = CardMatch[0].RelearnMoves; }
+                { EncounterMatch = CardMatch[0]; RelearnBase = CardMatch[0].RelearnMoves; return res; }
 
                 EncounterMatch = EncounterType = null;
                 goto noRelearn; // No WC match


### PR DESCRIPTION
As commit message says. Lack of return here made some legal event Pokémons (those that match only one Wonder Card, like ORAS Shiny Beldum) show up as illegal.