### PR TITLE
Move validation for evolutions by move, and fix static typed encounters

### DIFF
--- a/PKHeX/Legality/Checks.cs
+++ b/PKHeX/Legality/Checks.cs
@@ -3204,7 +3204,7 @@ namespace PKHeX.Core
             if (EncounterMatch == null && pkm.WasEgg && Legal.BabyEvolutionWithMove.Contains(pkm.Species) && !IncenseMovesLearned.Any() && !EggMovesSplitLearned[0].Any())
                 return;
 
-            var ValidMoves = Legal.getExclusivePostEvolutionMoves(pkm, pkm.Species, EvoChainsAllGens, GameVersion.Any);
+            var ValidMoves = Legal.getValidPostEvolutionMoves(pkm, pkm.Species, EvoChainsAllGens, GameVersion.Any);
             // Add the evolution moves to valid moves in case some of this moves could not be learned after evolving
             switch(pkm.Species)
             {

--- a/PKHeX/Legality/Checks.cs
+++ b/PKHeX/Legality/Checks.cs
@@ -134,7 +134,7 @@ namespace PKHeX.Core
             if (pkm.GenNumber >= 6 && pkm.PID == pkm.EncryptionConstant)
                 AddLine(Severity.Invalid, V208, CheckIdentifier.PID); // better to flag than 1:2^32 odds since RNG is not feasible to yield match
 
-            if (Type == typeof (EncounterStatic))
+            if (Type.IsSubclassOf(typeof(EncounterStatic)))
             {
                 var enc = (EncounterStatic)EncounterMatch;
                 if (enc.Shiny != null && (bool) enc.Shiny ^ pkm.IsShiny)
@@ -1501,7 +1501,7 @@ namespace PKHeX.Core
                 }
             }
 
-            if (Type == typeof(EncounterStatic))
+            if (Type.IsSubclassOf(typeof(EncounterStatic)))
             {
                 EncounterStatic enc = EncounterMatch as EncounterStatic;
                 if (enc?.Gift ?? false)
@@ -2179,9 +2179,9 @@ namespace PKHeX.Core
             switch (pkm.Species)
             {
                 case 25: // Pikachu
-                    if (pkm.Format == 6 && pkm.AltForm != 0 ^ Type == typeof(EncounterStatic))
+                    if (pkm.Format == 6 && pkm.AltForm != 0 ^ Type.IsSubclassOf(typeof(EncounterStatic)))
                     {
-                        string msg = Type == typeof (EncounterStatic) ? V305 : V306;
+                        string msg = Type.IsSubclassOf(typeof(EncounterStatic)) ? V305 : V306;
                         AddLine(Severity.Invalid, msg, CheckIdentifier.Form);
                         return;
                     }
@@ -2359,7 +2359,7 @@ namespace PKHeX.Core
                         AddLine(Severity.Invalid, V322, CheckIdentifier.Fateful);
                     return;
                 }
-                if (Type == typeof (EncounterStatic))
+                if (Type.IsSubclassOf(typeof(EncounterStatic)))
                 {
                     var enc = EncounterMatch as EncounterStatic;
                     if (enc.Fateful)
@@ -2711,7 +2711,7 @@ namespace PKHeX.Core
                 var BaseLvlMoves = 489 <= pkm.Species && pkm.Species <= 490 ? 1 : 100;
                 var LvlupEggMoves = Legal.getBaseEggMoves(pkm, ver, BaseLvlMoves);
                 // Level up, TMHM or tutor moves exclusive to the incense egg species, like Azurill, incompatible with the non-incense species egg moves
-                var ExclusiveIncenseMoves = issplitbreed ? Legal.getExclusiveEvolutionMoves(pkm, Legal.getBaseEggSpecies(pkm), EvoChainsAllGens,  ver) : null;
+                var ExclusiveIncenseMoves = issplitbreed ? Legal.getExclusivePreEvolutionMoves(pkm, Legal.getBaseEggSpecies(pkm), EvoChainsAllGens,  ver) : null;
                 var EggMoves = Legal.getEggMoves(pkm, ver);
                 
                 bool volt = (gen > 3 || ver == GameVersion.E) && Legal.LightBall.Contains(pkm.Species);
@@ -2804,7 +2804,7 @@ namespace PKHeX.Core
             var issplitbreed = pkm.WasEgg && Legal.SplitBreed.Contains(pkm.Species);
             var EggMoves = pkm.WasEgg? Legal.getEggMoves(pkm, game): emptyegg;
             // Level up, TMHM or tutor moves exclusive to the incense egg species, like Azurill, incompatible with the non-incense species egg moves
-            var ExclusiveIncenseMoves = issplitbreed ? Legal.getExclusiveEvolutionMoves(pkm, Legal.getBaseEggSpecies(pkm), EvoChainsAllGens, game) : empty;
+            var ExclusiveIncenseMoves = issplitbreed ? Legal.getExclusivePreEvolutionMoves(pkm, Legal.getBaseEggSpecies(pkm), EvoChainsAllGens, game) : empty;
 
             int[] RelearnMoves = pkm.RelearnMoves;
             int[] SpecialMoves = (EncounterMatch as IMoveset)?.Moves ?? new int[0];
@@ -3059,6 +3059,14 @@ namespace PKHeX.Core
                     ParseEvolutionsIncompatibleMoves(moves, tmhm[1], ref res);
                 }
 
+                if (Legal.EvolutionWithMove.Contains(pkm.Species))
+                {
+                    // Pokemon that evolved by leveling up while learning a specific move
+                    // This pokemon could only have 3 moves from preevolutions that are not the move used to evolved
+                    // including special and eggs moves before realearn generations
+                    ParseEvolutionLevelupMove(moves, EggMovesSplitLearned, IncenseMovesLearned, ref res);
+                }
+
                 if (res.All(r => r != null))
                     return res;
             }
@@ -3184,7 +3192,53 @@ namespace PKHeX.Core
             foreach (int m in ShedinjaEvoMovesLearned)
                 res[m] = new CheckResult(Severity.Invalid, V357, CheckIdentifier.Move);
         }
+        private void ParseEvolutionLevelupMove(int[] moves, List<int>[] EggMovesSplitLearned, List<int> IncenseMovesLearned, ref CheckResult[] res)
+        {
+            // Ignore if there is an invalid move or an empty move, this validtion is only for 4 non-empty moves that are all valid, but invalid as a 4 combination
+            // Ignore Mr.Mime and Sodowodoo from generations 1 to 3, they cant be evolved from Bonsly or Munchlax
+            // Ignore if encounter species is the evolution species, pokemon was not evolved by the player
+            if (!res.All(r => r?.Valid ?? false) || moves.Any(m => m == 0) || (Legal.BabyEvolutionWithMove.Contains(pkm.Species) && pkm.GenNumber <= 3) || (EncounterMatch as IEncounterable)?.Species == pkm.Species)
+                return;
 
+            // Mr.Mime and Sodowodoo from eggs that does not have any exclusive egg move or level up move from Mime Jr or Bonsly, egg can be assumed to be a non-incense egg, pokemon was not evolved by the player
+            if (EncounterMatch == null && pkm.WasEgg && Legal.BabyEvolutionWithMove.Contains(pkm.Species) && !IncenseMovesLearned.Any() && !EggMovesSplitLearned[0].Any())
+                return;
+
+            var ValidMoves = Legal.getExclusivePostEvolutionMoves(pkm, pkm.Species, EvoChainsAllGens, GameVersion.Any);
+            // Add the evolution moves to valid moves in case some of this moves could not be learned after evolving
+            switch(pkm.Species)
+            {
+                case 122: // Mr. Mime (Mime Jr with Mimic)
+                case 185: // Sudowoodo (Bonsly with Mimic)
+                    ValidMoves.Add(102);
+                    break;
+                case 424: // Ambipom (Aipom with Double Hit)
+                    ValidMoves.Add(458);
+                    break;
+                case 463: // Lickilicky (Lickitung with Rollout)
+                    ValidMoves.Add(205);
+                    break;
+                case 465: // Tangrowth (Tangela with Ancient Power)
+                case 469: // Yanmega (Yamma with Ancient Power)
+                case 473: // Mamoswine (Piloswine with Ancient Power)
+                    ValidMoves.Add(246);
+                    break;
+                case 700: // Sylveon (Eevee with Fairy Move)
+                    // Add every fairy moves without cheking if eevee learn it or not, pokemon moves are determined legal before this function
+                    ValidMoves.AddRange(Legal.FairyMoves);
+                    break;
+                case 763: // Tsareena (Steenee with Stomp)
+                    ValidMoves.Add(23);
+                    break;
+            }
+            if(!moves.Any(m => ValidMoves.Contains(m)))
+            {
+                for(int m = 0; m < 4; m++)
+                {
+                    res[m] = new CheckResult(Severity.Invalid, string.Format(V385, specieslist[pkm.Species]), CheckIdentifier.Move);
+                }
+            }
+        }
         private void verifyPreRelearn()
         {
             // For origins prior to relearn moves, need to try to match a mystery gift if applicable.

--- a/PKHeX/Legality/Core.cs
+++ b/PKHeX/Legality/Core.cs
@@ -1168,18 +1168,43 @@ namespace PKHeX.Core
             }
             return new int[0];
         }
-        internal static List<int>[] getExclusiveEvolutionMoves(PKM pkm, int Species,DexLevel[][] evoChains, GameVersion Version)
+        internal static List<int> getExclusivePostEvolutionMoves(PKM pkm, int Species, DexLevel[][] evoChains, GameVersion Version)
+        {
+            // Return moves that the pokemon could learn after evolving 
+            var moves = new List<int>();
+            for (int i = 1; i < evoChains.Length; i++)
+                if (evoChains[i].Any())
+                    moves.AddRange(getExclusivePostEvolutionMoves(pkm, Species, evoChains[i], i, Version));
+            if (pkm.GenNumber >= 6)
+                moves.AddRange(pkm.RelearnMoves.Where(m => m != 0));
+            return moves.Distinct().ToList();
+        }
+        internal static IEnumerable<int> getExclusivePostEvolutionMoves(PKM pkm, int Species, DexLevel[] evoChain, int Generation, GameVersion Version)
+        {
+            var evomoves = new List<int>();
+            var index = Array.FindIndex(evoChain, e => e.Species == Species);
+            for (int i = 0; i < evoChain.Length; i++)
+            {
+                var evo = evoChain[i];
+                var moves = getMoves(pkm, evo.Species, 1, evo.Level, pkm.AltForm, moveTutor: true, Version: Version, LVL: true, specialTutors: true, Machine: true, MoveReminder: false, RemoveTransferHM: false, Generation: Generation);
+                if (i <= index)
+                    // Moves from Species or any species after in the evolution phase
+                    evomoves.AddRange(moves);
+            }
+            return evomoves;
+        }
+        internal static List<int>[] getExclusivePreEvolutionMoves(PKM pkm, int Species,DexLevel[][] evoChains, GameVersion Version)
         {
             // Return moves that the pokemon could only learn throught the preevolution Species
             List<int>[] Moves = new List<int>[evoChains.Length];
             for (int i = 1; i < evoChains.Length; i++)
                 if (evoChains[i].Any())
-                    Moves[i] = getExclusiveEvolutionMoves(pkm, Species, evoChains[i], i, Version).ToList();
+                    Moves[i] = getExclusivePreEvolutionMoves(pkm, Species, evoChains[i], i, Version).ToList();
                 else
                     Moves[i] = new List<int>();
             return Moves;
         }
-        internal static IEnumerable<int> getExclusiveEvolutionMoves(PKM pkm, int Species, DexLevel[] evoChain, int Generation, GameVersion Version)
+        internal static IEnumerable<int> getExclusivePreEvolutionMoves(PKM pkm, int Species, DexLevel[] evoChain, int Generation, GameVersion Version)
         {
             var preevomoves = new List<int>();
             var evomoves = new List<int>();

--- a/PKHeX/Legality/Core.cs
+++ b/PKHeX/Legality/Core.cs
@@ -1183,13 +1183,12 @@ namespace PKHeX.Core
         {
             var evomoves = new List<int>();
             var index = Array.FindIndex(evoChain, e => e.Species == Species);
-            for (int i = 0; i < evoChain.Length; i++)
+            for (int i = 0; i <= index; i++)
             {
                 var evo = evoChain[i];
                 var moves = getMoves(pkm, evo.Species, 1, evo.Level, pkm.AltForm, moveTutor: true, Version: Version, LVL: true, specialTutors: true, Machine: true, MoveReminder: false, RemoveTransferHM: false, Generation: Generation);
-                if (i <= index)
-                    // Moves from Species or any species after in the evolution phase
-                    evomoves.AddRange(moves);
+                // Moves from Species or any species after in the evolution phase
+                evomoves.AddRange(moves);
             }
             return evomoves;
         }

--- a/PKHeX/Legality/Core.cs
+++ b/PKHeX/Legality/Core.cs
@@ -1186,7 +1186,7 @@ namespace PKHeX.Core
             for (int i = 0; i <= index; i++)
             {
                 var evo = evoChain[i];
-                var moves = getMoves(pkm, evo.Species, 1, evo.Level, pkm.AltForm, moveTutor: true, Version: Version, LVL: true, specialTutors: true, Machine: true, MoveReminder: false, RemoveTransferHM: false, Generation: Generation);
+                var moves = getMoves(pkm, evo.Species, 1, evo.Level, pkm.AltForm, moveTutor: true, Version: Version, LVL: true, specialTutors: true, Machine: true, MoveReminder: true, RemoveTransferHM: false, Generation: Generation);
                 // Moves from Species or any species after in the evolution phase
                 evomoves.AddRange(moves);
             }
@@ -1211,7 +1211,7 @@ namespace PKHeX.Core
             for (int i = 0; i < evoChain.Length; i++)
             {
                 var evo = evoChain[i];
-                var moves = getMoves(pkm, evo.Species, 1, evo.Level, pkm.AltForm, moveTutor: true, Version: Version, LVL: true, specialTutors: true, Machine: true, MoveReminder: false, RemoveTransferHM: false, Generation: Generation);
+                var moves = getMoves(pkm, evo.Species, 1, evo.Level, pkm.AltForm, moveTutor: true, Version: Version, LVL: true, specialTutors: true, Machine: true, MoveReminder: true, RemoveTransferHM: false, Generation: Generation);
                 if (i >= index)
                     // Moves from Species or any species bellow in the evolution phase
                     preevomoves.AddRange(moves);

--- a/PKHeX/Legality/Core.cs
+++ b/PKHeX/Legality/Core.cs
@@ -1168,18 +1168,18 @@ namespace PKHeX.Core
             }
             return new int[0];
         }
-        internal static List<int> getExclusivePostEvolutionMoves(PKM pkm, int Species, DexLevel[][] evoChains, GameVersion Version)
+        internal static List<int> getValidPostEvolutionMoves(PKM pkm, int Species, DexLevel[][] evoChains, GameVersion Version)
         {
             // Return moves that the pokemon could learn after evolving 
             var moves = new List<int>();
             for (int i = 1; i < evoChains.Length; i++)
                 if (evoChains[i].Any())
-                    moves.AddRange(getExclusivePostEvolutionMoves(pkm, Species, evoChains[i], i, Version));
+                    moves.AddRange(getValidPostEvolutionMoves(pkm, Species, evoChains[i], i, Version));
             if (pkm.GenNumber >= 6)
                 moves.AddRange(pkm.RelearnMoves.Where(m => m != 0));
             return moves.Distinct().ToList();
         }
-        internal static IEnumerable<int> getExclusivePostEvolutionMoves(PKM pkm, int Species, DexLevel[] evoChain, int Generation, GameVersion Version)
+        internal static IEnumerable<int> getValidPostEvolutionMoves(PKM pkm, int Species, DexLevel[] evoChain, int Generation, GameVersion Version)
         {
             var evomoves = new List<int>();
             var index = Array.FindIndex(evoChain, e => e.Species == Species);

--- a/PKHeX/Legality/LegalityCheckStrings.cs
+++ b/PKHeX/Legality/LegalityCheckStrings.cs
@@ -373,6 +373,7 @@ namespace PKHeX.Core
         public static string V378 {get; set;} = "Inherited move learned by Level-up. Not expected in a gift egg.";
         public static string V379 {get; set;} = "{0} Inherited Move. Incompatible with {1} inherited moves.";
         public static string V381 {get; set;} = "Encounter Type does not match encounter.";
+        public static string V385 {get; set;} = "Moves combinations is not compatible with {0} evolution.";
         #endregion
 
     }

--- a/PKHeX/Legality/Structures/EncounterStatic.cs
+++ b/PKHeX/Legality/Structures/EncounterStatic.cs
@@ -125,7 +125,7 @@
 
     public class EncounterStaticTyped : EncounterStatic
     {
-        public EncounterType TypeEncounter = EncounterType.None;
+        public EncounterType TypeEncounter = EncounterType.Any;
 
         protected override EncounterStatic Clone(int location)
         {

--- a/PKHeX/Legality/Tables.cs
+++ b/PKHeX/Legality/Tables.cs
@@ -219,6 +219,52 @@ namespace PKHeX.Core
         public static readonly int[] Arceus_Plate = {303, 306, 304, 305, 309, 308, 310, 313, 298, 299, 301, 300, 307, 302, 311, 312, 644};
         public static readonly int[] Arceus_ZCrystal = {782, 785, 783, 784, 788, 787, 789, 792, 777, 778, 780, 779, 786, 781, 790, 791, 793};
 
+        internal static int[] BabyEvolutionWithMove =
+        {
+            122, // Mr. Mime (Mime Jr with Mimic)
+            185, // Sudowoodo (Bonsly with Mimic)
+        };
+
+        internal static int[] EvolutionWithMove =
+        {
+            122, // Mr. Mime (Mime Jr with Mimic)
+            185, // Sudowoodo (Bonsly with Mimic)
+            424, // Ambipom (Aipom with Double Hit)
+            463, // Lickilicky (Lickitung with Rollout)
+            465, // Tangrowth (Tangela with Ancient Power)
+            469, // Yanmega (Yamma with Ancient Power)
+            473, // Mamoswine (Piloswine with Ancient Power)
+            700, // Sylveon (Eevee with Fairy Move)
+            763, // Tsareena (Steenee with Stomp)
+        };
+
+        internal static int[] FairyMoves =
+        {
+            186, //Sweet Kiss
+            204, //Charm
+            236, //Moonlight 
+            574, //Disarming Voice 
+            577, //Draining Kiss 
+            578, //Crafty Shield 
+            579, //Flower Shield 
+            581, //Misty Terrain 
+            583, //Play Rough 
+            584, //Fairy Wind 
+            585, //Moonblast 
+            587, //Fairy Lock 
+            597, //Aromatic Mist 
+            601, //Geomancy 
+            605, //Dazzling Gleam 
+            608, //Baby-Doll Eyes 
+            617, //Light of Ruin 
+            656, //Twinkle Tackle 
+            657, //Twinkle Tackle 
+            666, //Floral Healing 
+            698, //Guardian of Alola 
+            705, //Fleur Cannon 
+            717, //Nature's Madness 
+        };
+
         #region Games
 
         public static readonly int[] Games_7vc2 = { 39, 40, 41 }; // Gold, Silver, Crystal

--- a/PKHeX/Legality/Tables4.cs
+++ b/PKHeX/Legality/Tables4.cs
@@ -449,7 +449,7 @@ namespace PKHeX.Core
             new EncounterStaticTyped { Species = 145, Level = 60, Roaming = true, TypeEncounter = EncounterType.Surfing_Fishing, Version = GameVersion.Pt }, // Zapdos
             new EncounterStaticTyped { Species = 146, Level = 60, Roaming = true, TypeEncounter = EncounterType.Surfing_Fishing, Version = GameVersion.Pt }, // Moltres
         };
-        internal static readonly EncounterStaticTyped[] Encounter_DPPt_Regular =
+        internal static readonly EncounterStatic[] Encounter_DPPt_Regular =
         {
             //Starters
             new EncounterStaticTyped { Gift = true, Species = 387, Level = 5, Location = 076, TypeEncounter = EncounterType.Starter_Fossil_Gift_DP, Version = GameVersion.DP }, // Turtwig @ Lake Verity
@@ -470,9 +470,9 @@ namespace PKHeX.Core
             new EncounterStaticTyped { Gift = true, Species = 133, Level = 05, Location = 010, Version = GameVersion.DP, TypeEncounter = EncounterType.Starter_Fossil_Gift_DP, }, //Eevee @ Hearthome City 
             new EncounterStaticTyped { Gift = true, Species = 133, Level = 20, Location = 010, Version = GameVersion.Pt, TypeEncounter = EncounterType.Starter_Fossil_Gift_Pt_DPTrio, }, //Eevee @ Hearthome City 
             new EncounterStaticTyped { Gift = true, Species = 137, Level = 25, Location = 012, Version = GameVersion.Pt, TypeEncounter = EncounterType.Starter_Fossil_Gift_Pt_DPTrio, }, //Porygon @ Veilstone City
-            new EncounterStaticTyped { Gift = true, Species = 175, Level = 01, EggLocation = 2011, TypeEncounter = EncounterType.None, Version = GameVersion.Pt,}, //Togepi Egg from Cynthia
-            new EncounterStaticTyped { Gift = true, Species = 440, Level = 01, EggLocation = 2009, TypeEncounter = EncounterType.None, Version = GameVersion.DP,}, //Happiny Egg from Traveling Man
-            new EncounterStaticTyped { Gift = true, Species = 447, Level = 01, EggLocation = 2010, TypeEncounter = EncounterType.None, }, //Riolu Egg from Riley
+            new EncounterStatic { Gift = true, Species = 175, Level = 01, EggLocation = 2011, Version = GameVersion.Pt,}, //Togepi Egg from Cynthia
+            new EncounterStatic { Gift = true, Species = 440, Level = 01, EggLocation = 2009, Version = GameVersion.DP,}, //Happiny Egg from Traveling Man
+            new EncounterStatic { Gift = true, Species = 447, Level = 01, EggLocation = 2010, }, //Riolu Egg from Riley
             //Stationary
             new EncounterStaticTyped { Species = 425, Level = 22, Location = 47, Version = GameVersion.DP, TypeEncounter = EncounterType.TallGrass, },// Drifloon @ Valley Windworks 
             new EncounterStaticTyped { Species = 425, Level = 15, Location = 47, Version = GameVersion.Pt, TypeEncounter = EncounterType.TallGrass, },// Drifloon @ Valley Windworks 
@@ -557,7 +557,7 @@ namespace PKHeX.Core
             new EncounterStaticTyped { Species = 380, Level = 35, Version = GameVersion.HG, Roaming = true, TypeEncounter = EncounterType.Surfing_Fishing, }, //Latias
             new EncounterStaticTyped { Species = 381, Level = 35, Version = GameVersion.SS, Roaming = true, TypeEncounter = EncounterType.Surfing_Fishing, }, //Latios
         };
-        internal static readonly EncounterStaticTyped[] Encounter_HGSS_Regular =
+        internal static readonly EncounterStatic[] Encounter_HGSS_Regular =
         {
             //Starters
             new EncounterStaticTyped { Gift = true, Species = 001, Level = 05, Location = 138, TypeEncounter = EncounterType.Starter_Fossil_Gift_DP, }, // Bulbasaur @ Pallet Town
@@ -581,10 +581,10 @@ namespace PKHeX.Core
             new EncounterStaticTyped { Gift = true, Species = 133, Level = 05, Location = 131, TypeEncounter = EncounterType.Starter_Fossil_Gift_Pt_DPTrio }, // Eevee @ Goldenrod City
             new EncounterStaticTyped { Gift = true, Species = 147, Level = 15, Location = 222, Moves = new[] {245}, }, // Dratini @ Dragon's Den (ExtremeSpeed)
             new EncounterStaticTyped { Gift = true, Species = 236, Level = 10, Location = 216, TypeEncounter = EncounterType.Starter_Fossil_Gift_DP,  }, // Tyrogue @ Mt. Mortar
-            new EncounterStaticTyped { Gift = true, Species = 175, Level = 01, EggLocation = 2013, TypeEncounter = EncounterType.None, Moves = new[] {326} }, // Togepi Egg from Mr. Pokemon (Extrasensory as Egg move)
-            new EncounterStaticTyped { Gift = true, Species = 179, Level = 01, EggLocation = 2014, TypeEncounter = EncounterType.None, }, // Mareep Egg from Primo
-            new EncounterStaticTyped { Gift = true, Species = 194, Level = 01, EggLocation = 2014, TypeEncounter = EncounterType.None, }, // Wooper Egg from Primo
-            new EncounterStaticTyped { Gift = true, Species = 218, Level = 01, EggLocation = 2014, TypeEncounter = EncounterType.None, }, // Slugma Egg from Primo
+            new EncounterStatic { Gift = true, Species = 175, Level = 01, EggLocation = 2013, Moves = new[] {326} }, // Togepi Egg from Mr. Pokemon (Extrasensory as Egg move)
+            new EncounterStatic { Gift = true, Species = 179, Level = 01, EggLocation = 2014, }, // Mareep Egg from Primo
+            new EncounterStatic { Gift = true, Species = 194, Level = 01, EggLocation = 2014, }, // Wooper Egg from Primo
+            new EncounterStatic { Gift = true, Species = 218, Level = 01, EggLocation = 2014, }, // Slugma Egg from Primo
             // Celadon City Game Corner
             new EncounterStaticTyped { Gift = true, Species = 122, Level = 15, Location = 144, TypeEncounter = EncounterType.Starter_Fossil_Gift_Pt_DPTrio, }, // Mr. Mime
             new EncounterStaticTyped { Gift = true, Species = 133, Level = 15, Location = 144, TypeEncounter = EncounterType.Starter_Fossil_Gift_Pt_DPTrio }, // Eevee
@@ -605,7 +605,7 @@ namespace PKHeX.Core
             new EncounterStaticTyped { Species = 101, Level = 23, Location = 213, TypeEncounter = EncounterType.Building_EnigmaStone, }, //Electrode @ Team Rocket HQ
             new EncounterStaticTyped { Species = 143, Level = 50, Location = 159, }, //Snorlax @ Route 11
             new EncounterStaticTyped { Species = 143, Level = 50, Location = 160, }, //Snorlax @ Route 12
-            new EncounterStaticTyped { Species = 185, Level = 20, Location = 184, TypeEncounter = EncounterType.None, }, //Sudowoodo @ Route 36
+            new EncounterStatic { Species = 185, Level = 20, Location = 184, }, //Sudowoodo @ Route 36, Encounter does not have type
             new EncounterStaticTyped { Species = 172, Level = 30, Location = 214, Gender = 1, Form = 1, Moves = new[]{344,270,207,220} },  //Spiky-eared Pichu @ Ilex forest
             //Stationary Lengerdary
             new EncounterStaticTyped { Species = 144, Level = 50, Location = 203, }, //Articuno @ Seafoam Islands

--- a/PKHeX/Resources/text/en/LegalityCheckStrings_en.txt
+++ b/PKHeX/Resources/text/en/LegalityCheckStrings_en.txt
@@ -315,3 +315,4 @@ V377 = Egg Move. Not expected in a gift egg.
 V378 = Inherited move learned by Level-up. Not expected in a gift egg.
 V379 = {0} Inherited Move. Incompatible with {1} inherited moves.
 V381 = Encounter Type does not match encounter.
+V385 = Moves combinations is not compatible with {0} evolution.

--- a/PKHeX/Resources/text/ko/LegalityCheckStrings_ko.txt
+++ b/PKHeX/Resources/text/ko/LegalityCheckStrings_ko.txt
@@ -314,3 +314,4 @@ V377 = 자력기입니다. 이벤트 알에서 예상된 기술이 아닙니다.
 V378 = 유전받은 레벨업 기술입니다. 이벤트 알에서 예상된 기술이 아닙니다.
 V379 = 유전받은 {0} 기술입니다. 유전받은 {1} 기술과 함께 존재할 수 없습니다.
 V381 = Encounter Type does not match encounter.
+V385 = Moves combinations is not compatible with {0} evolution.

--- a/PKHeX/Resources/text/zh/LegalityCheckStrings_zh.txt
+++ b/PKHeX/Resources/text/zh/LegalityCheckStrings_zh.txt
@@ -314,3 +314,4 @@ V377 = 遗传招式。礼物蛋不应有。
 V378 = 遗传升级招式。礼物蛋不应有。
 V379 = {0}的遗传招式。与遗传的招式{1}不共存。
 V381 = Encounter Type does not match encounter.
+V385 = Moves combinations is not compatible with {0} evolution.


### PR DESCRIPTION
I added validation for pokemon that evolve while leveling up with a specific move learned.
Those pokemon if they have 4 moves they must have at least one move learned after the evolution or the move that make them evolve. The valid moves are those that can be learned after evolving, including realearn moves, and the moves that trigger the evolution. At least one move must be from this valid moves.

For example a generation 5 eevee transfered to XY that have 4 non-fairy egg moves must forget one move and learn a fairy type move to evolve into Sylveon. If that Sylveon have those 4 moves is illegal.

Excluded are Sudowoodo and Mr.Mime from generation 1-3, pokemon with empty moves (they can forget the evolve move) and pokemon wich encounter is the evolved species. Also Sudowoodo and Mr.Mime are ignored if they were eggs and dont have any exclusive Bonsly or Mime Jr moves, we can assume were non incense eggs.

Also fixed generation 4 typed encounters, there are some encounters with type = none, HGSS sudowodoo and static eggs, i change the type from this to encounterstatic because the filter is ignored them with encounterstatictyped. Also changed the default type to Any for those encounters that must be  encounterstatictyped but we dont have yet defined the valid type, that does not means the legal value for this is None, means we need to verify the legal value and temporarly all values should be allowed.

Also changed the comprobations when is checked the type is encounterstatic like balls verification to included encounterstatictype as subclass.