### PR TITLE
Safari ball and sport ball checking

### DIFF
--- a/PKHeX/Legality/Checks.cs
+++ b/PKHeX/Legality/Checks.cs
@@ -1356,7 +1356,7 @@ namespace PKHeX.Core
 
                 if (pkm.Met_Location == 30016 && pkm.Gen7) // Poké Pelago
                     verifyBallEquals(4); // Pokeball
-                // For gen3/4 safari zones and BCC verify encounter already filter to not return
+                // For gen3/4 safari zones and BCC getValidWildEncounters already filter to not return
                 // mixed possible encounters between safari, BCC and other encounters
                 // That means is the first encounter is not safari then there is no safari encounter in the array
                 else if (3 <= pkm.GenNumber && pkm.GenNumber <= 4 && Legal.IsSafariSlot(enc.First().Type))

--- a/PKHeX/Legality/Checks.cs
+++ b/PKHeX/Legality/Checks.cs
@@ -1352,8 +1352,17 @@ namespace PKHeX.Core
             }
             if (EncounterType == typeof (EncounterSlot[]))
             {
+                EncounterSlot[] enc = EncounterMatch as EncounterSlot[];
+
                 if (pkm.Met_Location == 30016 && pkm.Gen7) // Poké Pelago
                     verifyBallEquals(4); // Pokeball
+                // For gen3/4 safari zones and BCC verify encounter already filter to not return
+                // mixed possible encounters between safari, BCC and other encounters
+                // That means is the first encounter is not safari then there is no safari encounter in the array
+                else if (3 <= pkm.GenNumber && pkm.GenNumber <= 4 && Legal.IsSafariSlot(enc.First().Type))
+                    verifyBallEquals(5); // Safariball
+                else if (pkm.GenNumber == 4 && pkm.HGSS && enc.First().Type == SlotType.BugContest)
+                    verifyBallEquals(0x18); // Sportball
                 else
                     verifyBallEquals(Legal.getWildBalls(pkm));
                 return;

--- a/PKHeX/Legality/Checks.cs
+++ b/PKHeX/Legality/Checks.cs
@@ -499,7 +499,7 @@ namespace PKHeX.Core
         private CheckResult verifyEncounterEgg()
         {
             // Check Species
-            if (Legal.NoHatchFromEgg.Contains(pkm.Species) && (pkm.GenNumber != 4 || pkm.Species == 490))
+            if ((Legal.NoHatchFromEgg.Contains(pkm.Species) && pkm.Species != 490) || (pkm.GenNumber != 4 && pkm.Species == 490))
                 return new CheckResult(Severity.Invalid, V50, CheckIdentifier.Encounter);
 
             switch (pkm.GenNumber)
@@ -1315,7 +1315,11 @@ namespace PKHeX.Core
 
             if (EncounterIsMysteryGift)
             {
-                verifyBallEquals(((MysteryGift)EncounterMatch).Ball);
+                if (pkm.Species == 490 && pkm.Gen4 && ((MysteryGift)EncounterMatch).Ball == 0)
+                    // there is no ball data in Manaphy Mystery Gift
+                    verifyBallEquals(4); // Pokeball
+                else
+                    verifyBallEquals(((MysteryGift)EncounterMatch).Ball);
                 return;
             }
             if (EncounterType == typeof (EncounterLink))
@@ -2184,7 +2188,12 @@ namespace PKHeX.Core
                     return;
                 }
                 if (pkm.FatefulEncounter)
-                    AddLine(Severity.Invalid, V325, CheckIdentifier.Fateful);
+                {
+                    if(pkm.Gen3 && (pkm.Species==386 || pkm.Species==151))
+                        AddLine(Severity.Invalid, V324, CheckIdentifier.Fateful);
+                    else
+                        AddLine(Severity.Invalid, V325, CheckIdentifier.Fateful);
+                }
                 if (pkm.Format == 5)
                 {
                     var enc = EncounterMatch as EncounterStatic;

--- a/PKHeX/Legality/Checks.cs
+++ b/PKHeX/Legality/Checks.cs
@@ -2205,12 +2205,8 @@ namespace PKHeX.Core
                     return;
                 }
                 if (pkm.FatefulEncounter)
-                {
-                    if(pkm.Gen3 && (pkm.Species==386 || pkm.Species==151))
-                        AddLine(Severity.Invalid, V324, CheckIdentifier.Fateful);
-                    else
-                        AddLine(Severity.Invalid, V325, CheckIdentifier.Fateful);
-                }
+                    AddLine(Severity.Invalid, V325, CheckIdentifier.Fateful);
+                
                 if (pkm.Format == 5)
                 {
                     var enc = EncounterMatch as EncounterStatic;

--- a/PKHeX/Legality/Checks.cs
+++ b/PKHeX/Legality/Checks.cs
@@ -791,6 +791,7 @@ namespace PKHeX.Core
             CheckResult InvalidTransferResult = null;
             CheckResult EggResult = null;
             CheckResult G3Result = null;
+            object G3Encounter = null;
             bool WasEgg = Legal.getWasEgg23(pkm) && !Legal.NoHatchFromEgg.Contains(pkm.Species);
             if (WasEgg)
             {
@@ -804,20 +805,30 @@ namespace PKHeX.Core
                 InvalidTransferResult = new CheckResult(Severity.Invalid, V60, CheckIdentifier.Encounter);
             if (pkm.Format != 4 && pkm.Met_Location != 30001)
                 InvalidTransferResult = new CheckResult(Severity.Invalid, V61, CheckIdentifier.Encounter);
-            
+
             if (null != (EncounterMatch = Legal.getValidStaticEncounter(pkm)))
             {
                 G3Result = verifyEncounterStatic();
+                if (G3Result?.Valid ?? false)
+                    G3Encounter = EncounterMatch;
             }
 
-            if (G3Result !=null)
+            if (G3Result != null)
             {
                 EncounterMatch = null; // Reset Encounter Object, test for remaining encounters
                 if (null != (EncounterMatch = Legal.getValidWildEncounters(pkm)))
+                {
                     G3Result = verifyEncounterWild();
+                    if (G3Result?.Valid ?? false)
+                        G3Encounter = EncounterMatch;
+                }
 
                 if (null != (EncounterMatch = Legal.getValidIngameTrade(pkm)))
+                {
                     G3Result = verifyEncounterTrade();
+                    if (G3Result?.Valid ?? false)
+                        G3Encounter = EncounterMatch;
+                }
             }
 
             // Check events after static, to match Mew/Deoxys static encounters
@@ -838,19 +849,25 @@ namespace PKHeX.Core
             // Even if EggResult is not returned WasEgg is keep true to check in verifymoves first the 
             // non egg encounter moves and after that egg encounter moves, because there is no way to tell 
             // what of the two encounters was the real origin
-            if (EggResult != null && G3Result!=null)
+            if (EggResult != null && G3Result != null)
             {
                 // keep the valid encounter, also if both are valid returns non egg information, because 
                 // there is more data in the pokemon to found normal encounter
                 if (EggResult.Valid && !G3Result.Valid)
+                {
                     G3Result = EggResult;
+                    G3Encounter = null;
+                }
             }
+
+            if (G3Result?.Valid ?? false)
+                EncounterMatch = G3Encounter;
 
             // No gen 3 result
             if (G3Result == null)
             {
                 // Return both errors, invalid transfer and not a valid encounter found in G3
-                return InvalidTransferResult != null?
+                return InvalidTransferResult != null ?
                       new CheckResult(Severity.Invalid, V80 + Environment.NewLine + InvalidTransferResult.Comment, CheckIdentifier.Encounter)
                     : new CheckResult(Severity.Invalid, V80, CheckIdentifier.Encounter);
             }

--- a/PKHeX/Legality/Core.cs
+++ b/PKHeX/Legality/Core.cs
@@ -2290,6 +2290,9 @@ namespace PKHeX.Core
             if (FormChangeMoves.Contains(species)) // Deoxys & Shaymin & Giratina (others don't have extra but whatever)
             {
                 int formcount = pkm.PersonalInfo.FormeCount;
+                if (species == 386 && pkm.Format == 3)
+                    // In gen 3 deoxys has different forms depending on the current game, in personal info there is no alter form info
+                    formcount = 4;
                 for (int i = 0; i < formcount; i++)
                     r.AddRange(getMoves(pkm, species, vs.First().Level, i, moveTutor, Version, LVL, Tutor, Machine, MoveReminder, RemoveTransferHM, Generation));
                 if (Relearn) r.AddRange(pkm.RelearnMoves);

--- a/PKHeX/Legality/Core.cs
+++ b/PKHeX/Legality/Core.cs
@@ -1215,7 +1215,7 @@ namespace PKHeX.Core
             if (pkm.Species == 490 && (pkm.WasEgg || pkm.IsEgg)) // Manaphy
             {
                 int loc = pkm.IsEgg ? pkm.Met_Location : pkm.Egg_Location;
-                bool valid = loc == 2001; // Link Trade Egg
+                bool valid = loc == 2002; // Link Trade Egg
                 valid |= loc == 3001 && !pkm.IsShiny; // Ranger & notShiny
                 if (valid)
                     validPCD.Add(new PGT { Data = { [0] = 7, [8] = 1 } });
@@ -1749,7 +1749,7 @@ namespace PKHeX.Core
         internal static int getMaxLevelGeneration(PKM pkm, int generation)
         {
             if (!pkm.InhabitedGeneration(generation))
-                return 0;
+                return -1;
 
             if (pkm.Format <= 2)
             {
@@ -1772,7 +1772,11 @@ namespace PKHeX.Core
         internal static int getMinLevelEncounter(PKM pkm)
         {
             if (pkm.Format == 3 && pkm.WasEgg)
+                // Only for gen 3 pokemon in format 3, after transfer to gen 4 it should return transfer level
                 return 5;
+            if (pkm.Format == 4 && pkm.GenNumber == 4 && pkm.WasEgg) 
+                // Only for gen 4 pokemon in format 4, after transfer to gen 5 it should return transfer level
+                return 1;
             return pkm.HasOriginalMetLocation ? pkm.Met_Level : getMaxLevelGeneration(pkm);
         }
         internal static int getMinLevelGeneration(PKM pkm)

--- a/PKHeX/Legality/Structures/EncounterArea.cs
+++ b/PKHeX/Legality/Structures/EncounterArea.cs
@@ -408,7 +408,7 @@ namespace PKHeX.Core
                         continue;
 
                     var slot = GrassSlots[slotnums[j]].Clone();
-                    slot.Species = j;
+                    slot.Species = species;
                     slot.Type = t;
                     slots.Add(slot);
                 }

--- a/PKHeX/Legality/Tables4.cs
+++ b/PKHeX/Legality/Tables4.cs
@@ -507,7 +507,7 @@ namespace PKHeX.Core
             new EncounterStatic { Gift = true, Species = 023, Level = 15, Location = 131, Version = GameVersion.HG }, // Ekans
             new EncounterStatic { Gift = true, Species = 027, Level = 15, Location = 131, Version = GameVersion.SS }, // Sandshrew
             new EncounterStatic { Gift = true, Species = 147, Level = 15, Location = 131 }, // Dratini
-            //Team_Rocket_HQ Trap Floor
+            // Team Rocket HQ Trap Floor
             // new EncounterStatic { Species = 101, Level = 23, Location = 213, }, // Electrode Overlaps stationary 
             new EncounterStatic { Species = 100, Level = 23, Location = 213, }, // Voltorb
             new EncounterStatic { Species = 074, Level = 23, Location = 213, }, // Geodude

--- a/PKHeX/Legality/Tables4.cs
+++ b/PKHeX/Legality/Tables4.cs
@@ -438,7 +438,6 @@ namespace PKHeX.Core
             new EncounterStatic { Species = 487, Level = 47, Location = 117, Version = GameVersion.Pt, Form = 1, }, //Giratina @ Distortion World
             new EncounterStatic { Species = 487, Level = 47, Location = 062, Version = GameVersion.Pt, Form = 0, }, //Giratina @ Turnback Cave
             //Event
-            new EncounterStatic { Species = 490, Level = 01, EggLocation = 3001, Fateful = true, Gift = true }, //Manaphy from Pokemon Ranger
             new EncounterStatic { Species = 491, Level = 40, Location = 079, Version = GameVersion.DP,}, //Darkrai @ Newmoon Island
             new EncounterStatic { Species = 491, Level = 50, Location = 079, Version = GameVersion.Pt,}, //Darkrai @ Newmoon Island
             new EncounterStatic { Species = 492, Form = 0, Level = 30, Location = 063, Fateful = true,}, //Shaymin @ Flower Paradise (Unreleased in Diamond and Pearl)


### PR DESCRIPTION
Remember getValidWildEncounters was implemented to filter by ball for safari zone and bug catching contest in case there were more that one possible encounter, that means to check safariball and sportball checking the first slot is enought.

getValidWildEncounters will never return an array of slot with safari and non safari encounters at the same time, nor bug-catching encounters and non bug-catching encounters

