### PR TITLE
Fix gen7 Eevee eggs checking and cleanup

### DIFF
--- a/PKHeX/Legality/Analysis.cs
+++ b/PKHeX/Legality/Analysis.cs
@@ -112,7 +112,6 @@ namespace PKHeX.Core
             verifyNickname();
             verifyDVs();
             verifyG1OT();
-            AddLine(verifyEggMoves());
         }
         private void parsePK3(PKM pk)
         {
@@ -124,7 +123,6 @@ namespace PKHeX.Core
             updateMoveLegality();
             updateEncounterInfo();
             updateChecks();
-            AddLine(verifyEggMoves());
         }
         private void parsePK4(PKM pk)
         {
@@ -137,7 +135,6 @@ namespace PKHeX.Core
             updateMoveLegality();
             updateEncounterInfo();
             updateChecks();
-            AddLine(verifyEggMoves());
         }
         private void parsePK5(PKM pk)
         {
@@ -150,7 +147,6 @@ namespace PKHeX.Core
             updateMoveLegality();
             updateEncounterInfo();
             updateChecks();
-            AddLine(verifyEggMoves());
         }
         private void parsePK6(PKM pk)
         {
@@ -234,8 +230,6 @@ namespace PKHeX.Core
                 verifyRegion();
                 verifyVersionEvolution();
             }
-            if (pkm.GenNumber <= 5)
-                verifyEggMoves();
 
             // SecondaryChecked = true;
         }

--- a/PKHeX/Legality/Checks.cs
+++ b/PKHeX/Legality/Checks.cs
@@ -2478,6 +2478,14 @@ namespace PKHeX.Core
         {
             CheckResult[] res = new CheckResult[4];
 
+            // Gen 1-3 could have an egg origin and a non-egg origin, check first non-egg origin
+            if (pkm.GenNumber <= 3 && !pkm.HasOriginalMetLocation && EncounterMatch != null)
+            {
+                res = parseMovesSpecialMoveset(Moves, validLevelMoves, validTMHM, validTutor);
+                if (res.All(r => r.Valid)) // moves are satisfactory
+                     return res;
+            }
+
             // Some games can have different egg movepools. Have to check all situations.
             GameVersion[] Games = { };
             switch (pkm.GenNumber)
@@ -2557,11 +2565,6 @@ namespace PKHeX.Core
             if (pkm.GenNumber >= 6 && MatchIsMysteryGift)
                 RelearnBase = (EncounterMatch as MysteryGift).RelearnMoves;
             return res;
-        }
-        private CheckResult[] parseMovesPreRelearnEncounter(int[] Moves, List<int>[] validLevelMoves, List<int>[] validTMHM, List<int>[] validTutor)
-        {
-            int[] SpecialMoves = (EncounterMatch as IMoveset)?.Moves ?? new int[0];
-            return parseMoves(Moves, validLevelMoves, new int[0], validTMHM, validTutor, SpecialMoves, new int[0], new int[0], new int[0]);
         }
         private CheckResult[] parseMovesRelearnSplitBreed(int[] Moves, List<int>[] validLevelMoves, List<int>[] validTMHM, List<int>[] validTutor, GameVersion game)
         {

--- a/PKHeX/Legality/Checks.cs
+++ b/PKHeX/Legality/Checks.cs
@@ -881,7 +881,7 @@ namespace PKHeX.Core
             if (pkm.Format != 4 && pkm.Met_Location != 30001)
                 AddLine(Severity.Invalid, V61, CheckIdentifier.Encounter);
 
-            return G3Result ?? new CheckResult(Severity.Invalid, V80, CheckIdentifier.Encounter);
+            return G3Result ?? EggResult ?? new CheckResult(Severity.Invalid, V80, CheckIdentifier.Encounter);
         }
         private CheckResult verifyEncounterG4Transfer()
         {
@@ -931,14 +931,14 @@ namespace PKHeX.Core
             switch (pkm.Species)
             {
                 case 251: // Celebi
-                    if (pkm.Met_Location == 30010 || pkm.Met_Location == 30011) // unused || used
+                    if (loc == 30010 || loc == 30011) // unused || used
                         return Gen4Result;
                     return new CheckResult(Severity.Invalid, V351, CheckIdentifier.Encounter);
                     
                 case 243: // Raikou
                 case 244: // Entei
                 case 245: // Suicune
-                    if (pkm.Met_Location == 30012 || pkm.Met_Location == 30013) // unused || used
+                    if (loc == 30012 || loc == 30013) // unused || used
                         return Gen4Result;
                     return new CheckResult(Severity.Invalid, V351, CheckIdentifier.Encounter);
             }

--- a/PKHeX/Legality/Checks.cs
+++ b/PKHeX/Legality/Checks.cs
@@ -2503,7 +2503,7 @@ namespace PKHeX.Core
                 for (int i = 0; i <= splitctr; i++)
                 {
                     var LvlupEggMoves = Legal.getBaseEggMoves(pkm, i, ver, 100)?.ToArray() ?? new int[0];
-                    var EggMoves = !pkm.WasEventEgg && !pkm.WasGiftEgg ? Legal.getEggMoves(pkm, i, ver).ToArray() : new int[0];
+                    var EggMoves = Legal.getEggMoves(pkm, i, ver).ToArray();
 
                     res = parseMoves(Moves, validLevelMoves, new int[0], validTMHM, validTutor, new int[0], LvlupEggMoves, EggMoves, EventEggMoves);
 

--- a/PKHeX/Legality/Core.cs
+++ b/PKHeX/Legality/Core.cs
@@ -835,7 +835,7 @@ namespace PKHeX.Core
         }
         internal static IEnumerable<EncounterStatic> getG3SpecialEggEncounter(PKM pkm)
         {
-            foreach (EncounterStatic e in Encounter_Box)
+            foreach (EncounterStatic e in EventEgg_G3)
             {
                 if (e.Species != pkm.Species)
                     continue;

--- a/PKHeX/Legality/Core.cs
+++ b/PKHeX/Legality/Core.cs
@@ -833,10 +833,19 @@ namespace PKHeX.Core
         {
             return getEggMoves(pkm, getBaseSpecies(pkm, skipOption), 0, Version);
         }
-
-        internal static IEnumerable<int> getSpecialEggMoves(PKM pkm, GameVersion Version)
+        internal static IEnumerable<EncounterStatic> getG3SpecialEggEncounter(PKM pkm)
         {
-            return getSpecialEggMoves(pkm, getBaseSpecies(pkm), 0, Version);
+            foreach (EncounterStatic e in Encounter_Box)
+            {
+                if (e.Species != pkm.Species)
+                    continue;
+                if (e.Nature != Nature.Random && pkm.Nature != (int)e.Nature)
+                    continue;
+                if (e.Gender != -1 && e.Gender != pkm.Gender)
+                    continue;
+
+                yield return e;
+            }
         }
 
         // Encounter
@@ -2638,22 +2647,6 @@ namespace PKHeX.Core
                     return r;
             }
             return r;
-        }
-        private static IEnumerable<int> getSpecialEggMoves(PKM pkm, int species, int alform, GameVersion Version = GameVersion.Any)
-        {
-            if (!pkm.InhabitedGeneration(pkm.GenNumber, species))
-                return new List<int>();
-            switch (pkm.GenNumber)
-            {
-                case 3:
-                    {
-                        var boxencounter = Encounter_Box.FirstOrDefault(e => e.Species == species);
-                        if (boxencounter != null)
-                            return boxencounter.Moves;
-                        break;
-                    }
-            }
-            return new List<int>();
         }
         private static IEnumerable<int> getEggMoves(PKM pkm, int species, int formnum, GameVersion Version = GameVersion.Any)
         {

--- a/PKHeX/Legality/Core.cs
+++ b/PKHeX/Legality/Core.cs
@@ -835,10 +835,10 @@ namespace PKHeX.Core
         }
         internal static IEnumerable<EncounterStatic> getG3SpecialEggEncounter(PKM pkm)
         {
-            foreach (EncounterStatic e in EventEgg_G3)
+            IEnumerable<DexLevel> dl = getValidPreEvolutions(pkm,MaxSpeciesID_3);
+            var table = EventEgg_G3.Where(e => dl.Any(d => d.Species == e.Species));
+            foreach (EncounterStatic e in table)
             {
-                if (e.Species != pkm.Species)
-                    continue;
                 if (pkm.Moves.All(m => !e.Moves.Contains(m)))  // No special move
                     continue;
                 if (e.Nature != Nature.Random && pkm.Nature != (int)e.Nature)

--- a/PKHeX/Legality/Core.cs
+++ b/PKHeX/Legality/Core.cs
@@ -839,6 +839,8 @@ namespace PKHeX.Core
             {
                 if (e.Species != pkm.Species)
                     continue;
+                if (pkm.Moves.All(m => !e.Moves.Contains(m)))  // No special move
+                    continue;
                 if (e.Nature != Nature.Random && pkm.Nature != (int)e.Nature)
                     continue;
                 if (e.Gender != -1 && e.Gender != pkm.Gender)

--- a/PKHeX/Legality/Structures/EncounterStatic.cs
+++ b/PKHeX/Legality/Structures/EncounterStatic.cs
@@ -3,7 +3,7 @@
     public class EncounterStatic : IEncounterable, IMoveset
     {
         public int Species { get; set; }
-        public int[] Moves { get; set; } = new int[4];
+        public int[] Moves { get; set; }
         public int Level;
 
         public int Location;

--- a/PKHeX/Legality/Tables3.cs
+++ b/PKHeX/Legality/Tables3.cs
@@ -218,7 +218,7 @@ namespace PKHeX.Core
         };
         internal static readonly EncounterStatic[] EventEgg_G3 = Encounter_Box.Concat(new[]
         {
-            //PokePark Eggs
+            // PokePark Eggs
             new EncounterStatic { Species = 054, Level = 05, EggLocation = 255, Version = GameVersion.RSBOX, Moves = new[]{300} }, // Psyduck with Mud Sport
             new EncounterStatic { Species = 172, Level = 05, EggLocation = 255, Version = GameVersion.RSBOX, Moves = new[]{266} }, // Pichu with Follow me
             new EncounterStatic { Species = 174, Level = 05, EggLocation = 255, Version = GameVersion.RSBOX, Moves = new[]{321} }, // Igglybuff with Tickle
@@ -234,6 +234,11 @@ namespace PKHeX.Core
             new EncounterStatic { Species = 331, Level = 05, EggLocation = 255, Version = GameVersion.RSBOX, Moves = new[]{227} }, // Cacnea with Encore
             new EncounterStatic { Species = 341, Level = 05, EggLocation = 255, Version = GameVersion.RSBOX, Moves = new[]{346} }, // Corphish with Water Sport
             new EncounterStatic { Species = 360, Level = 05, EggLocation = 255, Version = GameVersion.RSBOX, Moves = new[]{321} }, // Wynaut with Tickle
+            // Egg Pokémon Present Eggs
+            new EncounterStatic { Species = 043, Level = 05, EggLocation = 255, Version = GameVersion.FRLG, Moves = new[]{073} }, // Oddish with Leech Seed
+            new EncounterStatic { Species = 052, Level = 05, EggLocation = 255, Version = GameVersion.FRLG, Moves = new[]{080} }, // Meowth with Petal Dance
+            new EncounterStatic { Species = 060, Level = 05, EggLocation = 255, Version = GameVersion.FRLG, Moves = new[]{186} }, // Poliwag with Sweet Kiss
+            new EncounterStatic { Species = 069, Level = 05, EggLocation = 255, Version = GameVersion.FRLG, Moves = new[]{298} }, // Bellsprout with Teeter Dance
         }).ToArray();
 
         internal static readonly EncounterStatic[] Encounter_RSE_Roam =

--- a/PKHeX/Legality/Tables3.cs
+++ b/PKHeX/Legality/Tables3.cs
@@ -216,6 +216,25 @@ namespace PKHeX.Core
             new EncounterStatic { Species = 300, Level = 05, EggLocation = 255, Version = GameVersion.RSBOX, Moves = new[]{6} }, // Skitty Egg with Pay Day
             new EncounterStatic { Species = 172, Level = 05, EggLocation = 255, Version = GameVersion.RSBOX, Moves = new[]{57} }, // Pichu Egg with Surf
         };
+        internal static readonly EncounterStatic[] EventEgg_G3 = Encounter_Box.Concat(new[]
+        {
+            //PokePark Eggs
+            new EncounterStatic { Species = 054, Level = 05, EggLocation = 255, Version = GameVersion.RSBOX, Moves = new[]{300} }, // Psyduck with Mud Sport
+            new EncounterStatic { Species = 172, Level = 05, EggLocation = 255, Version = GameVersion.RSBOX, Moves = new[]{266} }, // Pichu with Follow me
+            new EncounterStatic { Species = 174, Level = 05, EggLocation = 255, Version = GameVersion.RSBOX, Moves = new[]{321} }, // Igglybuff with Tickle
+            new EncounterStatic { Species = 222, Level = 05, EggLocation = 255, Version = GameVersion.RSBOX, Moves = new[]{300} }, // Corsola with Mud Sport
+            new EncounterStatic { Species = 276, Level = 05, EggLocation = 255, Version = GameVersion.RSBOX, Moves = new[]{294} }, // Taillow with Feather Dance
+            new EncounterStatic { Species = 283, Level = 05, EggLocation = 255, Version = GameVersion.RSBOX, Moves = new[]{300} }, // Surskit with Mud Sport
+            new EncounterStatic { Species = 293, Level = 05, EggLocation = 255, Version = GameVersion.RSBOX, Moves = new[]{298} }, // Whismur with Teeter Dance
+            new EncounterStatic { Species = 300, Level = 05, EggLocation = 255, Version = GameVersion.RSBOX, Moves = new[]{205} }, // Skitty with Rollout
+            new EncounterStatic { Species = 311, Level = 05, EggLocation = 255, Version = GameVersion.RSBOX, Moves = new[]{346} }, // Plusle with Water Sport
+            new EncounterStatic { Species = 312, Level = 05, EggLocation = 255, Version = GameVersion.RSBOX, Moves = new[]{300} }, // Minun with Mud Sport
+            new EncounterStatic { Species = 325, Level = 05, EggLocation = 255, Version = GameVersion.RSBOX, Moves = new[]{253} }, // Spoink with Uproar
+            new EncounterStatic { Species = 327, Level = 05, EggLocation = 255, Version = GameVersion.RSBOX, Moves = new[]{047} }, // Spinda with Sing
+            new EncounterStatic { Species = 331, Level = 05, EggLocation = 255, Version = GameVersion.RSBOX, Moves = new[]{227} }, // Cacnea with Encore
+            new EncounterStatic { Species = 341, Level = 05, EggLocation = 255, Version = GameVersion.RSBOX, Moves = new[]{346} }, // Corphish with Water Sport
+            new EncounterStatic { Species = 360, Level = 05, EggLocation = 255, Version = GameVersion.RSBOX, Moves = new[]{321} }, // Wynaut with Tickle
+        }).ToArray();
 
         internal static readonly EncounterStatic[] Encounter_RSE_Roam =
         {
@@ -330,8 +349,8 @@ namespace PKHeX.Core
             new EncounterStatic { Species = 386, Level = 30, Location = 187, Version = GameVersion.LG, Form = 2, Fateful = true }, // Deoxys @ Birth Island
         };
 
-        internal static readonly EncounterStatic[] Encounter_RSE = Encounter_RSE_Roam.SelectMany(e => e.Clone(Roaming_MetLocation_RSE)).Concat(Encounter_RSE_Regular).Concat(Encounter_Box).ToArray();
-        internal static readonly EncounterStatic[] Encounter_FRLG = Encounter_FRLG_Roam.SelectMany(e => e.Clone(Roaming_MetLocation_FRLG)).Concat(Encounter_FRLG_Stationary).Concat(Encounter_Box).ToArray();
+        internal static readonly EncounterStatic[] Encounter_RSE = Encounter_RSE_Roam.SelectMany(e => e.Clone(Roaming_MetLocation_RSE)).Concat(Encounter_RSE_Regular).Concat(EventEgg_G3).ToArray();
+        internal static readonly EncounterStatic[] Encounter_FRLG = Encounter_FRLG_Roam.SelectMany(e => e.Clone(Roaming_MetLocation_FRLG)).Concat(Encounter_FRLG_Stationary).Concat(EventEgg_G3).ToArray();
 
         private static readonly int[] TradeContest_Cool =   {30, 05, 05, 05, 05, 10};
         private static readonly int[] TradeContest_Beauty = {05, 30, 05, 05, 05, 10};


### PR DESCRIPTION
- there is a encounterstatic entry of Eevee egg in sm, needs to mark EncounterStaticMatch as null after checking. It happens when it's not the gift Eevee egg, i.e it has valid relearn moves
- remove some unnecessary code after refactoring
- skip valid level up move when checking levelup egg moves (wasegg pokemon)
- Add PokePark Encounter
- Add Egg Pokémon Present Eggs Encounter
- Fix gen3 eggs encounter recognition