### PR TITLE
Fix third gen balls on second gen starters with HA

### DIFF
--- a/Legality/Checks.cs
+++ b/Legality/Checks.cs
@@ -553,6 +553,8 @@ namespace PKHeX
                 {
                     if (Legal.Ban_Gen3Ball.Contains(pk6.Species))
                         return new LegalityCheck(Severity.Invalid, "Unobtainable capture for Gen4 Ball.");
+                    if (pk6.AbilityNumber == 4 && 152 <= pk6.Species && pk6.Species <= 160)
+                        return new LegalityCheck(Severity.Invalid, "Ball not possible for species with hidden ability.");
 
                     return new LegalityCheck(Severity.Valid, "Obtainable capture for Gen4 Ball.");
                 }


### PR DESCRIPTION
Second generation starters are legal with third generation introduced balls because you can catch their second stage on Pokemon Colosseum, but since back then Hidden Abilities didn't exist they're restricted to normal balls only.
Other balls are checked already but this ones weren't flagged as illegal.