### PR TITLE
More Gen 3 and 4 Encounters

### DIFF
--- a/PKHeX/Legality/Core.cs
+++ b/PKHeX/Legality/Core.cs
@@ -190,61 +190,20 @@ namespace PKHeX.Core
             // Species id are not included in encounter tables but levels can be copied from the encounter raw data
             foreach(EncounterArea Area in Areas)
             {
-                var Swarms = SwarmAreas.Where(a => a.Location == Area.Location);
-                foreach(EncounterArea Swarm in Swarms)
+                var SwarmSlots = SwarmAreas.Where(a => a.Location == Area.Location).SelectMany(s=>s.Slots);
+                foreach(EncounterSlot SwarmSlot in SwarmSlots)
                 {
                     var OutputSlots = new List<EncounterSlot>();
-                    var SwarmSlot = Swarm.Slots.First();
+                    var ReplacedSlots = Area.Slots.Where(s => s.Type == SwarmSlot.Type);
 
-                    if (SwarmSlot.Type == SlotType.Grass)
-                    {
-                        var SwarmRawSlot0 = Area.Slots.Where(s => s.Type == SlotType.Grass).First().Clone();
-                        SwarmRawSlot0.Species = SwarmSlot.Species;
-                        OutputSlots.Add(SwarmRawSlot0);
+                    var SwarmOutputSlot0 = ReplacedSlots.First().Clone();
+                    SwarmOutputSlot0.Species = SwarmSlot.Species;
+                    OutputSlots.Add(SwarmOutputSlot0);
 
-                        var SwarmRawSlot1 = Area.Slots.Where(s => s.Type == SlotType.Grass).Take(1).First().Clone();
-                        SwarmRawSlot1.Species = SwarmSlot.Species;
-                        OutputSlots.Add(SwarmRawSlot1);
-                    }
-
-                    if (SwarmSlot.Type == SlotType.Surf)
-                    {
-                        var SwarmRawSlot0 = Area.Slots.Where(s => s.Type == SlotType.Surf).First().Clone();
-                        SwarmRawSlot0.Species = SwarmSlot.Species;
-                        OutputSlots.Add(SwarmRawSlot0);
-
-                        var SwarmRawSlot1 = Area.Slots.Where(s => s.Type == SlotType.Surf).Take(1).First().Clone();
-                        SwarmRawSlot1.Species = SwarmSlot.Species;
-                        OutputSlots.Add(SwarmRawSlot1);
-                    }
-
-                    if (SwarmSlot.Type == SlotType.Super_Rod)
-                    {
-                        var SwarmRawSlot0_OR = Area.Slots.Where(s => s.Type == SlotType.Old_Rod).First().Clone();
-                        SwarmRawSlot0_OR.Species = SwarmSlot.Species;
-                        OutputSlots.Add(SwarmRawSlot0_OR);
-
-                        var SwarmRawSlot1_OR = Area.Slots.Where(s => s.Type == SlotType.Old_Rod).Take(1).First().Clone();
-                        SwarmRawSlot1_OR.Species = SwarmSlot.Species;
-                        OutputSlots.Add(SwarmRawSlot1_OR);
-
-                        var SwarmRawSlot0_GR = Area.Slots.Where(s => s.Type == SlotType.Good_Rod).First().Clone();
-                        SwarmRawSlot0_GR.Species = SwarmSlot.Species;
-                        OutputSlots.Add(SwarmRawSlot0_GR);
-
-                        var SwarmRawSlot1_GR = Area.Slots.Where(s => s.Type == SlotType.Good_Rod).Take(1).First().Clone();
-                        SwarmRawSlot1_GR.Species = SwarmSlot.Species;
-                        OutputSlots.Add(SwarmRawSlot1_GR);
-
-                        var SwarmRawSlot0_SR = Area.Slots.Where(s => s.Type == SlotType.Super_Rod).First().Clone();
-                        SwarmRawSlot0_SR.Species = SwarmSlot.Species;
-                        OutputSlots.Add(SwarmRawSlot0_SR);
-
-                        var SwarmRawSlot1_SR = Area.Slots.Where(s => s.Type == SlotType.Super_Rod).Take(1).First().Clone();
-                        SwarmRawSlot1_SR.Species = SwarmSlot.Species;
-                        OutputSlots.Add(SwarmRawSlot1_SR);
-                    }
-
+                    var SwarmOutputSlot1 = ReplacedSlots.Skip(1).First().Clone();
+                    SwarmOutputSlot1.Species = SwarmSlot.Species;
+                    OutputSlots.Add(SwarmOutputSlot1);
+                                        
                     Area.Slots = Area.Slots.Concat(OutputSlots).ToArray();
                 }
 

--- a/PKHeX/Legality/Core.cs
+++ b/PKHeX/Legality/Core.cs
@@ -183,6 +183,75 @@ namespace PKHeX.Core
                                      new EncounterArea { Location = a.First().Location, Slots = a.SelectMany(m => m.Slots).ToArray() }).
                           ToArray();
         }
+
+        private static void MarkG4SwarmSlots(ref EncounterArea[] Areas, EncounterArea[] SwarmAreas)
+        {
+            // Swarm slots replace slots 0 and 1 from encounters data
+            // Species id are not included in encounter tables but levels can be copied from the encounter raw data
+            foreach(EncounterArea Area in Areas)
+            {
+                var Swarms = SwarmAreas.Where(a => a.Location == Area.Location);
+                foreach(EncounterArea Swarm in Swarms)
+                {
+                    var OutputSlots = new List<EncounterSlot>();
+                    var SwarmSlot = Swarm.Slots.First();
+
+                    if (SwarmSlot.Type == SlotType.Grass)
+                    {
+                        var SwarmRawSlot0 = Area.Slots.Where(s => s.Type == SlotType.Grass).First().Clone();
+                        SwarmRawSlot0.Species = SwarmSlot.Species;
+                        OutputSlots.Add(SwarmRawSlot0);
+
+                        var SwarmRawSlot1 = Area.Slots.Where(s => s.Type == SlotType.Grass).Take(1).First().Clone();
+                        SwarmRawSlot1.Species = SwarmSlot.Species;
+                        OutputSlots.Add(SwarmRawSlot1);
+                    }
+
+                    if (SwarmSlot.Type == SlotType.Surf)
+                    {
+                        var SwarmRawSlot0 = Area.Slots.Where(s => s.Type == SlotType.Surf).First().Clone();
+                        SwarmRawSlot0.Species = SwarmSlot.Species;
+                        OutputSlots.Add(SwarmRawSlot0);
+
+                        var SwarmRawSlot1 = Area.Slots.Where(s => s.Type == SlotType.Surf).Take(1).First().Clone();
+                        SwarmRawSlot1.Species = SwarmSlot.Species;
+                        OutputSlots.Add(SwarmRawSlot1);
+                    }
+
+                    if (SwarmSlot.Type == SlotType.Super_Rod)
+                    {
+                        var SwarmRawSlot0_OR = Area.Slots.Where(s => s.Type == SlotType.Old_Rod).First().Clone();
+                        SwarmRawSlot0_OR.Species = SwarmSlot.Species;
+                        OutputSlots.Add(SwarmRawSlot0_OR);
+
+                        var SwarmRawSlot1_OR = Area.Slots.Where(s => s.Type == SlotType.Old_Rod).Take(1).First().Clone();
+                        SwarmRawSlot1_OR.Species = SwarmSlot.Species;
+                        OutputSlots.Add(SwarmRawSlot1_OR);
+
+                        var SwarmRawSlot0_GR = Area.Slots.Where(s => s.Type == SlotType.Good_Rod).First().Clone();
+                        SwarmRawSlot0_GR.Species = SwarmSlot.Species;
+                        OutputSlots.Add(SwarmRawSlot0_GR);
+
+                        var SwarmRawSlot1_GR = Area.Slots.Where(s => s.Type == SlotType.Good_Rod).Take(1).First().Clone();
+                        SwarmRawSlot1_GR.Species = SwarmSlot.Species;
+                        OutputSlots.Add(SwarmRawSlot1_GR);
+
+                        var SwarmRawSlot0_SR = Area.Slots.Where(s => s.Type == SlotType.Super_Rod).First().Clone();
+                        SwarmRawSlot0_SR.Species = SwarmSlot.Species;
+                        OutputSlots.Add(SwarmRawSlot0_SR);
+
+                        var SwarmRawSlot1_SR = Area.Slots.Where(s => s.Type == SlotType.Super_Rod).Take(1).First().Clone();
+                        SwarmRawSlot1_SR.Species = SwarmSlot.Species;
+                        OutputSlots.Add(SwarmRawSlot1_SR);
+                    }
+
+                    Area.Slots = Area.Slots.Concat(OutputSlots).ToArray();
+                }
+
+                Area.Slots = Area.Slots.Where(a => a.Species > 0).ToArray();
+            }
+        }
+
         private static void MarkG4Slots(ref EncounterArea[] Areas)
         {
             // Group areas by location id, the raw data have areas with different slots but the same location id
@@ -358,6 +427,12 @@ namespace PKHeX.Core
                 var D_HoneyTrees_Slots = SlotsD_HoneyTree.Clone(HoneyTreesLocation);
                 var P_HoneyTrees_Slots = SlotsP_HoneyTree.Clone(HoneyTreesLocation);
                 var Pt_HoneyTrees_Slots = SlotsPt_HoneyTree.Clone(HoneyTreesLocation);
+
+                MarkG4SwarmSlots(ref D_Slots, SlotsDP_Swarm);
+                MarkG4SwarmSlots(ref P_Slots, SlotsDP_Swarm);
+                MarkG4SwarmSlots(ref Pt_Slots, SlotsPt_Swarm);
+                MarkG4SwarmSlots(ref HG_Slots, SlotsHG_Swarm);
+                MarkG4SwarmSlots(ref SS_Slots, SlotsSS_Swarm);
 
                 MarkG4Slots(ref D_Slots);
                 MarkG4Slots(ref P_Slots);

--- a/PKHeX/Legality/Core.cs
+++ b/PKHeX/Legality/Core.cs
@@ -579,7 +579,15 @@ namespace PKHeX.Core
             {
                 if (e.Nature != Nature.Random && pkm.Nature != (int)e.Nature)
                     continue;
-                if (e.EggLocation != pkm.Egg_Location)
+                if(pkm.Gen3 && e.EggLocation != 0)
+                {   
+                    //Hartched gen 3 gift egg can not be differentiated form normal eggs 
+                    if (!pkm.IsEgg || pkm.Format > 3)
+                        continue;
+                    if (e.EggLocation != pkm.Met_Location)
+                        continue;
+                }
+                else if (e.EggLocation != pkm.Egg_Location)
                     continue;
                 if (pkm.HasOriginalMetLocation)
                 {

--- a/PKHeX/Legality/Structures/EncounterStatic.cs
+++ b/PKHeX/Legality/Structures/EncounterStatic.cs
@@ -26,6 +26,45 @@
         public bool RibbonWishing = false;
         public bool SkipFormCheck = false;
         public bool NSparkle = false;
+        public bool Roaming = false;
+
+        public EncounterStatic[] Clone(int[] locations)
+        {
+            EncounterStatic[] Encounters = new EncounterStatic[locations.Length];
+            for (int i = 0; i < locations.Length; i++)
+                Encounters[i] = Clone(locations[i]);
+            return Encounters;
+        }
+
+        public EncounterStatic Clone(int location)
+        {
+            return new EncounterStatic()
+            {
+                Species = Species,
+                Level = Level,
+                Location = location,
+                Ability = Ability,
+                Form = Form,
+                Shiny = Shiny,
+                Relearn = Relearn,
+                Moves = Moves,
+                Gender = Gender,
+                EggLocation = EggLocation,
+                Nature = Nature,
+                Gift = Gift,
+                Ball = Ball,
+                Version = Version,
+                IVs = IVs,
+                IV3 = IV3,
+                Contest = Contest,
+                HeldItem = HeldItem,
+                Fateful = Fateful,
+                RibbonWishing = RibbonWishing,
+                SkipFormCheck = SkipFormCheck,
+                NSparkle = NSparkle,
+                Roaming = Roaming
+            };
+        }
 
         public string Name
         {

--- a/PKHeX/Legality/Tables3.cs
+++ b/PKHeX/Legality/Tables3.cs
@@ -160,7 +160,7 @@ namespace PKHeX.Core
             //Gift
             new EncounterStatic { Gift = true, Species = 351, Level = 25, Location = 034, }, // Castform @ Weather Institute
             new EncounterStatic { Gift = true, Species = 374, Level = 5, Location = 013, }, // Beldum @ Mossdeep City
-            new EncounterStatic { Gift = true, Species = 360, Level = 5, }, // Wynaut Egg
+            new EncounterStatic { Gift = true, Species = 360, Level = 5, EggLocation = 253}, // Wynaut Egg
 
             //Stationary
             new EncounterStatic { Species = 352, Level = 30, Location = 034, }, //Kecleon @ Route 119
@@ -213,7 +213,7 @@ namespace PKHeX.Core
             new EncounterStatic { Gift = true, Species = 129, Level = 5, Location = 099, }, // Magikarp @ Route 4
             new EncounterStatic { Gift = true, Species = 131, Level = 25, Location = 134, }, // Lapras @ Silph Co.
             new EncounterStatic { Gift = true, Species = 133, Level = 25, Location = 094, }, // Eevee @ Celadon City
-            new EncounterStatic { Gift = true, Species = 175, Level = 5, }, // Togepi Egg
+            new EncounterStatic { Gift = true, Species = 175, Level = 5, EggLocation = 253 }, // Togepi Egg
 
             //Stationary
             new EncounterStatic { Species = 143, Level = 30, Location = 112, }, //Snorlax @ Route 12

--- a/PKHeX/Legality/Tables3.cs
+++ b/PKHeX/Legality/Tables3.cs
@@ -143,101 +143,157 @@ namespace PKHeX.Core
         internal static readonly int[] Tutor_E = {038, 223, 153, 210, 118, 102, 205, 214, 164, 207};
         internal static readonly int[] Tutor_FRLG = {034, 068, 038, 138, 153, 025, 005, 118, 102, 157, 069, 135, 164, 014, 086};
 
+        internal static readonly int[] Roaming_MetLocation_FRLG =
+        {
+            // TODO: Check if roaming encounter is possible in route 21
+            101, // Route 1
+            102, // Route 2
+            103, // Route 3
+            104, // Route 4
+            105, // Route 5
+            106, // Route 6
+            107, // Route 7
+            108, // Route 8
+            109, // Route 9
+            110, // Route 10
+            111, // Route 11
+            112, // Route 12
+            113, // Route 13
+            114, // Route 14
+            115, // Route 15
+            116, // Route 16
+            117, // Route 17
+            118, // Route 18
+            // Routes 19 and 20 only have surf encounters
+            121, // Route 21 Grass encounter in water route
+            122, // Route 22
+            123, // Route 23
+            124, // Route 24
+            125, // Route 25
+            // Kanto route 26 does not exits in gen 3
+        };
+
+        internal static readonly int[] Roaming_MetLocation_RSE =
+        {
+            // TODO: Check if roaming encounter is possible in routes 11, 119 and 120
+            16, // Route 101
+            17, // Route 102
+            18, // Route 103
+            19, // Route 104
+            // Routes 105 to 109 only have surf encounters
+            25, // Route 110
+            26, // Route 111 Deep sand
+            27, // Route 112
+            28, // Route 113
+            29, // Route 114
+            30, // Route 115
+            31, // Route 116
+            32, // Route 117
+            33, // Route 118
+            34, // Route 119 Long grass
+            35, // Route 120 Long grass
+            36, // Route 121
+            // Routes 122 only have surf encounters
+            38, // Route 123
+            // Routes 124 to 129 only have surf encounters
+            // Route 130 only have grass inMirage Island
+            // Routes 132 to 134 only have surf encounters
+        };
+
         internal static readonly EncounterStatic[] Encounter_RSE =
-        {
-            //Starters 
-            new EncounterStatic { Gift = true, Species = 152, Level = 5, Location = 000, Version = GameVersion.E, }, // Chikorita @ Littleroot Town
-            new EncounterStatic { Gift = true, Species = 155, Level = 5, Location = 000, Version = GameVersion.E, }, // Cyndaquil
-            new EncounterStatic { Gift = true, Species = 158, Level = 5, Location = 000, Version = GameVersion.E, }, // Totodile
-            new EncounterStatic { Gift = true, Species = 252, Level = 5, Location = 016, }, // Treecko @ Route 101
-            new EncounterStatic { Gift = true, Species = 255, Level = 5, Location = 016, }, // Torchic
-            new EncounterStatic { Gift = true, Species = 258, Level = 5, Location = 016, }, // Mudkip
+            (new EncounterStatic { Species = 380, Level = 40, Version = GameVersion.S, Roaming = true, }).Clone(Roaming_MetLocation_RSE).Concat( //Latias
+            (new EncounterStatic { Species = 380, Level = 40, Version = GameVersion.E, Roaming = true, }).Clone(Roaming_MetLocation_RSE)).Concat( //Latias
+            (new EncounterStatic { Species = 381, Level = 40, Version = GameVersion.R, Roaming = true, }).Clone(Roaming_MetLocation_RSE)).Concat( //Latios
+            (new EncounterStatic { Species = 381, Level = 40, Version = GameVersion.E, Roaming = true, }).Clone(Roaming_MetLocation_RSE)).Concat( //Latios
+            new EncounterStatic[]
+            {
+                //Starters 
+                new EncounterStatic { Gift = true, Species = 152, Level = 5, Location = 000, Version = GameVersion.E, }, // Chikorita @ Littleroot Town
+                new EncounterStatic { Gift = true, Species = 155, Level = 5, Location = 000, Version = GameVersion.E, }, // Cyndaquil
+                new EncounterStatic { Gift = true, Species = 158, Level = 5, Location = 000, Version = GameVersion.E, }, // Totodile
+                new EncounterStatic { Gift = true, Species = 252, Level = 5, Location = 016, }, // Treecko @ Route 101
+                new EncounterStatic { Gift = true, Species = 255, Level = 5, Location = 016, }, // Torchic
+                new EncounterStatic { Gift = true, Species = 258, Level = 5, Location = 016, }, // Mudkip
 
-            //Fossil @ Rustboro City
-            new EncounterStatic { Gift = true, Species = 345, Level = 20, Location = 010, }, // Lileep
-            new EncounterStatic { Gift = true, Species = 347, Level = 20, Location = 010, }, // Anorith
+                //Fossil @ Rustboro City
+                new EncounterStatic { Gift = true, Species = 345, Level = 20, Location = 010, }, // Lileep
+                new EncounterStatic { Gift = true, Species = 347, Level = 20, Location = 010, }, // Anorith
 
-            //Gift
-            new EncounterStatic { Gift = true, Species = 351, Level = 25, Location = 034, }, // Castform @ Weather Institute
-            new EncounterStatic { Gift = true, Species = 374, Level = 5, Location = 013, }, // Beldum @ Mossdeep City
-            new EncounterStatic { Gift = true, Species = 360, Level = 5, EggLocation = 253}, // Wynaut Egg
+                //Gift
+                new EncounterStatic { Gift = true, Species = 351, Level = 25, Location = 034, }, // Castform @ Weather Institute
+                new EncounterStatic { Gift = true, Species = 374, Level = 5, Location = 013, }, // Beldum @ Mossdeep City
+                new EncounterStatic { Gift = true, Species = 360, Level = 5, EggLocation = 253}, // Wynaut Egg
 
-            //Stationary
-            new EncounterStatic { Species = 352, Level = 30, Location = 034, }, //Kecleon @ Route 119
-            new EncounterStatic { Species = 352, Level = 30, Location = 035, }, //Kecleon @ Route 120
-            new EncounterStatic { Species = 101, Level = 30, Location = 066, Version = GameVersion.RS, }, //Electrode @ Hideout (R:Magma Hideout/S:Aqua Hideout)
-            new EncounterStatic { Species = 101, Level = 30, Location = 197, Version = GameVersion.E, }, //Electrode @ Aqua Hideout
-            new EncounterStatic { Species = 185, Level = 40, Location = 058, Version = GameVersion.E, }, //Sudowoodo @ Battle Frontier
+                //Stationary
+                new EncounterStatic { Species = 352, Level = 30, Location = 034, }, //Kecleon @ Route 119
+                new EncounterStatic { Species = 352, Level = 30, Location = 035, }, //Kecleon @ Route 120
+                new EncounterStatic { Species = 101, Level = 30, Location = 066, Version = GameVersion.RS, }, //Electrode @ Hideout (R:Magma Hideout/S:Aqua Hideout)
+                new EncounterStatic { Species = 101, Level = 30, Location = 197, Version = GameVersion.E, }, //Electrode @ Aqua Hideout
+                new EncounterStatic { Species = 185, Level = 40, Location = 058, Version = GameVersion.E, }, //Sudowoodo @ Battle Frontier
 
-            //Stationary Lengendary
-            new EncounterStatic { Species = 377, Level = 40, Location = 082, }, //Regirock @ Desert Ruins
-            new EncounterStatic { Species = 378, Level = 40, Location = 081, }, //Regice @ Island Cave
-            new EncounterStatic { Species = 379, Level = 40, Location = 083, }, //Registeel @ Ancient Tomb
-            new EncounterStatic { Species = 380, Level = 50, Location = 073, Version = GameVersion.R, }, //Latias @ Southern Island
-            new EncounterStatic { Species = 380, Level = 50, Location = 073, Version = GameVersion.E, }, //Latias @ Southern Island
-            new EncounterStatic { Species = 381, Level = 50, Location = 073, Version = GameVersion.S, }, //Latios @ Southern Island
-            new EncounterStatic { Species = 381, Level = 50, Location = 073, Version = GameVersion.E, }, //Latios @ Southern Island
-            new EncounterStatic { Species = 382, Level = 45, Location = 072, Version = GameVersion.S, }, //Kyogre @ Cave of Origin
-            new EncounterStatic { Species = 382, Level = 70, Location = 203, Version = GameVersion.E, }, //Kyogre @ Marine Cave
-            new EncounterStatic { Species = 383, Level = 45, Location = 072, Version = GameVersion.R, }, //Groudon @ Cave of Origin
-            new EncounterStatic { Species = 383, Level = 70, Location = 205, Version = GameVersion.E, }, //Groudon @ Terra Cave
-            new EncounterStatic { Species = 384, Level = 70, Location = 085, }, //Rayquaza @ Sky Pillar
+                //Stationary Lengendary
+                new EncounterStatic { Species = 377, Level = 40, Location = 082, }, //Regirock @ Desert Ruins
+                new EncounterStatic { Species = 378, Level = 40, Location = 081, }, //Regice @ Island Cave
+                new EncounterStatic { Species = 379, Level = 40, Location = 083, }, //Registeel @ Ancient Tomb
+                new EncounterStatic { Species = 380, Level = 50, Location = 073, Version = GameVersion.R, }, //Latias @ Southern Island
+                new EncounterStatic { Species = 380, Level = 50, Location = 073, Version = GameVersion.E, }, //Latias @ Southern Island
+                new EncounterStatic { Species = 381, Level = 50, Location = 073, Version = GameVersion.S, }, //Latios @ Southern Island
+                new EncounterStatic { Species = 381, Level = 50, Location = 073, Version = GameVersion.E, }, //Latios @ Southern Island
+                new EncounterStatic { Species = 382, Level = 45, Location = 072, Version = GameVersion.S, }, //Kyogre @ Cave of Origin
+                new EncounterStatic { Species = 382, Level = 70, Location = 203, Version = GameVersion.E, }, //Kyogre @ Marine Cave
+                new EncounterStatic { Species = 383, Level = 45, Location = 072, Version = GameVersion.R, }, //Groudon @ Cave of Origin
+                new EncounterStatic { Species = 383, Level = 70, Location = 205, Version = GameVersion.E, }, //Groudon @ Terra Cave
+                new EncounterStatic { Species = 384, Level = 70, Location = 085, }, //Rayquaza @ Sky Pillar
 
-            //Event
-            new EncounterStatic { Species = 151, Level = 30, Location = 201, Version = GameVersion.E, }, //Mew @ Faraway Island
-            new EncounterStatic { Species = 249, Level = 70, Location = 211, Version = GameVersion.E, }, //Lugia @ Navel Rock
-            new EncounterStatic { Species = 250, Level = 70, Location = 211, Version = GameVersion.E, }, //Ho-Oh @ Navel Rock
-            new EncounterStatic { Species = 386, Form = 3, Level = 30, Location = 200, Version = GameVersion.E, }, //Deoxys @ Birth Island
+                //Event
+                new EncounterStatic { Species = 151, Level = 30, Location = 201, Version = GameVersion.E, }, //Mew @ Faraway Island
+                new EncounterStatic { Species = 249, Level = 70, Location = 211, Version = GameVersion.E, }, //Lugia @ Navel Rock
+                new EncounterStatic { Species = 250, Level = 70, Location = 211, Version = GameVersion.E, }, //Ho-Oh @ Navel Rock
+                new EncounterStatic { Species = 386, Form = 3, Level = 30, Location = 200, Version = GameVersion.E, }, //Deoxys @ Birth Island
+            }).ToArray();
 
-            //Roaming
-            new EncounterStatic { Species = 380, Level = 40, Version = GameVersion.S, }, //Latias
-            new EncounterStatic { Species = 380, Level = 40, Version = GameVersion.E, }, //Latias
-            new EncounterStatic { Species = 381, Level = 40, Version = GameVersion.R, }, //Latios
-            new EncounterStatic { Species = 381, Level = 40, Version = GameVersion.E, }, //Latios
-        };
         internal static readonly EncounterStatic[] Encounter_FRLG =
-        {
-            //Starters @ Pallet Town
-            new EncounterStatic { Gift = true, Species = 1, Level = 5, Location = 088, }, // Bulbasaur 
-            new EncounterStatic { Gift = true, Species = 4, Level = 5, Location = 088, }, // Charmander
-            new EncounterStatic { Gift = true, Species = 9, Level = 5, Location = 088, }, // Squirtle
+            (new EncounterStatic { Species = 243, Level = 50, Roaming = true, }).Clone(Roaming_MetLocation_FRLG).Concat( //Raikou
+            (new EncounterStatic { Species = 244, Level = 50, Roaming = true, }).Clone(Roaming_MetLocation_FRLG)).Concat( //Entei
+            (new EncounterStatic { Species = 245, Level = 50, Roaming = true, }).Clone(Roaming_MetLocation_FRLG)).Concat( //Suicune
+            new EncounterStatic[]
+            {
+                //Starters @ Pallet Town
+                new EncounterStatic { Gift = true, Species = 1, Level = 5, Location = 088, }, // Bulbasaur 
+                new EncounterStatic { Gift = true, Species = 4, Level = 5, Location = 088, }, // Charmander
+                new EncounterStatic { Gift = true, Species = 9, Level = 5, Location = 088, }, // Squirtle
 
-            //Fossil @ Cinnabar Island
-            new EncounterStatic { Gift = true, Species = 138, Level = 30, Location = 096, }, // Omanyte
-            new EncounterStatic { Gift = true, Species = 140, Level = 30, Location = 096, }, // Kabuto
-            new EncounterStatic { Gift = true, Species = 142, Level = 30, Location = 096, }, // Aerodactyl
+                //Fossil @ Cinnabar Island
+                new EncounterStatic { Gift = true, Species = 138, Level = 30, Location = 096, }, // Omanyte
+                new EncounterStatic { Gift = true, Species = 140, Level = 30, Location = 096, }, // Kabuto
+                new EncounterStatic { Gift = true, Species = 142, Level = 30, Location = 096, }, // Aerodactyl
 
-            //Gift
-            new EncounterStatic { Gift = true, Species = 106, Level = 25, Location = 098, }, // Hitmonlee @ Saffron City
-            new EncounterStatic { Gift = true, Species = 107, Level = 25, Location = 098, }, // Hitmonchan @ Saffron City
-            new EncounterStatic { Gift = true, Species = 129, Level = 5, Location = 099, }, // Magikarp @ Route 4
-            new EncounterStatic { Gift = true, Species = 131, Level = 25, Location = 134, }, // Lapras @ Silph Co.
-            new EncounterStatic { Gift = true, Species = 133, Level = 25, Location = 094, }, // Eevee @ Celadon City
-            new EncounterStatic { Gift = true, Species = 175, Level = 5, EggLocation = 253 }, // Togepi Egg
+                //Gift
+                new EncounterStatic { Gift = true, Species = 106, Level = 25, Location = 098, }, // Hitmonlee @ Saffron City
+                new EncounterStatic { Gift = true, Species = 107, Level = 25, Location = 098, }, // Hitmonchan @ Saffron City
+                new EncounterStatic { Gift = true, Species = 129, Level = 5, Location = 099, }, // Magikarp @ Route 4
+                new EncounterStatic { Gift = true, Species = 131, Level = 25, Location = 134, }, // Lapras @ Silph Co.
+                new EncounterStatic { Gift = true, Species = 133, Level = 25, Location = 094, }, // Eevee @ Celadon City
+                new EncounterStatic { Gift = true, Species = 175, Level = 5, EggLocation = 253 }, // Togepi Egg
 
-            //Stationary
-            new EncounterStatic { Species = 143, Level = 30, Location = 112, }, //Snorlax @ Route 12
-            new EncounterStatic { Species = 143, Level = 30, Location = 116, }, //Snorlax @ Route 16
-            new EncounterStatic { Species = 101, Level = 34, Location = 142, }, //Electrode @ Power Plant
-            new EncounterStatic { Species = 097, Level = 30, Location = 176, }, //Hypno @ Berry Forest
+                //Stationary
+                new EncounterStatic { Species = 143, Level = 30, Location = 112, }, //Snorlax @ Route 12
+                new EncounterStatic { Species = 143, Level = 30, Location = 116, }, //Snorlax @ Route 16
+                new EncounterStatic { Species = 101, Level = 34, Location = 142, }, //Electrode @ Power Plant
+                new EncounterStatic { Species = 097, Level = 30, Location = 176, }, //Hypno @ Berry Forest
 
-            //Stationary Lengerdary
-            new EncounterStatic { Species = 144, Level = 50, Location = 139, }, //Articuno @ Seafoam Islands
-            new EncounterStatic { Species = 145, Level = 50, Location = 142, }, //Zapdos @ Power Plant
-            new EncounterStatic { Species = 146, Level = 50, Location = 175, }, //Moltres @ Mt. Ember. 
-            new EncounterStatic { Species = 150, Level = 70, Location = 141, }, //Mewtwo @ Cerulean Cave
+                //Stationary Lengerdary
+                new EncounterStatic { Species = 144, Level = 50, Location = 139, }, //Articuno @ Seafoam Islands
+                new EncounterStatic { Species = 145, Level = 50, Location = 142, }, //Zapdos @ Power Plant
+                new EncounterStatic { Species = 146, Level = 50, Location = 175, }, //Moltres @ Mt. Ember. 
+                new EncounterStatic { Species = 150, Level = 70, Location = 141, }, //Mewtwo @ Cerulean Cave
 
-            //Event
-            new EncounterStatic { Species = 249, Level = 70, Location = 174, }, //Lugia @ Navel Rock
-            new EncounterStatic { Species = 250, Level = 70, Location = 174, }, //Ho-Oh @ Navel Rock
-            new EncounterStatic { Species = 386, Form = 1, Level = 30, Location = 187, Version = GameVersion.FR, }, //Deoxys @ Birth Island
-            new EncounterStatic { Species = 386, Form = 2, Level = 30, Location = 187, Version = GameVersion.LG, }, //Deoxys @ Birth Island
-
-            //Roaming
-            new EncounterStatic { Species = 243, Level = 50, }, //Raikou
-            new EncounterStatic { Species = 244, Level = 50, }, //Entei
-            new EncounterStatic { Species = 245, Level = 50, }, //Suicune
-        };
+                //Event
+                new EncounterStatic { Species = 249, Level = 70, Location = 174, }, //Lugia @ Navel Rock
+                new EncounterStatic { Species = 250, Level = 70, Location = 174, }, //Ho-Oh @ Navel Rock
+                new EncounterStatic { Species = 386, Form = 1, Level = 30, Location = 187, Version = GameVersion.FR, }, //Deoxys @ Birth Island
+                new EncounterStatic { Species = 386, Form = 2, Level = 30, Location = 187, Version = GameVersion.LG, }, //Deoxys @ Birth Island
+            }).ToArray();
 
         private static readonly int[] TradeContest_Cool =   {30, 05, 05, 05, 05, 10};
         private static readonly int[] TradeContest_Beauty = {05, 30, 05, 05, 05, 10};

--- a/PKHeX/Legality/Tables3.cs
+++ b/PKHeX/Legality/Tables3.cs
@@ -274,12 +274,77 @@ namespace PKHeX.Core
         #region AltSlots
         private static readonly EncounterArea[] SlotsRSEAlt =
         {
+            // Swarm can be passed from one game to another via mixing records, that means emerald swarms can occurs in r/s and r/s swarms in emerald
+            // Ruby and Sapphire Swarm
+            new EncounterArea {
+                Location = 17, // Route 102
+                Slots = new[]
+                {
+                    new EncounterSlot { Species = 283, LevelMin = 3, LevelMax = 3, Type = SlotType.Grass}, // Surskit
+                },},
+            new EncounterArea {
+                Location = 29, // Route 114
+                Slots = new[]
+                {
+                    new EncounterSlot { Species = 283, LevelMin = 15, LevelMax = 15, Type = SlotType.Grass}, // Surskit
+                },},
+            new EncounterArea {
+                Location = 31, // Route 116
+                Slots = new[]
+                {
+                    new EncounterSlot { Species = 300, LevelMin = 15, LevelMax = 15, Type = SlotType.Grass}, // Skitty
+                },},
+            new EncounterArea {
+                Location = 32, // Route 117
+                Slots = new[]
+                {
+                    new EncounterSlot { Species = 283, LevelMin = 15, LevelMax = 15, Type = SlotType.Grass}, // Surskit
+                },},
+            new EncounterArea {
+                Location = 35, // Route 120
+                Slots = new[]
+                {
+                    new EncounterSlot { Species = 283, LevelMin = 28, LevelMax = 28, Type = SlotType.Grass}, // Surskit
+                },},
+
+            //Emerald Swarm
+            new EncounterArea {
+                Location = 17, // Route 102
+                Slots = new[]
+                {
+                    new EncounterSlot { Species = 273, LevelMin = 3, LevelMax = 3, Type = SlotType.Grass}, // Seedot
+                },},
+            new EncounterArea {
+                Location = 29, // Route 114
+                Slots = new[]
+                {
+                    new EncounterSlot { Species = 274, LevelMin = 15, LevelMax = 15, Type = SlotType.Grass}, // Nuzleaf
+                },},
+            new EncounterArea {
+                Location = 31, // Route 116
+                Slots = new[]
+                {
+                    new EncounterSlot { Species = 300, LevelMin = 8, LevelMax = 8, Type = SlotType.Grass}, // Skitty
+                },},
+            new EncounterArea {
+                Location = 32, // Route 117
+                Slots = new[]
+                {
+                    new EncounterSlot { Species = 273, LevelMin = 13, LevelMax = 13, Type = SlotType.Grass}, // Seedot
+                },},
+            new EncounterArea {
+                Location = 35, // Route 120
+                Slots = new[]
+                {
+                    new EncounterSlot { Species = 273, LevelMin = 25, LevelMax = 25, Type = SlotType.Grass}, // Seedot
+                },},
+            //Feebas fishing spot
             new EncounterArea {
                 Location = 34, // Route 119
                 Slots = new[]
                 {
-                    new EncounterSlot { Species = 349, LevelMin = 20, LevelMax = 25, Type = SlotType.Super_Rod, Form = 25 }, // Feebas
-                },}
+                    new EncounterSlot { Species = 349, LevelMin = 20, LevelMax = 25, Type = SlotType.Super_Rod } // Feebas
+                },},
         };
         private static readonly EncounterArea[] SlotsFRLGAlt =
         {

--- a/PKHeX/Legality/Tables4.cs
+++ b/PKHeX/Legality/Tables4.cs
@@ -170,6 +170,45 @@ namespace PKHeX.Core
             081, 366, 356, 388, 277, 272, 215, 067,
             143, 335, 450,
         };
+
+        internal static readonly EncounterStatic[] Encounter_HGSS_Swarm =
+        {
+            //Swarm 
+            //reference http://bulbapedia.bulbagarden.net/wiki/Pokémon_outbreak
+            new EncounterStatic { Species = 113, Level = 23, Location = 161, }, //Chansey @ Route 13
+            new EncounterStatic { Species = 132, Level = 34, Location = 195, }, //Ditto @ Route 47
+            new EncounterStatic { Species = 183, Level = 15, Location = 216, }, //Marill @ Mt. Mortar
+            new EncounterStatic { Species = 193, Level = 12, Location = 183, }, //Yanma @ Route 35
+            new EncounterStatic { Species = 206, Level = 2, Location = 220, }, //Dunsparce @ Dark Cave
+            new EncounterStatic { Species = 206, Level = 3, Location = 220, }, //Dunsparce @ Dark Cave
+            new EncounterStatic { Species = 209, Level = 16, Location = 186, }, //Snubbull @ Route 38
+            new EncounterStatic { Species = 211, Level = 40, Location = 180, }, //Qwilfish @ Route 32
+            new EncounterStatic { Species = 223, Level = 20, Location = 192, }, //Remoraid @ Route 44
+            new EncounterStatic { Species = 261, Level = 2, Location = 149, }, //Poochyena @ Route 1
+            new EncounterStatic { Species = 278, Level = 35, Location = 143, }, //Wingull @ Vermillion City
+            new EncounterStatic { Species = 280, Level = 10, Location = 182, }, //Ralts @ Route 34
+            new EncounterStatic { Species = 280, Level = 11, Location = 182, }, //Ralts @ Route 34
+            new EncounterStatic { Species = 302, Level = 13, Location = 157, Version = GameVersion.HG,}, //Sableye @ Route 9
+            new EncounterStatic { Species = 302, Level = 14, Location = 157, Version = GameVersion.HG,}, //Sableye @ Route 9
+            new EncounterStatic { Species = 302, Level = 15, Location = 157, Version = GameVersion.HG,}, //Sableye @ Route 9
+            new EncounterStatic { Species = 303, Level = 13, Location = 157, Version = GameVersion.SS,}, //Mawile @ Route 9
+            new EncounterStatic { Species = 303, Level = 14, Location = 157, Version = GameVersion.SS,}, //Mawile @ Route 9
+            new EncounterStatic { Species = 303, Level = 15, Location = 157, Version = GameVersion.SS,}, //Mawile @ Route 9
+            new EncounterStatic { Species = 316, Level = 5, Location = 151, Version = GameVersion.SS,}, //Gulpin @ Route 3
+            new EncounterStatic { Species = 333, Level = 23, Location = 193, }, //Swablu @ Route 45
+            new EncounterStatic { Species = 340, Level = 10, Location = 128, }, //Whiscash @ Violet City Old Rod
+            new EncounterStatic { Species = 340, Level = 20, Location = 128, }, //Whiscash @ Violet City Good Rod
+            new EncounterStatic { Species = 340, Level = 40, Location = 128, }, //Whiscash @ Violet City Super Rod
+            new EncounterStatic { Species = 343, Level = 5, Location = 151, Version = GameVersion.HG,}, //Baltoy @ Route 3
+            new EncounterStatic { Species = 366, Level = 35, Location = 167, }, //Clamperl @ Route 19
+            new EncounterStatic { Species = 369, Level = 40, Location = 160, }, //Relicanth @ Route 12
+            new EncounterStatic { Species = 370, Level = 20, Location = 175, }, //Luvdisc @ Route 27
+            new EncounterStatic { Species = 401, Level = 3, Location = 224, }, //Kricketot @ Viridian Forest
+            new EncounterStatic { Species = 427, Level = 8, Location = 173, }, //Buneary @ Route 25
+            new EncounterStatic { Species = 427, Level = 9, Location = 173, }, //Buneary @ Route 25
+            new EncounterStatic { Species = 427, Level = 10, Location = 173, }, //Buneary @ Route 25
+        };
+
         internal static readonly EncounterStatic[] Encounter_DPPt =
         {
             //Starters
@@ -227,76 +266,6 @@ namespace PKHeX.Core
             new EncounterStatic { Species = 144, Level = 60, Version = GameVersion.Pt, }, //Articuno
             new EncounterStatic { Species = 145, Level = 60, Version = GameVersion.Pt, }, //Zapdos
             new EncounterStatic { Species = 146, Level = 60, Version = GameVersion.Pt, }, //Moltres
-
-            //Swarm 
-            //reference http://bulbapedia.bulbagarden.net/wiki/Pokémon_outbreak
-            new EncounterStatic { Species = 016, Level = 51, Location = 044, Version = GameVersion.DP,}, //Pidgey @ Route 229
-            new EncounterStatic { Species = 081, Level = 28, Location = 049, Version = GameVersion.DP,}, //Magnemite @ Fuego Ironworks
-            new EncounterStatic { Species = 081, Level = 29, Location = 049, Version = GameVersion.DP,}, //Magnemite @ Fuego Ironworks
-            new EncounterStatic { Species = 083, Level = 28, Location = 036, Version = GameVersion.DP,}, //Farfetch'd @ Route 221
-            new EncounterStatic { Species = 083, Level = 28, Location = 036, Version = GameVersion.Pt,}, //Farfetch'd @ Route 221
-            new EncounterStatic { Species = 083, Level = 29, Location = 036, Version = GameVersion.Pt,}, //Farfetch'd @ Route 221
-            new EncounterStatic { Species = 084, Level = 2, Location = 016, }, //Doduo @ Route 201
-            new EncounterStatic { Species = 096, Level = 20, Location = 030, Version = GameVersion.DP,}, //Drowzee @ Route 215
-            new EncounterStatic { Species = 096, Level = 21, Location = 030, Version = GameVersion.DP,}, //Drowzee @ Route 215
-            new EncounterStatic { Species = 096, Level = 19, Location = 030, Version = GameVersion.Pt,}, //Drowzee @ Route 215
-            new EncounterStatic { Species = 096, Level = 20, Location = 030, Version = GameVersion.Pt,}, //Drowzee @ Route 215
-            new EncounterStatic { Species = 098, Level = 52, Location = 041, Version = GameVersion.DP,}, //Krabby @ Route 226
-            new EncounterStatic { Species = 098, Level = 48, Location = 041, Version = GameVersion.Pt,}, //Krabby @ Route 226
-            new EncounterStatic { Species = 098, Level = 49, Location = 041, Version = GameVersion.Pt,}, //Krabby @ Route 226
-            new EncounterStatic { Species = 100, Level = 28, Location = 033, Version = GameVersion.DP,}, //Voltorb @ Route 218
-            new EncounterStatic { Species = 100, Level = 28, Location = 033, Version = GameVersion.Pt,}, //Voltorb @ Route 218
-            new EncounterStatic { Species = 100, Level = 29, Location = 033, Version = GameVersion.Pt,}, //Voltorb @ Route 218
-            new EncounterStatic { Species = 104, Level = 4, Location = 018, }, //Cubone @ Route 203
-            new EncounterStatic { Species = 108, Level = 34, Location = 077, Version = GameVersion.DP,}, //Lickitung @ Lake Valor
-            new EncounterStatic { Species = 108, Level = 36, Location = 077, Version = GameVersion.DP,}, //Lickitung @ Lake Valor
-            new EncounterStatic { Species = 127, Level = 48, Location = 044, Version = GameVersion.Pt,}, //Pinsir @ Route 229
-            new EncounterStatic { Species = 127, Level = 49, Location = 044, Version = GameVersion.Pt,}, //Pinsir @ Route 229
-            new EncounterStatic { Species = 177, Level = 53, Location = 039, Version = GameVersion.DP,}, //Natu @ Route 224
-            new EncounterStatic { Species = 177, Level = 50, Location = 039, Version = GameVersion.Pt,}, //Natu @ Route 224
-            new EncounterStatic { Species = 206, Level = 16, Location = 023, Version = GameVersion.DP,}, //Dunsparce @ Route 208
-            new EncounterStatic { Species = 206, Level = 18, Location = 023, Version = GameVersion.Pt,}, //Dunsparce @ Route 208
-            new EncounterStatic { Species = 209, Level = 16, Location = 024, Version = GameVersion.DP,}, //Snubbull @ Route 209
-            new EncounterStatic { Species = 209, Level = 18, Location = 024, Version = GameVersion.Pt,}, //Snubbull @ Route 209
-            new EncounterStatic { Species = 209, Level = 19, Location = 024, Version = GameVersion.Pt,}, //Snubbull @ Route 209
-            new EncounterStatic { Species = 220, Level = 34, Location = 032, Version = GameVersion.DP,}, //Swinub @ Route 217
-            new EncounterStatic { Species = 222, Level = 50, Location = 045, Version = GameVersion.DP,}, //Corsola @ Route 230
-            new EncounterStatic { Species = 222, Level = 48, Location = 045, Version = GameVersion.Pt,}, //Corsola @ Route 230
-            new EncounterStatic { Species = 225, Level = 32, Location = 031, Version = GameVersion.DP,}, //Delibird @ Route 216
-            new EncounterStatic { Species = 225, Level = 32, Location = 032, Version = GameVersion.Pt,}, //Delibird @ Route 217
-            new EncounterStatic { Species = 225, Level = 33, Location = 032, Version = GameVersion.Pt,}, //Delibird @ Route 217
-            new EncounterStatic { Species = 231, Level = 5, Location = 022, Version = GameVersion.DP,}, //Phanpy @ Route 207
-            new EncounterStatic { Species = 231, Level = 5, Location = 022, Version = GameVersion.Pt,}, //Phanpy @ Route 207
-            new EncounterStatic { Species = 231, Level = 7, Location = 022, Version = GameVersion.Pt,}, //Phanpy @ Route 207
-            new EncounterStatic { Species = 238, Level = 35, Location = 078, Version = GameVersion.DP,}, //Smoochum @ Lake Acuity
-            new EncounterStatic { Species = 246, Level = 16, Location = 021, Version = GameVersion.Pt,}, //Larvitar @ Route 206
-            new EncounterStatic { Species = 263, Level = 3, Location = 017,}, //Zigzagoon @ Route 202
-            new EncounterStatic { Species = 283, Level = 2, Location = 076, Version = GameVersion.DP,}, //Surskit @ Lake Verity
-            new EncounterStatic { Species = 287, Level = 10, Location = 048, Version = GameVersion.DP,}, //Slakoth @ Eterna Forest
-            new EncounterStatic { Species = 287, Level = 10, Location = 048, Version = GameVersion.Pt,}, //Slakoth @ Eterna Forest
-            new EncounterStatic { Species = 287, Level = 11, Location = 048, Version = GameVersion.Pt,}, //Slakoth @ Eterna Forest
-            new EncounterStatic { Species = 296, Level = 50, Location = 040, Version = GameVersion.DP,}, //Makuhita @ Route 225
-            new EncounterStatic { Species = 296, Level = 51, Location = 040, Version = GameVersion.DP,}, //Makuhita @ Route 225
-            new EncounterStatic { Species = 296, Level = 48, Location = 040, Version = GameVersion.Pt,}, //Makuhita @ Route 225
-            new EncounterStatic { Species = 296, Level = 49, Location = 040, Version = GameVersion.Pt,}, //Makuhita @ Route 225
-            new EncounterStatic { Species = 299, Level = 14, Location = 021, Version = GameVersion.DP,}, //Nosepass @ Route 206
-            new EncounterStatic { Species = 300, Level = 40, Location = 037, Version = GameVersion.DP,}, //Skitty @ Route 222
-            new EncounterStatic { Species = 300, Level = 39, Location = 037, Version = GameVersion.Pt,}, //Skitty @ Route 222
-            new EncounterStatic { Species = 300, Level = 40, Location = 037, Version = GameVersion.Pt,}, //Skitty @ Route 222
-            new EncounterStatic { Species = 309, Level = 7, Location = 047, Version = GameVersion.DP,}, //Electrike @ Valley Windworks
-            new EncounterStatic { Species = 309, Level = 9, Location = 047, Version = GameVersion.Pt,}, //Electrike @ Valley Windworks
-            new EncounterStatic { Species = 309, Level = 10, Location = 047, Version = GameVersion.Pt,}, //Electrike @ Valley Windworks
-            new EncounterStatic { Species = 325, Level = 22, Location = 039, Version = GameVersion.DP,}, //Spoink @ Route 214
-            new EncounterStatic { Species = 325, Level = 23, Location = 039, Version = GameVersion.DP,}, //Spoink @ Route 214
-            new EncounterStatic { Species = 325, Level = 21, Location = 039, Version = GameVersion.Pt,}, //Spoink @ Route 214
-            new EncounterStatic { Species = 325, Level = 23, Location = 039, Version = GameVersion.Pt,}, //Spoink @ Route 214
-            new EncounterStatic { Species = 327, Level = 55, Location = 042, Version = GameVersion.DP,}, //Spinda @ Route 227
-            new EncounterStatic { Species = 327, Level = 53, Location = 042, Version = GameVersion.Pt,}, //Spinda @ Route 227
-            new EncounterStatic { Species = 327, Level = 54, Location = 042, Version = GameVersion.Pt,}, //Spinda @ Route 227
-            new EncounterStatic { Species = 359, Level = 20, Location = 028, Version = GameVersion.DP,}, //Absol @ Route 213
-            new EncounterStatic { Species = 374, Level = 53, Location = 043, Version = GameVersion.DP,}, //Beldum @ Route 228
-            new EncounterStatic { Species = 374, Level = 51, Location = 043, Version = GameVersion.Pt,}, //Beldum @ Route 228
-            new EncounterStatic { Species = 374, Level = 52, Location = 043, Version = GameVersion.Pt,}, //Beldum @ Route 228
         };
         internal static readonly EncounterStatic[] Encounter_HGSS =
         {
@@ -356,40 +325,6 @@ namespace PKHeX.Core
             new EncounterStatic { Species = 483, Level = 1, Location = 231, }, //Dialga @ Sinjoh Ruins
             new EncounterStatic { Species = 484, Level = 1, Location = 231, }, //Palkia @ Sinjoh Ruins
             new EncounterStatic { Species = 487, Level = 1, Location = 231, Form = 1}, //Giratina @ Sinjoh Ruins
-
-            //Swarm
-            new EncounterStatic { Species = 113, Level = 23, Location = 161, }, //Chansey @ Route 13
-            new EncounterStatic { Species = 132, Level = 34, Location = 195, }, //Ditto @ Route 47
-            new EncounterStatic { Species = 183, Level = 15, Location = 216, }, //Marill @ Mt. Mortar
-            new EncounterStatic { Species = 193, Level = 12, Location = 183, }, //Yanma @ Route 35
-            new EncounterStatic { Species = 206, Level = 2, Location = 220, }, //Dunsparce @ Dark Cave
-            new EncounterStatic { Species = 206, Level = 3, Location = 220, }, //Dunsparce @ Dark Cave
-            new EncounterStatic { Species = 209, Level = 16, Location = 186, }, //Snubbull @ Route 38
-            new EncounterStatic { Species = 211, Level = 40, Location = 180, }, //Qwilfish @ Route 32
-            new EncounterStatic { Species = 223, Level = 20, Location = 192, }, //Remoraid @ Route 44
-            new EncounterStatic { Species = 261, Level = 2, Location = 149, }, //Poochyena @ Route 1
-            new EncounterStatic { Species = 278, Level = 35, Location = 143, }, //Wingull @ Vermillion City
-            new EncounterStatic { Species = 280, Level = 10, Location = 182, }, //Ralts @ Route 34
-            new EncounterStatic { Species = 280, Level = 11, Location = 182, }, //Ralts @ Route 34
-            new EncounterStatic { Species = 302, Level = 13, Location = 157, Version = GameVersion.HG,}, //Sableye @ Route 9
-            new EncounterStatic { Species = 302, Level = 14, Location = 157, Version = GameVersion.HG,}, //Sableye @ Route 9
-            new EncounterStatic { Species = 302, Level = 15, Location = 157, Version = GameVersion.HG,}, //Sableye @ Route 9
-            new EncounterStatic { Species = 303, Level = 13, Location = 157, Version = GameVersion.SS,}, //Mawile @ Route 9
-            new EncounterStatic { Species = 303, Level = 14, Location = 157, Version = GameVersion.SS,}, //Mawile @ Route 9
-            new EncounterStatic { Species = 303, Level = 15, Location = 157, Version = GameVersion.SS,}, //Mawile @ Route 9
-            new EncounterStatic { Species = 316, Level = 5, Location = 151, Version = GameVersion.SS,}, //Gulpin @ Route 3
-            new EncounterStatic { Species = 333, Level = 23, Location = 193, }, //Swablu @ Route 45
-            new EncounterStatic { Species = 340, Level = 10, Location = 128, }, //Whiscash @ Violet City Old Rod
-            new EncounterStatic { Species = 340, Level = 20, Location = 128, }, //Whiscash @ Violet City Good Rod
-            new EncounterStatic { Species = 340, Level = 40, Location = 128, }, //Whiscash @ Violet City Super Rod
-            new EncounterStatic { Species = 343, Level = 5, Location = 151, Version = GameVersion.HG,}, //Baltoy @ Route 3
-            new EncounterStatic { Species = 366, Level = 35, Location = 167, }, //Clamperl @ Route 19
-            new EncounterStatic { Species = 369, Level = 40, Location = 160, }, //Relicanth @ Route 12
-            new EncounterStatic { Species = 370, Level = 20, Location = 175, }, //Luvdisc @ Route 27
-            new EncounterStatic { Species = 401, Level = 3, Location = 224, }, //Kricketot @ Viridian Forest
-            new EncounterStatic { Species = 427, Level = 8, Location = 173, }, //Buneary @ Route 25
-            new EncounterStatic { Species = 427, Level = 9, Location = 173, }, //Buneary @ Route 25
-            new EncounterStatic { Species = 427, Level = 10, Location = 173, }, //Buneary @ Route 25
 
             //Roaming
             new EncounterStatic { Species = 243, Level = 40, }, //Raikou
@@ -560,6 +495,458 @@ namespace PKHeX.Core
             49, // Fuego Ironworks
             58, //Floaroma Meadow
         };
+
+        private static readonly EncounterArea[] SlotsDPPT_Swarm =
+        {
+            //Swarm 
+            //reference http://bulbapedia.bulbagarden.net/wiki/Pokémon_outbreak
+            new EncounterArea
+            {
+                Location = 36, // Route 221
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 081, Type = SlotType.Grass }, // Farfetch'd
+                },
+            },
+            new EncounterArea
+            {
+                Location = 16, // Route 201
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 084, Type = SlotType.Grass }, // Doduo
+                },
+            },
+            new EncounterArea
+            {
+                Location = 30, // Route 215
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 096, Type = SlotType.Grass }, // Drowzee
+                },
+            },
+            new EncounterArea
+            {
+                Location = 41, // Route 226
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 098, Type = SlotType.Grass }, // Krabby
+                },
+            },
+            new EncounterArea
+            {
+                Location = 33, // Route 218
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 100, Type = SlotType.Grass }, // Voltorb
+                },
+            },
+            new EncounterArea
+            {
+                Location = 18, // Route 203
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 104, Type = SlotType.Grass }, // Cubone
+                },
+            },
+            new EncounterArea
+            {
+                Location = 39, // Route 224
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 177, Type = SlotType.Grass }, // Natu
+                },
+            },
+            new EncounterArea
+            {
+                Location = 23, // Route 208
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 206, Type = SlotType.Grass }, // Dunsparce
+                },
+            },
+            new EncounterArea
+            {
+                Location = 24, // Route 209
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 209, Type = SlotType.Grass }, // Snubbull
+                },
+            },
+            new EncounterArea
+            {
+                Location = 45, // Route 230
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 222, Type = SlotType.Grass }, // Corsola
+                },
+            },
+            new EncounterArea
+            {
+                Location = 31, // Route 216
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 225, Type = SlotType.Grass }, // Delibird
+                },
+            },
+            new EncounterArea
+            {
+                Location = 22, // Route 207
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 231, Type = SlotType.Grass }, // Phanpy
+                },
+            },
+            new EncounterArea
+            {
+                Location = 17, // Route 202
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 263, Type = SlotType.Grass }, // Zigzagoon
+                },
+            },
+            new EncounterArea
+            {
+                Location = 48, // Eterna Forest
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 287, Type = SlotType.Grass }, // Slakoth
+                },
+            },
+            new EncounterArea
+            {
+                Location = 40, // Route 225
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 296, Type = SlotType.Grass }, // Makuhita
+                },
+            },
+            new EncounterArea
+            {
+                Location = 37, // Route 222
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 300, Type = SlotType.Grass }, // Skitty
+                },
+            },
+            new EncounterArea
+            {
+                Location = 47, // Valley Windworks
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 309, Type = SlotType.Grass }, // Electrike
+                },
+            },
+            new EncounterArea
+            {
+                Location = 39, // Route 114
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 325, Type = SlotType.Grass }, // Spoink
+                },
+            },
+            new EncounterArea
+            {
+                Location = 42, // Route 227
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 327, Type = SlotType.Grass }, // Spinda
+                },
+            },
+            new EncounterArea
+            {
+                Location = 43, // Route 228
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 374, Type = SlotType.Grass }, // Beldum
+                },
+            },
+        };
+
+        private static readonly EncounterArea[] SlotsDP_Swarm = SlotsDPPT_Swarm.Concat(
+            new EncounterArea[] {
+                new EncounterArea
+                {
+                    Location = 44, // Route 229
+                    Slots = new[]
+                    {
+                         new EncounterSlot { Species = 016, Type = SlotType.Grass }, // Pidgey
+                    },
+                },
+                new EncounterArea
+                {
+                    Location = 49, // Fuego Ironworks
+                    Slots = new[]
+                    {
+                         new EncounterSlot { Species = 081, Type = SlotType.Grass }, // Magnemite
+                    },
+                },
+                new EncounterArea
+                {
+                    Location = 77, // Lake Valor
+                    Slots = new[]
+                    {
+                         new EncounterSlot { Species = 108, Type = SlotType.Grass }, // Lickitung
+                    },
+                },
+                new EncounterArea
+                {
+                    Location = 32, // Route 217
+                    Slots = new[]
+                    {
+                         new EncounterSlot { Species = 220, Type = SlotType.Grass }, // Swinub
+                    },
+                },
+                new EncounterArea
+                {
+                    Location = 78, // Lake Acuity
+                    Slots = new[]
+                    {
+                         new EncounterSlot { Species = 238, Type = SlotType.Grass }, // Smoochum
+                    },
+                },
+                new EncounterArea
+                {
+                    Location = 32, // Route 217
+                    Slots = new[]
+                    {
+                         new EncounterSlot { Species = 225, Type = SlotType.Grass }, // Delibird
+                    },
+                },
+                new EncounterArea
+                {
+                    Location = 76, // Lake Verity
+                    Slots = new[]
+                    {
+                         new EncounterSlot { Species = 283, Type = SlotType.Grass }, // Surskit
+                    },
+                },
+                new EncounterArea
+                {
+                    Location = 21, // Route 206
+                    Slots = new[]
+                    {
+                         new EncounterSlot { Species = 299, Type = SlotType.Grass }, // Nosepass
+                    },
+                },
+                new EncounterArea
+                {
+                    Location = 28, // Route 213
+                    Slots = new[]
+                    {
+                         new EncounterSlot { Species = 359, Type = SlotType.Grass }, // Absol
+                    },
+                },
+            }).ToArray();
+
+        private static readonly EncounterArea[] SlotsPt_Swarm = SlotsDPPT_Swarm.Concat(
+            new EncounterArea[] {
+                new EncounterArea
+                {
+                    Location = 44, // Route 229
+                    Slots = new[]
+                    {
+                            new EncounterSlot { Species = 127, Type = SlotType.Grass }, // Pinsir
+                    },
+                },
+                new EncounterArea
+                {
+                    Location = 21, // Route 206
+                    Slots = new[]
+                    {
+                            new EncounterSlot { Species = 246, Type = SlotType.Grass }, // Larvitar
+                    },
+                },
+            }).ToArray();
+
+        private static readonly EncounterArea[] SlotsHGSS_Swarm =
+        {
+            //Swarm 
+            //reference http://bulbapedia.bulbagarden.net/wiki/Pokémon_outbreak
+            new EncounterArea
+            {
+                Location = 161, // Route 113
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 113, Type = SlotType.Grass }, // Chansey
+                },
+            },
+            new EncounterArea
+            {
+                Location = 195, // Route 43
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 132, Type = SlotType.Grass }, // Ditto
+                },
+            },
+            new EncounterArea
+            {
+                Location = 216, // Mt. Mortar
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 189, Type = SlotType.Grass }, // Marill
+                },
+            },
+            new EncounterArea
+            {
+                Location = 183, // Route 35
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 193, Type = SlotType.Grass }, // Yanma
+                },
+            },
+            new EncounterArea
+            {
+                Location = 220, // Dark Cave
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 206, Type = SlotType.Grass }, // Dunsparce
+                },
+            },
+            new EncounterArea
+            {
+                Location = 186, // Route 38
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 209, Type = SlotType.Grass }, // Snubbull
+                },
+            },
+            new EncounterArea
+            {
+                Location = 180, // Route 32
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 211, Type = SlotType.Super_Rod }, // Qwilfish
+                },
+            },
+            new EncounterArea
+            {
+                Location = 192, // Route 44
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 223, Type = SlotType.Super_Rod }, // Remoraid
+                },
+            },
+            new EncounterArea
+            {
+                Location = 149, // Route 1
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 261, Type = SlotType.Grass }, // Poochyena
+                },
+            },
+            new EncounterArea
+            {
+                Location = 143, // Vermillion City
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 278, Type = SlotType.Surf }, // Wingull
+                },
+            },
+            new EncounterArea
+            {
+                Location = 182, // Route 34
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 280, Type = SlotType.Grass }, // Ralts
+                },
+            },
+            new EncounterArea
+            {
+                Location = 193, // Route 45
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 333, Type = SlotType.Grass }, // Swablu
+                },
+            },
+            new EncounterArea
+            {
+                Location = 128, // Violet City
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 340, Type = SlotType.Super_Rod }, // Whiscash
+                },
+            },
+            new EncounterArea
+            {
+                Location = 167, // Route 19
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 366, Type = SlotType.Surf }, // Clamperl
+                },
+            },
+            new EncounterArea
+            {
+                Location = 160, // Route 12
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 369, Type = SlotType.Super_Rod }, // Relicanth
+                },
+            },
+            new EncounterArea
+            {
+                Location = 175, // Route 27
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 370, Type = SlotType.Surf }, // Luvdisc
+                },
+            },
+            new EncounterArea
+            {
+                Location = 224, // Viridian Forest
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 401, Type = SlotType.Grass }, // Kricketot
+                },
+            },
+            new EncounterArea
+            {
+                Location = 173, // Route 25
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 427, Type = SlotType.Grass }, // Buneary
+                },
+            },
+        };
+
+        private static readonly EncounterArea[] SlotsHG_Swarm = SlotsHGSS_Swarm.Concat(
+            new EncounterArea[] {
+                new EncounterArea
+                {
+                    Location = 157, // Route 9
+                    Slots = new[]
+                    {
+                            new EncounterSlot { Species = 302, Type = SlotType.Grass }, // Sableye
+                    },
+                },
+                new EncounterArea
+                {
+                    Location = 151, // Route 3
+                    Slots = new[]
+                    {
+                            new EncounterSlot { Species = 343, Type = SlotType.Grass }, // Baltoy
+                    },
+                },
+            }).ToArray();
+
+        private static readonly EncounterArea[] SlotsSS_Swarm = SlotsHGSS_Swarm.Concat(
+            new EncounterArea[] {
+                new EncounterArea
+                {
+                    Location = 157, // Route 9
+                    Slots = new[]
+                    {
+                            new EncounterSlot { Species = 303, Type = SlotType.Grass }, // Mawile
+                    },
+                },
+                new EncounterArea
+                {
+                    Location = 151, // Route 3
+                    Slots = new[]
+                    {
+                            new EncounterSlot { Species = 316, Type = SlotType.Grass }, // Gulpin
+                    },
+                },
+            }).ToArray();
 
         #endregion
 

--- a/PKHeX/Legality/Tables4.cs
+++ b/PKHeX/Legality/Tables4.cs
@@ -502,14 +502,6 @@ namespace PKHeX.Core
             //reference http://bulbapedia.bulbagarden.net/wiki/Pokémon_outbreak
             new EncounterArea
             {
-                Location = 36, // Route 221
-                Slots = new[]
-                {
-                     new EncounterSlot { Species = 081, Type = SlotType.Grass }, // Farfetch'd
-                },
-            },
-            new EncounterArea
-            {
                 Location = 16, // Route 201
                 Slots = new[]
                 {
@@ -518,26 +510,10 @@ namespace PKHeX.Core
             },
             new EncounterArea
             {
-                Location = 30, // Route 215
+                Location = 17, // Route 202
                 Slots = new[]
                 {
-                     new EncounterSlot { Species = 096, Type = SlotType.Grass }, // Drowzee
-                },
-            },
-            new EncounterArea
-            {
-                Location = 41, // Route 226
-                Slots = new[]
-                {
-                     new EncounterSlot { Species = 098, Type = SlotType.Grass }, // Krabby
-                },
-            },
-            new EncounterArea
-            {
-                Location = 33, // Route 218
-                Slots = new[]
-                {
-                     new EncounterSlot { Species = 100, Type = SlotType.Grass }, // Voltorb
+                     new EncounterSlot { Species = 263, Type = SlotType.Grass }, // Zigzagoon
                 },
             },
             new EncounterArea
@@ -550,10 +526,10 @@ namespace PKHeX.Core
             },
             new EncounterArea
             {
-                Location = 39, // Route 224
+                Location = 22, // Route 207
                 Slots = new[]
                 {
-                     new EncounterSlot { Species = 177, Type = SlotType.Grass }, // Natu
+                     new EncounterSlot { Species = 231, Type = SlotType.Grass }, // Phanpy
                 },
             },
             new EncounterArea
@@ -574,10 +550,10 @@ namespace PKHeX.Core
             },
             new EncounterArea
             {
-                Location = 45, // Route 230
+                Location = 30, // Route 215
                 Slots = new[]
                 {
-                     new EncounterSlot { Species = 222, Type = SlotType.Grass }, // Corsola
+                     new EncounterSlot { Species = 096, Type = SlotType.Grass }, // Drowzee
                 },
             },
             new EncounterArea
@@ -590,34 +566,18 @@ namespace PKHeX.Core
             },
             new EncounterArea
             {
-                Location = 22, // Route 207
+                Location = 33, // Route 218
                 Slots = new[]
                 {
-                     new EncounterSlot { Species = 231, Type = SlotType.Grass }, // Phanpy
+                     new EncounterSlot { Species = 100, Type = SlotType.Grass }, // Voltorb
                 },
             },
             new EncounterArea
             {
-                Location = 17, // Route 202
+                Location = 36, // Route 221
                 Slots = new[]
                 {
-                     new EncounterSlot { Species = 263, Type = SlotType.Grass }, // Zigzagoon
-                },
-            },
-            new EncounterArea
-            {
-                Location = 48, // Eterna Forest
-                Slots = new[]
-                {
-                     new EncounterSlot { Species = 287, Type = SlotType.Grass }, // Slakoth
-                },
-            },
-            new EncounterArea
-            {
-                Location = 40, // Route 225
-                Slots = new[]
-                {
-                     new EncounterSlot { Species = 296, Type = SlotType.Grass }, // Makuhita
+                     new EncounterSlot { Species = 081, Type = SlotType.Grass }, // Farfetch'd
                 },
             },
             new EncounterArea
@@ -630,18 +590,27 @@ namespace PKHeX.Core
             },
             new EncounterArea
             {
-                Location = 47, // Valley Windworks
+                Location = 39, // Route 224
                 Slots = new[]
                 {
-                     new EncounterSlot { Species = 309, Type = SlotType.Grass }, // Electrike
+                     new EncounterSlot { Species = 177, Type = SlotType.Grass }, // Natu
+                     new EncounterSlot { Species = 325, Type = SlotType.Grass }, // Spoink
                 },
             },
             new EncounterArea
             {
-                Location = 39, // Route 114
+                Location = 40, // Route 225
                 Slots = new[]
                 {
-                     new EncounterSlot { Species = 325, Type = SlotType.Grass }, // Spoink
+                     new EncounterSlot { Species = 296, Type = SlotType.Grass }, // Makuhita
+                },
+            },
+            new EncounterArea
+            {
+                Location = 41, // Route 226
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 098, Type = SlotType.Grass }, // Krabby
                 },
             },
             new EncounterArea
@@ -660,10 +629,59 @@ namespace PKHeX.Core
                      new EncounterSlot { Species = 374, Type = SlotType.Grass }, // Beldum
                 },
             },
+            new EncounterArea
+            {
+                Location = 45, // Route 230
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 222, Type = SlotType.Grass }, // Corsola
+                },
+            },
+            new EncounterArea
+            {
+                Location = 47, // Valley Windworks
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 309, Type = SlotType.Grass }, // Electrike
+                },
+            },
+            new EncounterArea
+            {
+                Location = 48, // Eterna Forest
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 287, Type = SlotType.Grass }, // Slakoth
+                },
+            },
         };
 
         private static readonly EncounterArea[] SlotsDP_Swarm = SlotsDPPT_Swarm.Concat(
             new EncounterArea[] {
+                new EncounterArea
+                {
+                    Location = 21, // Route 206
+                    Slots = new[]
+                    {
+                         new EncounterSlot { Species = 299, Type = SlotType.Grass }, // Nosepass
+                    },
+                },
+                new EncounterArea
+                {
+                    Location = 28, // Route 213
+                    Slots = new[]
+                    {
+                         new EncounterSlot { Species = 359, Type = SlotType.Grass }, // Absol
+                    },
+                },
+                new EncounterArea
+                {
+                    Location = 32, // Route 217
+                    Slots = new[]
+                    {
+                         new EncounterSlot { Species = 220, Type = SlotType.Grass }, // Swinub
+                         new EncounterSlot { Species = 225, Type = SlotType.Grass }, // Delibird
+                    },
+                },
                 new EncounterArea
                 {
                     Location = 44, // Route 229
@@ -682,18 +700,18 @@ namespace PKHeX.Core
                 },
                 new EncounterArea
                 {
-                    Location = 77, // Lake Valor
+                    Location = 76, // Lake Verity
                     Slots = new[]
                     {
-                         new EncounterSlot { Species = 108, Type = SlotType.Grass }, // Lickitung
+                         new EncounterSlot { Species = 283, Type = SlotType.Grass }, // Surskit
                     },
                 },
                 new EncounterArea
                 {
-                    Location = 32, // Route 217
+                    Location = 77, // Lake Valor
                     Slots = new[]
                     {
-                         new EncounterSlot { Species = 220, Type = SlotType.Grass }, // Swinub
+                         new EncounterSlot { Species = 108, Type = SlotType.Grass }, // Lickitung
                     },
                 },
                 new EncounterArea
@@ -704,56 +722,24 @@ namespace PKHeX.Core
                          new EncounterSlot { Species = 238, Type = SlotType.Grass }, // Smoochum
                     },
                 },
-                new EncounterArea
-                {
-                    Location = 32, // Route 217
-                    Slots = new[]
-                    {
-                         new EncounterSlot { Species = 225, Type = SlotType.Grass }, // Delibird
-                    },
-                },
-                new EncounterArea
-                {
-                    Location = 76, // Lake Verity
-                    Slots = new[]
-                    {
-                         new EncounterSlot { Species = 283, Type = SlotType.Grass }, // Surskit
-                    },
-                },
-                new EncounterArea
-                {
-                    Location = 21, // Route 206
-                    Slots = new[]
-                    {
-                         new EncounterSlot { Species = 299, Type = SlotType.Grass }, // Nosepass
-                    },
-                },
-                new EncounterArea
-                {
-                    Location = 28, // Route 213
-                    Slots = new[]
-                    {
-                         new EncounterSlot { Species = 359, Type = SlotType.Grass }, // Absol
-                    },
-                },
             }).ToArray();
 
         private static readonly EncounterArea[] SlotsPt_Swarm = SlotsDPPT_Swarm.Concat(
             new EncounterArea[] {
                 new EncounterArea
                 {
-                    Location = 44, // Route 229
-                    Slots = new[]
-                    {
-                            new EncounterSlot { Species = 127, Type = SlotType.Grass }, // Pinsir
-                    },
-                },
-                new EncounterArea
-                {
                     Location = 21, // Route 206
                     Slots = new[]
                     {
                             new EncounterSlot { Species = 246, Type = SlotType.Grass }, // Larvitar
+                    },
+                },
+                new EncounterArea
+                {
+                    Location = 44, // Route 229
+                    Slots = new[]
+                    {
+                            new EncounterSlot { Species = 127, Type = SlotType.Grass }, // Pinsir
                     },
                 },
             }).ToArray();
@@ -764,10 +750,122 @@ namespace PKHeX.Core
             //reference http://bulbapedia.bulbagarden.net/wiki/Pokémon_outbreak
             new EncounterArea
             {
+                Location = 128, // Violet City
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 340, Type = SlotType.Old_Rod }, // Whiscash
+                     new EncounterSlot { Species = 340, Type = SlotType.Good_Rod }, // Whiscash
+                     new EncounterSlot { Species = 340, Type = SlotType.Super_Rod }, // Whiscash
+                },
+            },
+            new EncounterArea
+            {
+                Location = 143, // Vermillion City
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 278, Type = SlotType.Surf }, // Wingull
+                },
+            },
+            new EncounterArea
+            {
+                Location = 149, // Route 1
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 261, Type = SlotType.Grass }, // Poochyena
+                },
+            },
+            new EncounterArea
+            {
+                Location = 160, // Route 12
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 369, Type = SlotType.Old_Rod }, // Relicanth
+                     new EncounterSlot { Species = 369, Type = SlotType.Good_Rod }, // Relicanth
+                     new EncounterSlot { Species = 369, Type = SlotType.Super_Rod }, // Relicanth
+                },
+            },
+            new EncounterArea
+            {
                 Location = 161, // Route 113
                 Slots = new[]
                 {
                      new EncounterSlot { Species = 113, Type = SlotType.Grass }, // Chansey
+                },
+            },
+            new EncounterArea
+            {
+                Location = 167, // Route 19
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 366, Type = SlotType.Surf }, // Clamperl
+                },
+            },
+            new EncounterArea
+            {
+                Location = 173, // Route 25
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 427, Type = SlotType.Grass }, // Buneary
+                },
+            },
+            new EncounterArea
+            {
+                Location = 175, // Route 27
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 370, Type = SlotType.Surf }, // Luvdisc
+                },
+            },
+            new EncounterArea
+            {
+                Location = 180, // Route 32
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 211, Type = SlotType.Old_Rod }, // Qwilfish
+                     new EncounterSlot { Species = 211, Type = SlotType.Good_Rod }, // Qwilfish
+                     new EncounterSlot { Species = 211, Type = SlotType.Super_Rod }, // Qwilfish
+                },
+            },
+            new EncounterArea
+            {
+                Location = 182, // Route 34
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 280, Type = SlotType.Grass }, // Ralts
+                },
+            },
+            new EncounterArea
+            {
+                Location = 183, // Route 35
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 193, Type = SlotType.Grass }, // Yanma
+                },
+            },
+            new EncounterArea
+            {
+                Location = 186, // Route 38
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 209, Type = SlotType.Grass }, // Snubbull
+                },
+            },
+            new EncounterArea
+            {
+                Location = 192, // Route 44
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 223, Type = SlotType.Old_Rod }, // Remoraid
+                     new EncounterSlot { Species = 223, Type = SlotType.Good_Rod }, // Remoraid
+                     new EncounterSlot { Species = 223, Type = SlotType.Super_Rod }, // Remoraid
+                },
+            },
+            new EncounterArea
+            {
+                Location = 193, // Route 45
+                Slots = new[]
+                {
+                     new EncounterSlot { Species = 333, Type = SlotType.Grass }, // Swablu
                 },
             },
             new EncounterArea
@@ -788,106 +886,10 @@ namespace PKHeX.Core
             },
             new EncounterArea
             {
-                Location = 183, // Route 35
-                Slots = new[]
-                {
-                     new EncounterSlot { Species = 193, Type = SlotType.Grass }, // Yanma
-                },
-            },
-            new EncounterArea
-            {
                 Location = 220, // Dark Cave
                 Slots = new[]
                 {
                      new EncounterSlot { Species = 206, Type = SlotType.Grass }, // Dunsparce
-                },
-            },
-            new EncounterArea
-            {
-                Location = 186, // Route 38
-                Slots = new[]
-                {
-                     new EncounterSlot { Species = 209, Type = SlotType.Grass }, // Snubbull
-                },
-            },
-            new EncounterArea
-            {
-                Location = 180, // Route 32
-                Slots = new[]
-                {
-                     new EncounterSlot { Species = 211, Type = SlotType.Super_Rod }, // Qwilfish
-                },
-            },
-            new EncounterArea
-            {
-                Location = 192, // Route 44
-                Slots = new[]
-                {
-                     new EncounterSlot { Species = 223, Type = SlotType.Super_Rod }, // Remoraid
-                },
-            },
-            new EncounterArea
-            {
-                Location = 149, // Route 1
-                Slots = new[]
-                {
-                     new EncounterSlot { Species = 261, Type = SlotType.Grass }, // Poochyena
-                },
-            },
-            new EncounterArea
-            {
-                Location = 143, // Vermillion City
-                Slots = new[]
-                {
-                     new EncounterSlot { Species = 278, Type = SlotType.Surf }, // Wingull
-                },
-            },
-            new EncounterArea
-            {
-                Location = 182, // Route 34
-                Slots = new[]
-                {
-                     new EncounterSlot { Species = 280, Type = SlotType.Grass }, // Ralts
-                },
-            },
-            new EncounterArea
-            {
-                Location = 193, // Route 45
-                Slots = new[]
-                {
-                     new EncounterSlot { Species = 333, Type = SlotType.Grass }, // Swablu
-                },
-            },
-            new EncounterArea
-            {
-                Location = 128, // Violet City
-                Slots = new[]
-                {
-                     new EncounterSlot { Species = 340, Type = SlotType.Super_Rod }, // Whiscash
-                },
-            },
-            new EncounterArea
-            {
-                Location = 167, // Route 19
-                Slots = new[]
-                {
-                     new EncounterSlot { Species = 366, Type = SlotType.Surf }, // Clamperl
-                },
-            },
-            new EncounterArea
-            {
-                Location = 160, // Route 12
-                Slots = new[]
-                {
-                     new EncounterSlot { Species = 369, Type = SlotType.Super_Rod }, // Relicanth
-                },
-            },
-            new EncounterArea
-            {
-                Location = 175, // Route 27
-                Slots = new[]
-                {
-                     new EncounterSlot { Species = 370, Type = SlotType.Surf }, // Luvdisc
                 },
             },
             new EncounterArea
@@ -898,26 +900,10 @@ namespace PKHeX.Core
                      new EncounterSlot { Species = 401, Type = SlotType.Grass }, // Kricketot
                 },
             },
-            new EncounterArea
-            {
-                Location = 173, // Route 25
-                Slots = new[]
-                {
-                     new EncounterSlot { Species = 427, Type = SlotType.Grass }, // Buneary
-                },
-            },
         };
 
         private static readonly EncounterArea[] SlotsHG_Swarm = SlotsHGSS_Swarm.Concat(
             new EncounterArea[] {
-                new EncounterArea
-                {
-                    Location = 157, // Route 9
-                    Slots = new[]
-                    {
-                            new EncounterSlot { Species = 302, Type = SlotType.Grass }, // Sableye
-                    },
-                },
                 new EncounterArea
                 {
                     Location = 151, // Route 3
@@ -926,24 +912,32 @@ namespace PKHeX.Core
                             new EncounterSlot { Species = 343, Type = SlotType.Grass }, // Baltoy
                     },
                 },
+                new EncounterArea
+                {
+                    Location = 157, // Route 9
+                    Slots = new[]
+                    {
+                            new EncounterSlot { Species = 302, Type = SlotType.Grass }, // Sableye
+                    },
+                },
             }).ToArray();
 
         private static readonly EncounterArea[] SlotsSS_Swarm = SlotsHGSS_Swarm.Concat(
             new EncounterArea[] {
                 new EncounterArea
                 {
-                    Location = 157, // Route 9
-                    Slots = new[]
-                    {
-                            new EncounterSlot { Species = 303, Type = SlotType.Grass }, // Mawile
-                    },
-                },
-                new EncounterArea
-                {
                     Location = 151, // Route 3
                     Slots = new[]
                     {
                             new EncounterSlot { Species = 316, Type = SlotType.Grass }, // Gulpin
+                    },
+                },
+                new EncounterArea
+                {
+                    Location = 157, // Route 9
+                    Slots = new[]
+                    {
+                            new EncounterSlot { Species = 303, Type = SlotType.Grass }, // Mawile
                     },
                 },
             }).ToArray();


### PR DESCRIPTION
- Gen 3 Swarm slots
- Added locations to gen 3 roaming static encounters
- Added egg location to gen 3 gift eggs and adapted encounter legal analysis, only unhatched gen 3 eggs can be differentiated from normal gen 3 eggs, if hatched assume normal egg for analysis purpose. In case of pokemon that can have special egg moves we can not know what king of egg was and we should check for both possible range of valid moves without mixing, egg moves and event egg moves
- Move gen 4 swarm encounter to encounter slot instead of encounter static. Also changed the data to hardcode only location and species id, levels can be loaded from normal encounters raw data because swarm slots replace slots 0 and 1