### PR TITLE
Added "All Files" to save filters

### DIFF
--- a/PKHeX/Saves/SAV1.cs
+++ b/PKHeX/Saves/SAV1.cs
@@ -6,7 +6,7 @@ namespace PKHeX
     public sealed class SAV1 : SaveFile
     {
         public override string BAKName => $"{FileName} [{OT} ({Version}) - {PlayTimeString}].bak";
-        public override string Filter => "SAV File|*.sav";
+        public override string Filter => "SAV File|*.sav|All Files|*.*";
         public override string Extension => ".sav";
 
         public SAV1(byte[] data = null)

--- a/PKHeX/Saves/SAV2.cs
+++ b/PKHeX/Saves/SAV2.cs
@@ -6,7 +6,7 @@ namespace PKHeX
     public sealed class SAV2 : SaveFile
     {
         public override string BAKName => $"{FileName} [{OT} ({Version}) - {PlayTimeString}].bak";
-        public override string Filter => "SAV File|*.sav";
+        public override string Filter => "SAV File|*.sav|All Files|*.*";
         public override string Extension => ".sav";
 
         public SAV2(byte[] data = null)

--- a/PKHeX/Saves/SAV3.cs
+++ b/PKHeX/Saves/SAV3.cs
@@ -6,7 +6,7 @@ namespace PKHeX
     public sealed class SAV3 : SaveFile
     {
         public override string BAKName => $"{FileName} [{OT} ({Version}) - {PlayTimeString}].bak";
-        public override string Filter => "SAV File|*.sav";
+        public override string Filter => "SAV File|*.sav|All Files|*.*";
         public override string Extension => ".sav";
 
         /* SAV3 Structure:

--- a/PKHeX/Saves/SAV3Colosseum.cs
+++ b/PKHeX/Saves/SAV3Colosseum.cs
@@ -7,7 +7,7 @@ namespace PKHeX
     public sealed class SAV3Colosseum : SaveFile
     {
         public override string BAKName => $"{FileName} [{OT} ({Version}) - {PlayTimeString}].bak";
-        public override string Filter => "GameCube Save File|*.gci";
+        public override string Filter => "GameCube Save File|*.gci|All Files|*.*";
         public override string Extension => ".gci";
 
         // 3 Save files are stored

--- a/PKHeX/Saves/SAV3RSBox.cs
+++ b/PKHeX/Saves/SAV3RSBox.cs
@@ -6,7 +6,7 @@ namespace PKHeX
     public sealed class SAV3RSBox : SaveFile
     {
         public override string BAKName => $"{FileName} [{Version} #{SaveCount.ToString("0000")}].bak";
-        public override string Filter => "GameCube Save File|*.gci";
+        public override string Filter => "GameCube Save File|*.gci|All Files|*.*";
         public override string Extension => ".gci";
 
         public SAV3RSBox(byte[] data = null)

--- a/PKHeX/Saves/SAV3XD.cs
+++ b/PKHeX/Saves/SAV3XD.cs
@@ -6,7 +6,7 @@ namespace PKHeX
     public sealed class SAV3XD : SaveFile
     {
         public override string BAKName => $"{FileName} [{OT} ({Version}) #{SaveCount.ToString("0000")}].bak";
-        public override string Filter => "GameCube Save File|*.gci";
+        public override string Filter => "GameCube Save File|*.gci|All Files|*.*";
         public override string Extension => ".gci";
 
         private const int SLOT_SIZE = 0x28000;

--- a/PKHeX/Saves/SAV4.cs
+++ b/PKHeX/Saves/SAV4.cs
@@ -6,7 +6,7 @@ namespace PKHeX
     public sealed class SAV4 : SaveFile
     {
         public override string BAKName => $"{FileName} [{OT} ({Version}) - {PlayTimeString}].bak";
-        public override string Filter => (Footer.Length > 0 ? "DeSmuME DSV|*.dsv|" : "") + "SAV File|*.sav";
+        public override string Filter => (Footer.Length > 0 ? "DeSmuME DSV|*.dsv|" : "") + "SAV File|*.sav|All Files|*.*";
         public override string Extension => ".sav";
         public SAV4(byte[] data = null, GameVersion versionOverride = GameVersion.Any)
         {

--- a/PKHeX/Saves/SAV5.cs
+++ b/PKHeX/Saves/SAV5.cs
@@ -8,7 +8,7 @@ namespace PKHeX
     {
         // Save Data Attributes
         public override string BAKName => $"{FileName} [{OT} ({(GameVersion)Game}) - {PlayTimeString}].bak";
-        public override string Filter => (Footer.Length > 0 ? "DeSmuME DSV|*.dsv|" : "") + "SAV File|*.sav";
+        public override string Filter => (Footer.Length > 0 ? "DeSmuME DSV|*.dsv|" : "") + "SAV File|*.sav|All Files|*.*";
         public override string Extension => ".sav";
         public SAV5(byte[] data = null, GameVersion versionOverride = GameVersion.Any)
         {


### PR DESCRIPTION
From PP IRC:
```
<Sylveon700> when saving ds games you use dsv and pkhex saves as dsv
<Sylveon700> but save sa1 it will rename the file .sa1.sav
<Sylveon700> i feel nobody understands me
```

This pull request should help fix exactly that issue.