### PR TITLE
Complete gen 3 and 4 tutor moves

### DIFF
--- a/PKHeX/Legality/Core.cs
+++ b/PKHeX/Legality/Core.cs
@@ -2079,9 +2079,22 @@ namespace PKHeX.Core
                         if (Machine)
                         {
                             var pi_hgss = PersonalTable.HGSS[index];
-                            r.AddRange(TMHM_HGSS.Where((t, m) => pi_hgss.TMHM[m]));
                             var pi_dppt = PersonalTable.Pt[index];
-                            r.AddRange(TMHM_DPPt.Where((t, m) => pi_dppt.TMHM[m]));
+                            r.AddRange(TM_4.Where((t, m) => pi_hgss.TMHM[m]));
+                            if (pkm.Format > 4)
+                            {
+                                // The combination of both these moves is illegal, it should be checked that the pokemon only learn one
+                                // except if it can learn any of these moves in gen 5 or later
+                                if (pi_hgss.TMHM[96])
+                                    r.Add(250); // Whirlpool
+                                if (pi_dppt.TMHM[96])
+                                    r.Add(432); // Defog
+                            }
+                            else
+                            {
+                                r.AddRange(HM_DPPt.Where((t, m) => pi_dppt.TMHM[m + 92]));
+                                r.AddRange(HM_HGSS.Where((t, m) => pi_hgss.TMHM[m + 92]));
+                            }
                         }
                         if (moveTutor)
                             r.AddRange(getTutorMoves(pkm, species, form, specialTutors, Generation));

--- a/PKHeX/Legality/Core.cs
+++ b/PKHeX/Legality/Core.cs
@@ -315,7 +315,7 @@ namespace PKHeX.Core
             var h_s = EncounterArea.getArray2_H(Resources.encounter_silver_h);
             var h = h_c.Concat(h_g).Concat(h_s);
 
-                return addExtraTableSlots(g, s).Concat(c).Concat(f).Concat(h).ToArray();
+            return addExtraTableSlots(g, s).Concat(c).Concat(f).Concat(h).ToArray();
         }
         static Legal() // Setup
         {
@@ -2042,19 +2042,15 @@ namespace PKHeX.Core
                             {
                                 switch(form)
                                 {
-                                    case 0: r.AddRange(LevelUpRS[index].getMoves(lvl));break;
+                                    case 0: r.AddRange(LevelUpRS[index].getMoves(lvl)); break;
                                     case 1: r.AddRange(LevelUpFR[index].getMoves(lvl)); break;
                                     case 2: r.AddRange(LevelUpLG[index].getMoves(lvl)); break;
                                     case 3: r.AddRange(LevelUpE[index].getMoves(lvl)); break;
                                 }
                             }
-                            else
-                            {
-                                r.AddRange(LevelUpRS[index].getMoves(lvl));
+                            else //Add only emerald moves, all the gen 3 level up tables are equal except deoxys level up tables
                                 r.AddRange(LevelUpE[index].getMoves(lvl));
-                                r.AddRange(LevelUpFR[index].getMoves(lvl));
-                                r.AddRange(LevelUpLG[index].getMoves(lvl));
-                            }
+                            
                         }
                         if (Machine)
                         {

--- a/PKHeX/Legality/Tables3.cs
+++ b/PKHeX/Legality/Tables3.cs
@@ -140,8 +140,66 @@ namespace PKHeX.Core
             new[] {135, 069, 138, 005, 025, 034, 157, 068, 086, 014},
             new[] {111, 173, 189, 129, 196, 203, 244, 008, 009, 007},
         };
-        internal static readonly int[] Tutor_E = {038, 223, 153, 210, 118, 102, 205, 214, 164, 207};
-        internal static readonly int[] Tutor_FRLG = {034, 068, 038, 138, 153, 025, 005, 118, 102, 157, 069, 135, 164, 014, 086};
+
+        internal static readonly int[] Tutor_E =
+        {
+            005, 014, 025, 034, 038, 068, 069, 102, 118, 135,
+            138, 086, 153, 157, 164, 223, 205, 244, 173, 196,
+            203, 189, 008, 207, 214, 129, 111, 009, 007, 210
+        };
+
+        internal static readonly int[] Tutor_FRLG =
+        {
+            005, 014, 025, 034, 038, 068, 069, 102, 118, 135,
+            138, 086, 153, 157, 164
+        };
+
+        internal static readonly int[] SpecialTutors_FRLG =
+        {
+            307, 308, 338
+        };
+
+        internal static readonly int[][] SpecialTutors_Compatibility_FRLG =
+        {
+            new int[] { 6 },
+            new int[] { 9 },
+            new int[] { 3 },
+        };
+
+        // Tutor moves from XD that can be learned as tutor moves in emerald
+        // For this moves compatibility data is the same in XD and Emerald
+        internal static readonly int[] SpecialTutors_XD_Emerald =
+        {
+            034, 038, 069, 086, 102, 120, 138, 143, 164, 171, 196, 207,
+        };
+
+        internal static readonly int[] SpecialTutors_XD_Exclusive =
+        {
+            120, 143, 171
+        };
+
+        internal static readonly int[] SpecialTutors_XD = SpecialTutors_XD_Emerald.Concat(SpecialTutors_XD_Exclusive).ToArray();
+
+        internal static readonly int[][] SpecialTutors_Compatibility_XD_Exclusive =
+        {
+            new int[] { 074, 075, 076, 088, 089, 090, 091, 092, 093, 094, 095,
+                        100, 101, 102, 103, 109, 110, 143, 150, 151, 185, 204,
+                        205, 208, 211, 218, 219, 222, 273, 274, 275, 299, 316,
+                        317, 320, 321, 323, 324, 337, 338, 343, 344, 362, 375,
+                        376, 377, 378, 379 },
+
+            new int[] { 016, 017, 018, 021, 022, 084, 085, 142, 144, 145, 146,
+                        151, 163, 164, 176, 177, 178, 198, 225, 227, 250, 276,
+                        277, 278, 279, 333, 334 },
+
+            new int[] { 012, 035, 036, 039, 040, 052, 053, 063, 064, 065, 079,
+                        080, 092, 093, 094, 096, 097, 102, 103, 108, 121, 122,
+                        124, 131, 137, 150, 151, 163, 164, 173, 174, 177, 178,
+                        190, 196, 197, 198, 199, 200, 203, 206, 215, 228, 229,
+                        233, 234, 238, 248, 249, 250, 251, 280, 281, 282, 284,
+                        292, 302, 315, 316, 317, 327, 353, 354, 355, 356, 358,
+                        359, 385, 386 }
+        };
 
         internal static readonly int[] Roaming_MetLocation_FRLG =
         {

--- a/PKHeX/Legality/Tables4.cs
+++ b/PKHeX/Legality/Tables4.cs
@@ -119,7 +119,29 @@ namespace PKHeX.Core
             404, 214, 363, 398, 138, 447, 207, 365, 369, 164,
             430, 433,
 
-            015, 019, 057, 070, 250, 432, 249, 127, 431 // Defog(DPPt) & Whirlpool(HGSS)
+            015, 019, 057, 070, 250, 249, 127, 431 // Defog(DPPt) & Whirlpool(HGSS)
+        };
+
+        internal static readonly int[] TMHM_DPPt =
+        {
+            264, 337, 352, 347, 046, 092, 258, 339, 331, 237,
+            241, 269, 058, 059, 063, 113, 182, 240, 202, 219,
+            218, 076, 231, 085, 087, 089, 216, 091, 094, 247,
+            280, 104, 115, 351, 053, 188, 201, 126, 317, 332,
+            259, 263, 290, 156, 213, 168, 211, 285, 289, 315,
+            355, 411, 412, 206, 362, 374, 451, 203, 406, 409,
+            261, 318, 373, 153, 421, 371, 278, 416, 397, 148,
+            444, 419, 086, 360, 014, 446, 244, 445, 399, 157,
+            404, 214, 363, 398, 138, 447, 207, 365, 369, 164,
+            430, 433,
+
+            015, 019, 057, 070, 432, 249, 127, 431 // Defog(DPPt) & Whirlpool(HGSS)
+        };
+
+
+        internal static readonly int[] HM_4_RemovePokeTransfer =
+        {
+            015, 019, 057, 070, 249, 127, 431 // Defog(DPPt) & Whirlpool(HGSS) excluded
         };
 
         internal static readonly int[] MovePP_DP =
@@ -169,6 +191,19 @@ namespace PKHeX.Core
             271, 257, 282, 389, 129, 253, 162, 220,
             081, 366, 356, 388, 277, 272, 215, 067,
             143, 335, 450,
+        };
+
+        internal static readonly int[] SpecialTutors_4 =
+        {
+            307, 308, 338, 434
+        };
+
+        internal static readonly int[][] SpecialTutors_Compatibility_4 =
+        {
+            new int[] { 006, 157, 257, 392 },
+            new int[] { 009, 160, 260, 395 },
+            new int[] { 003, 154, 254, 389 },
+            new int[] { 147, 148, 149, 230, 329, 330, 334, 371, 372, 373, 380, 381, 384, 443, 444, 445, 483, 484, 487 }
         };
 
         internal static readonly EncounterStatic[] Encounter_HGSS_Swarm =

--- a/PKHeX/Legality/Tables4.cs
+++ b/PKHeX/Legality/Tables4.cs
@@ -106,7 +106,7 @@ namespace PKHeX.Core
         internal static readonly ushort[] HeldItems_HGSS = new ushort[1].Concat(Pouch_Items_HGSS).Concat(Pouch_Mail_HGSS).Concat(Pouch_Medicine_HGSS).Concat(Pouch_Berries_HGSS).Concat(Pouch_Ball_Pt).Concat(Pouch_TMHM_HGSS.Take(Pouch_TMHM_HGSS.Length - 8)).ToArray();
         #endregion
 
-        internal static readonly int[] TMHM_HGSS =
+        internal static readonly int[] TM_4 =
         {
             264, 337, 352, 347, 046, 092, 258, 339, 331, 237,
             241, 269, 058, 059, 063, 113, 182, 240, 202, 219,
@@ -118,23 +118,15 @@ namespace PKHeX.Core
             444, 419, 086, 360, 014, 446, 244, 445, 399, 157,
             404, 214, 363, 398, 138, 447, 207, 365, 369, 164,
             430, 433,
+        };
 
+        internal static readonly int[] HM_HGSS =
+        {
             015, 019, 057, 070, 250, 249, 127, 431 // Defog(DPPt) & Whirlpool(HGSS)
         };
 
-        internal static readonly int[] TMHM_DPPt =
+        internal static readonly int[] HM_DPPt =
         {
-            264, 337, 352, 347, 046, 092, 258, 339, 331, 237,
-            241, 269, 058, 059, 063, 113, 182, 240, 202, 219,
-            218, 076, 231, 085, 087, 089, 216, 091, 094, 247,
-            280, 104, 115, 351, 053, 188, 201, 126, 317, 332,
-            259, 263, 290, 156, 213, 168, 211, 285, 289, 315,
-            355, 411, 412, 206, 362, 374, 451, 203, 406, 409,
-            261, 318, 373, 153, 421, 371, 278, 416, 397, 148,
-            444, 419, 086, 360, 014, 446, 244, 445, 399, 157,
-            404, 214, 363, 398, 138, 447, 207, 365, 369, 164,
-            430, 433,
-
             015, 019, 057, 070, 432, 249, 127, 431 // Defog(DPPt) & Whirlpool(HGSS)
         };
 


### PR DESCRIPTION
Get tutor moves for gen 3 and 4 pokemon, including special tutors
Filter deoxys gen 3 level moves by form
Remove HMs in gen 3 and 4 when transfered to another generation, even if gen 3 HMs are not added some pokemon can learn HMs by leveling up
Defog and Whirlpoll are not removed because a pokemon can be transfered to gen 5 learning only one, should be analyzed that a pokemon in gen 5 with both moves is illegal