### PR TITLE
Fix Gen 7 Dates

### DIFF
--- a/PKHeX/Saves/SAV7.cs
+++ b/PKHeX/Saves/SAV7.cs
@@ -510,13 +510,50 @@ namespace PKHeX
             get { return Data[PlayTime + 3]; }
             set { Data[PlayTime + 3] = (byte)value; }
         }
-        public uint LastSaved { get { return BitConverter.ToUInt32(Data, PlayTime + 0x4); } set { BitConverter.GetBytes(value).CopyTo(Data, PlayTime + 0x4); } }
-        public int LastSavedYear { get { return (int)(LastSaved & 0xFFF); } set { LastSaved = LastSaved & 0xFFFFF000 | (uint)value; } }
-        public int LastSavedMonth { get { return (int)(LastSaved >> 12 & 0xF); } set { LastSaved = LastSaved & 0xFFFF0FFF | ((uint)value & 0xF) << 12; } }
-        public int LastSavedDay { get { return (int)(LastSaved >> 16 & 0x1F); } set { LastSaved = LastSaved & 0xFFE0FFFF | ((uint)value & 0x1F) << 16; } }
-        public int LastSavedHour { get { return (int)(LastSaved >> 21 & 0x1F); } set { LastSaved = LastSaved & 0xFC1FFFFF | ((uint)value & 0x1F) << 21; } }
-        public int LastSavedMinute { get { return (int)(LastSaved >> 26 & 0x3F); } set { LastSaved = LastSaved & 0x03FFFFFF | ((uint)value & 0x3F) << 26; } }
+        private uint LastSaved { get { return BitConverter.ToUInt32(Data, PlayTime + 0x4); } set { BitConverter.GetBytes(value).CopyTo(Data, PlayTime + 0x4); } }
+        private int LastSavedYear { get { return (int)(LastSaved & 0xFFF); } set { LastSaved = LastSaved & 0xFFFFF000 | (uint)value; } }
+        private int LastSavedMonth { get { return (int)(LastSaved >> 12 & 0xF); } set { LastSaved = LastSaved & 0xFFFF0FFF | ((uint)value & 0xF) << 12; } }
+        private int LastSavedDay { get { return (int)(LastSaved >> 16 & 0x1F); } set { LastSaved = LastSaved & 0xFFE0FFFF | ((uint)value & 0x1F) << 16; } }
+        private int LastSavedHour { get { return (int)(LastSaved >> 21 & 0x1F); } set { LastSaved = LastSaved & 0xFC1FFFFF | ((uint)value & 0x1F) << 21; } }
+        private int LastSavedMinute { get { return (int)(LastSaved >> 26 & 0x3F); } set { LastSaved = LastSaved & 0x03FFFFFF | ((uint)value & 0x3F) << 26; } }
         public string LastSavedTime => $"{LastSavedYear:0000}{LastSavedMonth:00}{LastSavedDay:00}{LastSavedHour:00}{LastSavedMinute:00}";
+        public DateTime? LastSavedDate
+        {
+            get
+            {
+                // Check to see if date is valid
+                if (!Util.IsDateValid(LastSavedYear, LastSavedMonth, LastSavedDay))
+                {
+                    return null;
+                }
+                else
+                {
+                    return new DateTime(LastSavedYear, LastSavedMonth, LastSavedDay, LastSavedHour, LastSavedMinute, 0);
+                }
+            }
+            set
+            {
+                if (value.HasValue)
+                {
+                    // Only update the properties if a value is provided.
+                    LastSavedYear = value.Value.Year;
+                    LastSavedMonth = value.Value.Month;
+                    LastSavedDay = value.Value.Day;
+                    LastSavedHour = value.Value.Hour;
+                    LastSavedMinute = value.Value.Minute;
+                }
+                else
+                {
+                    // Clear the date.
+                    // If code tries to access MetDate again, null will be returned.
+                    LastSavedYear = 0;
+                    LastSavedMonth = 0;
+                    LastSavedDay = 0;
+                    LastSavedHour = 0;
+                    LastSavedMinute = 0;
+                }
+            }
+        }
 
         public int ResumeYear { get { return BitConverter.ToInt32(Data, AdventureInfo + 0x4); } set { BitConverter.GetBytes(value).CopyTo(Data,AdventureInfo + 0x4); } }
         public int ResumeMonth { get { return Data[AdventureInfo + 0x8]; } set { Data[AdventureInfo + 0x8] = (byte)value; } }

--- a/PKHeX/Subforms/Save Editors/Gen7/SAV_Trainer7.Designer.cs
+++ b/PKHeX/Subforms/Save Editors/Gen7/SAV_Trainer7.Designer.cs
@@ -1007,7 +1007,7 @@ namespace PKHeX
             this.CAL_HoFDate.Format = System.Windows.Forms.DateTimePickerFormat.Short;
             this.CAL_HoFDate.Location = new System.Drawing.Point(89, 72);
             this.CAL_HoFDate.MaxDate = new System.DateTime(2050, 12, 31, 0, 0, 0, 0);
-            this.CAL_HoFDate.MinDate = new System.DateTime(2000, 1, 1, 0, 0, 0, 0);
+            this.CAL_HoFDate.MinDate = new System.DateTime(1932, 1, 1, 0, 0, 0, 0);
             this.CAL_HoFDate.Name = "CAL_HoFDate";
             this.CAL_HoFDate.Size = new System.Drawing.Size(99, 20);
             this.CAL_HoFDate.TabIndex = 39;
@@ -1040,7 +1040,7 @@ namespace PKHeX
             this.CAL_AdventureStartDate.Format = System.Windows.Forms.DateTimePickerFormat.Short;
             this.CAL_AdventureStartDate.Location = new System.Drawing.Point(89, 35);
             this.CAL_AdventureStartDate.MaxDate = new System.DateTime(2050, 12, 31, 0, 0, 0, 0);
-            this.CAL_AdventureStartDate.MinDate = new System.DateTime(2000, 1, 1, 0, 0, 0, 0);
+            this.CAL_AdventureStartDate.MinDate = new System.DateTime(1932, 1, 1, 0, 0, 0, 0);
             this.CAL_AdventureStartDate.Name = "CAL_AdventureStartDate";
             this.CAL_AdventureStartDate.Size = new System.Drawing.Size(99, 20);
             this.CAL_AdventureStartDate.TabIndex = 35;

--- a/PKHeX/Subforms/Save Editors/Gen7/SAV_Trainer7.cs
+++ b/PKHeX/Subforms/Save Editors/Gen7/SAV_Trainer7.cs
@@ -115,8 +115,12 @@ namespace PKHeX
             MT_Minutes.Text = SAV.PlayedMinutes.ToString();
             MT_Seconds.Text = SAV.PlayedSeconds.ToString();
             
-            CAL_LastSavedDate.Value = new DateTime(SAV.LastSavedYear, SAV.LastSavedMonth, SAV.LastSavedDay);
-            CAL_LastSavedTime.Value = new DateTime(2000, 1, 1, SAV.LastSavedHour, SAV.LastSavedMinute, 0);
+            if (SAV.LastSavedDate.HasValue)
+            {
+                CAL_LastSavedDate.Value = SAV.LastSavedDate.Value;
+                CAL_LastSavedTime.Value = SAV.LastSavedDate.Value;
+            }
+                
             CAL_AdventureStartDate.Value = new DateTime(2000, 1, 1).AddSeconds(SAV.SecondsToStart);
             CAL_AdventureStartTime.Value = new DateTime(2000, 1, 1).AddSeconds(SAV.SecondsToStart % 86400);
             CAL_HoFDate.Value = new DateTime(2000, 1, 1).AddSeconds(SAV.SecondsToFame);
@@ -189,11 +193,8 @@ namespace PKHeX
             fame += (int)(CAL_HoFTime.Value - new DateTime(2000, 1, 1)).TotalSeconds;
             SAV.SecondsToFame = fame;
 
-            SAV.LastSavedYear = CAL_LastSavedDate.Value.Year;
-            SAV.LastSavedMonth = CAL_LastSavedDate.Value.Month;
-            SAV.LastSavedDay = CAL_LastSavedDate.Value.Day;
-            SAV.LastSavedHour = CAL_LastSavedTime.Value.Hour;
-            SAV.LastSavedMinute = CAL_LastSavedTime.Value.Minute;
+            var lastSavedDate = new DateTime(CAL_LastSavedDate.Value.Year, CAL_LastSavedDate.Value.Month, CAL_LastSavedDate.Value.Day, CAL_LastSavedTime.Value.Hour, CAL_LastSavedTime.Value.Minute, 0);
+            SAV.LastSavedDate = lastSavedDate;
 
             SAV.BP = (uint)NUD_BP.Value;
             SAV.FestaCoins = (uint)NUD_FC.Value;


### PR DESCRIPTION
This PR attempts to fix the bug described [here](https://projectpokemon.org/forums/forums/topic/39557-error-on-pkhex-trying-to-edit-trainer-info-sun-and-moon/), but also fixed an error opening the trainer editor with the default blank save.

The changes:

- **Refactored LastSavedDate** - improves usage IMO and fixes a crash when opeining the trainer editor with the default blank save, since both the year and month were 0.
- **Extended the MinDate for HOF and Adventure Started** - What if HOFSeconds or AdventureStartedSeconds were negative?  That could result in the original bug report.  By my calculations, Integer.MinValue seconds results in the year 1932, which is the new min year (although now that I think about it I didn't consider month or day).

These changes have not been tested with a real save, and the reasoning behind the MinDate extension is purely theoretical; however, upon closing the trainer editor, there were no exceptions.