### PR TITLE
Made FileNotFoundException check more specific

### DIFF
--- a/PKHeX.WinForms/Program.cs
+++ b/PKHeX.WinForms/Program.cs
@@ -48,7 +48,6 @@ namespace PKHeX.WinForms
 
         private static void StartPKHeX()
         {
-
             // Run the application
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);

--- a/PKHeX.WinForms/Program.cs
+++ b/PKHeX.WinForms/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Reflection;
 using System.Threading;
 using System.Windows.Forms;
 
@@ -28,14 +29,26 @@ namespace PKHeX.WinForms
             {
                 StartPKHeX();
             }
-            catch (FileNotFoundException)
+            catch (FileNotFoundException ex)
             {
-                MessageBox.Show("Could not locate PKHeX.Core.dll. Make sure you're running PKHeX together with its code library. Usually caused when all files are not extracted.", "PKHeX Error", MessageBoxButtons.OK, MessageBoxIcon.Stop);
+                // Check whether or not the exception was from missing PKHeX.Core, rather than something else in the constructor of Main
+                if (ex.TargetSite == typeof(Program).GetMethod(nameof(StartPKHeX), BindingFlags.Static | BindingFlags.NonPublic))
+                {
+                    // Exception came from StartPKHeX and (probably) corresponds to missing PKHeX.Core
+                    MessageBox.Show("Could not locate PKHeX.Core.dll. Make sure you're running PKHeX together with its code library. Usually caused when all files are not extracted.", "PKHeX Error", MessageBoxButtons.OK, MessageBoxIcon.Stop);
+                    return;
+                }
+                else
+                {
+                    // Exception came from Main
+                    throw;
+                }
             }
         }
 
-        static void StartPKHeX()
+        private static void StartPKHeX()
         {
+
             // Run the application
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);


### PR DESCRIPTION
[This post](https://projectpokemon.org/forums/forums/topic/39971-is-wine-mac-os-x-even-able-to-detect-the-dll-file/) got me thinking... Is the error message really the fault of Wine?  It's possible, but the FileNotFound exception could really have come from anywhere in Main's constructor, which does all the things, including searching for potential saves.  In the past, there have been errors related to that, so there's no telling what the FileNotFound exception is really about.  This PR fixes that: if a FileNotFound exception is thrown, the target site is examined.  If it comes from StartPKHeX, then it means PKHeX.Core.dll could not be  loaded.  If it comes from Main's constructor (like if you put `throw new FileNotFoundException();` in the first line), then it's due to something else, in which case the exception is thrown to be handled as usual.