### PR TITLE
Geolocation and memory 49 checks

### DIFF
--- a/Legality/Analysis.cs
+++ b/Legality/Analysis.cs
@@ -10,8 +10,8 @@ namespace PKHeX
         private object EncounterMatch;
         private List<WC6> CardMatch;
         private Type EncounterType;
-        private LegalityCheck ECPID, Nickname, IDs, IVs, EVs, Encounter, Level, Ribbons, Ability, Ball, History, OTMemory, HTMemory, Form, Misc;
-        private LegalityCheck[] Checks => new[] { Encounter, Level, Form, Ball, Ability, Ribbons, ECPID, Nickname, IVs, EVs, IDs, History, OTMemory, HTMemory, Misc };
+        private LegalityCheck ECPID, Nickname, IDs, IVs, EVs, Encounter, Level, Ribbons, Ability, Ball, History, OTMemory, HTMemory, Region, Form, Misc;
+        private LegalityCheck[] Checks => new[] { Encounter, Level, Form, Ball, Ability, Ribbons, ECPID, Nickname, IVs, EVs, IDs, History, OTMemory, HTMemory, Region, Misc };
 
         public bool Valid = true;
         public bool SecondaryChecked;
@@ -59,6 +59,7 @@ namespace PKHeX
             History = verifyHistory();
             OTMemory = verifyOTMemory();
             HTMemory = verifyHTMemory();
+            Region = verifyRegion();
             Form = verifyForm();
             Misc = verifyMisc();
             SecondaryChecked = true;

--- a/Legality/Checks.cs
+++ b/Legality/Checks.cs
@@ -733,6 +733,43 @@ namespace PKHeX
             }
             return verifyCommonMemory(1);
         }
+        private LegalityCheck verifyRegion()
+        {
+            switch (pk6.ConsoleRegion)
+            {
+                // Japan
+                case 0:
+                    if (!(pk6.Country == 1))
+                        return new LegalityCheck(Severity.Invalid, "Geolocation: Country is not on 3DS region.");
+                    break;
+                // America
+                case 1:
+                    if (!((pk6.Country >= 8 && pk6.Country <= 52) || pk6.Country == 153 || pk6.Country == 156 || pk6.Country == 168 || pk6.Country == 174 || pk6.Country == 186))
+                        return new LegalityCheck(Severity.Invalid, "Geolocation: Country is not on 3DS region.");
+                    break;
+                // Europe
+                case 2:
+                    if (!((pk6.Country >= 64 && pk6.Country <= 127) || pk6.Country == 169 || pk6.Country == 184 || pk6.Country == 185))
+                        return new LegalityCheck(Severity.Invalid, "Geolocation: Country is not on 3DS region.");
+                    break;
+                // China
+                case 4:
+                    if (!(pk6.Country == 144 || pk6.Country == 160))
+                        return new LegalityCheck(Severity.Invalid, "Geolocation: Country is not on 3DS region.");
+                    break;
+                // Korea
+                case 5:
+                    if (!(pk6.Country == 136))
+                        return new LegalityCheck(Severity.Invalid, "Geolocation: Country is not on 3DS region.");
+                    break;
+                // Taiwan
+                case 6:
+                    if (!(pk6.Country == 128))
+                        return new LegalityCheck(Severity.Invalid, "Geolocation: Country is not on 3DS region.");
+                    break;
+            }
+            return new LegalityCheck(Severity.Valid, "Geolocation: Country is on 3DS region.");
+        }
         private LegalityCheck verifyForm()
         {
             if (!Encounter.Valid)

--- a/Legality/Checks.cs
+++ b/Legality/Checks.cs
@@ -672,6 +672,10 @@ namespace PKHeX
             {
                 return new LegalityCheck(Severity.Invalid, resultPrefix + "Memory: Species cannot know this move.");
             }
+            if (m == 49 && (t == 0 || !Legal.getCanRelearnMove(pk6, t, 1))) // {0} was able to remember {2} at {1}'s instruction. {4} that {3}.
+            {
+                return new LegalityCheck(Severity.Invalid, resultPrefix + "Memory: Species cannot relearn this move.");
+            }
             return new LegalityCheck(Severity.Valid, resultPrefix + "Memory is valid.");
         }
         private LegalityCheck verifyOTMemory()


### PR DESCRIPTION
During first setup depending of the region of the 3DS it only allows certain countries to be selected, this values all also applied on the savefile and on Pokemon as well when they're obtained so per example having a Pokemon with a 3DS region set to Japan but country as Spain is illegal.
Actually some events are region locked, the ones distributed through codes or Network, local wireless distributions are region-free, so in the future the WC6 checking should also include checking if the 3DS region set for that Pokemon is legal based on how the event was distributed.

Also check for memorie number 49 that refers to remembering a move. This actually flagged one of my Pokemon, A Torterra that remembers relearning Electro Ball lol

Also idk if you saw my post on the forum regarding the fishing slots and the items allowed on the memories: https://projectpokemon.org/forums/showthread.php?48612-Bug-and-some-more-minor-legality-checks
