### PR TITLE
Past generations legallity tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ local.properties
 *.suo
 *.user
 *.sln.docstates
+*.vs
 
 # Build results
 

--- a/PKHeX/Legality/Analysis.cs
+++ b/PKHeX/Legality/Analysis.cs
@@ -8,6 +8,7 @@ namespace PKHeX.Core
     {
         private PKM pkm;
         private DexLevel[] EvoChain;
+        private DexLevel[][] EvoChainsAllGens;
         private readonly List<CheckResult> Parse = new List<CheckResult>();
 
         private object EncounterMatch;
@@ -143,6 +144,7 @@ namespace PKHeX.Core
             Encounter = verifyEncounter();
             Parse.Add(Encounter);
             EvoChain = Legal.getEvolutionChain(pkm, EncounterMatch);
+            EvoChainsAllGens = Legal.getEvolutionChainsAllGens(pkm, EncounterMatch);
         }
         private void updateEncounterInfo()
         {

--- a/PKHeX/Legality/Analysis.cs
+++ b/PKHeX/Legality/Analysis.cs
@@ -259,7 +259,7 @@ namespace PKHeX.Core
                 return null;
             if (!Parsed)
                 return new int[4];
-            return Legal.getValidMoves(pkm, EvoChain, Tutor: tutor, Machine: tm, MoveReminder: reminder).Skip(1).ToArray(); // skip move 0
+            return Legal.getValidMoves(pkm, EvoChainsAllGens, Tutor: tutor, Machine: tm, MoveReminder: reminder).Skip(1).ToArray(); // skip move 0
         }
 
         public EncounterStatic getSuggestedMetInfo()

--- a/PKHeX/Legality/Checks.cs
+++ b/PKHeX/Legality/Checks.cs
@@ -526,9 +526,9 @@ namespace PKHeX.Core
         {
             // Since encounter matching is super weak due to limited stored data in the structure
             // Calculate all 3 at the same time and pick the best result (by species).
-            var s = Legal.getValidStaticEncounter(pkm);
+            var s = Legal.getValidStaticEncounter(pkm, gen1Encounter: true);
             var e = Legal.getValidWildEncounters(pkm);
-            var t = Legal.getValidIngameTrade(pkm);
+            var t = Legal.getValidIngameTrade(pkm, gen1Encounter: true);
 
             const byte invalid = 255;
 

--- a/PKHeX/Legality/Checks.cs
+++ b/PKHeX/Legality/Checks.cs
@@ -1433,8 +1433,11 @@ namespace PKHeX.Core
                     resultPrefix = "HT ";
                     break;
             }
+            int[] generations = new int[1] { pkm.Format };
+            if (pkm.GenNumber == 6 && pkm.Format == 7)
+                generations = new int[2] { 6, 7 };
             int matchingMoveMemory = Array.IndexOf(Legal.MoveSpecificMemories[0], m);
-            if (matchingMoveMemory != -1 && pkm.Species != 235  && !Legal.getCanLearnMachineMove(pkm, Legal.MoveSpecificMemories[1][matchingMoveMemory]))
+            if (matchingMoveMemory != -1 && pkm.Species != 235  && !Legal.getCanLearnMachineMove(pkm, Legal.MoveSpecificMemories[1][matchingMoveMemory], generations))
             {
                 return new CheckResult(Severity.Invalid, resultPrefix + "Memory: Species cannot learn this move.", CheckIdentifier.Memory);
             }
@@ -1444,14 +1447,14 @@ namespace PKHeX.Core
             }
             if (m == 21) // {0} saw {2} carrying {1} on its back. {4} that {3}.
             {
-                if (!Legal.getCanLearnMachineMove(new PK6 {Species = t, EXP = PKX.getEXP(100, t)}, 19))
+                if (!Legal.getCanLearnMachineMove(new PK6 {Species = t, EXP = PKX.getEXP(100, t)}, 19, generations))
                     return new CheckResult(Severity.Invalid, resultPrefix + "Memory: Argument Species cannot learn Fly.", CheckIdentifier.Memory);
             }
-            if ((m == 16 || m == 48) && (t == 0 || !Legal.getCanKnowMove(pkm, t, GameVersion.Any)))
+            if ((m == 16 || m == 48) && (t == 0 || !Legal.getCanKnowMove(pkm, t, generations, GameVersion.Any)))
             {
                 return new CheckResult(Severity.Invalid, resultPrefix + "Memory: Species cannot know this move.", CheckIdentifier.Memory);
             }
-            if (m == 49 && (t == 0 || !Legal.getCanRelearnMove(pkm, t, GameVersion.Any))) // {0} was able to remember {2} at {1}'s instruction. {4} that {3}.
+            if (m == 49 && (t == 0 || !Legal.getCanRelearnMove(pkm, t, generations, GameVersion.Any))) // {0} was able to remember {2} at {1}'s instruction. {4} that {3}.
             {
                 return new CheckResult(Severity.Invalid, resultPrefix + "Memory: Species cannot relearn this move.", CheckIdentifier.Memory);
             }
@@ -1897,9 +1900,9 @@ namespace PKHeX.Core
             for (int i = 0; i < 4; i++)
                 res[i] = new CheckResult(CheckIdentifier.Move);
             
-            var validMoves = Legal.getValidMoves(pkm, EvoChain, Tutor: false, Machine: false).ToArray();
-            var validTMHM = Legal.getValidMoves(pkm, EvoChain, Tutor: false, MoveReminder: false).ToArray();
-            var validTutor = Legal.getValidMoves(pkm, EvoChain, Machine: false, MoveReminder: false).ToArray();
+            var validMoves = Legal.getValidMoves(pkm, EvoChainsAllGens, Tutor: false, Machine: false).ToArray();
+            var validTMHM = Legal.getValidMoves(pkm, EvoChainsAllGens, Tutor: false, MoveReminder: false).ToArray();
+            var validTutor = Legal.getValidMoves(pkm, EvoChainsAllGens, Machine: false, MoveReminder: false).ToArray();
             if (pkm.Species == 235) // Smeargle
             {
                 for (int i = 0; i < 4; i++)

--- a/PKHeX/Legality/Core.cs
+++ b/PKHeX/Legality/Core.cs
@@ -331,7 +331,7 @@ namespace PKHeX.Core
 
             int lvl = (pkm.HasOriginalMetLocation) ? pkm.Met_Level : getMaxLevelGeneration(pkm);
             if (lvl <= 0)
-                return lvl;
+                return null;
             // Get valid pre-evolutions
             IEnumerable<DexLevel> p = getValidPreEvolutions(pkm);
 

--- a/PKHeX/Legality/Core.cs
+++ b/PKHeX/Legality/Core.cs
@@ -1162,7 +1162,7 @@ namespace PKHeX.Core
             }
 
             foreach (DexLevel evo in vs)
-                r.AddRange(getMoves(pkm, evo.Species, evo.Level, evo.Form, moveTutor, Version, LVL, Tutor, Machine, Generation, MoveReminder));
+                r.AddRange(getMoves(pkm, evo.Species, evo.Level, pkm.AltForm, moveTutor, Version, LVL, Tutor, Machine, Generation, MoveReminder));
 
             if (pkm.Format <= 3)
                 return r.Distinct().ToArray();

--- a/PKHeX/Legality/Core.cs
+++ b/PKHeX/Legality/Core.cs
@@ -821,8 +821,6 @@ namespace PKHeX.Core
 
             if (pkm.Gen3 && pkm.Format > 4 && pkm.Met_Level == pkm.CurrentLevel && FutureEvolutionsGen3_LevelUp.Contains(pkm.Species))
                 return pkm.Met_Level - 1;
-            if (pkm.VC2 && FutureEvolutionsGen1_Gen2LevelUp.Contains(pkm.Species))
-                return pkm.Met_Level - 1;
 
             return pkm.CurrentLevel;
         }
@@ -896,7 +894,7 @@ namespace PKHeX.Core
                     if (gen == 3 && pkm.Format>4 && currengenlevel == pkm.CurrentLevel && CompleteEvoChain.First().Species > MaxSpeciesID_3 && CompleteEvoChain.First().RequiresLvlUp)
                         currengenlevel--;
                     //The same condition for gen2 evolution of gen 1 pokemon, level of the pokemon in gen 1 games would be CurrentLevel -1 one level bellow gen 2 level
-                    if (gen == 1 && (pkm.Format == 2 || pkm.VC2 ) && currengenlevel == pkm.CurrentLevel && CompleteEvoChain.First().Species > MaxSpeciesID_1 && CompleteEvoChain.First().RequiresLvlUp)
+                    if (gen == 1 && pkm.Format == 2 && currengenlevel == pkm.CurrentLevel && CompleteEvoChain.First().Species > MaxSpeciesID_1 && CompleteEvoChain.First().RequiresLvlUp)
                         currengenlevel--;
                     CompleteEvoChain = CompleteEvoChain.Skip(1);
                 };

--- a/PKHeX/Legality/Core.cs
+++ b/PKHeX/Legality/Core.cs
@@ -824,7 +824,10 @@ namespace PKHeX.Core
             if (pkm.Gen3 && pkm.Format > 4 && pkm.Met_Level == pkm.CurrentLevel && FutureEvolutionsGen3_LevelUp.Contains(pkm.Species))
                 return pkm.Met_Level - 1;
 
-            return pkm.CurrentLevel;
+			if(!pkm.HasOriginalMetLocation))
+				return pkm.Met_Level;
+			
+			return pkm.CurrentLevel;
         }
 
         internal static int getMinLevelGeneration(PKM pkm)

--- a/PKHeX/Legality/Core.cs
+++ b/PKHeX/Legality/Core.cs
@@ -824,7 +824,7 @@ namespace PKHeX.Core
             if (pkm.Gen3 && pkm.Format > 4 && pkm.Met_Level == pkm.CurrentLevel && FutureEvolutionsGen3_LevelUp.Contains(pkm.Species))
                 return pkm.Met_Level - 1;
 
-			if(!pkm.HasOriginalMetLocation))
+			if(!pkm.HasOriginalMetLocation)
 				return pkm.Met_Level;
 			
 			return pkm.CurrentLevel;

--- a/PKHeX/Legality/Core.cs
+++ b/PKHeX/Legality/Core.cs
@@ -1166,21 +1166,22 @@ namespace PKHeX.Core
 
             if (pkm.Format <= 3)
                 return r.Distinct().ToArray();
+            if (LVL)
+            { 
+                if (species == 479 && Generation >= 4) // Rotom
+                    r.Add(RotomMoves[pkm.AltForm]);
+                if (species == 648 && Generation >= 5) // Meloetta
+                    r.Add(547); // Relic Song
 
-            if (species == 479) // Rotom
-                r.Add(RotomMoves[pkm.AltForm]);
-            if (species == 648) // Meloetta
-                r.Add(547); // Relic Song
+                if (species == 25 && pkm.Format == 6 && Generation == 6) // Pikachu
+                    r.Add(PikachuMoves[pkm.AltForm]);
 
-            if (species == 25 && pkm.Format == 6 && pkm.GenNumber == 6) // Pikachu
-                r.Add(PikachuMoves[pkm.AltForm]);
-
-            if (species == 718 && pkm.GenNumber == 7) // Zygarde
-                r.AddRange(ZygardeMoves);
-            if ((species == 25 || species == 26) && pkm.Format == 7) // Pikachu/Raichu Tutor
+                if (species == 718 && Generation == 7) // Zygarde
+                    r.AddRange(ZygardeMoves);
+            }
+            if ((species == 25 || species == 26) && Generation == 7 && moveTutor) // Pikachu/Raichu Tutor
                 r.Add(344); // Volt Tackle
-
-            if (Relearn) r.AddRange(pkm.RelearnMoves);
+            if (Relearn && Generation >= 6) r.AddRange(pkm.RelearnMoves);
             return r.Distinct().ToArray();
         }
         private static IEnumerable<int> getMoves(PKM pkm, int species, int lvl, int form, bool moveTutor, GameVersion Version, bool LVL, bool specialTutors, bool Machine, bool MoveReminder)

--- a/PKHeX/Legality/Core.cs
+++ b/PKHeX/Legality/Core.cs
@@ -282,7 +282,8 @@ namespace PKHeX.Core
             IEnumerable<EncounterStatic> poss = getStaticEncounters(pkm);
 
             int lvl = (pkm.HasOriginalMetLocation) ? pkm.Met_Level : getMaxLevelGeneration(pkm);
-
+            if (lvl <= 0)
+                return null; ;
             // Back Check against pkm
             foreach (EncounterStatic e in poss)
             {
@@ -329,7 +330,8 @@ namespace PKHeX.Core
                 return null;
 
             int lvl = (pkm.HasOriginalMetLocation) ? pkm.Met_Level : getMaxLevelGeneration(pkm);
-
+            if (lvl <= 0)
+                return lvl;
             // Get valid pre-evolutions
             IEnumerable<DexLevel> p = getValidPreEvolutions(pkm);
 
@@ -1086,6 +1088,8 @@ namespace PKHeX.Core
             IEnumerable<EncounterSlot> slots = loc.Slots.Where(slot => vs.Any(evo => evo.Species == slot.Species && (ignoreSlotLevel || evo.Level >= slot.LevelMin - df)));
 
             int lvl = (pkm.HasOriginalMetLocation) ? pkm.Met_Level: getMaxLevelGeneration(pkm);
+            if (lvl <= 0)
+                return slotdata;
             int gen = pkm.GenNumber;
             IEnumerable<EncounterSlot> encounterSlots;
             if(pkm.HasOriginalMetLocation)

--- a/PKHeX/Legality/Core.cs
+++ b/PKHeX/Legality/Core.cs
@@ -421,7 +421,20 @@ namespace PKHeX.Core
                 default: return -1;
             }
         }
-        
+
+        internal static int[] getFutureGenEvolutions(int generation)
+        {
+            switch (generation)
+            {
+                case 1: return FutureEvolutionsGen1;
+                case 2: return FutureEvolutionsGen2;
+                case 3: return FutureEvolutionsGen3;
+                case 4: return FutureEvolutionsGen4;
+                case 5: return FutureEvolutionsGen5;
+                default: return new int[0];
+            }
+        }
+
         internal static int getMaxSpeciesOrigin(PKM pkm)
         {
             if (pkm.Format == 1 || pkm.VC1) // Gen1 VC could not trade with gen 2 yet

--- a/PKHeX/Legality/Core.cs
+++ b/PKHeX/Legality/Core.cs
@@ -803,7 +803,7 @@ namespace PKHeX.Core
             for (int gen = 1; gen <= 7; gen++)
                 GensEvoChains[gen] = new DexLevel[0];
 
-            if(pkm.GenU || pkm.Species==0)//Illegal origin or empty pokemon, return only chain for current format
+            if((pkm.Format >2 && pkm.GenU) || pkm.Species==0)//Illegal origin or empty pokemon, return only chain for current format
             {
                 GensEvoChains[pkm.Format] = CompleteEvoChain.ToArray();
                 return GensEvoChains;
@@ -820,10 +820,10 @@ namespace PKHeX.Core
                 if ((pkm.Gen2 || pkm.VC2) && 3 <= gen && gen <= 6)
                     continue;
                 if (!pkm.HasOriginalMetLocation && pkm.Format >2 && gen <= 4 && currengenlevel > pkm.Met_Level)
-                    //Met location was lost at this point but it also means the pokemon existed in generations 1 to 4 with maximun level met level
+                    //Met location was lost at this point but it also means the pokemon existed in generations 1 to 4 with maximun level equals to met level
                     currengenlevel = pkm.Met_Level;
                 //Remove future gen evolutions after a few special considerations, 
-                //it he pokemon origin is illegal like a "gen 3" Infernape the list will be emptied, it didnt existed in gen 3 in any evolution phase
+                //it the pokemon origin is illegal like a "gen 3" Infernape the list will be emptied, it didnt existed in gen 3 in any evolution phase
                 while (CompleteEvoChain.Any() && CompleteEvoChain.First().Species > getMaxSpeciesOrigin(gen))
                 {   
                     //Eeve requieres to level one time to be Sylveon, it can be deduced in gen 5 and before it existed with maximun one level bellow current
@@ -832,7 +832,7 @@ namespace PKHeX.Core
                     //This is a gen 3 pokemon in a gen 4 phase evolution that requieres level up and then transfered to gen 5,6 or 7
                     //We can deduce that it existed in gen 4 until met level,
                     //but if current level is met level we can also deduce it existed in gen 3 until maximun met level -1
-                    if (gen == 3 && pkm.Format>4 && currengenlevel == pkm.CurrentLevel && CompleteEvoChain.First().RequiresLvlUp)
+                    if (gen == 3 && pkm.Format>4 && currengenlevel == pkm.CurrentLevel && CompleteEvoChain.First().Species > MaxSpeciesID_3 && CompleteEvoChain.First().RequiresLvlUp)
                         currengenlevel--;
                     CompleteEvoChain = CompleteEvoChain.Skip(1);
                 };

--- a/PKHeX/Legality/Core.cs
+++ b/PKHeX/Legality/Core.cs
@@ -1054,13 +1054,7 @@ namespace PKHeX.Core
             if (slotMax != null)
                 slotMax = new EncounterSlot(slotMax) { Pressure = true, Form = pkm.AltForm };
 
-            if (gen < 4)
-            {
-                if (slotMax != null)
-                    slotdata.Add(slotMax);
-                return slotdata;
-            }
-            if (gen == 6 || !DexNav)
+            if (gen >= 6 && !DexNav)
             {
                 // Filter for Form Specific
                 slotdata.AddRange(WildForms.Contains(pkm.Species)
@@ -1072,7 +1066,7 @@ namespace PKHeX.Core
             }
 
             List<EncounterSlot> eslots = encounterSlots.Where(slot => !WildForms.Contains(pkm.Species) || slot.Form == pkm.AltForm).ToList();
-            if(gen <=4)
+            if(gen <= 5)
             {
                 slotdata.AddRange(eslots);
                 return slotdata;

--- a/PKHeX/Legality/Core.cs
+++ b/PKHeX/Legality/Core.cs
@@ -833,7 +833,7 @@ namespace PKHeX.Core
 
             int currengenlevel = pkm.CurrentLevel;
             int maxgen = (pkm.Format <= 2) ? 2 : pkm.Format;
-            int mingen = (pkm.Format <= 2) ? 1 : pkm.GenNumber;
+            int mingen = (pkm.VC2 || pkm.Format <= 2) ? 1 : pkm.GenNumber;
             //Iterate generations backwards because level will be decreased from current level in each generation
             for (int gen = maxgen; gen >= mingen; gen--)
             {

--- a/PKHeX/Legality/Structures/DexLevel.cs
+++ b/PKHeX/Legality/Structures/DexLevel.cs
@@ -5,12 +5,13 @@
         public int Species;
         public int Level;
         public int MinLevel;
+        public bool RequiresLvlUp;
         public int Form = -1;
         public int Flag = -1;
 
         public DexLevel Copy(int lvl)
         {
-            return new DexLevel {Species = Species, Level = lvl, MinLevel = MinLevel, Form = Form, Flag = -1};
+            return new DexLevel {Species = Species, Level = lvl, MinLevel = MinLevel, RequiresLvlUp = RequiresLvlUp, Form = Form, Flag = -1};
         }
         public bool Matches(int species, int form)
         {

--- a/PKHeX/Legality/Structures/DexLevel.cs
+++ b/PKHeX/Legality/Structures/DexLevel.cs
@@ -4,12 +4,13 @@
     {
         public int Species;
         public int Level;
+        public int MinLevel;
         public int Form = -1;
         public int Flag = -1;
 
         public DexLevel Copy(int lvl)
         {
-            return new DexLevel {Species = Species, Level = lvl, Form = Form, Flag = -1};
+            return new DexLevel {Species = Species, Level = lvl, MinLevel = MinLevel, Form = Form, Flag = -1};
         }
         public bool Matches(int species, int form)
         {

--- a/PKHeX/Legality/Structures/EvolutionTree.cs
+++ b/PKHeX/Legality/Structures/EvolutionTree.cs
@@ -416,22 +416,25 @@ namespace PKHeX.Core
                         continue;
 
                     oneValid = true;
-                    if (evo.Level == 0 && !evo.RequiresLevelUp) //Evolutions like elemental stones
+                    if (evo.Level == 0 && !evo.RequiresLevelUp) //Evolutions like elemental stones, trade, etc
+                    {
                         dl.Last().MinLevel = 1;
+                    }
                     else if(evo.Level ==0) //Evolutions like frienship, picho -> pikachu, eeve -> umbreon, etc
                     {
                         dl.Last().MinLevel = 2;
-                        if (dl.Count() > 1 && dl.First().MinLevel == 1)
-                            dl.First().MinLevel = 2;
+                        if (dl.Count() > 1 && !dl.First().RequiresLvlUp)
+                            dl.First().MinLevel = 2; //Raichu from Pikachu would have minimun level 1, but with Pichu included Raichu minimun level is 2
                     }
-                    else
+                    else //level up evolutions
                     {
                         dl.Last().MinLevel = evo.Level;
-                        if (dl.Count() > 1 && dl.First().MinLevel == 1)
+                        if (dl.Count() > 1 && dl.First().MinLevel < evo.Level && !dl.First().RequiresLvlUp)
                             dl.First().MinLevel = evo.Level; //Pokemon like Nidoqueen, its minimun level is Nidorina minimun level
-                        if (dl.Count() > 1 && dl.First().MinLevel == 2)
+                        if (dl.Count() > 1 && dl.First().MinLevel <= evo.Level && dl.First().RequiresLvlUp)
                             dl.First().MinLevel = evo.Level + 1; //Pokemon like Crobat, its minimun level is Golbat minimun level + 1
                     }
+                    dl.Last().RequiresLvlUp = evo.RequiresLevelUp;
                     int species = evo.Species;
 
                     // Gen7 Personal Formes -- unmap the forme personal entry ID to the actual species ID since species are consecutive
@@ -452,8 +455,9 @@ namespace PKHeX.Core
             if (dl.Any(d => d.Species <= maxSpeciesOrigin) && dl.Last().Species > maxSpeciesOrigin)
                 dl.RemoveAt(dl.Count - 1); 
 
-            //Last species is the wild/hatched species, the minimu is 1 because it has not evolved from previous species
+            //Last species is the wild/hatched species, the minimun is 1 because it has not evolved from previous species
             dl.Last().MinLevel = 1;
+            dl.Last().RequiresLvlUp = false;
             return dl;
         }
     }

--- a/PKHeX/Legality/Structures/EvolutionTree.cs
+++ b/PKHeX/Legality/Structures/EvolutionTree.cs
@@ -420,18 +420,18 @@ namespace PKHeX.Core
                     {
                         dl.Last().MinLevel = 1;
                     }
-                    else if(evo.Level ==0) //Evolutions like frienship, picho -> pikachu, eeve -> umbreon, etc
+                    else if(evo.Level ==0) //Evolutions like frienship, pichu -> pikachu, eevee -> umbreon, etc
                     {
                         dl.Last().MinLevel = 2;
-                        if (dl.Count() > 1 && !dl.First().RequiresLvlUp)
+                        if (dl.Count > 1 && !dl.First().RequiresLvlUp)
                             dl.First().MinLevel = 2; //Raichu from Pikachu would have minimun level 1, but with Pichu included Raichu minimun level is 2
                     }
                     else //level up evolutions
                     {
                         dl.Last().MinLevel = evo.Level;
-                        if (dl.Count() > 1 && dl.First().MinLevel < evo.Level && !dl.First().RequiresLvlUp)
+                        if (dl.Count > 1 && dl.First().MinLevel < evo.Level && !dl.First().RequiresLvlUp)
                             dl.First().MinLevel = evo.Level; //Pokemon like Nidoqueen, its minimun level is Nidorina minimun level
-                        if (dl.Count() > 1 && dl.First().MinLevel <= evo.Level && dl.First().RequiresLvlUp)
+                        if (dl.Count > 1 && dl.First().MinLevel <= evo.Level && dl.First().RequiresLvlUp)
                             dl.First().MinLevel = evo.Level + 1; //Pokemon like Crobat, its minimun level is Golbat minimun level + 1
                     }
                     dl.Last().RequiresLvlUp = evo.RequiresLevelUp;

--- a/PKHeX/Legality/Structures/EvolutionTree.cs
+++ b/PKHeX/Legality/Structures/EvolutionTree.cs
@@ -153,7 +153,7 @@ namespace PKHeX.Core
 
             return Personal.getFormeIndex(evolvesToSpecies, evolvesToForm);
         }
-        public IEnumerable<DexLevel> getValidPreEvolutions(PKM pkm, int lvl, bool skipChecks = false)
+        public IEnumerable<DexLevel> getValidPreEvolutions(PKM pkm, int lvl,bool skipChecks = false)
         {
             int index = getIndex(pkm);
             int maxSpeciesOrigin = Legal.getMaxSpeciesOrigin(pkm);
@@ -354,7 +354,7 @@ namespace PKHeX.Core
                     return false;
             }
         }
-
+        
         public DexLevel GetDexLevel(int species, int lvl)
         {
 
@@ -416,6 +416,22 @@ namespace PKHeX.Core
                         continue;
 
                     oneValid = true;
+                    if (evo.Level == 0 && !evo.RequiresLevelUp) //Evolutions like elemental stones
+                        dl.Last().MinLevel = 1;
+                    else if(evo.Level ==0) //Evolutions like frienship, picho -> pikachu, eeve -> umbreon, etc
+                    {
+                        dl.Last().MinLevel = 2;
+                        if (dl.Count() > 1 && dl.First().MinLevel == 1)
+                            dl.First().MinLevel = 2;
+                    }
+                    else
+                    {
+                        dl.Last().MinLevel = evo.Level;
+                        if (dl.Count() > 1 && dl.First().MinLevel == 1)
+                            dl.First().MinLevel = evo.Level; //Pokemon like Nidoqueen, its minimun level is Nidorina minimun level
+                        if (dl.Count() > 1 && dl.First().MinLevel == 2)
+                            dl.First().MinLevel = evo.Level + 1; //Pokemon like Crobat, its minimun level is Golbat minimun level + 1
+                    }
                     int species = evo.Species;
 
                     // Gen7 Personal Formes -- unmap the forme personal entry ID to the actual species ID since species are consecutive
@@ -436,6 +452,8 @@ namespace PKHeX.Core
             if (dl.Any(d => d.Species <= maxSpeciesOrigin) && dl.Last().Species > maxSpeciesOrigin)
                 dl.RemoveAt(dl.Count - 1); 
 
+            //Last species is the wild/hatched species, the minimu is 1 because it has not evolved from previous species
+            dl.Last().MinLevel = 1;
             return dl;
         }
     }

--- a/PKHeX/Legality/Tables1.cs
+++ b/PKHeX/Legality/Tables1.cs
@@ -114,5 +114,10 @@ namespace PKHeX.Core
             new EncounterSlot1 {Species = 118, LevelMin = 10, LevelMax = 10, Type = SlotType.Good_Rod, Rate = -1, }, // Goldeen
             new EncounterSlot1 {Species = 060, LevelMin = 10, LevelMax = 10, Type = SlotType.Good_Rod, Rate = -1, }, // Poliwag
         }};
+
+        internal static readonly int[] FutureEvolutionsGen1 =
+        {
+            169,182,186,196,197,199,208,212,230,233,242,462,463,464,465,466,467,470,471,474,700
+        };
     }
 }

--- a/PKHeX/Legality/Tables1.cs
+++ b/PKHeX/Legality/Tables1.cs
@@ -119,5 +119,11 @@ namespace PKHeX.Core
         {
             169,182,186,196,197,199,208,212,230,233,242,462,463,464,465,466,467,470,471,474,700
         };
+
+        internal static readonly int[] FutureEvolutionsGen1_Gen2LevelUp = new int[]
+        {
+              169,196,197,242
+        };
+        //Crobat Espeon Umbreon Blissey
     }
 }

--- a/PKHeX/Legality/Tables2.cs
+++ b/PKHeX/Legality/Tables2.cs
@@ -36,5 +36,10 @@ namespace PKHeX.Core
             10, 00, 00, 00, 00
         };
         internal static readonly int[] WildPokeBalls2 = { 4 };
+
+        internal static readonly int[] FutureEvolutionsGen2 =
+        {
+            424,429,430,461,462,463,464,465,466,467,468,469,470,471,472,473,474,700
+        };
     }
 }

--- a/PKHeX/Legality/Tables3.cs
+++ b/PKHeX/Legality/Tables3.cs
@@ -82,5 +82,10 @@ namespace PKHeX.Core
             590, 591, 592, 593
         };
         internal static readonly int[] WildPokeBalls3 = {1, 2, 3, 4, 6, 7, 8, 9, 10, 11, 12};
+
+        internal static readonly int[] FutureEvolutionsGen3 =
+        {
+            407,424,429,430,461,462,463,464,465,466,467,468,469,470,471,472,473,474,475,476,477,700
+        };
     }
 }

--- a/PKHeX/Legality/Tables3.cs
+++ b/PKHeX/Legality/Tables3.cs
@@ -87,5 +87,12 @@ namespace PKHeX.Core
         {
             407,424,429,430,461,462,463,464,465,466,467,468,469,470,471,472,473,474,475,476,477,700
         };
+
+        internal static readonly int[] FutureEvolutionsGen3_LevelUp = new int[] 
+        {
+            424, 461, 462, 463, 465, 469, 470, 471, 472, 473, 476
+        };
+        // Ambipom Weavile Magnezone Lickilicky Tangrowth
+        // Yanmega Leafeon Glaceon Mamoswine Gliscor Probopass
     }
 }

--- a/PKHeX/Legality/Tables4.cs
+++ b/PKHeX/Legality/Tables4.cs
@@ -130,5 +130,10 @@ namespace PKHeX.Core
             17, 18, 19, 20, 21, 22,
             // Comp Ball not usable in wild
         };
+
+        internal static readonly int[] FutureEvolutionsGen4 =
+        {
+            700
+        };
     }
 }

--- a/PKHeX/Legality/Tables5.cs
+++ b/PKHeX/Legality/Tables5.cs
@@ -89,5 +89,10 @@ namespace PKHeX.Core
             // HGSS balls not usable
             // Dream ball not usable in wild
         };
+
+        internal static readonly int[] FutureEvolutionsGen5 =
+        {
+            700
+        };
     }
 }

--- a/PKHeX/PKM/PKM.cs
+++ b/PKHeX/PKM/PKM.cs
@@ -453,7 +453,11 @@ namespace PKHeX.Core
             if (species < 0)
                 species = Species;
 
-            if (Format == 1 && Generation ==2 && Legal.MaxSpeciesID_2 >= species)
+            if (Format == 1 && Generation ==2 && (Legal.MaxSpeciesID_2 >= species || Legal.FutureEvolutionsGen2.Contains(species)))
+                return true;
+
+            if (Format == Generation)
+                //Every pokemon even those with illegal data inhabit the generation of its current format
                 return true;
 
             if (Format < Generation)
@@ -463,7 +467,7 @@ namespace PKHeX.Core
                 return false;
 
             // Sanity Check Species ID
-            if (Legal.getMaxSpeciesOrigin(GenNumber) < species)
+            if (Legal.getMaxSpeciesOrigin(GenNumber) < species && !Legal.getFutureGenEvolutions(GenNumber).Contains(species))
                 return false;
 
             int gen = GenNumber;

--- a/PKHeX/PKM/PKM.cs
+++ b/PKHeX/PKM/PKM.cs
@@ -277,7 +277,7 @@ namespace PKHeX.Core
         public bool Gen3 => Version >= 1 && Version <= 5 || Version == 15;
         public bool Gen2 => Version == (int)GameVersion.GSC;
         public bool Gen1 => Version == (int)GameVersion.RBY;
-        public bool GenU => !(Gen7 || Gen6 || Gen5 || Gen4 || Gen3 || Gen2 || Gen1);
+        public bool GenU => !(Gen7 || Gen6 || Gen5 || Gen4 || Gen3 || Gen2 || Gen1 || VC);
         public int GenNumber
         {
             get
@@ -453,6 +453,9 @@ namespace PKHeX.Core
             if (species < 0)
                 species = Species;
 
+            if (Format == 1 && Generation ==2 && Legal.MaxSpeciesID_2 >= species)
+                return true;
+
             if (Format < Generation)
                 return false; // Future
 
@@ -466,8 +469,8 @@ namespace PKHeX.Core
             int gen = GenNumber;
             switch (Generation)
             {
-                case 1: return VC;
-                case 2: return VC;
+                case 1: return Format == 1 || VC1;
+                case 2: return Format <= 2 || VC2;
                 case 3: return Gen3;
                 case 4: return 3 <= gen && gen <= 4;
                 case 5: return 3 <= gen && gen <= 5;

--- a/PKHeX/PKM/PKM.cs
+++ b/PKHeX/PKM/PKM.cs
@@ -473,7 +473,7 @@ namespace PKHeX.Core
             int gen = GenNumber;
             switch (Generation)
             {
-                case 1: return Format == 1 || VC1;
+                case 1: return Format == 1 || VC;
                 case 2: return Format <= 2 || VC2;
                 case 3: return Gen3;
                 case 4: return 3 <= gen && gen <= 4;


### PR DESCRIPTION
4 months ago i started to create files to help making past generation legal checks, the levelup, eggmoves and tmhm tables.

Back then it can yet be used because PKHeX was not ready.
Now with the last refactors made to the program I have resumed the extraction and i have also the encounter tables for gen 3 and 4. When i complete the extraction of encounters for gen 5 and evolution tables for gen 3 to 5 i will make a pull request to include it in PKHeX

For now i made some tweaks to the legalliy checks that would make more easy to start those past gen legal chechks.

The most important one is to generate different evolution chain arrays depending on the generation, to allow for a given pokemon to know the evolution chain across all the generation that it has inhabited, chaind that can be different not only because of future gen evolutions, but also to take into account what if the max level in what the pokemon inhabited every generation, that would make some of the evolutions phases impossible in some generations, if a level 100 XY pokemon was originated in gen 3 and transfered to gen 4 with level 40... it coldnt learn any move above level 40 in gens 3 and 4

The second important change is to use met level to filter encounter slots even if the original met encounter is lost. Okay, in those cases some information is lost, but that not means every encounter slot is valid, the pokemon was captured with level equals or bellow the met level, that exclude every encounter with min level greather that met level