### PR TITLE
Fix reorder moves and clear PP values for empty moves.

### DIFF
--- a/PKHeX/PKM/PKM.cs
+++ b/PKHeX/PKM/PKM.cs
@@ -332,28 +332,41 @@ namespace PKHeX
         public void RefreshChecksum() { Checksum = CalculateChecksum(); }
         public void FixMoves()
         {
+            ReorderMoves();
+
+            if (Move1 == 0) { Move1_PP = 0; Move1_PPUps = 0; }
+            if (Move2 == 0) { Move2_PP = 0; Move2_PPUps = 0; }
+            if (Move3 == 0) { Move3_PP = 0; Move3_PPUps = 0; }
+            if (Move4 == 0) { Move4_PP = 0; Move4_PPUps = 0; }
+        }
+
+        private void ReorderMoves()
+        {
             if (Move4 != 0 && Move3 == 0)
             {
                 Move3 = Move4;
                 Move3_PP = Move4_PP;
                 Move3_PPUps = Move4_PPUps;
-                Move4 = Move4_PP = Move4_PPUps = 0;
+                Move4 = 0;
             }
             if (Move3 != 0 && Move2 == 0)
             {
                 Move2 = Move3;
                 Move2_PP = Move3_PP;
                 Move2_PPUps = Move3_PPUps;
-                Move3 = Move3_PP = Move3_PPUps = 0;
+                Move3 = 0;
+                ReorderMoves();
             }
             if (Move2 != 0 && Move1 == 0)
             {
                 Move1 = Move2;
                 Move1_PP = Move2_PP;
                 Move1_PPUps = Move2_PPUps;
-                Move2 = Move2_PP = Move2_PPUps = 0;
+                Move2 = 0;
+                ReorderMoves();
             }
         }
+
         public int PotentialRating
         {
             get


### PR DESCRIPTION
With further checking the PKMs that were migrated from PK4 to PK5, I noticed that when the conversion removed HM moves, the `FixMoves()` call was not shifting the moves up correctly. I also noticed that if the HM move was in the last position, the PP value for it would not be cleared by the `FixMoves()` call.

Some examples to Illustrate what I mean:
A Pokemon with:

1. Cut 30 PP --> Removed on conversion
2. Crunch 15 PP
3. Giga Drain 10 PP
4. Frenzy Plant 5 PP

Would result in:

1. Crunch 15 PP
2. ---
3. Giga Drain 10 PP
4. Frenzy Plant 5 PP

Because the code checks for moving first from below, it simply moved the second move to the first slot and then it didn't check any further.

I think the fix is a quick fix that can be done better, but this does the trick.