### PR TITLE
Fixed crash in DateUtil when Year is 0

### DIFF
--- a/PKHeX/MysteryGifts/PGF.cs
+++ b/PKHeX/MysteryGifts/PGF.cs
@@ -102,7 +102,7 @@ namespace PKHeX
             get
             {
                 // Check to see if date is valid
-                if (!Util.IsDateValid(Year, Month, Day))
+                if (!Util.IsDateValid(2000 + Year, Month, Day))
                 {
                     return null;
                 }

--- a/PKHeX/MysteryGifts/WC6.cs
+++ b/PKHeX/MysteryGifts/WC6.cs
@@ -52,7 +52,7 @@ namespace PKHeX
             get
             {
                 // Check to see if date is valid
-                if (!Util.IsDateValid(Year, Month, Day))
+                if (!Util.IsDateValid(2000 + Year, Month, Day))
                 {
                     return null;
                 }

--- a/PKHeX/PKM/PKM.cs
+++ b/PKHeX/PKM/PKM.cs
@@ -141,7 +141,7 @@ namespace PKHeX
             get
             {
                 // Check to see if date is valid
-                if (!Util.IsDateValid(Met_Year, Met_Month, Met_Day))
+                if (!Util.IsDateValid(2000 + Met_Year, Met_Month, Met_Day))
                 {
                     return null;
                 }
@@ -186,7 +186,7 @@ namespace PKHeX
             get
             {
                 // Check to see if date is valid
-                if (!Util.IsDateValid(Egg_Year, Egg_Month, Egg_Day))
+                if (!Util.IsDateValid(2000 + Egg_Year, Egg_Month, Egg_Day))
                 {
                     return null;
                 }

--- a/PKHeX/Util/DateUtil.cs
+++ b/PKHeX/Util/DateUtil.cs
@@ -16,7 +16,7 @@ namespace PKHeX
         /// <returns>A boolean indicating whether or not the date is valid.</returns>
         public static bool IsDateValid(int year, int month, int day)
         {
-            return !(year < 0 || year > DateTime.MaxValue.Year || month < 1 || month > 12 || day < 1 || day > DateTime.DaysInMonth(year, month));
+            return !(year <= 0 || year > DateTime.MaxValue.Year || month < 1 || month > 12 || day < 1 || day > DateTime.DaysInMonth(year, month));
         }
 
         /// <summary>

--- a/Tests/PKHeX.Tests/PKM/PKMTests.cs
+++ b/Tests/PKHeX.Tests/PKM/PKMTests.cs
@@ -22,13 +22,19 @@ namespace PKHeX.Tests.PKM
             pk.MetDay = 0;
             pk.MetMonth = 0;
             pk.MetYear = 0;
-            Assert.IsFalse(pk.MetDate.HasValue, "MetDate should be null when date components are all 0.");
+            Assert.IsFalse(pk.MetDate.HasValue, "MetDate should be null when date components are all 0.");           
 
             // Ensure MetDate gives correct date
             pk.MetDay = 10;
             pk.MetMonth = 8;
             pk.MetYear = 16;
             Assert.AreEqual(new DateTime(2016, 8, 10).Date, pk.MetDate.Value.Date, "Met date does not return correct date.");
+
+            // Ensure 0 year is calculated correctly
+            pk.MetDay = 1;
+            pk.MetMonth = 1;
+            pk.MetYear = 0;
+            Assert.AreEqual(2000, pk.MetDate.Value.Date.Year, "Year is not calculated correctly.");
         }
 
         [TestMethod]

--- a/Tests/PKHeX.Tests/Util/DateUtilTests.cs
+++ b/Tests/PKHeX.Tests/Util/DateUtilTests.cs
@@ -103,6 +103,13 @@ namespace PKHeX.Tests.Util
 
         [TestMethod]
         [TestCategory(DateUtilCategory)]
+        public void FailsWithZeroYear()
+        {
+            Assert.IsFalse(PKHeX.Util.IsDateValid(0, 1, 1));
+        }
+
+        [TestMethod]
+        [TestCategory(DateUtilCategory)]
         public void TestUIntOverload()
         {
             Assert.IsTrue(PKHeX.Util.IsDateValid((uint)2000, (uint)1, (uint)1), "Failed 1/1/2000");


### PR DESCRIPTION
So I tried out this Pokemon using my latest code, and things broke (live version doesn't have the date refactoring yet):
http://pkmdb.skyeditor.org/Pokemon/Details/c29e5bf0-a63c-4c61-a949-f21c07f72c18

Turns out DateUtil was crashing because it incorrectly got `0` instead of `2000`, so I fixed that.  I also fixed it crashing when it gets a zero year.