### PR TITLE
Get lineage using the source generation of the pokemon

### DIFF
--- a/PKHeX/Legality/Checks.cs
+++ b/PKHeX/Legality/Checks.cs
@@ -369,7 +369,7 @@ namespace PKHeX.Core
 
             if (pkm.VC)
             {
-                int baseSpecies = Legal.getEvolutionChain(pkm, null).Min(entry => entry.Species);
+                int baseSpecies = Legal.getBaseSpecies(pkm);
                 if ((pkm.VC1 && baseSpecies > Legal.MaxSpeciesID_1) || 
                     (pkm.VC2 && baseSpecies > Legal.MaxSpeciesID_2))
                     return new CheckResult(Severity.Invalid, "VC: Unobtainable species.", CheckIdentifier.Encounter);

--- a/PKHeX/Legality/Core.cs
+++ b/PKHeX/Legality/Core.cs
@@ -393,7 +393,7 @@ namespace PKHeX.Core
         {
             if (pkm.Format == 1 || pkm.VC1) //Gen1 VC could not trade with gen 2 yet
                 return getMaxSpeciesOrigin(1);
-            if (pkm.Format == 2 || pkm.VC2)
+            else if (pkm.Format == 2 || pkm.VC2)
                 return getMaxSpeciesOrigin(2);
             else
                 return getMaxSpeciesOrigin(pkm.GenNumber);

--- a/PKHeX/Legality/Core.cs
+++ b/PKHeX/Legality/Core.cs
@@ -384,17 +384,16 @@ namespace PKHeX.Core
                     return Legal.MaxSpeciesID_6;
                 case 7:
                     return Legal.MaxSpeciesID_7;
-
                 default:
-                    return Legal.MaxSpeciesID_6;
+                    return Legal.MaxSpeciesID_7;
             }
         }
 
         internal static int getMaxSpeciesOrigin(PKM pkm)
         {
-            if (pkm.VC1)
+            if (pkm.Format == 1 || pkm.VC1) //Gen1 VC could not trade with gen 2 yet
                 return getMaxSpeciesOrigin(1);
-            else if (pkm.VC2)
+            if (pkm.Format == 2 || pkm.VC2)
                 return getMaxSpeciesOrigin(2);
             else
                 return getMaxSpeciesOrigin(pkm.GenNumber);

--- a/PKHeX/Legality/Core.cs
+++ b/PKHeX/Legality/Core.cs
@@ -365,6 +365,41 @@ namespace PKHeX.Core
                     return Evolves6;
             }
         }
+
+        private static int getMaxSpeciesOrigin(int generation)
+        {
+            switch (generation)
+            {
+                case 1:
+                    return Legal.MaxSpeciesID_1;
+                case 2:
+                    return Legal.MaxSpeciesID_2;
+                case 3:
+                    return Legal.MaxSpeciesID_3;
+                case 4:
+                    return Legal.MaxSpeciesID_4;
+                case 5:
+                    return Legal.MaxSpeciesID_5;
+                case 6:
+                    return Legal.MaxSpeciesID_6;
+                case 7:
+                    return Legal.MaxSpeciesID_7;
+
+                default:
+                    return Legal.MaxSpeciesID_6;
+            }
+        }
+
+        internal static int getMaxSpeciesOrigin(PKM pkm)
+        {
+            if (pkm.VC1)
+                return getMaxSpeciesOrigin(1);
+            else if (pkm.VC2)
+                return getMaxSpeciesOrigin(2);
+            else
+                return getMaxSpeciesOrigin(pkm.GenNumber);
+        }
+
         internal static IEnumerable<MysteryGift> getValidGifts(PKM pkm)
         {
             switch (pkm.GenNumber)

--- a/PKHeX/Legality/Structures/EvolutionTree.cs
+++ b/PKHeX/Legality/Structures/EvolutionTree.cs
@@ -149,7 +149,7 @@ namespace PKHeX.Core
         public IEnumerable<DexLevel> getValidPreEvolutions(PKM pkm, int lvl, bool skipChecks = false)
         {
             int index = getIndex(pkm);
-            return Lineage[index].getExplicitLineage(pkm, lvl, skipChecks, MaxSpecies);
+            return Lineage[index].getExplicitLineage(pkm, lvl,skipChecks, MaxSpecies);
         }
     }
 
@@ -376,6 +376,8 @@ namespace PKHeX.Core
                 if (!oneValid)
                     break;
             }
+            if (dl.Count > 1 && dl.Last().Species > Legal.getMaxSpeciesOrigin(pkm))
+                dl.RemoveAt(dl.Count - 1);//remove future gen preevolutions, no munchlax in a gen3 snorlax, no pichu in a gen1 vc raichu, etc
             return dl;
         }
     }

--- a/PKHeX/Legality/Structures/EvolutionTree.cs
+++ b/PKHeX/Legality/Structures/EvolutionTree.cs
@@ -354,6 +354,7 @@ namespace PKHeX.Core
 
         public IEnumerable<DexLevel> getExplicitLineage(PKM pkm, int lvl, bool skipChecks, int maxSpecies)
         {
+            int maxSpeciesOrigin = Legal.getMaxSpeciesOrigin(pkm);
             List<DexLevel> dl = new List<DexLevel> { new DexLevel { Species = pkm.Species, Level = lvl, Form = pkm.AltForm } };
             for (int i = Chain.Count-1; i >= 0; i--) // reverse evolution!
             {
@@ -376,7 +377,7 @@ namespace PKHeX.Core
                 if (!oneValid)
                     break;
             }
-            if (dl.Count > 1 && dl.Last().Species > Legal.getMaxSpeciesOrigin(pkm))
+            if (dl.Any(d=>d.Species <= maxSpeciesOrigin) && dl.Last().Species > maxSpeciesOrigin)
                 dl.RemoveAt(dl.Count - 1);//remove future gen preevolutions, no munchlax in a gen3 snorlax, no pichu in a gen1 vc raichu, etc
             return dl;
         }

--- a/PKHeX/Legality/Structures/EvolutionTree.cs
+++ b/PKHeX/Legality/Structures/EvolutionTree.cs
@@ -149,7 +149,7 @@ namespace PKHeX.Core
         public IEnumerable<DexLevel> getValidPreEvolutions(PKM pkm, int lvl, bool skipChecks = false)
         {
             int index = getIndex(pkm);
-            return Lineage[index].getExplicitLineage(pkm, lvl,skipChecks, MaxSpecies);
+            return Lineage[index].getExplicitLineage(pkm, lvl, skipChecks, MaxSpecies);
         }
     }
 


### PR DESCRIPTION
Modified the get lineage function to do not include preevolutions from generations above the source game of the pokemon.
This will work with gen 1 vc legal analisys but also it can be used in the future with gen 2 vc or other past gen
Example a gen 3 Snorlax wont return Munchlax in its lineage, nor a gen 1 vc raichu include pichu but gen 4 to 7 Snorlax and gen 2 vc and gen 3 to 7 raichu will include both Muchlax and Pichu