### PR TITLE
Changed min and max of NumericUpDown from short to ushort

### DIFF
--- a/PKHeX/Subforms/Save Editors/SAV_EventFlags.cs
+++ b/PKHeX/Subforms/Save Editors/SAV_EventFlags.cs
@@ -171,8 +171,8 @@ namespace PKHeX
                 };
                 var mtb = new NumericUpDown
                 {
-                    Maximum = short.MaxValue,
-                    Minimum = short.MinValue,
+                    Maximum = ushort.MaxValue,
+                    Minimum = ushort.MinValue,
                     Value = Constants[num[i]],
                     Name = constTag + num[i].ToString("0000"),
                     Margin = Padding.Empty,


### PR DESCRIPTION
                var mtb = new NumericUpDown
                {
                    Maximum = short.MaxValue,
                    Minimum = short.MinValue,
                    Value = Constants[num[i]],

In the above code snippet, Constants[num[i]] is a ushort, while the min and max of the NumericUpDown are being set to the min and max of short.  This commit fixes that, and by extension, #196.

I'm opening a PR instead of directly pushing both because that's what I'm in the habit of doing now, but also to give others a chance to decide whether or not Constants[num[i]] should really be a short.  I chose to make the range a ushort since that's the smaller/safer of the two possible solutions I see.