### PR TITLE
F/autocorrect settings

### DIFF
--- a/PKHeX.WinForms/MainWindow/Main.cs
+++ b/PKHeX.WinForms/MainWindow/Main.cs
@@ -168,7 +168,21 @@ namespace PKHeX.WinForms
                 var settingsFilename = (e.InnerException as ConfigurationErrorsException)?.Filename;
                 if (File.Exists(settingsFilename))
                 {
-                    File.Delete(settingsFilename);
+                    if (MessageBox.Show("PKHeX's settings are corrupt.  Would you like to reset the settings?  (Click Yes to delete the settings or No to close the program.", "PKHeX", MessageBoxButtons.YesNo) == DialogResult.Yes)
+                    {
+                        File.Delete(settingsFilename);
+
+                        // This should theoretically work, but has failed in evandixon's testing
+                        // Properties.Settings.Default.Reload();
+
+                        // Instead, restart the application
+                        MessageBox.Show("The settings have been deleted.  Please restart PKHeX.");
+                        Process.GetCurrentProcess().Kill();
+                    }
+                    else
+                    {
+                        Process.GetCurrentProcess().Kill();
+                    }
                 }
                 else
                 {

--- a/PKHeX.WinForms/MainWindow/Main.cs
+++ b/PKHeX.WinForms/MainWindow/Main.cs
@@ -166,7 +166,7 @@ namespace PKHeX.WinForms
             {
                 // Delete the settings if they exist
                 var settingsFilename = (e.InnerException as ConfigurationErrorsException)?.Filename;
-                if (File.Exists(settingsFilename))
+                if (!string.IsNullOrEmpty(settingsFilename) && File.Exists(settingsFilename))
                 {
                     if (MessageBox.Show("PKHeX's settings are corrupt.  Would you like to reset the settings?  (Click Yes to delete the settings or No to close the program.", "PKHeX", MessageBoxButtons.YesNo) == DialogResult.Yes)
                     {

--- a/PKHeX.WinForms/MainWindow/Main.cs
+++ b/PKHeX.WinForms/MainWindow/Main.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using System.Windows.Forms;
 using PKHeX.Core;
 using PKHeX.Core.Properties;
+using System.Configuration;
 
 namespace PKHeX.WinForms
 {
@@ -161,9 +162,18 @@ namespace PKHeX.WinForms
                 ConfigUtil.checkConfig();
                 loadConfig(out BAKprompt, out showChangelog, out languageID); 
             }
-            catch (Exception e)
+            catch (ConfigurationErrorsException e)
             {
-                WinFormsUtil.Error("Failed to access settings:" + Environment.NewLine + e.Message, "Please delete corrupt user.config file.");
+                // Delete the settings if they exist
+                var settingsFilename = (e.InnerException as ConfigurationErrorsException)?.Filename;
+                if (File.Exists(settingsFilename))
+                {
+                    File.Delete(settingsFilename);
+                }
+                else
+                {
+                    WinFormsUtil.Error("Unable to load settings.", e);
+                }
             }
             CB_MainLanguage.SelectedIndex = languageID;
 


### PR DESCRIPTION
People are still experiencing corrupt settings (#914).  [Turns out we don't need to require the user to manually delete the settings](https://www.codeproject.com/articles/30216/handling-corrupt-user-config-settings).

I was unable to automatically reload the settings without restarting the application, so the user will still have to manually restart the application, but that's still far better than having to delete a file.