### PR TITLE
Checks for memories 16/48 and fix Smeargle exception

### DIFF
--- a/Legality/Checks.cs
+++ b/Legality/Checks.cs
@@ -668,6 +668,10 @@ namespace PKHeX
                 if (!Legal.getCanLearnMachineMove(new PK6 {Species = t, EXP = PKX.getEXP(100, t)}, 19))
                     return new LegalityCheck(Severity.Invalid, resultPrefix + "Memory: Argument Species cannot learn Fly.");
             }
+            if ((m == 16 || m == 48) && (t == 0 || !Legal.getCanKnowMove(pk6, t, 1)))
+            {
+                return new LegalityCheck(Severity.Invalid, resultPrefix + "Memory: Species cannot know this move.");
+            }
             return new LegalityCheck(Severity.Valid, resultPrefix + "Memory is valid.");
         }
         private LegalityCheck verifyOTMemory()

--- a/Legality/Core.cs
+++ b/Legality/Core.cs
@@ -376,6 +376,8 @@ namespace PKHeX
         }
         internal static bool getCanKnowMove(PK6 pk6, int move, int version = -1)
         {
+            if (pk6.Species == 235 && !Legal.InvalidSketch.Contains(move))
+                return true;
             return getValidMoves(pk6, Version: version, LVL: true, Relearn: true, Tutor: true, Machine: true).Contains(move);
         }
 


### PR DESCRIPTION
{0} used {2} at {1}'s instruction, but it had no effect
The Move Deleter that {0} met through {1} made it forget {2}

For this to work properly with Smeargle we must check only if the specified move is valid as Sketch method because getValidMoves will only return Sketch as the one Smeargle can learn through level and through relearn.