### PR TITLE
Don't check base moves if the pkm can't be hatched

### DIFF
--- a/Legality/Checks.cs
+++ b/Legality/Checks.cs
@@ -935,7 +935,7 @@ namespace PKHeX
                 goto noRelearn; // No WC match
             }
 
-            if (pk6.WasEgg)
+            if (pk6.WasEgg && !Legal.NoHatchFromEgg.Contains(pk6.Species))
             {
                 const int games = 2;
                 bool checkAllGames = pk6.WasTradedEgg;


### PR DESCRIPTION
There's no point of saying a Landorus, per example, is missing Fissure, Block, Mud Shot and Rock Romb as relearn moves just because it was hatched from an egg because to start with the species cannot be hatched.