### PR TITLE
Add Framework check for non-windows OS

### DIFF
--- a/PKHeX.WinForms/Program.cs
+++ b/PKHeX.WinForms/Program.cs
@@ -29,16 +29,33 @@ namespace PKHeX.WinForms
 
             try
             {
-                if (GetFrameworkVersion() >= 393295)
-                {
-                    StartPKHeX();
-                }
-                else
-                {
-                    // Todo: make this translatable
-                    MessageBox.Show(".NET Framework 4.6 needs to be installed for this version of PKHeX to run.", "PKHeX Error", MessageBoxButtons.OK, MessageBoxIcon.Stop);
-                    Process.Start(@"https://www.microsoft.com/download/details.aspx?id=48130");
-                }
+				if (IsOnWindows())
+				{
+					if (GetFrameworkVersion() >= 393295)
+					{
+						StartPKHeX();
+					}
+					else
+					{
+						// Todo: make this translatable
+						MessageBox.Show(".NET Framework 4.6 needs to be installed for this version of PKHeX to run.", "PKHeX Error", MessageBoxButtons.OK, MessageBoxIcon.Stop);
+						Process.Start(@"https://www.microsoft.com/download/details.aspx?id=48130");
+					}
+				}
+				else
+				{
+					//CLR Version 4.0.30319 is equivalent to .NET Framework version 4.6
+					if ((Environment.Version.CompareTo(Version.Parse("4.0.30319.42000"))) >= 0)
+					{
+						StartPKHeX();
+					}
+					else
+					{
+						MessageBox.Show("Your version of Mono needs to target the .NET Framework 4.6 or higher for this version of PKHeX to run.",
+										"PKHeX Error", MessageBoxButtons.OK, MessageBoxIcon.Stop);
+					}
+				}
+                
             }
             catch (FileNotFoundException ex)
             {
@@ -62,6 +79,16 @@ namespace PKHeX.WinForms
             Application.SetCompatibleTextRenderingDefault(false);
             Application.Run(new Main());
         }
+
+		public static bool IsOnWindows()
+		{
+			// 4 -> UNIX, 6 -> Mac OSX, 128 -> UNIX (old)
+			int p = (int)Environment.OSVersion.Platform;
+			if ((p == 4) || (p == 6) || (p == 128))
+				return false;
+			return true;
+		}
+
 
         public static int GetFrameworkVersion()
         {

--- a/PKHeX.WinForms/Program.cs
+++ b/PKHeX.WinForms/Program.cs
@@ -29,32 +29,32 @@ namespace PKHeX.WinForms
 
             try
             {
-				if (IsOnWindows())
-				{
-					if (GetFrameworkVersion() >= 393295)
-					{
-						StartPKHeX();
-					}
-					else
-					{
-						// Todo: make this translatable
-						MessageBox.Show(".NET Framework 4.6 needs to be installed for this version of PKHeX to run.", "PKHeX Error", MessageBoxButtons.OK, MessageBoxIcon.Stop);
-						Process.Start(@"https://www.microsoft.com/download/details.aspx?id=48130");
-					}
-				}
-				else
-				{
-					//CLR Version 4.0.30319 is equivalent to .NET Framework version 4.6
-					if ((Environment.Version.CompareTo(Version.Parse("4.0.30319.42000"))) >= 0)
-					{
-						StartPKHeX();
-					}
-					else
-					{
-						MessageBox.Show("Your version of Mono needs to target the .NET Framework 4.6 or higher for this version of PKHeX to run.",
-										"PKHeX Error", MessageBoxButtons.OK, MessageBoxIcon.Stop);
-					}
-				}
+                if (IsOnWindows())
+                {
+                    if (GetFrameworkVersion() >= 393295)
+                    {
+                        StartPKHeX();
+                    }
+                    else
+                    {
+                        // Todo: make this translatable
+                        MessageBox.Show(".NET Framework 4.6 needs to be installed for this version of PKHeX to run.", "PKHeX Error", MessageBoxButtons.OK, MessageBoxIcon.Stop);
+                        Process.Start(@"https://www.microsoft.com/download/details.aspx?id=48130");
+                    }
+                }
+                else
+                {
+                    //CLR Version 4.0.30319.42000 is equivalent to .NET Framework version 4.6
+                    if ((Environment.Version.CompareTo(Version.Parse("4.0.30319.42000"))) >= 0)
+                    {
+                        StartPKHeX();
+                    }
+                    else
+                    {
+                        MessageBox.Show("Your version of Mono needs to target the .NET Framework 4.6 or higher for this version of PKHeX to run.",
+                                        "PKHeX Error", MessageBoxButtons.OK, MessageBoxIcon.Stop);
+                    }
+                }
                 
             }
             catch (FileNotFoundException ex)
@@ -80,14 +80,14 @@ namespace PKHeX.WinForms
             Application.Run(new Main());
         }
 
-		public static bool IsOnWindows()
-		{
-			// 4 -> UNIX, 6 -> Mac OSX, 128 -> UNIX (old)
-			int p = (int)Environment.OSVersion.Platform;
-			if ((p == 4) || (p == 6) || (p == 128))
-				return false;
-			return true;
-		}
+        public static bool IsOnWindows()
+        {
+            // 4 -> UNIX, 6 -> Mac OSX, 128 -> UNIX (old)
+            int p = (int)Environment.OSVersion.Platform;
+            if ((p == 4) || (p == 6) || (p == 128))
+                return false;
+            return true;
+        }
 
 
         public static int GetFrameworkVersion()


### PR DESCRIPTION
GetFrameworkVersion() throws an System.NullReferenceException since
there is no Registry on non-windows systems.

Fixed by checking the OS under which the program runs. If it's not
Windows, check the CLR Version instead of querying the (non-existant)
registry.