### PR TITLE
Fixed crash when opening SAV_BoxLayout with Gen 4 save

### DIFF
--- a/PKHeX/Subforms/Save Editors/Gen6/SAV_BoxLayout.cs
+++ b/PKHeX/Subforms/Save Editors/Gen6/SAV_BoxLayout.cs
@@ -15,11 +15,21 @@ namespace PKHeX
             // Repopulate Wallpaper names
             CB_BG.Items.Clear();
 
-            if (SAV.Generation == 6)
-                CB_BG.Items.AddRange(Main.GameStrings.wallpapernames);
-            else if (SAV.Generation == 7)
-                CB_BG.Items.AddRange(Main.GameStrings.wallpapernames.Take(16).ToArray());
-            
+            switch (SAV.Generation)
+            {
+                case 4:
+                case 5:
+                case 6:
+                    CB_BG.Items.AddRange(Main.GameStrings.wallpapernames);
+                    break;
+                case 7:
+                    CB_BG.Items.AddRange(Main.GameStrings.wallpapernames.Take(16).ToArray());
+                    break;
+                default:
+                    Util.Error("Box layout is not supported for this game.");
+                    return;
+            }
+
             // Go
             LB_BoxSelect.Items.Clear();
             for (int i = 0; i < SAV.BoxCount; i++)


### PR DESCRIPTION
Should fix issue #415 

The form itself should now support generations 4-7, although Gen 5 doesn't show the button to open this form.  The [wallpaper names](http://bulbapedia.bulbagarden.net/wiki/Pok%C3%A9mon_Storage_System#Generation_V) are the same, so once proper support is introduced, they should not have to be adjusted.