### PR TITLE
Made internal PKHeX.Util.getStringList functions public

### DIFF
--- a/Util/DataUtil.cs
+++ b/Util/DataUtil.cs
@@ -6,7 +6,7 @@ namespace PKHeX
 {
     public partial class Util
     {
-        internal static string[] getStringList(string f)
+        public static string[] getStringList(string f)
         {
             object txt = Properties.Resources.ResourceManager.GetObject(f); // Fetch File, \n to list.
             if (txt == null) return new string[0];
@@ -15,7 +15,7 @@ namespace PKHeX
                 rawlist[i] = rawlist[i].Trim();
             return rawlist;
         }
-        internal static string[] getStringList(string f, string l)
+        public static string[] getStringList(string f, string l)
         {
             object txt = Properties.Resources.ResourceManager.GetObject("text_" + f + "_" + l); // Fetch File, \n to list.
             if (txt == null) return new string[0];


### PR DESCRIPTION
Allows external programs to get string lists for use with displaying lists of PKHeX objects.

Example usage:
http://www.skyeditor.org/2016/07/status-update-pkhex-integration.html