### PR TITLE
Correct translation for 'None' in Spanish.

### DIFF
--- a/PKHeX/Resources/text/es/text_Items_es.txt
+++ b/PKHeX/Resources/text/es/text_Items_es.txt
@@ -1,4 +1,4 @@
-Ningún objeto
+Ninguno
 Master Ball
 Ultra Ball
 Super Ball


### PR DESCRIPTION
Because 'ningún objeto' means 'no object', and it is used for moves too.