### PR TITLE
Fix truncation of box unlocked BG flags

### DIFF
--- a/SAV/SAV_BoxLayout.Designer.cs
+++ b/SAV/SAV_BoxLayout.Designer.cs
@@ -129,7 +129,7 @@
             // 
             this.MT_BG1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.MT_BG1.Location = new System.Drawing.Point(136, 202);
-            this.MT_BG1.Mask = "00";
+            this.MT_BG1.Mask = "000";
             this.MT_BG1.Name = "MT_BG1";
             this.MT_BG1.Size = new System.Drawing.Size(29, 20);
             this.MT_BG1.TabIndex = 6;


### PR DESCRIPTION
In the box layout editor, the textbox mask for the first unlocked BG flag is "00", which led to unexpected truncation.

This leads to a side effect in-game in which the player can select only the first 4 out of the available 8 special PC wallpapers. (the "next" option will be hidden by the game)

For existing savefiles affected by this issue, the correct flag for post-Elite 4 wallpaper unlock is "131".