### PR TITLE
Removed "Any CPU" build configuration

### DIFF
--- a/PKHeX.WinForms/PKHeX.WinForms.csproj
+++ b/PKHeX.WinForms/PKHeX.WinForms.csproj
@@ -29,34 +29,31 @@
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <PlatformTarget>x86</PlatformTarget>
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;CLICKONCE;WINDOWS</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-    <UseVSHostingProcess>false</UseVSHostingProcess>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <PlatformTarget>x86</PlatformTarget>
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>CLICKONCE;WINDOWS</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <Prefer32Bit>false</Prefer32Bit>
-  </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>icon.ico</ApplicationIcon>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Mono-Debug|AnyCPU' ">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\Debug-Mono\</OutputPath>
+    <OutputPath>bin\x86\Debug\</OutputPath>
+    <DefineConstants>DEBUG;CLICKONCE;WINDOWS</DefineConstants>
+    <DebugType>full</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
+    <OutputPath>bin\x86\Release\</OutputPath>
+    <DefineConstants>CLICKONCE;WINDOWS</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Mono-Debug|x86'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\x86\Mono-Debug\</OutputPath>
     <DefineConstants>DEBUG;MONO</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>x86</PlatformTarget>
@@ -64,8 +61,8 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Mono-Release|AnyCPU'">
-    <OutputPath>bin\Mono-Release\</OutputPath>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Mono-Release|x86'">
+    <OutputPath>bin\x86\Mono-Release\</OutputPath>
     <DefineConstants>MONO</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>

--- a/PKHeX.WinForms/PKHeX.WinForms.csproj
+++ b/PKHeX.WinForms/PKHeX.WinForms.csproj
@@ -34,7 +34,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\x86\Debug\</OutputPath>
+    <OutputPath>bin\Debug\</OutputPath>
     <DefineConstants>DEBUG;CLICKONCE;WINDOWS</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>x86</PlatformTarget>
@@ -43,7 +43,7 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
-    <OutputPath>bin\x86\Release\</OutputPath>
+    <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>CLICKONCE;WINDOWS</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
@@ -53,7 +53,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Mono-Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\x86\Mono-Debug\</OutputPath>
+    <OutputPath>bin\Mono-Debug\</OutputPath>
     <DefineConstants>DEBUG;MONO</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>x86</PlatformTarget>
@@ -62,7 +62,7 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Mono-Release|x86'">
-    <OutputPath>bin\x86\Mono-Release\</OutputPath>
+    <OutputPath>bin\Mono-Release\</OutputPath>
     <DefineConstants>MONO</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>

--- a/PKHeX.sln
+++ b/PKHeX.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PKHeX.Core", "PKHeX\PKHeX.Core.csproj", "{B4EFF030-C75A-49F9-A4BC-738D1B61C4AF}"
 EndProject
@@ -19,58 +19,36 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PKHeX.WinForms", "PKHeX.Win
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
 		Debug|x86 = Debug|x86
-		Mono-Debug|Any CPU = Mono-Debug|Any CPU
 		Mono-Debug|x86 = Mono-Debug|x86
-		Mono-Release|Any CPU = Mono-Release|Any CPU
 		Mono-Release|x86 = Mono-Release|x86
-		Release|Any CPU = Release|Any CPU
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{B4EFF030-C75A-49F9-A4BC-738D1B61C4AF}.Debug|Any CPU.ActiveCfg = Debug|x86
 		{B4EFF030-C75A-49F9-A4BC-738D1B61C4AF}.Debug|x86.ActiveCfg = Debug|x86
 		{B4EFF030-C75A-49F9-A4BC-738D1B61C4AF}.Debug|x86.Build.0 = Debug|x86
-		{B4EFF030-C75A-49F9-A4BC-738D1B61C4AF}.Mono-Debug|Any CPU.ActiveCfg = Mono-Debug|x86
 		{B4EFF030-C75A-49F9-A4BC-738D1B61C4AF}.Mono-Debug|x86.ActiveCfg = Mono-Debug|x86
 		{B4EFF030-C75A-49F9-A4BC-738D1B61C4AF}.Mono-Debug|x86.Build.0 = Mono-Debug|x86
-		{B4EFF030-C75A-49F9-A4BC-738D1B61C4AF}.Mono-Release|Any CPU.ActiveCfg = Mono-Release|x86
 		{B4EFF030-C75A-49F9-A4BC-738D1B61C4AF}.Mono-Release|x86.ActiveCfg = Mono-Release|x86
 		{B4EFF030-C75A-49F9-A4BC-738D1B61C4AF}.Mono-Release|x86.Build.0 = Mono-Release|x86
-		{B4EFF030-C75A-49F9-A4BC-738D1B61C4AF}.Release|Any CPU.ActiveCfg = Release|x86
 		{B4EFF030-C75A-49F9-A4BC-738D1B61C4AF}.Release|x86.ActiveCfg = Release|x86
 		{B4EFF030-C75A-49F9-A4BC-738D1B61C4AF}.Release|x86.Build.0 = Release|x86
-		{8E2499BC-C11A-4809-8737-66D35A625425}.Debug|Any CPU.ActiveCfg = Debug|x86
 		{8E2499BC-C11A-4809-8737-66D35A625425}.Debug|x86.ActiveCfg = Debug|x86
 		{8E2499BC-C11A-4809-8737-66D35A625425}.Debug|x86.Build.0 = Debug|x86
-		{8E2499BC-C11A-4809-8737-66D35A625425}.Mono-Debug|Any CPU.ActiveCfg = Release|x86
-		{8E2499BC-C11A-4809-8737-66D35A625425}.Mono-Debug|Any CPU.Build.0 = Release|x86
 		{8E2499BC-C11A-4809-8737-66D35A625425}.Mono-Debug|x86.ActiveCfg = Debug|x86
 		{8E2499BC-C11A-4809-8737-66D35A625425}.Mono-Debug|x86.Build.0 = Debug|x86
-		{8E2499BC-C11A-4809-8737-66D35A625425}.Mono-Release|Any CPU.ActiveCfg = Release|x86
-		{8E2499BC-C11A-4809-8737-66D35A625425}.Mono-Release|Any CPU.Build.0 = Release|x86
 		{8E2499BC-C11A-4809-8737-66D35A625425}.Mono-Release|x86.ActiveCfg = Release|x86
 		{8E2499BC-C11A-4809-8737-66D35A625425}.Mono-Release|x86.Build.0 = Release|x86
-		{8E2499BC-C11A-4809-8737-66D35A625425}.Release|Any CPU.ActiveCfg = Release|x86
 		{8E2499BC-C11A-4809-8737-66D35A625425}.Release|x86.ActiveCfg = Release|x86
 		{8E2499BC-C11A-4809-8737-66D35A625425}.Release|x86.Build.0 = Release|x86
-		{D1B91861-A448-4762-A313-C7BC179F4415}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{D1B91861-A448-4762-A313-C7BC179F4415}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D1B91861-A448-4762-A313-C7BC179F4415}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{D1B91861-A448-4762-A313-C7BC179F4415}.Debug|x86.Build.0 = Debug|Any CPU
-		{D1B91861-A448-4762-A313-C7BC179F4415}.Mono-Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{D1B91861-A448-4762-A313-C7BC179F4415}.Mono-Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D1B91861-A448-4762-A313-C7BC179F4415}.Mono-Debug|x86.ActiveCfg = Mono-Debug|Any CPU
-		{D1B91861-A448-4762-A313-C7BC179F4415}.Mono-Debug|x86.Build.0 = Mono-Debug|Any CPU
-		{D1B91861-A448-4762-A313-C7BC179F4415}.Mono-Release|Any CPU.ActiveCfg = Release|Any CPU
-		{D1B91861-A448-4762-A313-C7BC179F4415}.Mono-Release|Any CPU.Build.0 = Release|Any CPU
-		{D1B91861-A448-4762-A313-C7BC179F4415}.Mono-Release|x86.ActiveCfg = Mono-Release|Any CPU
-		{D1B91861-A448-4762-A313-C7BC179F4415}.Mono-Release|x86.Build.0 = Mono-Release|Any CPU
-		{D1B91861-A448-4762-A313-C7BC179F4415}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{D1B91861-A448-4762-A313-C7BC179F4415}.Release|Any CPU.Build.0 = Release|Any CPU
-		{D1B91861-A448-4762-A313-C7BC179F4415}.Release|x86.ActiveCfg = Release|Any CPU
-		{D1B91861-A448-4762-A313-C7BC179F4415}.Release|x86.Build.0 = Release|Any CPU
+		{D1B91861-A448-4762-A313-C7BC179F4415}.Debug|x86.ActiveCfg = Debug|x86
+		{D1B91861-A448-4762-A313-C7BC179F4415}.Debug|x86.Build.0 = Debug|x86
+		{D1B91861-A448-4762-A313-C7BC179F4415}.Mono-Debug|x86.ActiveCfg = Mono-Debug|x86
+		{D1B91861-A448-4762-A313-C7BC179F4415}.Mono-Debug|x86.Build.0 = Mono-Debug|x86
+		{D1B91861-A448-4762-A313-C7BC179F4415}.Mono-Release|x86.ActiveCfg = Mono-Release|x86
+		{D1B91861-A448-4762-A313-C7BC179F4415}.Mono-Release|x86.Build.0 = Mono-Release|x86
+		{D1B91861-A448-4762-A313-C7BC179F4415}.Release|x86.ActiveCfg = Release|x86
+		{D1B91861-A448-4762-A313-C7BC179F4415}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Since the solution level one didn't build the dependencies, and the project level one built as x86 anyway