### PR TITLE
Reverted ClickOnce deployment code due to Mono and Wine not supporting it.

### DIFF
--- a/PKHeX/MainWindow/Main.cs
+++ b/PKHeX/MainWindow/Main.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Deployment.Application;
 using System.Diagnostics;
 using System.Drawing;
 using System.IO;
@@ -177,7 +176,18 @@ namespace PKHeX
 
         #region Path Variables
 
-        public static string WorkingDirectory => ApplicationDeployment.IsNetworkDeployed ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "PKHeX") : Environment.CurrentDirectory;
+        public static string WorkingDirectory
+        {
+            get
+            {
+                // This is how we'd do it with ClickOnce deployment (after importing System.Deployment)
+                // return ApplicationDeployment.IsNetworkDeployed ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "PKHeX") : Environment.CurrentDirectory;
+
+                // However, Mono and Wine don't implement this, so we're going to leave it like this, until ClickOnce deployment is a public feature.
+                return Environment.CurrentDirectory;
+            }
+        }
+            
         public static string DatabasePath => Path.Combine(WorkingDirectory, "db");
         private static string WC6DatabasePath => Path.Combine(WorkingDirectory, "wc6");
         private static string BackupPath => Path.Combine(WorkingDirectory, "bak");

--- a/PKHeX/PKHeX.csproj
+++ b/PKHeX/PKHeX.csproj
@@ -62,7 +62,6 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Deployment" />
     <Reference Include="System.Web" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />


### PR DESCRIPTION
Reverted ClickOnce deployment code due to Mono and Wine not supporting it.
Should fix issue #161

I know I could just push this directly into master, but on a widely used application like this, I think it improves code quality if others have the opportunity to review my changes, just in case I missed something.