### PR TITLE
General gen5 fixes

### DIFF
--- a/PKHeX/Legality/Checks.cs
+++ b/PKHeX/Legality/Checks.cs
@@ -308,14 +308,11 @@ namespace PKHeX.Core
                 }
                 return;
             }
-
-            // Insert Gen 3 Checks Here
-            if (pkm.Format == 3)
-            {
-                // Suppressing this temporarily
+            else if (3 <= pkm.Format && pkm.Format <= 5)
+            { 
+                // Suppressing temporarily
                 return;
             }
-            // End Gen 3 Checks
 
             if (validOT.Length == 0)
             {
@@ -1312,8 +1309,6 @@ namespace PKHeX.Core
         {
             if (pkm.Format < 3)
                 return; // no ball info saved
-            if (pkm.GenNumber < 6)
-                return; // not implemented
 
             if (!Encounter.Valid)
                 return;
@@ -1349,6 +1344,8 @@ namespace PKHeX.Core
                 EncounterStatic enc = EncounterMatch as EncounterStatic;
                 if (enc?.Gift ?? false)
                     verifyBallEquals(enc.Ball);
+                else if (pkm.Met_Location == 75 && pkm.Gen5) // DreamWorld
+                    verifyBallEquals(Legal.DreamWorldBalls);
                 else
                     verifyBallEquals(Legal.getWildBalls(pkm));
                 return;

--- a/PKHeX/Legality/Core.cs
+++ b/PKHeX/Legality/Core.cs
@@ -305,8 +305,8 @@ namespace PKHeX.Core
         {
             foreach (EncounterStatic s in t)
             {
-                s.Location = 75;  //Entree Forest. Location can be a flag from dream world
-                s.Ability = 4;    //What if 1=2=HA?
+                s.Location = 75;  //Entree Forest
+                s.Ability = (PersonalTable.B2W2.getAbilities(s.Species, s.Form)[2] == 0) ? 1 : 4; // Check if has HA
             }
         }
         private static void MarkG5Slots(ref EncounterArea[] Areas)
@@ -499,8 +499,6 @@ namespace PKHeX.Core
                 var Pt_Slots = getEncounterTables(GameVersion.Pt);
                 var HG_Slots = getEncounterTables(GameVersion.HG);
                 var SS_Slots = getEncounterTables(GameVersion.SS);
-                var DP_GreatMarshAlt = EncounterArea.getSimpleEncounterArea(DP_GreatMarshAlt_Speices, new[] {22,22, 24,24, 26,26}, 52, SlotType.Grass_Safari);
-                var Pt_GreatMarshAlt = EncounterArea.getSimpleEncounterArea(Pt_GreatMarshAlt_Speices, new[] {27,30}, 52, SlotType.Grass_Safari);
                 var DP_Trophy = EncounterArea.getTrophyArea(TrophyDP, new[] {16, 18});
                 var Pt_Trophy = EncounterArea.getTrophyArea(TrophyPt, new[] {22, 22});
                 var HG_Headbutt_Slots = EncounterArea.getArray4HGSS_Headbutt(Data.unpackMini(Resources.encunters_hb_hg, "hg"));
@@ -564,7 +562,7 @@ namespace PKHeX.Core
                 MarkBWSwarmSlots(ref SlotsB_Swarm);
                 MarkBWSwarmSlots(ref SlotsW_Swarm);
                 SlotsB = addExtraTableSlots(BSlots, SlotsB_Swarm);
-                SlotsW = addExtraTableSlots(WSlots, SlotsW_Swarm);
+                SlotsW = addExtraTableSlots(WSlots, SlotsW_Swarm, WhiteForestSlot);
 
                 var B2Slots = getEncounterTables(GameVersion.B2);
                 var W2Slots = getEncounterTables(GameVersion.W2);
@@ -937,7 +935,7 @@ namespace PKHeX.Core
 
             EncounterTrade[] table = getEncounterTradeTable(pkm);
 
-            var poss = table?.Where(f => p.Any(r => r.Species == f.Species)).ToList();
+            var poss = table?.Where(f => p.Any(r => r.Species == f.Species) && f.Version.Contains((GameVersion)pkm.Version)).ToList();
 
             if (poss == null || poss.Count == 0)
                 return null;

--- a/PKHeX/Legality/Structures/EncounterStatic.cs
+++ b/PKHeX/Legality/Structures/EncounterStatic.cs
@@ -89,7 +89,7 @@
                 Gender = Gender,
                 EggLocation = EggLocation,
                 Nature = Nature,
-                Gift = Gift,
+                Gift = true,    //Only
                 Ball = 25,      //Dream Ball
                 Version = Version,
                 IVs = IVs,

--- a/PKHeX/Legality/Structures/EncounterTrade.cs
+++ b/PKHeX/Legality/Structures/EncounterTrade.cs
@@ -21,7 +21,7 @@
 
         public string Name => "In-game Trade";
 
-        public static int[] DefalutMetLocation = new[]
+        public static int[] DefalutMetLocation = 
         {
            254, 2001, 30002, 30001, 30001,
         };
@@ -31,5 +31,4 @@
     {
         public uint PID;
     }
-
 }

--- a/PKHeX/Legality/Tables4.cs
+++ b/PKHeX/Legality/Tables4.cs
@@ -524,7 +524,7 @@ namespace PKHeX.Core
             //Stationary Lengerdary
             new EncounterStatic { Species = 144, Level = 50, Location = 203, }, //Articuno @ Seafoam Islands
             new EncounterStatic { Species = 145, Level = 50, Location = 158, }, //Zapdos @ Route 10
-            new EncounterStatic { Species = 146, Level = 50, Location = 137, }, //Moltres @ Mt. Silver
+            new EncounterStatic { Species = 146, Level = 50, Location = 219, }, //Moltres @ Mt. Silver Cave
             new EncounterStatic { Species = 150, Level = 70, Location = 199, }, //Mewtwo @ Cerulean Cave
             new EncounterStatic { Species = 245, Level = 40, Location = 173, }, //Suicune @ Route 25
             new EncounterStatic { Species = 245, Level = 40, Location = 206, }, //Suicune @ Burned Tower
@@ -1011,12 +1011,15 @@ namespace PKHeX.Core
             183,194,195,298,399,400,        // Pre-National Pokédex
             046,102,115,193,285,316,452,454 // Post-National Pokédex
         };
+        private static readonly EncounterArea[] DP_GreatMarshAlt = EncounterArea.getSimpleEncounterArea(DP_GreatMarshAlt_Speices, new[] { 22, 22, 24, 24, 26, 26 }, 52, SlotType.Grass_Safari);
+
         private static readonly int[] Pt_GreatMarshAlt_Speices =
         {
             114,193,195,357,451,453,455,
             194,                            // Pre-National Pokédex
             046,102,115,285,316,352,452,454 // Post-National Pokédex
         };
+        private static readonly EncounterArea[] Pt_GreatMarshAlt = EncounterArea.getSimpleEncounterArea(Pt_GreatMarshAlt_Speices, new[] { 27, 30 }, 52, SlotType.Grass_Safari);
 
         private static readonly int[] Shellos_EastSeaLocation_DP =
         {

--- a/PKHeX/Legality/Tables5.cs
+++ b/PKHeX/Legality/Tables5.cs
@@ -106,6 +106,7 @@ namespace PKHeX.Core
             // HGSS balls not usable
             // Dream ball not usable in wild
         };
+        internal static readonly int[] DreamWorldBalls = WildPokeBalls5.Concat(new[] { 25 }).ToArray();
 
         internal static readonly int[] FutureEvolutionsGen5 =
         {
@@ -531,7 +532,7 @@ namespace PKHeX.Core
             new EncounterStatic { Species = 646, Level = 75, Location = 61,}, //Kyurem @ Giant Chasm
             //Event
             new EncounterStatic { Species = 494, Level = 15, Location = 62, Shiny = false}, // Victini @ Liberty Garden
-            new EncounterStatic { Species = 570, Level = 10, Location = 32, Gender = 0, }, // Zorua @ Castelia City
+            new EncounterStatic { Species = 570, Level = 10, Location = 08, Gender = 0, }, // Zorua @ Castelia City
             new EncounterStatic { Species = 571, Level = 25, Location = 72, Gender = 1, }, // Zoroark @ Lostlorn Forest
         };
         internal static readonly EncounterStatic[] Encounter_BW = Encounter_BW_Roam.SelectMany(e => e.Clone(Roaming_MetLocation_BW)).Concat(Encounter_BW_Regular).ToArray();
@@ -662,6 +663,20 @@ namespace PKHeX.Core
         };
         #endregion
         #region Alt Slots
+
+        // White forest white version only
+        private static readonly int[] WhiteForest_GrassSpecies =
+        {
+            016,029,032,043,063,066,069,081,092,111,
+            137,175,179,187,239,240,265,270,273,280,
+            287,293,298,304,328,371,396,403,406,440,
+        };
+        private static readonly int[] WhiteForest_SurfSpecies =
+        {
+            194,270,283,341,
+        };
+        private static readonly EncounterArea[] WhiteForestSlot = EncounterArea.getSimpleEncounterArea(WhiteForest_GrassSpecies, new[] { 5, 5 }, 51, SlotType.Grass).Concat(
+                                                                  EncounterArea.getSimpleEncounterArea(WhiteForest_SurfSpecies, new[] { 5, 5 }, 51, SlotType.Surf)).ToArray();
         private static readonly EncounterArea[] SlotsBW_Swarm =
         {
             //level range and Slottype will be marked later
@@ -689,7 +704,7 @@ namespace PKHeX.Core
                 new EncounterArea {Location = 16, Slots = new[]{new EncounterSlot {Species = 314},},},// Illumise @ Route 3
                 new EncounterArea {Location = 19, Slots = new[]{new EncounterSlot {Species = 312},},},// Minun @ Route 6
                 new EncounterArea {Location = 22, Slots = new[]{new EncounterSlot {Species = 261},},},// Poochyena @ Route 9
-                new EncounterArea {Location = 24, Slots = new[]{new EncounterSlot {Species = 048},},},// Paras @ Route 11
+                new EncounterArea {Location = 24, Slots = new[]{new EncounterSlot {Species = 046},},},// Paras @ Route 11
         }).ToArray();
 
         private static readonly EncounterArea[] SlotsB2W2_Swarm =
@@ -705,7 +720,7 @@ namespace PKHeX.Core
             new EncounterArea {Location = 026, Slots = new[]{new EncounterSlot {Species = 277},},},// Swellow @ Route 13
             new EncounterArea {Location = 028, Slots = new[]{new EncounterSlot {Species = 022},},},// Fearow @ Route 15
             new EncounterArea {Location = 029, Slots = new[]{new EncounterSlot {Species = 204},},},// Pineco @ Route 16
-            new EncounterArea {Location = 030, Slots = new[]{new EncounterSlot {Species = 187},},},// Hoppip @ Route 18
+            new EncounterArea {Location = 031, Slots = new[]{new EncounterSlot {Species = 187},},},// Hoppip @ Route 18
             new EncounterArea {Location = 032, Slots = new[]{new EncounterSlot {Species = 097},},},// Hypno @ Dreamyard
             new EncounterArea {Location = 034, Slots = new[]{new EncounterSlot {Species = 450},},},// Hippowdon @ Desert Resort
             new EncounterArea {Location = 070, Slots = new[]{new EncounterSlot {Species = 079},},},// Slowpoke @ Abundant shrine
@@ -714,7 +729,7 @@ namespace PKHeX.Core
         private static readonly EncounterArea[] SlotsB2_Swarm = SlotsB2W2_Swarm.Concat(new[] {
                 new EncounterArea {Location = 016, Slots = new[]{new EncounterSlot {Species = 313},},},// Volbeat @ Route 3
                 new EncounterArea {Location = 019, Slots = new[]{new EncounterSlot {Species = 311},},},// Plusle @ Route 6
-                new EncounterArea {Location = 125, Slots = new[]{new EncounterSlot {Species = 184},},},// Sudowoodo @ Route 20
+                new EncounterArea {Location = 125, Slots = new[]{new EncounterSlot {Species = 185},},},// Sudowoodo @ Route 20
                 new EncounterArea {Location = 127, Slots = new[]{new EncounterSlot {Species = 168},},},// Ariados @ Route 22
         }).ToArray();
         private static readonly EncounterArea[] SlotsW2_Swarm = SlotsB2W2_Swarm.Concat(new[] {


### PR DESCRIPTION
- begin to impl ball checking
- add white forest encounters for white 
- move greatmarshaltslots to table4
- fix several datapoints
- fix ability from dream world for pkm has no HA
- add version exlusive in-game trade filtering