### PR TITLE
Fix tabs for bag pouches not showing on Linux/Mono

### DIFF
--- a/PKHeX.WinForms/Subforms/Save Editors/SAV_Inventory.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/SAV_Inventory.cs
@@ -51,7 +51,7 @@ namespace PKHeX.WinForms
         private void initBags()
         {
             tabControl1.SizeMode = TabSizeMode.Fixed;
-            tabControl1.ItemSize = new Size(IL_Pouch.Images[0].Width + 4, 0);
+            tabControl1.ItemSize = new Size(IL_Pouch.Images[0].Width + 4, IL_Pouch.Images[0].Height + 4);
             for (int i = 0; i < Pouches.Length; i++)
             {
                 // Add Tab


### PR DESCRIPTION
Passing a height of 0 lets the TabControl dissapear, making it
impossible to switch tabs between different pouches.

To fix this, use the same approach as for the width and pass the height
of the first icon.

----

I can only test this on Linux, but I hope this issue isn't Linux-specific.