### PR TITLE
Checks for OT memory 2: hatched from an egg

### DIFF
--- a/Legality/Checks.cs
+++ b/Legality/Checks.cs
@@ -696,6 +696,10 @@ namespace PKHeX
             }
             switch (pk6.OT_Memory)
             {
+                case 2: // {0} hatched from an Egg and saw {1} for the first time at... {2}. {4} that {3}.
+                    if (!pk6.WasEgg)
+                        return new LegalityCheck(Severity.Invalid, "OT Memory: OT did not hatch this.");
+                    return new LegalityCheck(Severity.Valid, "OT Memory is valid.");
                 case 4: // {0} became {1}’s friend when it arrived via Link Trade at... {2}. {4} that {3}.
                     return new LegalityCheck(Severity.Invalid, "OT Memory: Link Trade is not a valid first memory.");
                 case 6: // {0} went to the Pokémon Center in {2} with {1} and had its tired body healed there. {4} that {3}.

--- a/Legality/Checks.cs
+++ b/Legality/Checks.cs
@@ -726,7 +726,7 @@ namespace PKHeX
         private LegalityCheck verifyHTMemory()
         {
             if (!History.Valid)
-                return new LegalityCheck(Severity.Valid, "Skipped OT Memory check as History is not valid.");
+                return new LegalityCheck(Severity.Valid, "Skipped HT Memory check as History is not valid.");
 
             switch (pk6.HT_Memory)
             {


### PR DESCRIPTION
This will flag Pokemon with this memory, but did not hatch from an egg.

Also, a second commit that fixes a typo in verifyHTMemory.