### PR TITLE
Distinguish between Leagues of both regions in location dropdown

### DIFF
--- a/PKX/f1-Main.cs
+++ b/PKX/f1-Main.cs
@@ -949,6 +949,8 @@ namespace PKHeX
             metBW2_60000[3 - 1] += " (" + eggname + ")";  // Egg Treasure Hunter/Breeder, whatever...
 
             metXY_00000[104] += " (X/Y)";              // Victory Road
+            metXY_00000[106] += " (X/Y)";              // Pokémon League
+            metXY_00000[202] += " (OR/AS)";            // Pokémon League
             metXY_00000[298] += " (OR/AS)";            // Victory Road
             metXY_30000[0] += " (NPC)";                // Anything from an NPC
             metXY_30000[1] += " (" + eggname + ")";    // Egg From Link Trade


### PR DESCRIPTION
An oddity will otherwise force the smaller index (Kalos') to be selected instead.