### PR TITLE
Made clickonce less intrusive to normal builds

### DIFF
--- a/PKHeX.WinForms/PKHeX.WinForms.csproj
+++ b/PKHeX.WinForms/PKHeX.WinForms.csproj
@@ -35,7 +35,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\x86\Debug\</OutputPath>
-    <DefineConstants>DEBUG;CLICKONCE;WINDOWS</DefineConstants>
+    <DefineConstants>DEBUG;WINDOWS</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>x86</PlatformTarget>
     <UseVSHostingProcess>false</UseVSHostingProcess>
@@ -45,7 +45,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x86'">
     <OutputPath>bin\x86\Release\</OutputPath>
-    <DefineConstants>CLICKONCE;WINDOWS</DefineConstants>
+    <DefineConstants>WINDOWS</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>x86</PlatformTarget>
@@ -77,7 +77,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;CLICKONCE;WINDOWS</DefineConstants>
+    <DefineConstants>DEBUG;WINDOWS</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <UseVSHostingProcess>false</UseVSHostingProcess>
@@ -87,7 +87,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>CLICKONCE;WINDOWS</DefineConstants>
+    <DefineConstants>WINDOWS</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -116,14 +116,37 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>true</Prefer32Bit>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'ClickOnce|x86'">
+    <OutputPath>bin\x86\ClickOnce\</OutputPath>
+    <DefineConstants>CLICKONCE;WINDOWS</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>x86</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <NoWin32Manifest>true</NoWin32Manifest>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'ClickOnce|AnyCPU'">
+    <OutputPath>bin\ClickOnce\</OutputPath>
+    <DefineConstants>CLICKONCE;WINDOWS</DefineConstants>
+    <Optimize>true</Optimize>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <ErrorReport>prompt</ErrorReport>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Prefer32Bit>true</Prefer32Bit>
+    <NoWin32Manifest>true</NoWin32Manifest>
+  </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.configuration" />
+    <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Deployment" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Web" />
     <Reference Include="System.Windows.Forms" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(Configuration)' == 'ClickOnce'">
+    <Reference Include="System.Deployment" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainWindow\Main.cs">

--- a/PKHeX.sln
+++ b/PKHeX.sln
@@ -19,6 +19,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PKHeX.WinForms", "PKHeX.Win
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		ClickOnce|Any CPU = ClickOnce|Any CPU
+		ClickOnce|x86 = ClickOnce|x86
 		Debug|Any CPU = Debug|Any CPU
 		Debug|x86 = Debug|x86
 		Mono-Debug|Any CPU = Mono-Debug|Any CPU
@@ -29,6 +31,10 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B4EFF030-C75A-49F9-A4BC-738D1B61C4AF}.ClickOnce|Any CPU.ActiveCfg = Release|Any CPU
+		{B4EFF030-C75A-49F9-A4BC-738D1B61C4AF}.ClickOnce|Any CPU.Build.0 = Release|Any CPU
+		{B4EFF030-C75A-49F9-A4BC-738D1B61C4AF}.ClickOnce|x86.ActiveCfg = Release|x86
+		{B4EFF030-C75A-49F9-A4BC-738D1B61C4AF}.ClickOnce|x86.Build.0 = Release|x86
 		{B4EFF030-C75A-49F9-A4BC-738D1B61C4AF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{B4EFF030-C75A-49F9-A4BC-738D1B61C4AF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B4EFF030-C75A-49F9-A4BC-738D1B61C4AF}.Debug|x86.ActiveCfg = Debug|x86
@@ -45,6 +51,10 @@ Global
 		{B4EFF030-C75A-49F9-A4BC-738D1B61C4AF}.Release|Any CPU.Build.0 = Release|Any CPU
 		{B4EFF030-C75A-49F9-A4BC-738D1B61C4AF}.Release|x86.ActiveCfg = Release|x86
 		{B4EFF030-C75A-49F9-A4BC-738D1B61C4AF}.Release|x86.Build.0 = Release|x86
+		{8E2499BC-C11A-4809-8737-66D35A625425}.ClickOnce|Any CPU.ActiveCfg = Release|Any CPU
+		{8E2499BC-C11A-4809-8737-66D35A625425}.ClickOnce|Any CPU.Build.0 = Release|Any CPU
+		{8E2499BC-C11A-4809-8737-66D35A625425}.ClickOnce|x86.ActiveCfg = Release|x86
+		{8E2499BC-C11A-4809-8737-66D35A625425}.ClickOnce|x86.Build.0 = Release|x86
 		{8E2499BC-C11A-4809-8737-66D35A625425}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{8E2499BC-C11A-4809-8737-66D35A625425}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8E2499BC-C11A-4809-8737-66D35A625425}.Debug|x86.ActiveCfg = Debug|x86
@@ -57,6 +67,10 @@ Global
 		{8E2499BC-C11A-4809-8737-66D35A625425}.Release|Any CPU.Build.0 = Release|Any CPU
 		{8E2499BC-C11A-4809-8737-66D35A625425}.Release|x86.ActiveCfg = Release|x86
 		{8E2499BC-C11A-4809-8737-66D35A625425}.Release|x86.Build.0 = Release|x86
+		{D1B91861-A448-4762-A313-C7BC179F4415}.ClickOnce|Any CPU.ActiveCfg = ClickOnce|Any CPU
+		{D1B91861-A448-4762-A313-C7BC179F4415}.ClickOnce|Any CPU.Build.0 = ClickOnce|Any CPU
+		{D1B91861-A448-4762-A313-C7BC179F4415}.ClickOnce|x86.ActiveCfg = Release|x86
+		{D1B91861-A448-4762-A313-C7BC179F4415}.ClickOnce|x86.Build.0 = Release|x86
 		{D1B91861-A448-4762-A313-C7BC179F4415}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D1B91861-A448-4762-A313-C7BC179F4415}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D1B91861-A448-4762-A313-C7BC179F4415}.Debug|x86.ActiveCfg = Debug|x86

--- a/PKHeX/PKHeX.Core.csproj
+++ b/PKHeX/PKHeX.Core.csproj
@@ -75,7 +75,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\x86\Debug\</OutputPath>
-    <DefineConstants>DEBUG;CLICKONCE;WINDOWS</DefineConstants>
+    <DefineConstants>DEBUG;WINDOWS</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>x86</PlatformTarget>
     <UseVSHostingProcess>false</UseVSHostingProcess>
@@ -85,7 +85,7 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
-    <DefineConstants>CLICKONCE;WINDOWS</DefineConstants>
+    <DefineConstants>WINDOWS</DefineConstants>
     <OutputPath>bin\x86\Release\</OutputPath>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
@@ -122,7 +122,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;CLICKONCE;WINDOWS</DefineConstants>
+    <DefineConstants>DEBUG;WINDOWS</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <UseVSHostingProcess>false</UseVSHostingProcess>
@@ -132,7 +132,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
     <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>CLICKONCE;WINDOWS</DefineConstants>
+    <DefineConstants>WINDOWS</DefineConstants>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>


### PR DESCRIPTION
ClickOnce needs a special setting not required by other builds (NoWin32Manifest).  Other builds do not need ClickOnce's System.Deployment.  Now, only the ClickOnce build configuration uses System.Deployment and no other configuration knows anything about it.

The super-secret dev clickonce has been updated to the results of this branch, but automatic uploads are not currently enabled.  The build results of the Team City build configuration can be seen by creating an account and asking me for access.