### PR TITLE
Gen3 WasEgg Pokemon in gen 4 or later, Gen 4 transfer encounter

### DIFF
--- a/PKHeX/Legality/Checks.cs
+++ b/PKHeX/Legality/Checks.cs
@@ -722,17 +722,17 @@ namespace PKHeX.Core
             if (pkm.WasLink)
                 return verifyEncounterLink();
 
+            if (pkm.Gen3 && !pkm.HasOriginalMetLocation)
+            {
+                return verifyEncounterG3Transfer();
+            }
+
             bool wasEvent = pkm.WasEvent || pkm.WasEventEgg;
             if (wasEvent)
             {
                 var result = verifyEncounterEvent();
                 if (result != null)
                     return result;
-            }
-
-            if (pkm.Gen3 && !pkm.HasOriginalMetLocation)
-            {
-                return verifyEncounterG3Transfer();
             }
 
             if (null != (EncounterMatch = Legal.getValidStaticEncounter(pkm)))
@@ -770,8 +770,11 @@ namespace PKHeX.Core
             {
                 pkm.WasEgg = true;
                 EggResult = verifyEncounterEgg3Transfer();
+                if (pkm.IsEgg)
+                    return EggResult;
             }
 
+            // TODO: Include also gen 3 events
             if (null != (EncounterMatch = Legal.getValidStaticEncounter(pkm)))
             {
                 NonEggResult = verifyEncounterStatic();

--- a/PKHeX/Legality/Checks.cs
+++ b/PKHeX/Legality/Checks.cs
@@ -494,7 +494,7 @@ namespace PKHeX.Core
         private CheckResult verifyEncounterEgg()
         {
             // Check Species
-            if (Legal.NoHatchFromEgg.Contains(pkm.Species))
+            if (Legal.NoHatchFromEgg.Contains(pkm.Species) && (pkm.GenNumber != 4 || pkm.Species == 490))
                 return new CheckResult(Severity.Invalid, V50, CheckIdentifier.Encounter);
 
             switch (pkm.GenNumber)

--- a/PKHeX/Legality/Checks.cs
+++ b/PKHeX/Legality/Checks.cs
@@ -659,13 +659,17 @@ namespace PKHeX.Core
         {
             var s = (EncounterStatic)EncounterMatch;
 
+            if (pkm.GenNumber == 3 && pkm.Species == 151 && s.Location == 201 && pkm.Language != 1)
+            {
+                return new CheckResult(Severity.Invalid, V353, CheckIdentifier.Encounter);
+            }
             if (pkm.GenNumber == 4 && pkm.Species == 493 && s.Location == 086)
             {
                   return new CheckResult(Severity.Invalid, V352, CheckIdentifier.Encounter);
             }
-            if (pkm.GenNumber == 3 && pkm.Species == 151 && s.Location == 201 && pkm.Language != 1)
+            if (pkm.GenNumber == 4 && pkm.Species == 492 && s.Location == 063 && pkm.Version != (int)GameVersion.Pt)
             {
-                return new CheckResult(Severity.Invalid, V353, CheckIdentifier.Encounter);
+                return new CheckResult(Severity.Invalid, V354, CheckIdentifier.Encounter);
             }
 
             // Re-parse relearn moves
@@ -797,7 +801,7 @@ namespace PKHeX.Core
             // TODO: Include also gen 3 events
             if (null != (EncounterMatch = Legal.getValidStaticEncounter(pkm)))
             {
-                NonEggResult = new CheckResult(Severity.Valid, V75, CheckIdentifier.Encounter);
+                NonEggResult = verifyEncounterStatic();
             }
 
             if (NonEggResult !=null)

--- a/PKHeX/Legality/Checks.cs
+++ b/PKHeX/Legality/Checks.cs
@@ -729,7 +729,7 @@ namespace PKHeX.Core
 
             if (pkm.Gen4 && !pkm.HasOriginalMetLocation)
             {
-                return verifyEncounterG3Transfer();
+                return verifyEncounterG4Transfer();
             }
 
             bool wasEvent = pkm.WasEvent || pkm.WasEventEgg;
@@ -839,7 +839,7 @@ namespace PKHeX.Core
                 CrownLocation = pkm.Species == 251 ? 30010 : 30012; // Celebi : Beast
             
             if (pkm.Met_Location != 30001 && (!AllowCrownLocation || pkm.Met_Location != CrownLocation))
-                InvalidTransferResult = new CheckResult(Severity.Invalid, V61, CheckIdentifier.Encounter);
+                InvalidTransferResult = new CheckResult(Severity.Invalid, AllowCrownLocation ? V351 : V61, CheckIdentifier.Encounter);
 
             bool wasEvent = pkm.WasEvent || pkm.WasEventEgg;
             if (wasEvent)

--- a/PKHeX/Legality/Checks.cs
+++ b/PKHeX/Legality/Checks.cs
@@ -659,6 +659,15 @@ namespace PKHeX.Core
         {
             var s = (EncounterStatic)EncounterMatch;
 
+            if (pkm.GenNumber == 4 && pkm.Species == 493 && s.Location == 086)
+            {
+                  return new CheckResult(Severity.Invalid, V352, CheckIdentifier.Encounter);
+            }
+            if (pkm.GenNumber == 3 && pkm.Species == 151 && s.Location == 201 && pkm.Language != 1)
+            {
+                return new CheckResult(Severity.Invalid, V353, CheckIdentifier.Encounter);
+            }
+
             // Re-parse relearn moves
             if (s.EggLocation != 60002 || vRelearn.Any(rl => !rl.Valid))
             {

--- a/PKHeX/Legality/Core.cs
+++ b/PKHeX/Legality/Core.cs
@@ -1090,7 +1090,7 @@ namespace PKHeX.Core
         }
         internal static Tuple<object, int, byte> getEncounter12(PKM pkm, bool gen2)
         {
-            var g1 = getEncounter12(pkm, GameVersion.RBY);
+            var g1 = pkm.IsEgg ? null :getEncounter12(pkm, GameVersion.RBY);
             var g2 = gen2 ? getEncounter12(pkm, GameVersion.GSC) : null;
 
             if (g1 == null || g2 == null)
@@ -1139,13 +1139,20 @@ namespace PKHeX.Core
 
             return slots.Any() ? slots.ToArray() : null;
         }
-        private static bool getWasEgg23(PKM pkm)
+        internal static bool getWasEgg23(PKM pkm)
         {
+            if (pkm.IsEgg)
+                return true;
             if (pkm.Format > 2 && pkm.Ball != 4)
                 return false;
+            if (pkm.Format == 3)
+                return pkm.WasEgg;
 
             int lvl = pkm.CurrentLevel;
             if (lvl < 5)
+                return false;
+
+            if(pkm.Format > 3 && pkm.Met_Level <5)
                 return false;
 
             return getEvolutionValid(pkm);

--- a/PKHeX/Legality/LegalityCheckStrings.cs
+++ b/PKHeX/Legality/LegalityCheckStrings.cs
@@ -336,7 +336,8 @@ namespace PKHeX.Core
         public static string V347 {get; set;} = "Inherited move learned by Level-up.Not expected in an event egg.";
         public static string V348 {get; set;} = "Inherited tutor move. Not expected in an event egg.";
         public static string V350 {get; set;} = "Inherited TM/HM move. Not expected in an event egg.";
+        public static string V351 {get; set;} = "Invalid Met Location, expected Transporter or Crown."; // Invalid
         #endregion
 
-        }
+    }
 }

--- a/PKHeX/Legality/LegalityCheckStrings.cs
+++ b/PKHeX/Legality/LegalityCheckStrings.cs
@@ -339,6 +339,7 @@ namespace PKHeX.Core
         public static string V351 {get; set;} = "Invalid Met Location, expected Transporter or Crown."; // Invalid
         public static string V352 {get; set;} = "Arceus from Hall of Origin. Unreleased event.";
         public static string V353 {get; set;} = "Non japanese Mew from Faraway Island. Unreleased event.";
+        public static string V354 {get; set;} = "Non Platinum Shaymin from Flower Paradise. Unreleased event.";
         #endregion
 
     }

--- a/PKHeX/Legality/LegalityCheckStrings.cs
+++ b/PKHeX/Legality/LegalityCheckStrings.cs
@@ -337,6 +337,8 @@ namespace PKHeX.Core
         public static string V348 {get; set;} = "Inherited tutor move. Not expected in an event egg.";
         public static string V350 {get; set;} = "Inherited TM/HM move. Not expected in an event egg.";
         public static string V351 {get; set;} = "Invalid Met Location, expected Transporter or Crown."; // Invalid
+        public static string V352 {get; set;} = "Arceus from Hall of Origin. Unreleased event.";
+        public static string V353 {get; set;} = "Non japanese Mew from Faraway Island. Unreleased event.";
         #endregion
 
     }

--- a/PKHeX/Legality/Tables3.cs
+++ b/PKHeX/Legality/Tables3.cs
@@ -265,7 +265,7 @@ namespace PKHeX.Core
             new EncounterStatic { Species = 384, Level = 70, Location = 085, }, // Rayquaza @ Sky Pillar
 
             // Event
-            new EncounterStatic { Species = 151, Level = 30, Location = 201, Version = GameVersion.E, Fateful = true }, // Mew @ Faraway Island
+            new EncounterStatic { Species = 151, Level = 30, Location = 201, Version = GameVersion.E, Fateful = true }, // Mew @ Faraway Island (Unreleased outside of Japan)
             new EncounterStatic { Species = 249, Level = 70, Location = 211, Version = GameVersion.E, }, // Lugia @ Navel Rock
             new EncounterStatic { Species = 250, Level = 70, Location = 211, Version = GameVersion.E, }, // Ho-Oh @ Navel Rock
             new EncounterStatic { Species = 386, Level = 30, Location = 200, Version = GameVersion.E, Form = 3, Fateful = true }, // Deoxys @ Birth Island

--- a/PKHeX/Legality/Tables4.cs
+++ b/PKHeX/Legality/Tables4.cs
@@ -441,7 +441,7 @@ namespace PKHeX.Core
             new EncounterStatic { Species = 490, Level = 01, EggLocation = 3001, Fateful = true, Gift = true }, //Manaphy from Pokemon Ranger
             new EncounterStatic { Species = 491, Level = 40, Location = 079, Version = GameVersion.DP,}, //Darkrai @ Newmoon Island
             new EncounterStatic { Species = 491, Level = 50, Location = 079, Version = GameVersion.Pt,}, //Darkrai @ Newmoon Island
-            new EncounterStatic { Species = 492, Form = 0, Level = 30, Location = 063, Fateful = true,}, //Shaymin @ Flower Paradise
+            new EncounterStatic { Species = 492, Form = 0, Level = 30, Location = 063, Fateful = true,}, //Shaymin @ Flower Paradise (Unreleased in Diamond and Pearl)
             new EncounterStatic { Species = 493, Form = 0, Level = 80, Location = 086,}, //Arceus @ Hall of Origin (Unreleased)
         };
         internal static readonly EncounterStatic[] Encounter_DPPt = Encounter_DPPt_Roam.SelectMany(e => e.Clone(Roaming_MetLocation_DPPt)).Concat(Encounter_DPPt_Regular).ToArray();

--- a/PKHeX/Legality/Tables4.cs
+++ b/PKHeX/Legality/Tables4.cs
@@ -442,7 +442,7 @@ namespace PKHeX.Core
             new EncounterStatic { Species = 491, Level = 40, Location = 079, Version = GameVersion.DP,}, //Darkrai @ Newmoon Island
             new EncounterStatic { Species = 491, Level = 50, Location = 079, Version = GameVersion.Pt,}, //Darkrai @ Newmoon Island
             new EncounterStatic { Species = 492, Form = 0, Level = 30, Location = 063, Fateful = true,}, //Shaymin @ Flower Paradise
-            //new EncounterStatic { Species = 493, Level = 80, Location = 086,}, //Arceus @ Hall of Origin
+            new EncounterStatic { Species = 493, Form = 0, Level = 80, Location = 086,}, //Arceus @ Hall of Origin (Unreleased)
         };
         internal static readonly EncounterStatic[] Encounter_DPPt = Encounter_DPPt_Roam.SelectMany(e => e.Clone(Roaming_MetLocation_DPPt)).Concat(Encounter_DPPt_Regular).ToArray();
 

--- a/PKHeX/PKM/PK4.cs
+++ b/PKHeX/PKM/PK4.cs
@@ -385,7 +385,7 @@ namespace PKHeX.Core
         }
         // Legality Extensions
         public override bool WasEgg => GenNumber < 4 ? base.WasEgg : Egg_Location > 0;
-
+        public override bool WasEvent => Met_Location >= 3000 && Met_Location <= 3076 || FatefulEncounter && Species != 386;
         // Methods
         public override byte[] Encrypt()
         {

--- a/PKHeX/PKM/PK4.cs
+++ b/PKHeX/PKM/PK4.cs
@@ -383,7 +383,9 @@ namespace PKHeX.Core
                 return pm6stat * 5 + maxIV % 5;
             }
         }
-        
+        // Legality Extensions
+        public override bool WasEgg => GenNumber < 4 ? base.WasEgg : Egg_Location > 0;
+
         // Methods
         public override byte[] Encrypt()
         {

--- a/PKHeX/PKM/PK5.cs
+++ b/PKHeX/PKM/PK5.cs
@@ -299,7 +299,10 @@ namespace PKHeX.Core
                 return pm6stat * 5 + maxIV % 5;
             }
         }
-        
+
+        // Legality Extensions
+        public override bool WasEgg => GenNumber < 4 ? base.WasEgg : GenNumber == 4 ? Egg_Location > 0 : Legal.EggLocations.Contains(Egg_Location);
+
         // Methods
         public override byte[] Encrypt()
         {

--- a/PKHeX/PKM/PK6.cs
+++ b/PKHeX/PKM/PK6.cs
@@ -584,11 +584,11 @@ namespace PKHeX.Core
 
         // Legality Properties
         public override bool WasLink => Met_Location == 30011;
-        public override bool WasEgg => GenNumber < 5 ? base.WasEgg : Legal.EggLocations.Contains(Egg_Location);
+        public override bool WasEgg => GenNumber < 4 ? base.WasEgg : GenNumber == 4 ? Egg_Location > 0 : Legal.EggLocations.Contains(Egg_Location);
         public override bool WasEvent => Met_Location > 40000 && Met_Location < 50000 || FatefulEncounter && Species != 386;
         public override bool WasEventEgg => ((Egg_Location > 40000 && Egg_Location < 50000) || (FatefulEncounter && Egg_Location == 30002)) && Met_Level == 1;
-        public override bool WasTradedEgg => GenNumber < 5 ? base.WasEgg : Egg_Location == 30002;
-        public override bool WasIngameTrade => GenNumber < 5 ? base.WasEgg : Met_Location == 30001;
+        public override bool WasTradedEgg => Egg_Location == 30002 || GenNumber == 4 && Egg_Location == 2002;
+        public override bool WasIngameTrade => Met_Location == 30001 || GenNumber == 4 && Egg_Location == 2001;
 
         public PK7 convertToPK7()
         {

--- a/PKHeX/PKM/PK6.cs
+++ b/PKHeX/PKM/PK6.cs
@@ -584,11 +584,11 @@ namespace PKHeX.Core
 
         // Legality Properties
         public override bool WasLink => Met_Location == 30011;
-        public override bool WasEgg => Legal.EggLocations.Contains(Egg_Location);
+        public override bool WasEgg => GenNumber < 5 ? base.WasEgg : Legal.EggLocations.Contains(Egg_Location);
         public override bool WasEvent => Met_Location > 40000 && Met_Location < 50000 || FatefulEncounter && Species != 386;
         public override bool WasEventEgg => ((Egg_Location > 40000 && Egg_Location < 50000) || (FatefulEncounter && Egg_Location == 30002)) && Met_Level == 1;
-        public override bool WasTradedEgg => Egg_Location == 30002;
-        public override bool WasIngameTrade => Met_Location == 30001;
+        public override bool WasTradedEgg => GenNumber < 5 ? base.WasEgg : Egg_Location == 30002;
+        public override bool WasIngameTrade => GenNumber < 5 ? base.WasEgg : Met_Location == 30001;
 
         public PK7 convertToPK7()
         {

--- a/PKHeX/PKM/PK7.cs
+++ b/PKHeX/PKM/PK7.cs
@@ -621,10 +621,10 @@ namespace PKHeX.Core
 
         // Legality Properties
         public override bool WasLink => Met_Location == 30011;
-        public override bool WasEgg => Legal.EggLocations.Contains(Egg_Location);
+        public override bool WasEgg => GenNumber < 5 ? base.WasEgg : Legal.EggLocations.Contains(Egg_Location);
         public override bool WasEvent => Met_Location > 40000 && Met_Location < 50000 || FatefulEncounter && Species != 386;
         public override bool WasEventEgg => ((Egg_Location > 40000 && Egg_Location < 50000) || (FatefulEncounter && Egg_Location == 30002)) && Met_Level == 1;
-        public override bool WasTradedEgg => Egg_Location == 30002;
-        public override bool WasIngameTrade => Met_Location == 30001;
+        public override bool WasTradedEgg => GenNumber < 5 ? base.WasEgg : Egg_Location == 30002;
+        public override bool WasIngameTrade => GenNumber < 5 ? base.WasEgg : Met_Location == 30001;
     }
 }

--- a/PKHeX/PKM/PK7.cs
+++ b/PKHeX/PKM/PK7.cs
@@ -621,10 +621,10 @@ namespace PKHeX.Core
 
         // Legality Properties
         public override bool WasLink => Met_Location == 30011;
-        public override bool WasEgg => GenNumber < 5 ? base.WasEgg : Legal.EggLocations.Contains(Egg_Location);
+        public override bool WasEgg => GenNumber < 4 ? base.WasEgg : GenNumber == 4 ? Egg_Location > 0 : Legal.EggLocations.Contains(Egg_Location);
         public override bool WasEvent => Met_Location > 40000 && Met_Location < 50000 || FatefulEncounter && Species != 386;
         public override bool WasEventEgg => ((Egg_Location > 40000 && Egg_Location < 50000) || (FatefulEncounter && Egg_Location == 30002)) && Met_Level == 1;
-        public override bool WasTradedEgg => GenNumber < 5 ? base.WasEgg : Egg_Location == 30002;
-        public override bool WasIngameTrade => GenNumber < 5 ? base.WasEgg : Met_Location == 30001;
+        public override bool WasTradedEgg => Egg_Location == 30002 || GenNumber == 4 && Egg_Location == 2002;
+        public override bool WasIngameTrade => Met_Location == 30001 || GenNumber == 4 && Egg_Location == 2001;
     }
 }

--- a/PKHeX/Resources/text/en/LegalityCheckStrings_en.txt
+++ b/PKHeX/Resources/text/en/LegalityCheckStrings_en.txt
@@ -272,3 +272,5 @@ V347 = Inherited move learned by Level-up. Not expected in an event egg.
 V348 = Inherited tutor move. Not expected in an event egg.
 V350 = Inherited TM/HM move. Not expected in an event egg.
 V351 = Invalid Met Location, expected Transporter or Crown.
+V352 = Arceus from Hall of Origin. Unreleased event.
+V353 = Non japanese Mew from Faraway Island. Unreleased event.

--- a/PKHeX/Resources/text/en/LegalityCheckStrings_en.txt
+++ b/PKHeX/Resources/text/en/LegalityCheckStrings_en.txt
@@ -274,3 +274,4 @@ V350 = Inherited TM/HM move. Not expected in an event egg.
 V351 = Invalid Met Location, expected Transporter or Crown.
 V352 = Arceus from Hall of Origin. Unreleased event.
 V353 = Non japanese Mew from Faraway Island. Unreleased event.
+V354 = Non Platinum Shaymin from Flower Paradise. Unreleased event.

--- a/PKHeX/Resources/text/en/LegalityCheckStrings_en.txt
+++ b/PKHeX/Resources/text/en/LegalityCheckStrings_en.txt
@@ -271,3 +271,4 @@ V343 = Expected the following Moves: {0}
 V347 = Inherited move learned by Level-up. Not expected in an event egg.
 V348 = Inherited tutor move. Not expected in an event egg.
 V350 = Inherited TM/HM move. Not expected in an event egg.
+V351 = Invalid Met Location, expected Transporter or Crown.


### PR DESCRIPTION
pkm.WasEgg is never true for gen 3 pokemon because there is no egg data to identify. Like gen 2 assume every pokemon above level 5 in pokeball that can be hatched from an egg that are eggs

For this pokemon check always for an egg encounter first, if does not match egg encounter then check other encounters

When verify moves for this pokemon it here is a non egg possible encounter first check moves from that encounter and if does not match check egg moves

Also for gen 2 unhatched eggs ignore gen 1 encounters