### PR TITLE
B/memecrypto winxp

### DIFF
--- a/PKHeX/MainWindow/Main.cs
+++ b/PKHeX/MainWindow/Main.cs
@@ -783,11 +783,14 @@ namespace PKHeX
             if (sav == null || sav.Version == GameVersion.Invalid)
             { Util.Error("Invalid save file loaded. Aborting.", path); return; }
 
-            if (sav.RequiresMemeCrypto && !MemeCrypto.CanUseMemeCrypto())
+            if (!string.IsNullOrEmpty(path)) // If path is null, this is the default save
             {
-                Util.Error("Your platform does not support the required cryptography components.", "In order to be able to save your changes, you must either upgrade to a newer version of Windows or disable FIPS compliance mode.");
-                // Don't abort loading; user can still view save and fix checksum on another platform.
-            }
+                if (sav.RequiresMemeCrypto && !MemeCrypto.CanUseMemeCrypto())
+                {
+                    Util.Error("Your platform does not support the required cryptography components.", "In order to be able to save your changes, you must either upgrade to a newer version of Windows or disable FIPS compliance mode.");
+                    // Don't abort loading; user can still view save and fix checksum on another platform.
+                }
+            }            
 
             // Finish setting up the save file.
             if (sav.IndeterminateGame && sav.Generation == 3)

--- a/PKHeX/MainWindow/Main.cs
+++ b/PKHeX/MainWindow/Main.cs
@@ -783,6 +783,12 @@ namespace PKHeX
             if (sav == null || sav.Version == GameVersion.Invalid)
             { Util.Error("Invalid save file loaded. Aborting.", path); return; }
 
+            if (sav.RequiresMemeCrypto && !MemeCrypto.CanUseMemeCrypto())
+            {
+                Util.Error("Your platform does not support the required cryptography components.", "In order to be able to save your changes, you must either upgrade to a newer version of Windows or disable FIPS compliance mode.");
+                // Don't abort loading; user can still view save and fix checksum on another platform.
+            }
+
             // Finish setting up the save file.
             if (sav.IndeterminateGame && sav.Generation == 3)
             {

--- a/PKHeX/PKHeX.csproj
+++ b/PKHeX/PKHeX.csproj
@@ -420,6 +420,7 @@
     </Compile>
     <Compile Include="Game\ComboItem.cs" />
     <Compile Include="Util\BigEndian.cs" />
+    <Compile Include="Util\CryptoUtil.cs" />
     <Compile Include="Util\DataUtil.cs" />
     <Compile Include="Util\DateUtil.cs" />
     <Compile Include="Util\DeployUtil.cs" />

--- a/PKHeX/Saves/SAV7.cs
+++ b/PKHeX/Saves/SAV7.cs
@@ -819,24 +819,35 @@ namespace PKHeX
         // Writeback Validity
         public override string MiscSaveChecks()
         {
-            string r = "";
+            var r = new StringBuilder();
+
+            // MemeCrypto check
+            if (RequiresMemeCrypto && !MemeCrypto.CanUseMemeCrypto())
+            {
+                r.AppendLine("Platform does not support required cryptography providers.");
+                r.AppendLine("Checksum will be broken until the file is saved using an OS without FIPS compliance enabled or a newer OS.");
+                r.AppendLine();
+            }
+
+            // FFFF checks
             byte[] FFFF = Enumerable.Repeat((byte)0xFF, 0x200).ToArray();
             for (int i = 0; i < Data.Length / 0x200; i++)
             {
                 if (!FFFF.SequenceEqual(Data.Skip(i * 0x200).Take(0x200))) continue;
-                r = $"0x200 chunk @ 0x{(i*0x200).ToString("X5")} is FF'd."
-                    + Environment.NewLine + "Cyber will screw up (as of August 31st 2014)." + Environment.NewLine + Environment.NewLine;
+                r.AppendLine($"0x200 chunk @ 0x{(i * 0x200).ToString("X5")} is FF'd.");
+                r.AppendLine("Cyber will screw up (as of August 31st 2014).");
+                r.AppendLine();
 
                 // Check to see if it is in the Pokedex
                 if (i * 0x200 > PokeDex && i * 0x200 < PokeDex + 0x900)
                 {
-                    r += "Problem lies in the Pokedex. ";
+                    r.Append("Problem lies in the Pokedex. ");
                     if (i * 0x200 == PokeDex + 0x400)
-                        r += "Remove a language flag for a species < 585, ie Petilil";
+                        r.Append("Remove a language flag for a species < 585, ie Petilil");
                 }
                 break;
             }
-            return r;
+            return r.ToString();
         }
         public override string MiscSaveInfo()
         {

--- a/PKHeX/Saves/SAV7.cs
+++ b/PKHeX/Saves/SAV7.cs
@@ -854,5 +854,13 @@ namespace PKHeX
             return Blocks.Aggregate("", (current, b) => current +
                 $"{b.ID.ToString("00")}: {b.Offset.ToString("X5")}-{(b.Offset + b.Length).ToString("X5")}, {b.Length.ToString("X5")}{Environment.NewLine}");
         }
+
+        public override bool RequiresMemeCrypto
+        {
+            get
+            {
+                return true;
+            }
+        }
     }
 }

--- a/PKHeX/Saves/SaveFile.cs
+++ b/PKHeX/Saves/SaveFile.cs
@@ -550,5 +550,7 @@ namespace PKHeX
             input.CopyTo(Data, Offset);
             Edited = true;
         }
+
+        public virtual bool RequiresMemeCrypto { get { return false; } }
     }
 }

--- a/PKHeX/Saves/SaveUtil.cs
+++ b/PKHeX/Saves/SaveUtil.cs
@@ -586,7 +586,7 @@ namespace PKHeX
         }
         public static byte[] Resign7(byte[] sav7)
         {
-            return MemeCrypto.Resign(sav7);
+            return MemeCrypto.Resign(sav7, false);
         }
         /// <summary>Calculates the 32bit checksum over an input byte array. Used in GBA save files.</summary>
         /// <param name="data">Input byte array</param>

--- a/PKHeX/Saves/Substructures/MemeCrypto.cs
+++ b/PKHeX/Saves/Substructures/MemeCrypto.cs
@@ -227,7 +227,14 @@ namespace PKHeX
             return null;
         }
 
-        public static byte[] Resign(byte[] sav7)
+        /// <summary>
+        /// Resigns save data.
+        /// </summary>
+        /// <param name="sav7">The save data to resign.</param>
+        /// <param name="throwIfUnsupported">If true, throw an <see cref="InvalidOperationException"/> if MemeCrypto is unsupported.  If false, calling this function will have no effect.</param>
+        /// <exception cref="InvalidOperationException">Thrown if the current platform has FIPS mode enabled on a platform that does not support the required crypto service providers.</exception>
+        /// <returns>The resigned save data.</returns>
+        public static byte[] Resign(byte[] sav7, bool throwIfUnsupported = true)
         {
             if (sav7 == null || sav7.Length != 0x6BE00)
                 return null;            
@@ -267,6 +274,19 @@ namespace PKHeX
             }            
 
             return outSav;
+        }
+
+        public static bool CanUseMemeCrypto()
+        {
+            try
+            {
+                Util.GetSHA256Provider();
+            }
+            catch (InvalidOperationException)
+            {
+                return false;
+            }
+            return true;
         }
     }
 

--- a/PKHeX/Saves/Substructures/MemeCrypto.cs
+++ b/PKHeX/Saves/Substructures/MemeCrypto.cs
@@ -14,7 +14,7 @@ namespace PKHeX
         {
             using (MemoryStream ms = new MemoryStream())
             {
-                using (var aes = new AesCryptoServiceProvider())
+                using (var aes = Util.GetAesProvider())
                 {
                     aes.Mode = CipherMode.ECB;
                     aes.Padding = PaddingMode.None;
@@ -34,7 +34,7 @@ namespace PKHeX
         {
             using (MemoryStream ms = new MemoryStream())
             {
-                using (var aes = new AesCryptoServiceProvider())
+                using (var aes = Util.GetAesProvider())
                 {
                     aes.Mode = CipherMode.ECB;
                     aes.Padding = PaddingMode.None;
@@ -204,62 +204,67 @@ namespace PKHeX
             if (input.Length != 0x80)
                 throw new ArgumentException("Invalid Memecrypto decryption byte[]!");
 
-            var sha1 = new SHA1CryptoServiceProvider();
+            using (var sha1 = Util.GetSHA1Provider())
+            {
+                byte[] PubKeyDer = "307C300D06092A864886F70D0101010500036B003068026100B61E192091F90A8F76A6EAAA9A3CE58C863F39AE253F037816F5975854E07A9A456601E7C94C29759FE155C064EDDFA111443F81EF1A428CF6CD32F9DAC9D48E94CFB3F690120E8E6B9111ADDAF11E7C96208C37C0143FF2BF3D7E831141A9730203010001".ToByteArray();
+                byte[] enc = new byte[0x60];
+                Array.Copy(input, 0x20, enc, 0, 0x60);
 
-            byte[] PubKeyDer = "307C300D06092A864886F70D0101010500036B003068026100B61E192091F90A8F76A6EAAA9A3CE58C863F39AE253F037816F5975854E07A9A456601E7C94C29759FE155C064EDDFA111443F81EF1A428CF6CD32F9DAC9D48E94CFB3F690120E8E6B9111ADDAF11E7C96208C37C0143FF2BF3D7E831141A9730203010001".ToByteArray();
-            byte[] enc = new byte[0x60];
-            Array.Copy(input, 0x20, enc, 0, 0x60);
+                byte[] keybuf = new byte[PubKeyDer.Length + 0x20];
+                Array.Copy(PubKeyDer, keybuf, PubKeyDer.Length);
+                Array.Copy(input, 0, keybuf, PubKeyDer.Length, 0x20);
+                byte[] key = sha1.ComputeHash(keybuf).Take(0x10).ToArray();
 
-            byte[] keybuf = new byte[PubKeyDer.Length + 0x20];
-            Array.Copy(PubKeyDer, keybuf, PubKeyDer.Length);
-            Array.Copy(input, 0, keybuf, PubKeyDer.Length, 0x20);
-            byte[] key = sha1.ComputeHash(keybuf).Take(0x10).ToArray();
-
-            byte[] RSA = RSAEncrypt(enc);
-            var dec = MemeCryptoAESDecrypt(key, RSA);
-            if (sha1.ComputeHash(dec).Take(0x8).SequenceEqual(dec.Skip(0x58)))
-                return dec;
-            RSA[0] |= 0x80;
-            dec = MemeCryptoAESDecrypt(key, RSA);
-            if (sha1.ComputeHash(dec).Take(0x8).SequenceEqual(dec.Skip(0x58)))
-                return dec;
+                byte[] RSA = RSAEncrypt(enc);
+                var dec = MemeCryptoAESDecrypt(key, RSA);
+                if (sha1.ComputeHash(dec).Take(0x8).SequenceEqual(dec.Skip(0x58)))
+                    return dec;
+                RSA[0] |= 0x80;
+                dec = MemeCryptoAESDecrypt(key, RSA);
+                if (sha1.ComputeHash(dec).Take(0x8).SequenceEqual(dec.Skip(0x58)))
+                    return dec;
+            }            
             return null;
         }
 
         public static byte[] Resign(byte[] sav7)
         {
             if (sav7 == null || sav7.Length != 0x6BE00)
-                return null;
-
-            var sha1 = new SHA1CryptoServiceProvider();
+                return null;            
 
             byte[] outSav = (byte[])sav7.Clone();
 
-            byte[] CurSig = new byte[0x80];
-            Array.Copy(sav7, 0x6BB00, CurSig, 0, 0x80);
+            using (var sha1 = Util.GetSHA1Provider())
+            {
+                using (var sha256 = Util.GetSHA256Provider())
+                {
+                    byte[] CurSig = new byte[0x80];
+                    Array.Copy(sav7, 0x6BB00, CurSig, 0, 0x80);
 
-            byte[] ChecksumTable = new byte[0x140];
-            Array.Copy(sav7, 0x6BC00, ChecksumTable, 0, 0x140);
-            byte[] Hash = new SHA256CryptoServiceProvider().ComputeHash(ChecksumTable);
+                    byte[] ChecksumTable = new byte[0x140];
+                    Array.Copy(sav7, 0x6BC00, ChecksumTable, 0, 0x140);
+                    byte[] Hash = sha256.ComputeHash(ChecksumTable);
 
-            byte[] PubKeyDer = "307C300D06092A864886F70D0101010500036B003068026100B61E192091F90A8F76A6EAAA9A3CE58C863F39AE253F037816F5975854E07A9A456601E7C94C29759FE155C064EDDFA111443F81EF1A428CF6CD32F9DAC9D48E94CFB3F690120E8E6B9111ADDAF11E7C96208C37C0143FF2BF3D7E831141A9730203010001".ToByteArray();
+                    byte[] PubKeyDer = "307C300D06092A864886F70D0101010500036B003068026100B61E192091F90A8F76A6EAAA9A3CE58C863F39AE253F037816F5975854E07A9A456601E7C94C29759FE155C064EDDFA111443F81EF1A428CF6CD32F9DAC9D48E94CFB3F690120E8E6B9111ADDAF11E7C96208C37C0143FF2BF3D7E831141A9730203010001".ToByteArray();
 
-            byte[] keybuf = new byte[PubKeyDer.Length + 0x20];
-            Array.Copy(PubKeyDer, keybuf, PubKeyDer.Length);
-            Array.Copy(Hash, 0, keybuf, PubKeyDer.Length, 0x20);
-            byte[] key = sha1.ComputeHash(keybuf).Take(0x10).ToArray();
+                    byte[] keybuf = new byte[PubKeyDer.Length + 0x20];
+                    Array.Copy(PubKeyDer, keybuf, PubKeyDer.Length);
+                    Array.Copy(Hash, 0, keybuf, PubKeyDer.Length, 0x20);
+                    byte[] key = sha1.ComputeHash(keybuf).Take(0x10).ToArray();
 
-            byte[] secret = ReverseCrypt(CurSig) ?? new byte[0x60];
-            byte[] secretWorkBuf = new byte[0x78];
-            Hash.CopyTo(secretWorkBuf, 0);
-            Array.Copy(secret, 0, secretWorkBuf, 0x20, 0x58);
-            Array.Copy(sha1.ComputeHash(secretWorkBuf), 0, secret, 0x58, 8);
+                    byte[] secret = ReverseCrypt(CurSig) ?? new byte[0x60];
+                    byte[] secretWorkBuf = new byte[0x78];
+                    Hash.CopyTo(secretWorkBuf, 0);
+                    Array.Copy(secret, 0, secretWorkBuf, 0x20, 0x58);
+                    Array.Copy(sha1.ComputeHash(secretWorkBuf), 0, secret, 0x58, 8);
 
-            Hash.CopyTo(outSav, 0x6BB00);
-            byte[] MemeCrypted = MemeCryptoAESEncrypt(key, secret);
-            MemeCrypted[0] &= 0x7F;
-            var RSA = RSADecrypt(MemeCrypted);
-            Array.Copy(RSA, 0, outSav, 0x6BB20, 0x60);
+                    Hash.CopyTo(outSav, 0x6BB00);
+                    byte[] MemeCrypted = MemeCryptoAESEncrypt(key, secret);
+                    MemeCrypted[0] &= 0x7F;
+                    var RSA = RSADecrypt(MemeCrypted);
+                    Array.Copy(RSA, 0, outSav, 0x6BB20, 0x60);
+                }                
+            }            
 
             return outSav;
         }

--- a/PKHeX/Util/CryptoUtil.cs
+++ b/PKHeX/Util/CryptoUtil.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace PKHeX
+{
+    public partial class Util
+    {
+
+        /// <summary>
+        /// Creates a new instance of <see cref="SHA1CryptoServiceProvider"/>, or <see cref="SHA1Managed"/> if not supported by the current platform.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">Thrown if FIPS mode is enabled on a platform that does not support <see cref="SHA1CryptoServiceProvider"/>.</exception>
+        public static SHA1 GetSHA1Provider()
+        {
+            SHA1 provider;
+            try
+            {
+                provider = new SHA1CryptoServiceProvider();
+            }
+            catch (PlatformNotSupportedException)
+            {
+                provider = new SHA1Managed();
+            }
+            return provider;
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="SHA256CryptoServiceProvider"/>, or <see cref="SHA256Managed"/> if not supported by the current platform.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">Thrown if FIPS mode is enabled on a platform that does not support <see cref="SHA256CryptoServiceProvider"/>.</exception>
+        public static SHA256 GetSHA256Provider()
+        {
+            SHA256 provider;
+            try
+            {
+                provider = new SHA256CryptoServiceProvider();
+            }
+            catch (PlatformNotSupportedException)
+            {
+                provider = new SHA256Managed();
+            }
+            return provider;
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="AesCryptoServiceProvider"/>, or <see cref="AesManaged"/> if not supported by the current platform.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">Thrown if FIPS mode is enabled on a platform that does not support <see cref="AesCryptoServiceProvider"/>.</exception>
+        public static Aes GetAesProvider()
+        {
+            Aes provider;
+            try
+            {
+                provider = new AesCryptoServiceProvider();
+            }
+            catch (PlatformNotSupportedException)
+            {
+                provider = new AesManaged();
+            }
+            return provider;
+        }
+    }
+}


### PR DESCRIPTION
# The Problem
* SHA256CryptoServiceProvider and friends are not supported on XP.
[Original Report](http://gbatemp.net/threads/can-someone-complile-the-new-gen-7-pkhex.447884/page-13#post-6825115)

# The Solution
The simple solution is to use SHA256Managed and friends instead.  This, however, undoes the fix introduced in PR #367.  Additions have been made to do the following:
1. Attempt to use SHA256CryptoServiceProvider and friends
2. If a PlatformNotSupportedException is thrown, use SHA256Managed and friends.
3. If an InvalidOperation exception is thrown, this likely means FIPS mode is enabled on Windows XP.  I'm not aware of anything that can be done, so the following actions are taken:
  - Upon opening a SAV7, an error is shown warning the user that saving cannot be done.  Care has been taken to ensure that this isn't shown when loading the default save (i.e. loading the form).
  - Upon attempting to save, a MiscSaveCheck is added warning that the checksum will be broken until saved on an OS without FIPS enabled or on a new OS.

Tested on a WinXP VM, before and after enabling FIPS mode.