### PR TITLE
Beat filthy cheaters

### DIFF
--- a/PKHeX/MainWindow/Main.cs
+++ b/PKHeX/MainWindow/Main.cs
@@ -3229,7 +3229,8 @@ namespace PKHeX
         {
             if (!verifiedPKM()) return;
             int slot = getSlot(sender);
-            if ((SAV.Version == GameVersion.SN || SAV.Version == GameVersion.MN) && IsLinkedSlot(slot, CB_BoxSelect.SelectedIndex)) {
+            if (SAV.IsLinkedSlot(slot, CB_BoxSelect.SelectedIndex)) {
+                Util.Alert("Failed to set to slot " + (slot + 1) + " of box " + (CB_BoxSelect.SelectedIndex + 1) + " because target is linked with battle box.");
                 return;
             }
             if (slot == 30 && (CB_Species.SelectedIndex == 0 || CHK_IsEgg.Checked))
@@ -3282,7 +3283,8 @@ namespace PKHeX
         private void clickDelete(object sender, EventArgs e)
         {
             int slot = getSlot(sender);
-            if ((SAV.Version == GameVersion.SN || SAV.Version == GameVersion.MN) && IsLinkedSlot(slot, CB_BoxSelect.SelectedIndex)) {
+            if (SAV.IsLinkedSlot(slot, CB_BoxSelect.SelectedIndex)) {
+                Util.Alert("Failed to delete from slot " + (slot + 1) + " of box " + (CB_BoxSelect.SelectedIndex + 1) + " because target is linked with battle box.");
                 return;
             }
             if (slot == 30 && SAV.PartyCount == 1 && !HaX) { Util.Alert("Can't delete first slot."); return; }
@@ -3390,7 +3392,8 @@ namespace PKHeX
 
             for (int i = 0; i < 30; i++) // set to every slot in box
             {
-                if ((SAV.Version == GameVersion.SN || SAV.Version == GameVersion.MN) && IsLinkedSlot(i, CB_BoxSelect.SelectedIndex)) {
+                if (SAV.IsLinkedSlot(i, CB_BoxSelect.SelectedIndex)) {
+                    Util.Alert("Failed to set to slot " + (i + 1) + " of box " + (CB_BoxSelect.SelectedIndex + 1) + " because target is linked with battle box.");
                     continue;
                 }
                 SAV.setStoredSlot(pk, getPKXOffset(i));
@@ -4163,9 +4166,13 @@ namespace PKHeX
             DragInfo.slotDestinationSlotNumber = getSlot(sender);
             DragInfo.slotDestinationOffset = getPKXOffset(DragInfo.slotDestinationSlotNumber);
             DragInfo.slotDestinationBoxNumber = CB_BoxSelect.SelectedIndex;
-            if ((SAV.Version == GameVersion.SN || SAV.Version == GameVersion.MN)
-                && (IsLinkedSlot(DragInfo.slotDestinationSlotNumber, DragInfo.slotDestinationBoxNumber)
-                    || IsLinkedSlot(DragInfo.slotSourceSlotNumber, DragInfo.slotSourceBoxNumber))) {
+
+            if (SAV.IsLinkedSlot(DragInfo.slotDestinationSlotNumber, DragInfo.slotDestinationBoxNumber)) {
+                Util.Alert("Failed to move into slot " + (DragInfo.slotDestinationSlotNumber + 1) + " of box " + (DragInfo.slotDestinationBoxNumber + 1) + " because target is linked with battle box.");
+                return;
+            }
+            if (SAV.IsLinkedSlot(DragInfo.slotSourceSlotNumber, DragInfo.slotSourceBoxNumber)) {
+                Util.Alert("Failed to move from slot " + (DragInfo.slotSourceSlotNumber + 1) + " of box " + (DragInfo.slotSourceBoxNumber + 1) + " because origin is linked with battle box.");
                 return;
             }
 
@@ -4315,21 +4322,6 @@ namespace PKHeX
                 return slotSource == form || slotDestination == form; // form already updated?
             }
         }
-        public static bool IsLinkedSlot(int slot, int box) {
-            for (int i = 0; i < 72; i++) {
-                int lslot = SAV.getData(19652 + i, 1)[0];
-                i++;
-                int lbox = SAV.getData(19652 + i, 1)[0];
-                if (lbox == box) {
-                    if (slot == lslot) {
-                        Util.Alert("Failed to modify slot "+ ++slot +" of box "+ ++box +" because is linked to a team. Take the Pokemon out of it in-game before trying again.");
-                        return true;
-                    }
-                }
-            }
-            return false;
-        }
-
         #endregion
     }
 }

--- a/PKHeX/Saves/SAV7.cs
+++ b/PKHeX/Saves/SAV7.cs
@@ -316,12 +316,12 @@ namespace PKHeX
             get { return Data[TrainerCard + 5]; }
             set { Data[TrainerCard + 5] = (byte)value; }
         }
-        public override int GameSyncIDSize => 32; // 128 bits
+        public override int GameSyncIDSize => 16; // 64 bits
         public override string GameSyncID
         {
             get
             {
-                var data = Data.Skip(TrainerCard + 0x18).Take(GameSyncIDSize/2).Reverse().ToArray();
+                var data = Data.Skip(TrainerCard + 0x10).Take(GameSyncIDSize/2).Reverse().ToArray();
                 return BitConverter.ToString(data).Replace("-", "");
             }
             set
@@ -329,6 +329,28 @@ namespace PKHeX
                 if (value == null)
                     return;
                 if (value.Length > GameSyncIDSize)
+                    return;
+
+                Enumerable.Range(0, value.Length)
+                     .Where(x => x % 2 == 0)
+                     .Reverse()
+                     .Select(x => Convert.ToByte(value.Substring(x, 2), 16))
+                     .ToArray().CopyTo(Data, TrainerCard + 0x10);
+            }
+        }
+        public int NexUniqueIDSize => 32; // 128 bits
+        public string NexUniqueID
+        {
+            get
+            {
+                var data = Data.Skip(TrainerCard + 0x18).Take(NexUniqueIDSize/2).Reverse().ToArray();
+                return BitConverter.ToString(data).Replace("-", "");
+            }
+            set
+            {
+                if (value == null)
+                    return;
+                if (value.Length > NexUniqueIDSize)
                     return;
 
                 Enumerable.Range(0, value.Length)

--- a/PKHeX/Saves/SAV7.cs
+++ b/PKHeX/Saves/SAV7.cs
@@ -1064,5 +1064,19 @@ namespace PKHeX
                 return true;
             }
         }
+        public override bool IsLinkedSlot(int slot, int box) {
+            if (Version != GameVersion.SN && Version != GameVersion.MN) { return false; }
+            for (int i = 0; i < 72; i++) {
+                int lslot = getData(19652 + i, 1)[0];
+                i++;
+                int lbox = getData(19652 + i, 1)[0];
+                if (lbox == box) {
+                    if (slot == lslot) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
     }
 }

--- a/PKHeX/Saves/SAV7.cs
+++ b/PKHeX/Saves/SAV7.cs
@@ -1065,7 +1065,6 @@ namespace PKHeX
             }
         }
         public override bool IsLinkedSlot(int slot, int box) {
-            if (Version != GameVersion.SN && Version != GameVersion.MN) { return false; }
             for (int i = 0; i < 72; i++) {
                 int lslot = getData(19652 + i, 1)[0];
                 i++;

--- a/PKHeX/Saves/SaveFile.cs
+++ b/PKHeX/Saves/SaveFile.cs
@@ -500,11 +500,11 @@ namespace PKHeX
 
             PKM[] pkms = BoxData;
             for (int i = 0; i < pkms.Length; i++) {
-                if (Version == GameVersion.SN || Version == GameVersion.MN) {
-                    int box = i / 30;
-                    int slot = i % 30;
-                    if (Main.IsLinkedSlot(slot, box))
-                        continue;
+                int box = i / 30;
+                int slot = i % 30;
+                if (IsLinkedSlot(slot, box)) {
+                    Util.Alert("Failed to set to slot " + (slot + 1) + " of box " + (box + 1) + " because target is linked with battle box.");
+                    continue;
                 }
                 pkms[i] = getPKM(decryptPKM(pkdata[i]));
             }
@@ -528,7 +528,8 @@ namespace PKHeX
 
             PKM[] pkms = BoxData;
             for (int i = 0; i < BoxSlotCount; i++) {
-                if ((Version == GameVersion.SN || Version == GameVersion.MN) && Main.IsLinkedSlot(i, box)) {
+                if (IsLinkedSlot(i, box)) {
+                    Util.Alert("Failed to set to slot " + (i + 1) + " of box " + (box + 1) + " because target is linked with battle box.");
                     continue;
                 }
                 pkms[box * BoxSlotCount + i] = getPKM(decryptPKM(pkdata[i]));
@@ -565,5 +566,6 @@ namespace PKHeX
         }
 
         public virtual bool RequiresMemeCrypto { get { return false; } }
+        public virtual bool IsLinkedSlot(int slot, int box) { return false; }
     }
 }

--- a/PKHeX/Saves/SaveFile.cs
+++ b/PKHeX/Saves/SaveFile.cs
@@ -497,10 +497,17 @@ namespace PKHeX
                 pkdata[i/len] = new byte[len];
                 Array.Copy(data, i, pkdata[i/len], 0, len);
             }
-            
+
             PKM[] pkms = BoxData;
-            for (int i = 0; i < pkms.Length; i++)
+            for (int i = 0; i < pkms.Length; i++) {
+                if (Version == GameVersion.SN || Version == GameVersion.MN) {
+                    int box = i / 30;
+                    int slot = i % 30;
+                    if (Main.IsLinkedSlot(slot, box))
+                        continue;
+                }
                 pkms[i] = getPKM(decryptPKM(pkdata[i]));
+            }
             BoxData = pkms;
             return true;
         }
@@ -520,8 +527,12 @@ namespace PKHeX
             }
 
             PKM[] pkms = BoxData;
-            for (int i = 0; i < BoxSlotCount; i++)
-                pkms[box*BoxSlotCount + i] = getPKM(decryptPKM(pkdata[i]));
+            for (int i = 0; i < BoxSlotCount; i++) {
+                if ((Version == GameVersion.SN || Version == GameVersion.MN) && Main.IsLinkedSlot(i, box)) {
+                    continue;
+                }
+                pkms[box * BoxSlotCount + i] = getPKM(decryptPKM(pkdata[i]));
+            }
             BoxData = pkms;
             return true;
         }


### PR DESCRIPTION
On seventh gen there's no longer a battle box where the Pokemon data is moved, we now instead have six fake box teams that just contains a reference to where the Pokemon is located in the PC using Box and Slot index.
This data is found at offset 0x4CC4 with a lenght of 72 bytes. Every set of two bytes conforms a link to one Pokemon, being the first one the slot index of the box whose index is stored in the second byte. Empty slots are always chopped with two terminators (FF FF).

Example here:
01 00 00 00 06 00 02 01 1C 05 1D 1F FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF

Team 1 is using Pokemon from Slot 2 (Index 01) of Box 1 (Index 0), from Slot 1 of Box 1, from Slot 7 of Box 1, from Slot 3 of Box 2, from Slot 29 of Box 6 and from Slot 30 of Box 32. Every other Team is empty.

We check against any version other than Sun/Moon and enter a loop to cover every byte in the lenght of the Team Box data. We must move one index forward on the array after getting slot info to get the corresponding box index. If any box index matches the box we're on we check the slot index and if it matches as well we show an alert and stop the insertion of the data.

This is mainly made with the intention of prevent as much people as posible to try to cheat on official tournaments. There's nothing to do about people with hexadecimal editor maneuvering, CFW with QR injections and old binaries of PkHeX, but is still better than nothing.