### PR TITLE
Added warning when closing PKHeX with unsaved changes

### DIFF
--- a/PKHeX/MainWindow/Main.Designer.cs
+++ b/PKHeX/MainWindow/Main.Designer.cs
@@ -5647,6 +5647,7 @@
             this.Name = "Main";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "PKHeX";
+            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.Main_FormClosing);
             this.DragDrop += new System.Windows.Forms.DragEventHandler(this.tabMain_DragDrop);
             this.DragEnter += new System.Windows.Forms.DragEventHandler(this.tabMain_DragEnter);
             this.tabMain.ResumeLayout(false);

--- a/PKHeX/MainWindow/Main.cs
+++ b/PKHeX/MainWindow/Main.cs
@@ -2994,6 +2994,17 @@ namespace PKHeX
 
             Cursor = DefaultCursor;
         }
+
+        private void Main_FormClosing(object sender, FormClosingEventArgs e)
+        {
+            if (SAV.Edited)
+            {
+                if (Util.Prompt(MessageBoxButtons.YesNo, "Any unsaved changes will be lost.  Are you sure you want to close PKHeX?") != DialogResult.Yes)
+                {
+                    e.Cancel = true;
+                }
+            }
+        }
         #endregion
 
         #region //// SAVE FILE FUNCTIONS ////
@@ -3054,6 +3065,7 @@ namespace PKHeX
 
             bool dsv = Path.GetExtension(main.FileName)?.ToLower() == ".dsv";
             File.WriteAllBytes(main.FileName, SAV.Write(dsv));
+            SAV.Edited = false;
             Util.Alert("SAV exported to:", main.FileName);
         }
 


### PR DESCRIPTION
Adds feature described in issue #325.

This PR adds a dialog asking for confirmation if someone tries to close the form when there's unsaved changes.  Saving through `clickExportSAV` marks the current save as no longer modified, and will not display the dialog.  I'm unsure if saving the backup with `clickExportSAVBAK` should mark the save as not modified, but it looks fine as-is.