### PR TITLE
Allow to see at a glance (in the box) the mons that are illegal.

### DIFF
--- a/PKHeX.WinForms/MainWindow/Main.cs
+++ b/PKHeX.WinForms/MainWindow/Main.cs
@@ -3402,6 +3402,7 @@ namespace PKHeX.WinForms
             updateBoxViewers();
 
             RedoStack.Clear(); Menu_Redo.Enabled = false;
+			checkIfLegalPKMSlot(pk, SlotPictureBoxes[slot]);
         }
         private void clickDelete(object sender, EventArgs e)
         {
@@ -3838,7 +3839,18 @@ namespace PKHeX.WinForms
             pb.Image = sprite;
             pb.BackColor = Color.Transparent;
             pb.Visible = true;
+			checkIfLegalPKMSlot(p, pb);
         }
+		private void checkIfLegalPKMSlot(PKM pk, PictureBox pb)
+		{
+			LegalityAnalysis la = new LegalityAnalysis(pk);
+			if (pk.GenNumber >= 6 && pk.Species != 0 && !la.Valid)
+			{
+				pb.BackColor = Color.FromArgb(150, Color.Red);
+			}
+			else
+				pb.BackColor = Color.Transparent;
+		}
         private void getSlotColor(int slot, Image color)
         {
             foreach (PictureBox t in SlotPictureBoxes)


### PR DESCRIPTION
When a pokémon is not legal changes the background of its slot.

Its only an idea, I thought that people will like to see at a glance if they have illegal pokemon, without having to see them one by one.

![ss](https://cloud.githubusercontent.com/assets/10855781/22596355/864fe7d0-ea2b-11e6-9668-d091d9c9982d.JPG)
