### PR TITLE
Beat filthy cheaters

### DIFF
--- a/PKHeX/MainWindow/Main.cs
+++ b/PKHeX/MainWindow/Main.cs
@@ -3229,6 +3229,19 @@ namespace PKHeX
         {
             if (!verifiedPKM()) return;
             int slot = getSlot(sender);
+            if (SAV.Version == GameVersion.SN || SAV.Version == GameVersion.MN) {
+                for (int i = 0; i < 72; i++) {
+                    int lslot = SAV.getData(19652 + i, 1)[0];
+                    i++;
+                    int lbox = SAV.getData(19652 + i, 1)[0];
+                    if (lbox == CB_BoxSelect.SelectedIndex) {
+                        if (slot == lslot) {
+                            Util.Alert("Failed to overwrite slot because is used by a Battle Box. Must take it out of team manually in-game.");
+                            return;
+                        }
+                    }
+                }
+            }
             if (slot == 30 && (CB_Species.SelectedIndex == 0 || CHK_IsEgg.Checked))
             { Util.Alert("Can't have empty/egg first slot."); return; }
 


### PR DESCRIPTION
On seventh gen there's no longer a battle box where the Pokemon data is moved, we now instead have six fake box teams that just contains a reference to where the Pokemon is located in the PC using Box and Slot index.
This data is found at offset 0x4CC4 with a lenght of 72 bytes. Every set of two bytes conforms a link to one Pokemon, being the first one the slot index of the box whose index is stored in the second byte. Empty slots are always chopped with two terminators (FF FF).

Example here:
01 00 00 00 06 00 02 01 1C 05 1D 1F FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF

Team 1 is using Pokemon from Slot 2 (Index 01) of Box 1 (Index 0), from Slot 1 of Box 1, from Slot 7 of Box 1, from Slot 3 of Box 2, from Slot 29 of Box 6 and from Slot 30 of Box 32. Every other Team is empty.

We check against any version other than Sun/Moon and enter a loop to cover every byte in the lenght of the Team Box data. We must move one index forward on the array after getting slot info to get the corresponding box index. If any box index matches the box we're on we check the slot index and if it matches as well we show an alert and stop the insertion of the data.

This is mainly made with the intention of prevent as much people as posible to try to cheat on official tournaments. There's nothing to do about people with hexadecimal editor maneuvering, CFW with QR injections and old binaries of PkHeX, but is still better than nothing.