### PR TITLE
B/detect save null reference

### DIFF
--- a/PKHeX/MainWindow/Main.cs
+++ b/PKHeX/MainWindow/Main.cs
@@ -181,7 +181,10 @@ namespace PKHeX
                 if (path != null && File.Exists(path))
                     openQuick(path, force: true);
                 else
+                {
                     openSAV(SAV, null);
+                    SAV.Edited = false; // Prevents form close warning from showing until changes are made
+                }                    
             }
 
             // Splash Screen closes on its own.

--- a/PKHeX/Misc/ErrorWindow.cs
+++ b/PKHeX/Misc/ErrorWindow.cs
@@ -18,7 +18,7 @@ namespace PKHeX.Misc
             var dialogResult = dialog.ShowDialog();
             if (dialogResult == DialogResult.Abort)
             {
-                Application.Exit();
+                Environment.Exit(1);
             }
             return dialogResult;
         }

--- a/PKHeX/Saves/SaveUtil.cs
+++ b/PKHeX/Saves/SaveUtil.cs
@@ -509,6 +509,24 @@ namespace PKHeX
         }
 
         /// <summary>
+        /// Determines if the given data is a valid save file with a valid checksum.
+        /// </summary>
+        /// <param name="data">Save data to check</param>
+        /// <returns>A boolean indicating whether or not the given data is a save file with valid checksums.</returns>
+        public static bool isVariantSAVValid(byte[] data)
+        {
+            var save = getVariantSAV(data);
+            if (save == null)
+            {
+                return false;                
+            }
+            else
+            {
+                return save.ChecksumsValid;
+            }
+        }
+
+        /// <summary>
         /// Detects a save file.
         /// </summary>
         /// <returns>Full path of a save file. Returns null if unable to find any.</returns>
@@ -544,7 +562,7 @@ namespace PKHeX
                 possiblePaths.AddRange(getSavesFromFolder(Path.Combine(pathCache), false));
 
             // return newest save file path that is valid (oh man)
-            return possiblePaths.OrderByDescending(f => new FileInfo(f).LastWriteTime).FirstOrDefault(p => getVariantSAV(File.ReadAllBytes(p)).ChecksumsValid);
+            return possiblePaths.OrderByDescending(f => new FileInfo(f).LastWriteTime).FirstOrDefault(p => isVariantSAVValid(File.ReadAllBytes(p)));
         }
         /// <summary>
         /// Retrieves the full path of the most recent file based on LastWriteTime.

--- a/PKHeX/Saves/SaveUtil.cs
+++ b/PKHeX/Saves/SaveUtil.cs
@@ -509,24 +509,6 @@ namespace PKHeX
         }
 
         /// <summary>
-        /// Determines if the given data is a valid save file with a valid checksum.
-        /// </summary>
-        /// <param name="data">Save data to check</param>
-        /// <returns>A boolean indicating whether or not the given data is a save file with valid checksums.</returns>
-        public static bool isVariantSAVValid(byte[] data)
-        {
-            var save = getVariantSAV(data);
-            if (save == null)
-            {
-                return false;                
-            }
-            else
-            {
-                return save.ChecksumsValid;
-            }
-        }
-
-        /// <summary>
         /// Detects a save file.
         /// </summary>
         /// <returns>Full path of a save file. Returns null if unable to find any.</returns>
@@ -562,7 +544,7 @@ namespace PKHeX
                 possiblePaths.AddRange(getSavesFromFolder(Path.Combine(pathCache), false));
 
             // return newest save file path that is valid (oh man)
-            return possiblePaths.OrderByDescending(f => new FileInfo(f).LastWriteTime).FirstOrDefault(p => isVariantSAVValid(File.ReadAllBytes(p)));
+            return possiblePaths.OrderByDescending(f => new FileInfo(f).LastWriteTime).FirstOrDefault(p => getVariantSAV(File.ReadAllBytes(p))?.ChecksumsValid ?? false);
         }
         /// <summary>
         /// Retrieves the full path of the most recent file based on LastWriteTime.


### PR DESCRIPTION
Fixes the issue described here: https://projectpokemon.org/forums/showthread.php?50334-Newer-PKHex-Releases-won-t-run&p=221387&viewfull=1#post221387

Also fixes two other issues I found during testing: the abort button in the Error Window doing nothing, and the form close warning showing when the blank save is loaded.