### PR TITLE
Fix geolocation checks

### DIFF
--- a/PKHeX/Legality/Checks.cs
+++ b/PKHeX/Legality/Checks.cs
@@ -1080,8 +1080,10 @@ namespace PKHeX
                     pkm.Geo1_Country, pkm.Geo2_Country, pkm.Geo3_Country, pkm.Geo4_Country, pkm.Geo5_Country,
                     pkm.Geo1_Region, pkm.Geo2_Region, pkm.Geo3_Region, pkm.Geo4_Region, pkm.Geo5_Region,
                 };
-                if (geo.Any(d => d != 0))
+                if (geo.Any(d => d != 0) && pkm.HT_Name.Length == 0)
                     return new CheckResult(Severity.Invalid, "Geolocation Memories should not be present.", CheckIdentifier.History);
+                if (pkm.Geo1_Country == 0 && pkm.HT_Name.Length != 0 && !pkm.WasEvent)
+                    return new CheckResult(Severity.Invalid, "Geolocation Memories should be present.", CheckIdentifier.History);
                 
                 if (pkm.XY && pkm.CNTs.Any(stat => stat > 0))
                     return new CheckResult(Severity.Invalid, "Untraded -- Contest stats on SM origin should be zero.", CheckIdentifier.History);


### PR DESCRIPTION
Trading Pokemon still sets Geolocation so we expect it as long as an Handling Trainer exists.
Also having a HT but not a location is wrong as long as its not an event.
I only checked the first country slot in last case because its the first one written if the Geolocation list is empty, so having Geo2_Country but not Geo1_Country should be flagged as well. GeoX_Region may be empty depending on the player.