### PR TITLE
Simplified OpenFileDialog logic

### DIFF
--- a/PKHeX/MainWindow/Main.cs
+++ b/PKHeX/MainWindow/Main.cs
@@ -280,27 +280,19 @@ namespace PKHeX
 
             OpenFileDialog ofd = new OpenFileDialog
             {
-                Filter = $"Decrypted PKM File|{supported}" +
+                Filter = $"Supported Files|main;*.sav;*.bin;*.{ekx};{supported}" +
+                         $"|3DS Main Files|main" +
+                         $"|Save Files|*.sav" +
+                         $"|Decrypted PKM File|{supported}" +
                          $"|Encrypted PKM File|*.{ekx}" +
                          "|Binary File|*.bin" +
-                         "|All Files|*.*",
-                RestoreDirectory = true,
-                FilterIndex = 4,
-                FileName = "main",
-            };
-
-            // Reset file dialog path if it no longer exists
-            if (!Directory.Exists(ofd.InitialDirectory))
-                ofd.InitialDirectory = WorkingDirectory;
+                         "|All Files|*.*"
+            };             
 
             // Detect main
             string path = SaveUtil.detectSaveFile();
             if (path != null)
-            { ofd.InitialDirectory = Path.GetDirectoryName(path); }
-            else if (File.Exists(Path.Combine(ofd.InitialDirectory, "main")))
-            { }
-            else if (!Directory.Exists(ofd.InitialDirectory))
-            { ofd.RestoreDirectory = false; ofd.FilterIndex = 1; ofd.FileName = ""; }
+            { ofd.FileName = path; }
 
             if (ofd.ShowDialog() == DialogResult.OK) 
                 openQuick(ofd.FileName);


### PR DESCRIPTION
[ddhelmet posted](https://projectpokemon.org/forums/files/file/1-pkhex/?tab=comments#comment-28):
```
Can it remember the last folder you took the save file from? It's a minor thing but would help me a lot
```
I'd like this too.  The default behavior of the OpenFileDialog is to do this, but PKHeX was doing its own stuff, resetting the directory _every single time_.

This PR will remove most of the stuff changing the OpenFileDialog initial directory, leaving auto-detecting the save file, in favor of the default dialog behavior of always using the previous last directory a file was opened from.  It also tweaks the default filter to allow all _supported_ files (main, sav, bin pk_, and ekx) instead of defaulting to All Files.