### PR TITLE
Fix acceptable PKX file extensions being off by one

### DIFF
--- a/PKHeX/PKM/PKX.cs
+++ b/PKHeX/PKM/PKX.cs
@@ -2449,7 +2449,7 @@ namespace PKHeX.Core
             const int gens = 7;
             var result = new List<string>();
             result.AddRange(new [] {"ck3", "xk3", "bk4"}); // Special Cases
-            for (int i = 1; i < gens; i++)
+            for (int i = 1; i <= gens; i++)
                 result.Add("pk"+i);
             return result.ToArray();
         }


### PR DESCRIPTION
The iterator in the for loop is executed only at the end of each iteration; this changes the comparison operator to avoid premature termination of the list at "pk6".