### PR TITLE
Fix abilties for pokemon with second ability with zero

### DIFF
--- a/PKHeX/Legality/Checks.cs
+++ b/PKHeX/Legality/Checks.cs
@@ -1281,7 +1281,7 @@ namespace PKHeX.Core
                 return;
             }
 
-            var abilities_count = abilities.Distinct().Count();
+            var abilities_count = abilities.Where(a => a != 0).Distinct().Count();
             var AbilityMatchPID = abilities_count == 2;
             if (pkm.Format >= 4 && pkm.InhabitedGeneration(3) && pkm.Species <= Legal.MaxSpeciesID_3)
             {


### PR DESCRIPTION
A simple fix, there are pokemon with the second ability 0 in the personal tables like the Kanto Starter in personal table for Emerald and Hearth Gold/Soul Silver.

The same table also have other pokemon with the second ability equals to the first ability.