### PR TITLE
Changed default platform configuration for PKHeX.Core

### DIFF
--- a/PKHeX/PKHeX.Core.csproj
+++ b/PKHeX/PKHeX.Core.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{B4EFF030-C75A-49F9-A4BC-738D1B61C4AF}</ProjectGuid>


### PR DESCRIPTION
Creating a nuget package with TC failed because it couldn't find bin\x86\Release, when it should have looked in bin\Release.

After this change, a [nuget package](http://teamcity.projectpokemon.org/repository/download/PKHeX_BuildWindows/886:id/PKHeX.Core.1.0.1845.nupkg) was successfully created.