### PR TITLE
Build Configuration Clarification

### DIFF
--- a/PKHeX.sln
+++ b/PKHeX.sln
@@ -9,28 +9,34 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PKHeX.Tests", "Tests\PKHeX.
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{7C0598C9-DDF3-4ACC-B15D-6A626ADB7530}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{0137B955-AED7-4769-BDFE-637034CA9F8A}"
+	ProjectSection(SolutionItems) = preProject
+		LICENSE.md = LICENSE.md
+		README.md = README.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		ClickOnce-Debug|x86 = ClickOnce-Debug|x86
-		ClickOnce-Release|x86 = ClickOnce-Release|x86
 		Debug|x86 = Debug|x86
+		Mono-Debug|x86 = Mono-Debug|x86
+		Mono-Release|x86 = Mono-Release|x86
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{B4EFF030-C75A-49F9-A4BC-738D1B61C4AF}.ClickOnce-Debug|x86.ActiveCfg = ClickOnce-Debug|x86
-		{B4EFF030-C75A-49F9-A4BC-738D1B61C4AF}.ClickOnce-Debug|x86.Build.0 = ClickOnce-Debug|x86
-		{B4EFF030-C75A-49F9-A4BC-738D1B61C4AF}.ClickOnce-Release|x86.ActiveCfg = ClickOnce-Release|x86
-		{B4EFF030-C75A-49F9-A4BC-738D1B61C4AF}.ClickOnce-Release|x86.Build.0 = ClickOnce-Release|x86
 		{B4EFF030-C75A-49F9-A4BC-738D1B61C4AF}.Debug|x86.ActiveCfg = Debug|x86
 		{B4EFF030-C75A-49F9-A4BC-738D1B61C4AF}.Debug|x86.Build.0 = Debug|x86
+		{B4EFF030-C75A-49F9-A4BC-738D1B61C4AF}.Mono-Debug|x86.ActiveCfg = Mono-Debug|x86
+		{B4EFF030-C75A-49F9-A4BC-738D1B61C4AF}.Mono-Debug|x86.Build.0 = Mono-Debug|x86
+		{B4EFF030-C75A-49F9-A4BC-738D1B61C4AF}.Mono-Release|x86.ActiveCfg = Mono-Release|x86
+		{B4EFF030-C75A-49F9-A4BC-738D1B61C4AF}.Mono-Release|x86.Build.0 = Mono-Release|x86
 		{B4EFF030-C75A-49F9-A4BC-738D1B61C4AF}.Release|x86.ActiveCfg = Release|x86
 		{B4EFF030-C75A-49F9-A4BC-738D1B61C4AF}.Release|x86.Build.0 = Release|x86
-		{8E2499BC-C11A-4809-8737-66D35A625425}.ClickOnce-Debug|x86.ActiveCfg = Debug|x86
-		{8E2499BC-C11A-4809-8737-66D35A625425}.ClickOnce-Debug|x86.Build.0 = Debug|x86
-		{8E2499BC-C11A-4809-8737-66D35A625425}.ClickOnce-Release|x86.ActiveCfg = Release|x86
-		{8E2499BC-C11A-4809-8737-66D35A625425}.ClickOnce-Release|x86.Build.0 = Release|x86
 		{8E2499BC-C11A-4809-8737-66D35A625425}.Debug|x86.ActiveCfg = Debug|x86
 		{8E2499BC-C11A-4809-8737-66D35A625425}.Debug|x86.Build.0 = Debug|x86
+		{8E2499BC-C11A-4809-8737-66D35A625425}.Mono-Debug|x86.ActiveCfg = Debug|x86
+		{8E2499BC-C11A-4809-8737-66D35A625425}.Mono-Debug|x86.Build.0 = Debug|x86
+		{8E2499BC-C11A-4809-8737-66D35A625425}.Mono-Release|x86.ActiveCfg = Release|x86
+		{8E2499BC-C11A-4809-8737-66D35A625425}.Mono-Release|x86.Build.0 = Release|x86
 		{8E2499BC-C11A-4809-8737-66D35A625425}.Release|x86.ActiveCfg = Release|x86
 		{8E2499BC-C11A-4809-8737-66D35A625425}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection

--- a/PKHeX/PKHeX.csproj
+++ b/PKHeX/PKHeX.csproj
@@ -30,8 +30,8 @@
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
-    <PlatformTarget>x86</PlatformTarget>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Mono-Debug|x86' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -42,7 +42,7 @@
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <LangVersion>6</LangVersion>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Mono-Release|x86' ">
     <PlatformTarget>x86</PlatformTarget>
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
@@ -58,7 +58,7 @@
   <PropertyGroup>
     <StartupObject>PKHeX.Program</StartupObject>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'ClickOnce-Debug|x86'">
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\x86\ClickOnce-Debug\</OutputPath>
     <DefineConstants>DEBUG;CLICKONCE</DefineConstants>
@@ -69,7 +69,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'ClickOnce-Release|x86'">
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <DefineConstants>CLICKONCE</DefineConstants>
     <OutputPath>bin\x86\ClickOnce-Release\</OutputPath>
     <Optimize>true</Optimize>
@@ -88,10 +88,10 @@
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
-  <ItemGroup Condition="'$(Configuration)|$(Platform)' == 'ClickOnce-Debug|x86'">
+  <ItemGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <Reference Include="System.Deployment" />
   </ItemGroup>
-  <ItemGroup Condition="'$(Configuration)|$(Platform)' == 'ClickOnce-Release|x86'">
+  <ItemGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <Reference Include="System.Deployment" />
   </ItemGroup>
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ PKHeX is a Windows Forms application which requires .NET Framework v4.0.
 
 The executable can be built with any compiler that supports C# 6.0.
 
+### Build Configurations
+
+Use the Debug or Release build configurations when building using the .Net Framework.  Use the Mono-Debug or Mono-Release build configurations when building using Mono.
+
 ## Dependencies
 
 PKHeX's QR code generation code is taken from [QRCoder](https://github.com/codebude/QRCoder), which is licensed under [the MIT license](https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).


### PR DESCRIPTION
Renamed build configurations to clarify usage (hopefully avoiding misconceptions like in #618).  Also added the README to the solution (so it can be easily modified from within VS) and modified it to briefly describe when to use each build configuration.

Commits 95501698175f87dd719af235a30aba5181fead0f and fcc77fcf54f79950656be8d86a03bfe37c65a3f7 from julroy67's fork can be adapted to apply only when Mono-Debug or Mono-Release is the active configuration, although depending on the exact implementation, a MONO compiler constant may need to be defined.