### PR TITLE
Possible fix for issue #347 (999 item count becomes 39)

### DIFF
--- a/PKHeX/Saves/Substructures/Inventory.cs
+++ b/PKHeX/Saves/Substructures/Inventory.cs
@@ -106,7 +106,7 @@ namespace PKHeX
                 Items[i].New |= OriginalItems.All(z => z.Index != Items[i].Index);
                 if (Items[i].New)
                     val |= 0x40000000;
-                BitConverter.GetBytes((ushort)val).CopyTo(Data, Offset + i * 4);
+                BitConverter.GetBytes(val).CopyTo(Data, Offset + i * 4);
             }
         }
 


### PR DESCRIPTION
I don't have a 7th gen save ready, so this is completely untested, but as long as the research in the comments is correct, I see no reason why this won't work.