### PR TITLE
Add gen5 Dream World table

### DIFF
--- a/PKHeX/Legality/Core.cs
+++ b/PKHeX/Legality/Core.cs
@@ -254,7 +254,10 @@ namespace PKHeX.Core
         private static void MarkG5DreamWorld(ref EncounterStatic[] t)
         {
             foreach (EncounterStatic s in t)
-                s.Location = 75;  //Location can use a flag from dream world
+            {
+                s.Location = 75;  //Entree Forest. Location can be a flag from dream world
+                s.Ability = 4;    //What if 1=2=HA?
+            }
         }
         private static void MarkG5Slots(ref EncounterArea[] Areas)
         {

--- a/PKHeX/Legality/Core.cs
+++ b/PKHeX/Legality/Core.cs
@@ -251,6 +251,11 @@ namespace PKHeX.Core
             foreach (EncounterSlot s in Areas[0].Slots) //Only 1 area
                 s.Type = SlotType.HiddenGrotto; 
         }
+        private static void MarkG5DreamWorld(ref EncounterStatic[] t)
+        {
+            foreach (EncounterStatic s in t)
+                s.Location = 75;  //Location can use a flag from dream world
+        }
         private static void MarkG5Slots(ref EncounterArea[] Areas)
         {
             foreach (var area in Areas)
@@ -482,10 +487,12 @@ namespace PKHeX.Core
             }
             // Gen 5
             {
-                StaticB = getStaticEncounters(GameVersion.B);
-                StaticW = getStaticEncounters(GameVersion.W);
-                StaticB2 = getStaticEncounters(GameVersion.B2);
-                StaticW2 = getStaticEncounters(GameVersion.W2);
+                MarkG5DreamWorld(ref BW_DreamWorld);
+                MarkG5DreamWorld(ref B2W2_DreamWorld);
+                StaticB = getStaticEncounters(GameVersion.B).Concat(BW_DreamWorld).ToArray();
+                StaticW = getStaticEncounters(GameVersion.W).Concat(BW_DreamWorld).ToArray();
+                StaticB2 = getStaticEncounters(GameVersion.B2).Concat(B2W2_DreamWorld).ToArray();
+                StaticW2 = getStaticEncounters(GameVersion.W2).Concat(B2W2_DreamWorld).ToArray();
 
                 var BSlots = getEncounterTables(GameVersion.B);
                 var WSlots = getEncounterTables(GameVersion.W);

--- a/PKHeX/Legality/Tables4.cs
+++ b/PKHeX/Legality/Tables4.cs
@@ -243,12 +243,18 @@ namespace PKHeX.Core
             new EncounterStatic { Gift = true, Species = 440, Level = 01, EggLocation = 2009, Version = GameVersion.DP,}, //Happiny Egg from Traveling Man
             new EncounterStatic { Gift = true, Species = 447, Level = 01, EggLocation = 2010,}, //Riolu Egg from Riley
 
+            //Stationary
+            new EncounterStatic { Species = 425, Level = 22, Location = 47, Version = GameVersion.DP, },// Drifloon @ Valley Windworks 
+            new EncounterStatic { Species = 425, Level = 15, Location = 47, Version = GameVersion.Pt, },// Drifloon @ Valley Windworks 
+            new EncounterStatic { Species = 479, Level = 15, Location = 70, Version = GameVersion.DP, },// Rotom @ Old Chateau 
+            new EncounterStatic { Species = 479, Level = 20, Location = 70, Version = GameVersion.Pt, },// Rotom @ Old Chateau 
+
             //Stationary Lengerdary
             new EncounterStatic { Species = 377, Level = 30, Location = 125, Version = GameVersion.Pt,}, //Regirock @ Rock Peak Ruins
             new EncounterStatic { Species = 378, Level = 30, Location = 124, Version = GameVersion.Pt,}, //Regice @ Iceberg Ruins
             new EncounterStatic { Species = 379, Level = 30, Location = 123, Version = GameVersion.Pt,}, //Registeel @ Iron Ruins
-            new EncounterStatic { Species = 480, Level = 50, Location = 078,}, //Uxie @ Lake Acuity
-            new EncounterStatic { Species = 482, Level = 50, Location = 077,}, //Azelf @ Lake Valor
+            new EncounterStatic { Species = 480, Level = 50, Location = 089,}, //Uxie @ Acuity Cavern
+            new EncounterStatic { Species = 482, Level = 50, Location = 088,}, //Azelf @ Valor Cavern
             new EncounterStatic { Species = 483, Level = 47, Location = 051, Version = GameVersion.D,}, //Dialga @ Spear Pillar
             new EncounterStatic { Species = 483, Level = 70, Location = 051, Version = GameVersion.Pt,}, //Dialga @ Spear Pillar
             new EncounterStatic { Species = 484, Level = 47, Location = 051, Version = GameVersion.P,}, //Palkia @ Spear Pillar
@@ -332,9 +338,11 @@ namespace PKHeX.Core
             //Stationary
             new EncounterStatic { Species = 130, Level = 30, Location = 135, Shiny = true }, //Gyarados @ Lake of Rage
             new EncounterStatic { Species = 131, Level = 20, Location = 210, }, //Lapras @ Union Cave Friday Only
+            new EncounterStatic { Species = 101, Level = 23, Location = 213, }, //Electrode @ Team Rocket HQ
             new EncounterStatic { Species = 143, Level = 50, Location = 159, }, //Snorlax @ Route 11
             new EncounterStatic { Species = 143, Level = 50, Location = 160, }, //Snorlax @ Route 12
             new EncounterStatic { Species = 185, Level = 20, Location = 184, }, //Sudowoodo @ Route 36
+            new EncounterStatic { Species = 172, Level = 30, Location = 214, Gender = 1, Form = 1, Moves = new[]{344,270,207,220} },  //Spiky-eared Pichu @ Ilex forest
 
             //Stationary Lengerdary
             new EncounterStatic { Species = 144, Level = 50, Location = 203, }, //Articuno @ Seafoam Islands
@@ -352,9 +360,9 @@ namespace PKHeX.Core
             new EncounterStatic { Species = 382, Level = 50, Location = 232, Version = GameVersion.HG, }, //Kyogre @ Embedded Tower
             new EncounterStatic { Species = 383, Level = 50, Location = 232, Version = GameVersion.SS, }, //Groudon @ Embedded Tower
             new EncounterStatic { Species = 384, Level = 50, Location = 232, }, //Rayquaza @ Embedded Tower
-            new EncounterStatic { Species = 483, Level = 01, Location = 231, }, //Dialga @ Sinjoh Ruins
-            new EncounterStatic { Species = 484, Level = 01, Location = 231, }, //Palkia @ Sinjoh Ruins
-            new EncounterStatic { Species = 487, Level = 01, Location = 231, Form = 1}, //Giratina @ Sinjoh Ruins
+            new EncounterStatic { Species = 483, Level = 01, Location = 231, Gift = true }, //Dialga @ Sinjoh Ruins
+            new EncounterStatic { Species = 484, Level = 01, Location = 231, Gift = true }, //Palkia @ Sinjoh Ruins
+            new EncounterStatic { Species = 487, Level = 01, Location = 231, Gift = true, Form = 1}, //Giratina @ Sinjoh Ruins
         };
 
         internal static readonly EncounterStatic[] Encounter_HGSS = Encounter_HGSS_KantoRoam.SelectMany(e => e.Clone(Roaming_MetLocation_HGSS_Kanto)).Concat(

--- a/PKHeX/Legality/Tables5.cs
+++ b/PKHeX/Legality/Tables5.cs
@@ -285,6 +285,13 @@ namespace PKHeX.Core
              new EncounterStatic { Species=133, Level = 10, Moves = new[]{270, 204, 129}, },	//Eevee
              new EncounterStatic { Species=235, Level = 10, Moves = new[]{166, 445, 214}, },	//Smeargle
              new EncounterStatic { Species=412, Level = 10, Moves = new[]{182, 450, 173}, },	//Burmy
+             //PGL
+             new EncounterStatic { Species=212, Level = 10, Moves = new[]{211}, Gender = 0, },   //Scizor
+             new EncounterStatic { Species=445, Level = 48, Gender = 0, },                       //Garchomp
+             new EncounterStatic { Species=149, Level = 55, Moves = new[]{009}, Gender = 0, },   //Dragonite
+             new EncounterStatic { Species=248, Level = 55, Moves = new[]{069}, Gender = 0, },   //Tyranitar
+             new EncounterStatic { Species=149, Level = 55, Moves = new[]{245}, Gender = 0, },   //Dragonite
+             new EncounterStatic { Species=376, Level = 45, Moves = new[]{038}, Gender = 2, },   //Metagross
         };
 
         internal static readonly EncounterStatic[] BW_DreamWorld = DreamWorld_Common.Concat(new[]
@@ -348,7 +355,36 @@ namespace PKHeX.Core
              new EncounterStatic { Species=415, Level = 10, Moves = new[]{16, 366, 314}, },	    //Combee      
              new EncounterStatic { Species=015, Level = 10, Moves = new[]{31, 314, 210}, },	    //Beedrill    
              new EncounterStatic { Species=335, Level = 10, Moves = new[]{98, 458, 67}, },	    //Zangoose    
-             new EncounterStatic { Species=336, Level = 10, Moves = new[]{44, 34, 401}, },	    //Seviper     
+             new EncounterStatic { Species=336, Level = 10, Moves = new[]{44, 34, 401}, },	    //Seviper    
+             //PGL
+             new EncounterStatic { Species=134, Level = 10, Gender = 0, },   //Vaporeon
+             new EncounterStatic { Species=135, Level = 10, Gender = 0, },   //Jolteon
+             new EncounterStatic { Species=136, Level = 10, Gender = 0, },   //Flareon
+             new EncounterStatic { Species=196, Level = 10, Gender = 0, },   //Espeon
+             new EncounterStatic { Species=197, Level = 10, Gender = 0, },   //Umbreon
+             new EncounterStatic { Species=470, Level = 10, Gender = 0, },   //Leafeon
+             new EncounterStatic { Species=471, Level = 10, Gender = 0, },   //Glaceon
+             new EncounterStatic { Species=001, Level = 10, Gender = 0, },   //Bulbasaur
+             new EncounterStatic { Species=004, Level = 10, Gender = 0, },   //Charmander
+             new EncounterStatic { Species=007, Level = 10, Gender = 0, },   //Squirtle
+             new EncounterStatic { Species=453, Level = 10, Gender = 0, },   //Croagunk
+             new EncounterStatic { Species=387, Level = 10, Gender = 0, },   //Turtwig
+             new EncounterStatic { Species=390, Level = 10, Gender = 0, },   //Chimchar
+             new EncounterStatic { Species=393, Level = 10, Gender = 0, },   //Piplup
+             new EncounterStatic { Species=493, Level = 100 },               //Arceus
+             new EncounterStatic { Species=252, Level = 10, Gender = 0, },   //Treecko
+             new EncounterStatic { Species=255, Level = 10, Gender = 0, },   //Torchic
+             new EncounterStatic { Species=258, Level = 10, Gender = 0, },   //Mudkip
+             new EncounterStatic { Species=468, Level = 10, Moves = new[]{217}, Gender = 0, },   //Togekiss
+             new EncounterStatic { Species=473, Level = 34, Gender = 0, },   //Mamoswine
+             new EncounterStatic { Species=137, Level = 10 },                //Porygon
+             new EncounterStatic { Species=384, Level = 50 },                //Rayquaza
+             new EncounterStatic { Species=354, Level = 37, Moves = new[]{538}, Gender = 1, },   //Banette
+             new EncounterStatic { Species=453, Level = 10, Moves = new[]{398}, Gender = 0, },   //Croagunk
+             new EncounterStatic { Species=334, Level = 35, Moves = new[]{206}, Gender = 0,},   //Altaria
+             new EncounterStatic { Species=242, Level = 10 },                //Blissey
+             new EncounterStatic { Species=448, Level = 10, Moves = new[]{418}, Gender = 0, },   //Lucario
+             new EncounterStatic { Species=189, Level = 27, Moves = new[]{206}, Gender = 0, },   //Jumpluff 
         }).ToArray();
 
         internal static readonly EncounterStatic[] B2W2_DreamWorld = DreamWorld_Common.Concat(new[]
@@ -394,7 +430,17 @@ namespace PKHeX.Core
              new EncounterStatic { Species=538, Level = 10, Moves = new[]{20, 8, 276}, },	    //Throh       
              new EncounterStatic { Species=539, Level = 10, Moves = new[]{249, 9, 530}, },	    //Sawk        
              new EncounterStatic { Species=559, Level = 10, Moves = new[]{67, 252, 409}, },	    //Scraggy     
-             new EncounterStatic { Species=533, Level = 25, Moves = new[]{67, 183, 409}, },	    //Gurdurr     
+             new EncounterStatic { Species=533, Level = 25, Moves = new[]{67, 183, 409}, },	    //Gurdurr   
+             //PGL
+             new EncounterStatic { Species=575, Level = 32, Moves = new[]{243}, Gender = 0, },   //Gothorita
+             new EncounterStatic { Species=025, Level = 10, Moves = new[]{029}, Gender = 0, },   //Pikachu
+             new EncounterStatic { Species=511, Level = 10, Moves = new[]{437}, Gender = 0, },   //Pansage
+             new EncounterStatic { Species=513, Level = 10, Moves = new[]{257}, Gender = 0, },   //Pansear
+             new EncounterStatic { Species=515, Level = 10, Moves = new[]{056}, Gender = 0, },   //Panpour
+             new EncounterStatic { Species=387, Level = 10, Moves = new[]{254}, Gender = 0, },   //Turtwig
+             new EncounterStatic { Species=390, Level = 10, Moves = new[]{252}, Gender = 0, },   //Chimchar
+             new EncounterStatic { Species=393, Level = 10, Moves = new[]{297}, Gender = 0, },   //Piplup
+             new EncounterStatic { Species=575, Level = 32, Moves = new[]{286}, Gender = 0, },   //Gothorita  
         }).ToArray();
         #endregion
 

--- a/PKHeX/Legality/Tables5.cs
+++ b/PKHeX/Legality/Tables5.cs
@@ -124,6 +124,280 @@ namespace PKHeX.Core
             new[] { 388, 380, 270, 495, 478, 472, 180, 278, 271, 446, 200, 283, 214, 285, 289, } // Nacrene City
         };
 
+        #region DreamWorld Encounter
+        internal static readonly EncounterStatic[] DreamWorld_Common =
+        {
+            // Pleasant forest
+             new EncounterStatic { Species=019, Level = 10, Moves = new[]{98, 382, 231}, },	    //Rattata
+             new EncounterStatic { Species=043, Level = 10, Moves = new[]{230, 298, 202}, },	//Oddish
+             new EncounterStatic { Species=069, Level = 10, Moves = new[]{22, 235, 402}, },	    //Bellsprout
+             new EncounterStatic { Species=077, Level = 10, Moves = new[]{33, 37, 257}, },	    //Ponyta
+             new EncounterStatic { Species=083, Level = 10, Moves = new[]{210, 355, 348}, },	//Farfetch'd
+             new EncounterStatic { Species=084, Level = 10, Moves = new[]{45, 175, 355}, },	    //Doduo
+             new EncounterStatic { Species=102, Level = 10, Moves = new[]{140, 235, 202}, },	//Exeggcute
+             new EncounterStatic { Species=108, Level = 10, Moves = new[]{122, 214, 431}, },	//Lickitung
+             new EncounterStatic { Species=114, Level = 10, Moves = new[]{79, 73, 402}, },	    //Tangela
+             new EncounterStatic { Species=115, Level = 10, Moves = new[]{252, 68, 409}, },	    //Kangaskhan
+             new EncounterStatic { Species=161, Level = 10, Moves = new[]{10, 203, 343}, },	    //Sentret
+             new EncounterStatic { Species=179, Level = 10, Moves = new[]{84, 115, 351}, },	    //Mareep
+             new EncounterStatic { Species=191, Level = 10, Moves = new[]{72, 230, 414}, },	    //Sunkern
+             new EncounterStatic { Species=234, Level = 10, Moves = new[]{33, 50, 285}, },	    //Stantler
+             new EncounterStatic { Species=261, Level = 10, Moves = new[]{336, 305, 399}, },	//Poochyena
+             new EncounterStatic { Species=283, Level = 10, Moves = new[]{145, 56, 202}, },	    //Surskit
+             new EncounterStatic { Species=399, Level = 10, Moves = new[]{33, 401, 290}, },	    //Bidoof
+             new EncounterStatic { Species=403, Level = 10, Moves = new[]{268, 393, 400}, },	//Shinx
+             new EncounterStatic { Species=431, Level = 10, Moves = new[]{252, 372, 290}, },	//Glameow
+             new EncounterStatic { Species=054, Level = 10, Moves = new[]{346, 227, 362}, },	//Psyduck
+             new EncounterStatic { Species=058, Level = 10, Moves = new[]{44, 34, 203}, },	    //Growlithe
+             new EncounterStatic { Species=123, Level = 10, Moves = new[]{98, 226, 366}, },	    //Scyther
+             new EncounterStatic { Species=128, Level = 10, Moves = new[]{99, 231, 431}, },	    //Tauros
+             new EncounterStatic { Species=183, Level = 10, Moves = new[]{111, 453, 8}, },	    //Marill
+             new EncounterStatic { Species=185, Level = 10, Moves = new[]{175, 205, 272}, },	//Sudowoodo
+             new EncounterStatic { Species=203, Level = 10, Moves = new[]{93, 243, 285}, },	    //Girafarig
+             new EncounterStatic { Species=241, Level = 10, Moves = new[]{111, 174, 231}, },	//Miltank
+             new EncounterStatic { Species=263, Level = 10, Moves = new[]{33, 271, 387}, },	    //Zigzagoon
+             new EncounterStatic { Species=427, Level = 10, Moves = new[]{193, 252, 409}, },	//Buneary
+             new EncounterStatic { Species=037, Level = 10, Moves = new[]{46, 257, 399}, },	    //Vulpix
+             new EncounterStatic { Species=060, Level = 10, Moves = new[]{95, 54, 214}, },	    //Poliwag
+             new EncounterStatic { Species=177, Level = 10, Moves = new[]{101, 297, 202}, },	//Natu
+             new EncounterStatic { Species=239, Level = 10, Moves = new[]{84, 238, 393}, },	    //Elekid
+             new EncounterStatic { Species=300, Level = 10, Moves = new[]{193, 321, 445}, },	//Skitty
+	         // Windskept Sky
+             new EncounterStatic { Species=016, Level = 10, Moves = new[]{16, 211, 290}, },	    //Pidgey
+             new EncounterStatic { Species=021, Level = 10, Moves = new[]{64, 185, 211}, },	    //Spearow
+             new EncounterStatic { Species=041, Level = 10, Moves = new[]{48, 95, 162}, },	    //Zubat
+             new EncounterStatic { Species=142, Level = 10, Moves = new[]{44, 372, 446}, },	    //Aerodactyl
+             new EncounterStatic { Species=165, Level = 10, Moves = new[]{4, 450, 9}, },	    //Ledyba
+             new EncounterStatic { Species=187, Level = 10, Moves = new[]{235, 227, 340}, },	//Hoppip
+             new EncounterStatic { Species=193, Level = 10, Moves = new[]{98, 364, 202}, },	    //Yanma
+             new EncounterStatic { Species=198, Level = 10, Moves = new[]{64, 109, 355}, },	    //Murkrow
+             new EncounterStatic { Species=207, Level = 10, Moves = new[]{28, 364, 366}, },	    //Gligar
+             new EncounterStatic { Species=225, Level = 10, Moves = new[]{217, 420, 264}, },	//Delibird
+             new EncounterStatic { Species=276, Level = 10, Moves = new[]{64, 203, 413}, },	    //Taillow
+             new EncounterStatic { Species=397, Level = 14, Moves = new[]{17, 297, 366}, },	    //Staravia
+             new EncounterStatic { Species=227, Level = 10, Moves = new[]{64, 65, 355}, },	    //Skarmory
+             new EncounterStatic { Species=357, Level = 10, Moves = new[]{16, 73, 318}, },	    //Tropius
+	         // Sprakling Sea
+             new EncounterStatic { Species=086, Level = 10, Moves = new[]{29, 333, 214}, },	    //Seel
+             new EncounterStatic { Species=090, Level = 10, Moves = new[]{110, 112, 196}, },	//Shellder
+             new EncounterStatic { Species=116, Level = 10, Moves = new[]{145, 190, 362}, },	//Horsea
+             new EncounterStatic { Species=118, Level = 10, Moves = new[]{64, 60, 352}, },	    //Goldeen
+             new EncounterStatic { Species=129, Level = 10, Moves = new[]{150, 175, 340}, },	//Magikarp
+             new EncounterStatic { Species=138, Level = 10, Moves = new[]{44, 330, 196}, },	    //Omanyte
+             new EncounterStatic { Species=140, Level = 10, Moves = new[]{71, 175, 446}, },	    //Kabuto
+             new EncounterStatic { Species=170, Level = 10, Moves = new[]{86, 133, 351}, },	    //Chinchou
+             new EncounterStatic { Species=194, Level = 10, Moves = new[]{55, 34, 401}, },	    //Wooper
+             new EncounterStatic { Species=211, Level = 10, Moves = new[]{40, 453, 290}, },	    //Qwilfish
+             new EncounterStatic { Species=223, Level = 10, Moves = new[]{199, 350, 362}, },	//Remoraid
+             new EncounterStatic { Species=226, Level = 10, Moves = new[]{48, 243, 314}, },	    //Mantine
+             new EncounterStatic { Species=320, Level = 10, Moves = new[]{55, 214, 340}, },	    //Wailmer
+             new EncounterStatic { Species=339, Level = 10, Moves = new[]{189, 214, 209}, },	//Barboach
+             new EncounterStatic { Species=366, Level = 10, Moves = new[]{250, 445, 392}, },	//Clamperl
+             new EncounterStatic { Species=369, Level = 10, Moves = new[]{55, 214, 414}, },	    //Relicanth
+             new EncounterStatic { Species=370, Level = 10, Moves = new[]{204, 300, 196}, },	//Luvdisc
+             new EncounterStatic { Species=418, Level = 10, Moves = new[]{346, 163, 352}, },	//Buizel
+             new EncounterStatic { Species=456, Level = 10, Moves = new[]{213, 186, 352}, },	//Finneon
+             new EncounterStatic { Species=072, Level = 10, Moves = new[]{48, 367, 202}, },	    //Tentacool
+             new EncounterStatic { Species=318, Level = 10, Moves = new[]{44, 37, 399}, },	    //Carvanha
+             new EncounterStatic { Species=341, Level = 10, Moves = new[]{106, 232, 283}, },	//Corphish
+             new EncounterStatic { Species=345, Level = 10, Moves = new[]{51, 243, 202}, },	    //Lileep
+             new EncounterStatic { Species=347, Level = 10, Moves = new[]{10, 446, 440}, },	    //Anorith
+             new EncounterStatic { Species=349, Level = 10, Moves = new[]{150, 445, 243}, },	//Feebas
+             new EncounterStatic { Species=131, Level = 10, Moves = new[]{109, 32, 196}, },	    //Lapras
+             new EncounterStatic { Species=147, Level = 10, Moves = new[]{86, 352, 225}, },	    //Dratini
+ 	        // Spooky Mannor
+             new EncounterStatic { Species=092, Level = 10, Moves = new[]{95, 50, 482}, },	    //Gastly
+             new EncounterStatic { Species=096, Level = 10, Moves = new[]{95, 427, 409}, },	    //Drowzee
+             new EncounterStatic { Species=122, Level = 10, Moves = new[]{112, 298, 285}, },	//Mr. Mime
+             new EncounterStatic { Species=167, Level = 10, Moves = new[]{40, 527, 450}, },	    //Spinarak
+             new EncounterStatic { Species=200, Level = 10, Moves = new[]{149, 194, 517}, },	//Misdreavus
+             new EncounterStatic { Species=228, Level = 10, Moves = new[]{336, 364, 399}, },	//Houndour
+             new EncounterStatic { Species=325, Level = 10, Moves = new[]{149, 285, 278}, },	//Spoink
+             new EncounterStatic { Species=353, Level = 10, Moves = new[]{101, 194, 220}, },	//Shuppet
+             new EncounterStatic { Species=355, Level = 10, Moves = new[]{50, 220, 271}, },	    //Duskull
+             new EncounterStatic { Species=358, Level = 10, Moves = new[]{35, 95, 304}, },	    //Chimecho
+             new EncounterStatic { Species=434, Level = 10, Moves = new[]{103, 492, 389}, },	//Stunky
+             new EncounterStatic { Species=209, Level = 10, Moves = new[]{204, 370, 38}, },	    //Snubbull
+             new EncounterStatic { Species=235, Level = 10, Moves = new[]{166, 445, 214}, },	//Smeargle
+             new EncounterStatic { Species=313, Level = 10, Moves = new[]{148, 271, 366}, },	//Volbeat
+             new EncounterStatic { Species=314, Level = 10, Moves = new[]{204, 313, 366}, },	//Illumise
+             new EncounterStatic { Species=063, Level = 10, Moves = new[]{100, 285, 356}, },	//Abra
+	         //Rugged Mountain
+             new EncounterStatic { Species=066, Level = 10, Moves = new[]{67, 418, 270}, },	    //Machop
+             new EncounterStatic { Species=081, Level = 10, Moves = new[]{319, 278, 356}, },	//Magnemite
+             new EncounterStatic { Species=109, Level = 10, Moves = new[]{123, 399, 482}, },	//Koffing
+             new EncounterStatic { Species=218, Level = 10, Moves = new[]{52, 517, 257}, },	    //Slugma
+             new EncounterStatic { Species=246, Level = 10, Moves = new[]{44, 399, 446}, },	    //Larvitar
+             new EncounterStatic { Species=324, Level = 10, Moves = new[]{52, 90, 446}, },	    //Torkoal
+             new EncounterStatic { Species=328, Level = 10, Moves = new[]{44, 324, 202}, },	    //Trapinch
+             new EncounterStatic { Species=331, Level = 10, Moves = new[]{71, 298, 9}, },	    //Cacnea
+             new EncounterStatic { Species=412, Level = 10, Moves = new[]{182, 450, 173}, },	//Burmy
+             new EncounterStatic { Species=449, Level = 10, Moves = new[]{44, 254, 276}, },	    //Hippopotas
+             new EncounterStatic { Species=240, Level = 10, Moves = new[]{52, 9, 257}, },	    //Magby
+             new EncounterStatic { Species=322, Level = 10, Moves = new[]{52, 34, 257}, },	    //Numel
+             new EncounterStatic { Species=359, Level = 10, Moves = new[]{364, 224, 276}, },	//Absol
+             new EncounterStatic { Species=453, Level = 10, Moves = new[]{40, 409, 441}, },	    //Croagunk
+             new EncounterStatic { Species=236, Level = 10, Moves = new[]{252, 364, 183}, },	//Tyrogue
+             new EncounterStatic { Species=371, Level = 10, Moves = new[]{44, 349, 200}, },	    //Bagon
+	         // Icy Cave
+             new EncounterStatic { Species=027, Level = 10, Moves = new[]{28, 68, 162}, },	    //Sandshrew
+             new EncounterStatic { Species=074, Level = 10, Moves = new[]{111, 446, 431}, },	//Geodude
+             new EncounterStatic { Species=095, Level = 10, Moves = new[]{20, 446, 431}, },	    //Onix
+             new EncounterStatic { Species=100, Level = 10, Moves = new[]{268, 324, 363}, },	//Voltorb
+             new EncounterStatic { Species=104, Level = 10, Moves = new[]{125, 195, 67}, },	    //Cubone
+             new EncounterStatic { Species=293, Level = 10, Moves = new[]{253, 283, 428}, },	//Whismur
+             new EncounterStatic { Species=304, Level = 10, Moves = new[]{106, 283, 457}, },	//Aron
+             new EncounterStatic { Species=337, Level = 10, Moves = new[]{93, 414, 236}, },	    //Lunatone
+             new EncounterStatic { Species=338, Level = 10, Moves = new[]{93, 428, 234}, },	    //Solrock
+             new EncounterStatic { Species=343, Level = 10, Moves = new[]{229, 356, 428}, },	//Baltoy
+             new EncounterStatic { Species=459, Level = 10, Moves = new[]{75, 419, 202}, },	    //Snover
+             new EncounterStatic { Species=050, Level = 10, Moves = new[]{28, 251, 446}, },	    //Diglett
+             new EncounterStatic { Species=215, Level = 10, Moves = new[]{269, 8, 67}, },	    //Sneasel
+             new EncounterStatic { Species=361, Level = 10, Moves = new[]{181, 311, 352}, },	//Snorunt
+             new EncounterStatic { Species=220, Level = 10, Moves = new[]{316, 246, 333}, },	//Swinub
+             new EncounterStatic { Species=443, Level = 10, Moves = new[]{82, 200, 203}, },	    //Gible
+	         // Dream Park
+             new EncounterStatic { Species=046, Level = 10, Moves = new[]{78, 440, 235}, },	    //Paras
+             new EncounterStatic { Species=204, Level = 10, Moves = new[]{120, 390, 356}, },	//Pineco
+             new EncounterStatic { Species=265, Level = 10, Moves = new[]{40, 450, 173}, },	    //Wurmple
+             new EncounterStatic { Species=273, Level = 10, Moves = new[]{74, 331, 492}, },	    //Seedot
+             new EncounterStatic { Species=287, Level = 10, Moves = new[]{281, 400, 389}, },	//Slakoth
+             new EncounterStatic { Species=290, Level = 10, Moves = new[]{141, 203, 400}, },	//Nincada
+             new EncounterStatic { Species=311, Level = 10, Moves = new[]{86, 435, 324}, },	    //Plusle
+             new EncounterStatic { Species=312, Level = 10, Moves = new[]{86, 435, 324}, },	    //Minun
+             new EncounterStatic { Species=316, Level = 10, Moves = new[]{139, 151, 202}, },	//Gulpin
+             new EncounterStatic { Species=352, Level = 10, Moves = new[]{185, 285, 513}, },	//Kecleon
+             new EncounterStatic { Species=401, Level = 10, Moves = new[]{522, 283, 253}, },	//Kricketot
+             new EncounterStatic { Species=420, Level = 10, Moves = new[]{73, 505, 331}, },	    //Cherubi
+             new EncounterStatic { Species=455, Level = 10, Moves = new[]{44, 476, 380}, },	    //Carnivine
+             new EncounterStatic { Species=023, Level = 10, Moves = new[]{40, 251, 399}, },	    //Ekans
+             new EncounterStatic { Species=175, Level = 10, Moves = new[]{118, 381, 253}, },	//Togepi
+             new EncounterStatic { Species=190, Level = 10, Moves = new[]{10, 252, 7}, },	    //Aipom
+             new EncounterStatic { Species=285, Level = 10, Moves = new[]{78, 331, 264}, },	    //Shroomish
+             new EncounterStatic { Species=315, Level = 10, Moves = new[]{74, 79, 129}, },	    //Roselia
+             new EncounterStatic { Species=113, Level = 10, Moves = new[]{45, 68, 270}, },	    //Chansey
+             new EncounterStatic { Species=127, Level = 10, Moves = new[]{11, 370, 382}, },	    //Pinsir
+             new EncounterStatic { Species=133, Level = 10, Moves = new[]{28, 204, 129}, },	    //Eevee
+             new EncounterStatic { Species=143, Level = 10, Moves = new[]{133, 7, 278}, },	    //Snorlax
+             new EncounterStatic { Species=214, Level = 10, Moves = new[]{30, 175, 264}, },	    //Heracross
+             // Pokémon Café Forest
+             new EncounterStatic { Species=061, Level = 25, Moves = new[]{240, 114, 352}, },	//Poliwhirl
+             new EncounterStatic { Species=133, Level = 10, Moves = new[]{270, 204, 129}, },	//Eevee
+             new EncounterStatic { Species=235, Level = 10, Moves = new[]{166, 445, 214}, },	//Smeargle
+             new EncounterStatic { Species=412, Level = 10, Moves = new[]{182, 450, 173}, },	//Burmy
+        };
+
+        internal static readonly EncounterStatic[] BW_DreamWorld = DreamWorld_Common.Concat(new[]
+        {
+             new EncounterStatic { Species=029, Level = 10, Moves = new[]{10, 389, 162}, },	    //Nidoran (F)
+             new EncounterStatic { Species=032, Level = 10, Moves = new[]{64, 68, 162}, },	    //Nidoran (M)
+             new EncounterStatic { Species=174, Level = 10, Moves = new[]{47, 313, 270}, },	    //Igglybuff  
+             new EncounterStatic { Species=187, Level = 10, Moves = new[]{235, 270, 331}, },	//Hoppip     
+             new EncounterStatic { Species=270, Level = 10, Moves = new[]{71, 73, 352}, },	    //Lotad      
+             new EncounterStatic { Species=276, Level = 10, Moves = new[]{64, 119, 366}, },	    //Taillow    
+             new EncounterStatic { Species=309, Level = 10, Moves = new[]{86, 423, 324}, },	    //Electrike  
+             new EncounterStatic { Species=351, Level = 10, Moves = new[]{52, 466, 352}, },	    //Castform   
+             new EncounterStatic { Species=417, Level = 10, Moves = new[]{98, 343, 351}, },	    //Pachirisu  
+             
+             new EncounterStatic { Species=012, Level = 10, Moves = new[]{93, 355, 314}, },	    //Butterfree 
+             new EncounterStatic { Species=163, Level = 10, Moves = new[]{193, 101, 278}, },	//Hoothoot   
+             new EncounterStatic { Species=278, Level = 10, Moves = new[]{55, 239, 351}, },	    //Wingull     
+             new EncounterStatic { Species=333, Level = 10, Moves = new[]{64, 297, 355}, },	    //Swablu      
+             new EncounterStatic { Species=425, Level = 10, Moves = new[]{107, 95, 285}, },	    //Drifloon    
+             new EncounterStatic { Species=441, Level = 10, Moves = new[]{119, 417, 272}, },	//Chatot      
+             
+             new EncounterStatic { Species=079, Level = 10, Moves = new[]{281, 335, 362}, },	//Slowpoke    
+             new EncounterStatic { Species=098, Level = 10, Moves = new[]{11, 133, 290}, },	    //Krabby      
+             new EncounterStatic { Species=119, Level = 33, Moves = new[]{352, 214, 203}, },	//Seaking     
+             new EncounterStatic { Species=120, Level = 10, Moves = new[]{55, 278, 196}, },	    //Staryu      
+             new EncounterStatic { Species=222, Level = 10, Moves = new[]{145, 109, 446}, },	//Corsola     
+             new EncounterStatic { Species=422, Level = 10, Moves = new[]{189, 281, 290},  Form = 0 },	//Shellos
+             new EncounterStatic { Species=422, Level = 10, Moves = new[]{189, 281, 290},  Form = 1 },
+
+             new EncounterStatic { Species=202, Level = 15, Moves = new[]{243, 204, 227}, },	//Wobbuffet   
+             new EncounterStatic { Species=238, Level = 10, Moves = new[]{186, 445, 285}, },	//Smoochum    
+             new EncounterStatic { Species=303, Level = 10, Moves = new[]{313, 424, 8}, },	    //Mawile      
+             new EncounterStatic { Species=307, Level = 10, Moves = new[]{96, 409, 203}, },	    //Meditite    
+             new EncounterStatic { Species=436, Level = 10, Moves = new[]{95, 285, 356}, },	    //Bronzor     
+             new EncounterStatic { Species=052, Level = 10, Moves = new[]{10, 95, 290}, },	    //Meowth      
+             new EncounterStatic { Species=479, Level = 10, Moves = new[]{86, 351, 324}, },	    //Rotom       
+             new EncounterStatic { Species=280, Level = 10, Moves = new[]{93, 194, 270}, },	    //Ralts       
+             new EncounterStatic { Species=302, Level = 10, Moves = new[]{193, 389, 180}, },	//Sableye     
+             new EncounterStatic { Species=442, Level = 10, Moves = new[]{180, 220, 196}, },	//Spiritomb   
+             
+             new EncounterStatic { Species=056, Level = 10, Moves = new[]{67, 179, 9}, },	    //Mankey      
+             new EncounterStatic { Species=111, Level = 10, Moves = new[]{30, 68, 38}, },	    //Rhyhorn     
+             new EncounterStatic { Species=231, Level = 10, Moves = new[]{175, 484, 402}, },	//Phanpy      
+             new EncounterStatic { Species=451, Level = 10, Moves = new[]{44, 97, 401}, },	    //Skorupi     
+             new EncounterStatic { Species=216, Level = 10, Moves = new[]{313, 242, 264}, },	//Teddiursa   
+             new EncounterStatic { Species=296, Level = 10, Moves = new[]{292, 270, 8}, },	    //Makuhita    
+             new EncounterStatic { Species=327, Level = 10, Moves = new[]{383, 252, 276}, },	//Spinda      
+             new EncounterStatic { Species=374, Level = 10, Moves = new[]{36, 428, 442}, },	    //Beldum      
+             new EncounterStatic { Species=447, Level = 10, Moves = new[]{203, 418, 264}, },	//Riolu       
+             
+             new EncounterStatic { Species=173, Level = 10, Moves = new[]{227, 312, 214}, },	//Cleffa      
+             new EncounterStatic { Species=213, Level = 10, Moves = new[]{227, 270, 504}, },	//Shuckle     
+             new EncounterStatic { Species=299, Level = 10, Moves = new[]{33, 446, 246}, },	    //Nosepass    
+             new EncounterStatic { Species=363, Level = 10, Moves = new[]{181, 90, 401}, },	    //Spheal      
+             new EncounterStatic { Species=408, Level = 10, Moves = new[]{29, 442, 7}, },	    //Cranidos    
+             new EncounterStatic { Species=206, Level = 10, Moves = new[]{111, 277, 446}, },	//Dunsparce   
+             new EncounterStatic { Species=410, Level = 10, Moves = new[]{182, 68, 90}, },	    //Shieldon    
+             
+             new EncounterStatic { Species=048, Level = 10, Moves = new[]{50, 226, 285}, }, 	//Venonat     
+             new EncounterStatic { Species=088, Level = 10, Moves = new[]{139, 114, 425}, },	//Grimer      
+             new EncounterStatic { Species=415, Level = 10, Moves = new[]{16, 366, 314}, },	    //Combee      
+             new EncounterStatic { Species=015, Level = 10, Moves = new[]{31, 314, 210}, },	    //Beedrill    
+             new EncounterStatic { Species=335, Level = 10, Moves = new[]{98, 458, 67}, },	    //Zangoose    
+             new EncounterStatic { Species=336, Level = 10, Moves = new[]{44, 34, 401}, },	    //Seviper     
+        }).ToArray();
+
+        internal static readonly EncounterStatic[] B2W2_DreamWorld = DreamWorld_Common.Concat(new[]
+        {
+             new EncounterStatic { Species=535, Level = 10, Moves = new[]{496, 414, 352}, },	//Tympole    
+             new EncounterStatic { Species=546, Level = 10, Moves = new[]{73, 227, 388}, },	    //Cottonee   
+             new EncounterStatic { Species=548, Level = 10, Moves = new[]{79, 204, 230}, },	    //Petilil    
+             new EncounterStatic { Species=588, Level = 10, Moves = new[]{203, 224, 450}, },	//Karrablast 
+             new EncounterStatic { Species=616, Level = 10, Moves = new[]{51, 226, 227}, },	    //Shelmet    
+             new EncounterStatic { Species=545, Level = 30, Moves = new[]{342, 390, 276}, },	//Scolipede  
+             
+             new EncounterStatic { Species=519, Level = 10, Moves = new[]{16, 95, 234}, },	    //Pidove      
+             new EncounterStatic { Species=561, Level = 10, Moves = new[]{95, 500, 257}, },	    //Sigilyph    
+             new EncounterStatic { Species=580, Level = 10, Moves = new[]{432, 362, 382}, },	//Ducklett    
+             new EncounterStatic { Species=587, Level = 10, Moves = new[]{98, 403, 204}, },	    //Emolga      
+             
+             new EncounterStatic { Species=550, Level = 10, Moves = new[]{29, 97, 428}, Form = 0 },	//Basculin
+             new EncounterStatic { Species=550, Level = 10, Moves = new[]{29, 97, 428}, Form = 1 },
+             new EncounterStatic { Species=594, Level = 10, Moves = new[]{392, 243, 220}, },	//Alomomola   
+             new EncounterStatic { Species=618, Level = 10, Moves = new[]{189, 174, 281}, },	//Stunfisk    
+             new EncounterStatic { Species=564, Level = 10, Moves = new[]{205, 175, 334}, },	//Tirtouga    
+             
+             new EncounterStatic { Species=605, Level = 10, Moves = new[]{377, 112, 417}, },	//Elgyem      
+             new EncounterStatic { Species=624, Level = 10, Moves = new[]{210, 427, 389}, },	//Pawniard    
+             new EncounterStatic { Species=596, Level = 36, Moves = new[]{486, 50, 228}, },	    //Galvantula  
+             new EncounterStatic { Species=578, Level = 32, Moves = new[]{105, 286, 271}, },	//Duosion     
+             new EncounterStatic { Species=622, Level = 10, Moves = new[]{205, 7, 9}, },	    //Golett 
+             
+             new EncounterStatic { Species=631, Level = 10, Moves = new[]{510, 257, 202}, },	//Heatmor     
+             new EncounterStatic { Species=632, Level = 10, Moves = new[]{210, 203, 422}, },	//Durant      
+             new EncounterStatic { Species=556, Level = 10, Moves = new[]{42, 73, 191}, },	    //Maractus    
+             new EncounterStatic { Species=558, Level = 34, Moves = new[]{157, 68, 400}, },	    //Crustle     
+             new EncounterStatic { Species=553, Level = 40, Moves = new[]{242, 68, 212}, },	    //Krookodile  
+             
+             new EncounterStatic { Species=529, Level = 10, Moves = new[]{229, 319, 431}, },	//Drilbur     
+             new EncounterStatic { Species=621, Level = 10, Moves = new[]{44, 424, 389}, },	    //Druddigon   
+             new EncounterStatic { Species=525, Level = 25, Moves = new[]{479, 174, 484}, },	//Boldore     
+             new EncounterStatic { Species=583, Level = 35, Moves = new[]{429, 420, 286}, },	//Vanillish   
+             new EncounterStatic { Species=600, Level = 38, Moves = new[]{451, 356, 393}, },	//Klang       
+             new EncounterStatic { Species=610, Level = 10, Moves = new[]{82, 68, 400}, },	    //Axew        
+             
+             new EncounterStatic { Species=531, Level = 10, Moves = new[]{270, 227, 281}, },	//Audino      
+             new EncounterStatic { Species=538, Level = 10, Moves = new[]{20, 8, 276}, },	    //Throh       
+             new EncounterStatic { Species=539, Level = 10, Moves = new[]{249, 9, 530}, },	    //Sawk        
+             new EncounterStatic { Species=559, Level = 10, Moves = new[]{67, 252, 409}, },	    //Scraggy     
+             new EncounterStatic { Species=533, Level = 25, Moves = new[]{67, 183, 409}, },	    //Gurdurr     
+        }).ToArray();
+        #endregion
+
         internal static readonly int[] Roaming_MetLocation_BW =
         {
             25,26,27,28, // Route 12,13,14,15 Night latter half
@@ -457,7 +731,7 @@ namespace PKHeX.Core
             new EncounterSlot{Species = 196, LevelMin = 10, LevelMax = 60, },
             new EncounterSlot{Species = 197, LevelMin = 10, LevelMax = 60, },
             new EncounterSlot{Species = 470, LevelMin = 10, LevelMax = 60, },
-            new EncounterSlot{Species = 471, LevelMin = 10, LevelMax = 60, }, 
+            new EncounterSlot{Species = 471, LevelMin = 10, LevelMax = 60, },
         };
         private static readonly EncounterArea[] SlotsB2_HiddenGrotto =
         {
@@ -492,7 +766,7 @@ namespace PKHeX.Core
             061, 062, 063, 064, 065, 066, 067, 068, 069, 070, 071, 072, 073, 074, 075, 076, 077, 078, 079, 080,
             081, 082, 083, 084, 085, 086, 087, 088, 089, 090, 091, 092, 093, 094, 095, 096, 097, 098, 099, 100,
             101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116,
-            
+
         };
         internal static readonly int[] ValidMet_B2W2 =
         {

--- a/PKHeX/Legality/Tables5.cs
+++ b/PKHeX/Legality/Tables5.cs
@@ -504,7 +504,7 @@ namespace PKHeX.Core
 
             //Event
             new EncounterStatic { Species = 494, Level = 15, Location = 62, Shiny = false}, // Victini @ Liberty Garden
-            new EncounterStatic { Species = 570, Level = 10, Location = 32, Gender = 0, Gift = true, }, // Zorua @ Castelia City
+            new EncounterStatic { Species = 570, Level = 10, Location = 32, Gender = 0, }, // Zorua @ Castelia City
             new EncounterStatic { Species = 571, Level = 25, Location = 72, Gender = 1, }, // Zoroark @ Lostlorn Forest
         };
 

--- a/PKHeX/Legality/VivillonTables.cs
+++ b/PKHeX/Legality/VivillonTables.cs
@@ -63,7 +63,7 @@ namespace PKHeX.Core
                 mainform = 01, // Polar
                 otherforms = new[]
                 {
-                    new FormSubregionTable { form = 01, region = new[] {12,13,14} },
+                    new FormSubregionTable { form = 00, region = new[] {12,13,14} },
                     new FormSubregionTable { form = 07, region = new[] {05} },
                     new FormSubregionTable { form = 10, region = new[] {04} },
                 }


### PR DESCRIPTION
- Add a lengthy dream world table with special moves and levels (wonder if there is already a binary database). I guess location can be a good flag from PDW.
- Fixed a minor typo at vivillontables.
- Working on adding PGL Gift from Dream World (finished)