### PR TITLE
Add legality checks for HM-specific memories

### DIFF
--- a/Legality/Checks.cs
+++ b/Legality/Checks.cs
@@ -628,6 +628,28 @@ namespace PKHeX
 
             return new LegalityCheck(Severity.Valid, "History is valid.");
         }
+        private LegalityCheck verifyCommonMemory(int handler)
+        {
+            int m = 0;
+            string resultPrefix = "";
+            switch (handler)
+            {
+                case 0:
+                    m = pk6.OT_Memory;
+                    resultPrefix = "OT ";
+                    break;
+                case 1:
+                    m = pk6.HT_Memory;
+                    resultPrefix = "HT ";
+                    break;
+            }
+            int matchingMoveMemory = Array.IndexOf(Legal.MoveSpecificMemories[0], m);
+            if (matchingMoveMemory != -1 && !Legal.isValidMachineMove(pk6, Legal.MoveSpecificMemories[1][matchingMoveMemory]))
+            {
+                return new LegalityCheck(Severity.Invalid, resultPrefix + "Memory: Species cannot learn this move.");
+            }
+            return new LegalityCheck(Severity.Valid, resultPrefix + "Memory is valid.");
+        }
         private LegalityCheck verifyOTMemory()
         {
             if (!History.Valid)
@@ -658,7 +680,7 @@ namespace PKHeX
             if (pk6.AO && Legal.Memory_NotAO.Contains(pk6.OT_Memory))
                 return new LegalityCheck(Severity.Invalid, "OT Memory: X/Y exclusive memory on OR/AS origin.");
 
-            return new LegalityCheck(Severity.Valid, "OT Memory is valid.");
+            return verifyCommonMemory(0);
         }
         private LegalityCheck verifyHTMemory()
         {
@@ -676,7 +698,7 @@ namespace PKHeX
                         return new LegalityCheck(Severity.Invalid, "HT Memory: Captured Species can not be captured in game.");
                     return new LegalityCheck(Severity.Valid, "HT Memory: Captured Species can be captured in game.");
             }
-            return new LegalityCheck(Severity.Valid, "HT Memory is valid.");
+            return verifyCommonMemory(1);
         }
         private LegalityCheck verifyForm()
         {

--- a/Legality/Core.cs
+++ b/Legality/Core.cs
@@ -574,5 +574,26 @@ namespace PKHeX
             moves.AddRange(TMHM_AO.Where((t, i) => pkAO.TMHM[i]));
             return moves;
         }
+        internal static bool isValidMachineMove(PK6 pk6, int move)
+        {
+            List<int> r = new List<int> { 0 };
+            int species = pk6.Species;
+            if (FormChangeMoves.Contains(species)) // Deoxys & Shaymin & Giratina (others don't have extra but whatever)
+            {
+                int formcount = PersonalAO[species].FormeCount;
+                for (int i = 0; i < formcount; i++)
+                {
+                    // Check all Forms
+                    r.AddRange(getMachineMoves(species, i));
+                }
+            }
+            r.AddRange(getMachineMoves(species, pk6.AltForm));
+            IEnumerable<DexLevel> vs = getValidPreEvolutions(pk6);
+            foreach (DexLevel evo in vs)
+            {
+                r.AddRange(getMachineMoves(evo.Species, pk6.AltForm));
+            }
+            return r.Contains(move);
+        }
     }
 }

--- a/Legality/Tables.cs
+++ b/Legality/Tables.cs
@@ -890,6 +890,19 @@
             57, // {0} went to a nice restaurant with {1} and ate until it got totally full. {4} that {3}.
             62, // {0} saw itself in a mirror in a mirror cave that it went to with {1}. {4} that {3}.
         };
+        internal static readonly int[][] MoveSpecificMemories =
+        {
+            new[] {
+                20, // {0} surfed across the water, carrying {1} on its back. {4} that {3}.
+                24, // {0} flew, carrying {1} on its back, to {2}. {4} that {3}.
+                35, // {0} proudly used Strength at {1}’s instruction in... {2}. {4} that {3}.
+                36, // {0} proudly used Cut at {1}’s instruction in... {2}. {4} that {3}.
+                37, // {0} shattered rocks to its heart’s content at {1}’s instruction in... {2}. {4} that {3}.
+                38, // {0} used Waterfall while carrying {1} on its back in... {2}. {4} that {3}.
+                69, // {1} asked {0} to dive. Down it went, deep into the ocean, to explore the bottom of the sea. {4} that {3}.
+            },
+            new[] { 57, 19, 70, 15, 249, 127, 291}, // Move IDs
+        };
         #endregion
     }
 }


### PR DESCRIPTION
This commit also adds one new method `Legality.isValidMachineMove` to the legality core, which was mostly copied from `getValidMoves`.

If I remember correctly, there is no Pokemon out there yet with different TM/HM learnsets across formes, so that method could be trimmed down further, or at least until S/M introduces such a species.