### PR TITLE
Static encounter refactor to return a list for pokemon with multiple statics but different moves

### DIFF
--- a/PKHeX/Game/GameVersion.cs
+++ b/PKHeX/Game/GameVersion.cs
@@ -43,8 +43,9 @@
         GBCartEraOnly,
         Stadium,
         Stadium2,
-        EventsGen1,
-        EventsGen2,
+        EventsGBGen1,
+        EventsGBGen2,
+        VCEvents
     }
 
     public static class Extension
@@ -58,21 +59,22 @@
                 case GameVersion.RBY:
                     return (g2 == GameVersion.RD || g2 == GameVersion.BU || g2 == GameVersion.YW || g2 == GameVersion.GN);
                 case GameVersion.Gen1:
-                    return ( GameVersion.RBY.Contains(g2) || g2 == GameVersion.Stadium|| g2 == GameVersion.EventsGen1);
+                    return ( GameVersion.RBY.Contains(g2) || g2 == GameVersion.Stadium || g2 == GameVersion.EventsGBGen1 || g2 == GameVersion.VCEvents);
                 case GameVersion.Stadium:
-                case GameVersion.EventsGen1:
+                case GameVersion.EventsGBGen1:
+                case GameVersion.VCEvents:
                     return GameVersion.RBY.Contains(g2);
 
                 case GameVersion.GS: return (g2 == GameVersion.GD || g2 == GameVersion.SV);
                 case GameVersion.GSC:
                     return (GameVersion.GS.Contains(g2) || g2 == GameVersion.C);
                 case GameVersion.Gen2:
-                    return (GameVersion.GSC.Contains(g2) || g2 == GameVersion.Stadium2 || g2 == GameVersion.EventsGen2);
+                    return (GameVersion.GSC.Contains(g2) || g2 == GameVersion.Stadium2 || g2 == GameVersion.EventsGBGen2);
                 case GameVersion.Stadium2:
-                case GameVersion.EventsGen2:
+                case GameVersion.EventsGBGen2:
                     return GameVersion.GSC.Contains(g2);
                 case GameVersion.GBCartEraOnly:
-                    return g2 == GameVersion.Stadium || g2 == GameVersion.Stadium2 || g2 == GameVersion.EventsGen1 || g2 == GameVersion.EventsGen2;
+                    return g2 == GameVersion.Stadium || g2 == GameVersion.Stadium2 || g2 == GameVersion.EventsGBGen1 || g2 == GameVersion.EventsGBGen2;
 
                 case GameVersion.RS: return (g2 == GameVersion.R || g2 == GameVersion.S);
                 case GameVersion.FRLG: return (g2 == GameVersion.FR || g2 == GameVersion.LG);

--- a/PKHeX/Legality/Analysis.cs
+++ b/PKHeX/Legality/Analysis.cs
@@ -16,6 +16,7 @@ namespace PKHeX.Core
         private bool EncounterIsMysteryGift => EncounterType.IsSubclassOf(typeof (MysteryGift));
         private string EncounterName => Legal.getEncounterTypeName(pkm, EncounterOriginal ?? EncounterMatch);
         private List<MysteryGift> EventGiftMatch;
+        private List<EncounterStatic> EncounterStaticMatch;
         private CheckResult Encounter, History;
         private int[] RelearnBase;
         // private bool SecondaryChecked;

--- a/PKHeX/Legality/Core.cs
+++ b/PKHeX/Legality/Core.cs
@@ -866,7 +866,7 @@ namespace PKHeX.Core
             List<EncounterSlot> s = new List<EncounterSlot>();
 
             foreach (var area in getEncounterAreas(pkm, gameSource))
-                s.AddRange(getValidEncounterSlots(pkm, area, DexNav: pkm.AO));
+                s.AddRange(getValidEncounterSlots(pkm, area, DexNav: pkm.AO, gameSource: gameSource));
 
             if (s.Count <= 1 || 3 > pkm.GenNumber || pkm.GenNumber > 4 || pkm.HasOriginalMetLocation)
                 return s.Any() ? s.ToArray() : null;
@@ -2163,7 +2163,7 @@ namespace PKHeX.Core
             bool noMet = !pkm.HasOriginalMetLocation;
             return noMet ? slots : slots.Where(area => area.Location == pkm.Met_Location);
         }
-        private static IEnumerable<EncounterSlot> getValidEncounterSlots(PKM pkm, EncounterArea loc, bool DexNav, bool ignoreLevel = false)
+        private static IEnumerable<EncounterSlot> getValidEncounterSlots(PKM pkm, EncounterArea loc, bool DexNav, bool ignoreLevel = false, GameVersion gameSource = GameVersion.Any)
         {
             int fluteBoost = pkm.Format < 3 ? 0 : 4;
             const int dexnavBoost = 30;
@@ -2172,8 +2172,12 @@ namespace PKHeX.Core
             int dn = DexNav ? fluteBoost + dexnavBoost : 0;
             List<EncounterSlot> slotdata = new List<EncounterSlot>();
 
+            var maxspeciesorigin = -1;
+            if (gameSource == GameVersion.RBY) maxspeciesorigin = MaxSpeciesID_1;
+            if (gameSource == GameVersion.GSC) maxspeciesorigin = MaxSpeciesID_2;
+
             // Get Valid levels
-            IEnumerable<DexLevel> vs = getValidPreEvolutions(pkm, ignoreLevel ? 100 : -1, ignoreLevel);
+            IEnumerable<DexLevel> vs = getValidPreEvolutions(pkm, maxspeciesorigin: maxspeciesorigin, lvl: ignoreLevel ? 100 : -1, skipChecks:ignoreLevel);
 
             // Get slots where pokemon can exist
             bool ignoreSlotLevel = ignoreLevel;

--- a/PKHeX/Legality/Core.cs
+++ b/PKHeX/Legality/Core.cs
@@ -2314,7 +2314,7 @@ namespace PKHeX.Core
                 };
 
             var et = getEvolutionTable(pkm);
-            return et.getValidPreEvolutions(pkm, maxspeciesorigin, lvl, skipChecks: skipChecks);
+            return et.getValidPreEvolutions(pkm, lvl: lvl, maxSpeciesOrigin: maxspeciesorigin, skipChecks: skipChecks);
         }
         private static IEnumerable<EncounterStatic> getStatic(PKM pkm, IEnumerable<EncounterStatic> table, int maxspeciesorigin =-1, int lvl = -1)
         {

--- a/PKHeX/Legality/Structures/EvolutionTree.cs
+++ b/PKHeX/Legality/Structures/EvolutionTree.cs
@@ -165,10 +165,11 @@ namespace PKHeX.Core
 
             return Personal.getFormeIndex(evolvesToSpecies, evolvesToForm);
         }
-        public IEnumerable<DexLevel> getValidPreEvolutions(PKM pkm, int lvl, bool skipChecks = false)
+        public IEnumerable<DexLevel> getValidPreEvolutions(PKM pkm, int lvl, int maxSpeciesOrigin =-1 ,bool skipChecks = false)
         {
             int index = getIndex(pkm);
-            int maxSpeciesOrigin = Legal.getMaxSpeciesOrigin(pkm);
+            if(maxSpeciesOrigin <= 0)
+                maxSpeciesOrigin = Legal.getMaxSpeciesOrigin(pkm);
             return Lineage[index].getExplicitLineage(pkm, lvl, skipChecks, MaxSpeciesTree, maxSpeciesOrigin);
         }
     }

--- a/PKHeX/Legality/Tables1.cs
+++ b/PKHeX/Legality/Tables1.cs
@@ -103,7 +103,7 @@ namespace PKHeX.Core
          // new EncounterStatic { Species = 007, Level = 10, Version = GameVersion.YW }, // Squirtle (Vermillion City)
 
             new EncounterStatic { Species = 054, Level = 15, Moves = new [] { 133, 10 }, Version = GameVersion.Stadium }, // Stadium Psyduck (Amnesia)
-            new EncounterStatic { Species = 151, Level = 5, IVs = new [] {15,15,15,15,15,15}, Version = GameVersion.EventsGen1 }, // Event Mew
+            new EncounterStatic { Species = 151, Level = 5, IVs = new [] {15,15,15,15,15,15}, Version = GameVersion.VCEvents }, // Event Mew
         };
         internal static readonly EncounterTrade[] TradeGift_RBY =
         {

--- a/PKHeX/Legality/Tables2.cs
+++ b/PKHeX/Legality/Tables2.cs
@@ -105,7 +105,7 @@ namespace PKHeX.Core
             
             new EncounterStatic { Species = 249, Level = 60, Location = 031, Version = GameVersion.C }, // Lugia @ Whirl Islands
             new EncounterStatic { Species = 250, Level = 60, Location = 023, Version = GameVersion.C }, // Ho-Oh @ Tin Tower
-            new EncounterStatic { Species = 251, Level = 30, Location = 014, Version = GameVersion.EventsGen2 }, // Celebi @ Ilex Forest
+            new EncounterStatic { Species = 251, Level = 30, Location = 014, Version = GameVersion.EventsGBGen2 }, // Celebi @ Ilex Forest
         };
 
         internal static readonly EncounterStatic[] Encounter_GS = Encounter_GSC_Common.Concat(Encounter_GS_Exclusive).ToArray();

--- a/PKHeX/Saves/SAV3GCMemoryCard.cs
+++ b/PKHeX/Saves/SAV3GCMemoryCard.cs
@@ -166,7 +166,7 @@ namespace PKHeX.Core
         private void restoreBackup()
         {
             Array.Copy(Data, DirectoryBackup_Block*BLOCK_SIZE, Data, Directory_Block*BLOCK_SIZE, BLOCK_SIZE);
-            Array.Copy(Data, BlockAlloc_Block*BLOCK_SIZE, Data, BlockAllocBackup_Block*BLOCK_SIZE, BLOCK_SIZE);
+            Array.Copy(Data, BlockAllocBackup_Block*BLOCK_SIZE, Data, BlockAlloc_Block*BLOCK_SIZE, BLOCK_SIZE);
         }
 
         public GCMemoryCardState LoadMemoryCardFile(byte[] data)


### PR DESCRIPTION
getValidStaticEncounters changed to return a list, the treatment of the list is similar than the mistery gift list for events encounters, it works like mistery gift encounters, the dragonite from DreamWorld in the issue #1011 now its flagged as legal

Also changed gen 1 and gen 2 encounters to take into account that the min species for an encounter can be a gen 2 preevolution, like tyroge -> hitmonlee, hitmonchan. 

When searching for static and wild encounters in gen 1 and 2 it will be used the maxSpecies of the game where the encounter is being searched, not the maxSpecies from the pkm format, the ordenation should return the min species in the evolutionary family tree, again tyrogue before himonlee or hitmonchan

Separate VC Events for GBCart Events. The event mew was being excluded in getValidStaticEncounter if AllowGBCartEra is false.

About the memory card files probably the save date is stored but in case a user have multiple savegames in the same memory card it should be possible to edit any pokémon savefile from the cart because maybe the user want to edit a different savegame that the last game he/she played.