### PR TITLE
Removes items when transferred from 6 to 7

### DIFF
--- a/PKHeX/PKM/PK6.cs
+++ b/PKHeX/PKM/PK6.cs
@@ -591,6 +591,7 @@ namespace PKHeX.Core
             for (var i = 0xE4; i < 0xE8; i++) pk7.Data[i] = 0; /* Unused. */
             pk7.Data[0x72] &= 0xFC; /* Clear lower two bits of Super training flags. */
             pk7.Data[0xDE] = 0; /* Gen IV encounter type. */
+            pk7.HeldItem = 0; /* Cannot bank with a held item. */
 
             // Fix Checksum
             pk7.RefreshChecksum();


### PR DESCRIPTION
Items cannot be banked from gen 6 to 7.