### PR TITLE
Fix issue #1001 Better approach for verifyEncounterG3Transfer function

### DIFF
--- a/PKHeX/Legality/Checks.cs
+++ b/PKHeX/Legality/Checks.cs
@@ -821,10 +821,11 @@ namespace PKHeX.Core
                 G3Result = verifyEncounterEvent() ?? new CheckResult(Severity.Invalid, V78, CheckIdentifier.Encounter);
             }
 
-            // Now check Mew and Deoxys, return only Event Result if a valid gen 3 event is found, if not return static encounter result
-            if (pkm.Species != 151 || pkm.Species != 386)
+            // Now check Mew and Deoxys, they can be event or static encounters both with fatefull encounter
+            if (pkm.Species == 151 || pkm.Species == 386)
             {
                 var EventResult = verifyEncounterEvent();
+                // Only return event if is valid, if not return result from static encounter
                 if (EventResult?.Valid ?? false)
                     G3Result = EventResult;
             }

--- a/PKHeX/Legality/Core.cs
+++ b/PKHeX/Legality/Core.cs
@@ -1163,6 +1163,8 @@ namespace PKHeX.Core
 
             if(pkm.Format > 3 && pkm.Met_Level <5)
                 return false;
+            if (pkm.Format > 3 && pkm.FatefulEncounter)
+                return false;
 
             return getEvolutionValid(pkm);
         }

--- a/PKHeX/PKM/PK4.cs
+++ b/PKHeX/PKM/PK4.cs
@@ -385,7 +385,7 @@ namespace PKHeX.Core
         }
         // Legality Extensions
         public override bool WasEgg => GenNumber < 4 ? base.WasEgg : Egg_Location > 0;
-        public override bool WasEvent => Met_Location >= 3000 && Met_Location <= 3076 || FatefulEncounter && Species != 386;
+        public override bool WasEvent => Met_Location >= 3000 && Met_Location <= 3076 || FatefulEncounter;
         // Methods
         public override byte[] Encrypt()
         {


### PR DESCRIPTION
Changed verifyEncounterG3Transfer, when both Egg Result and NonEgg Result happens Egg only overwrite if is the only valid encounter, if a normal result can be found and is possible to have a valid egg encounter then return egg encounter.

Also add checks on gen 3 WasEvent pokemon, but for now it will return Mistery Gift not found because there is no gen 3 events database, is better than give non-event errors. Special conditions for Mew and Deoxys.

Changed verifyEncounterG3Transfer and verifyEncounterG4Transfer to return both message error for InvalidTransfer and G3/G4 invalid encounter if both errors happen at the same time

And last excluded fateful encounter pokemon from getWasEgg23, it cant be WasEgg pokemon because FatefulEncounter from eggs is lost when hatch in gen 3 games