### PR TITLE
Only show suggested move prompt if there would be a change

### DIFF
--- a/PKHeX/MainWindow/Main.cs
+++ b/PKHeX/MainWindow/Main.cs
@@ -1811,7 +1811,6 @@ namespace PKHeX
                     m = m.Skip(m.Length - 4).ToArray();
                 Array.Resize(ref m, 4);
 
-
                 // Determine if application needs to be made
                 var alreadyEqual = (int)CB_Move1.SelectedValue == m[0] &&
                                    (int)CB_Move2.SelectedValue == m[1] &&
@@ -1823,12 +1822,12 @@ namespace PKHeX
                     string r = string.Join(Environment.NewLine, m.Select(v => v >= GameStrings.movelist.Length ? "ERROR" : GameStrings.movelist[v]));
                     if (DialogResult.Yes != Util.Prompt(MessageBoxButtons.YesNo, "Apply suggested current moves?", r))
                         return;
-                }                
 
-                CB_Move1.SelectedValue = m[0];
-                CB_Move2.SelectedValue = m[1];
-                CB_Move3.SelectedValue = m[2];
-                CB_Move4.SelectedValue = m[3];
+                    CB_Move1.SelectedValue = m[0];
+                    CB_Move2.SelectedValue = m[1];
+                    CB_Move3.SelectedValue = m[2];
+                    CB_Move4.SelectedValue = m[3];
+                }                     
             }
             else if (sender == GB_RelearnMoves)
             {
@@ -1846,12 +1845,13 @@ namespace PKHeX
                     string r = string.Join(Environment.NewLine, m.Select(v => v >= GameStrings.movelist.Length ? "ERROR" : GameStrings.movelist[v]));
                     if (DialogResult.Yes != Util.Prompt(MessageBoxButtons.YesNo, "Apply suggested relearn moves?", r))
                         return;
-                }                
 
-                CB_RelearnMove1.SelectedValue = m[0];
-                CB_RelearnMove2.SelectedValue = m[1];
-                CB_RelearnMove3.SelectedValue = m[2];
-                CB_RelearnMove4.SelectedValue = m[3];
+                    CB_RelearnMove1.SelectedValue = m[0];
+                    CB_RelearnMove2.SelectedValue = m[1];
+                    CB_RelearnMove3.SelectedValue = m[2];
+                    CB_RelearnMove4.SelectedValue = m[3];
+                } 
+
             }
 
             updateLegality();

--- a/PKHeX/MainWindow/Main.cs
+++ b/PKHeX/MainWindow/Main.cs
@@ -1810,9 +1810,20 @@ namespace PKHeX
                 if (m.Length > 4)
                     m = m.Skip(m.Length - 4).ToArray();
                 Array.Resize(ref m, 4);
-                string r = string.Join(Environment.NewLine, m.Select(v => v >= GameStrings.movelist.Length ? "ERROR" : GameStrings.movelist[v]));
-                if (DialogResult.Yes != Util.Prompt(MessageBoxButtons.YesNo, "Apply suggested current moves?", r))
-                    return;
+
+
+                // Determine if application needs to be made
+                var alreadyEqual = (int)CB_Move1.SelectedValue == m[0] &&
+                                   (int)CB_Move2.SelectedValue == m[1] &&
+                                   (int)CB_Move3.SelectedValue == m[2] &&
+                                   (int)CB_Move4.SelectedValue == m[3];
+
+                if (!alreadyEqual)
+                {
+                    string r = string.Join(Environment.NewLine, m.Select(v => v >= GameStrings.movelist.Length ? "ERROR" : GameStrings.movelist[v]));
+                    if (DialogResult.Yes != Util.Prompt(MessageBoxButtons.YesNo, "Apply suggested current moves?", r))
+                        return;
+                }                
 
                 CB_Move1.SelectedValue = m[0];
                 CB_Move2.SelectedValue = m[1];
@@ -1822,9 +1833,20 @@ namespace PKHeX
             else if (sender == GB_RelearnMoves)
             {
                 int[] m = Legality.getSuggestedRelearn();
-                string r = string.Join(Environment.NewLine, m.Select(v => v >= GameStrings.movelist.Length ? "ERROR" : GameStrings.movelist[v]));
-                if (DialogResult.Yes != Util.Prompt(MessageBoxButtons.YesNo, "Apply suggested relearn moves?", r))
-                    return;
+
+                // Determine if application needs to be made
+                var alreadyEqual = (int)CB_RelearnMove1.SelectedValue == m[0] &&
+                                   (int)CB_RelearnMove2.SelectedValue == m[1] &&
+                                   (int)CB_RelearnMove3.SelectedValue == m[2] &&
+                                   (int)CB_RelearnMove4.SelectedValue == m[3];
+                
+                // Only prompt if there would be a change
+                if (!alreadyEqual)
+                {
+                    string r = string.Join(Environment.NewLine, m.Select(v => v >= GameStrings.movelist.Length ? "ERROR" : GameStrings.movelist[v]));
+                    if (DialogResult.Yes != Util.Prompt(MessageBoxButtons.YesNo, "Apply suggested relearn moves?", r))
+                        return;
+                }                
 
                 CB_RelearnMove1.SelectedValue = m[0];
                 CB_RelearnMove2.SelectedValue = m[1];


### PR DESCRIPTION
When testing the performance of the form and concluding there's nothing that can be done to improve speed, I kept getting nagged with a message saying:
```
Apply suggested relearn moves?
(None)
(None)
(None)
(None)
```
when the current relearn moves were:
```
(None)
(None)
(None)
(None)
```
This PR makes it so that that prompt will only show if there would be a change.