### PR TITLE
Fix Encounter Type checks

### DIFF
--- a/PKHeX/Legality/Core.cs
+++ b/PKHeX/Legality/Core.cs
@@ -326,7 +326,8 @@ namespace PKHeX.Core
             {
                 // HGSS Safari encounters have normal water/grass encounter type, not safari encounter type
                 case SlotType.Grass:
-                case SlotType.Grass_Safari: return GrassType;
+                case SlotType.Grass_Safari:
+                case SlotType.BugContest: return GrassType;
                 case SlotType.Surf:
                 case SlotType.Old_Rod:
                 case SlotType.Good_Rod:
@@ -671,12 +672,12 @@ namespace PKHeX.Core
                 SlotsHG = addExtraTableSlots(HG_Slots, HG_Headbutt_Slots, SlotsHGSSAlt);
                 SlotsSS = addExtraTableSlots(SS_Slots, SS_Headbutt_Slots, SlotsHGSSAlt);
 
-                MarkDPPtEncounterTypeSlots(ref D_Slots);
-                MarkDPPtEncounterTypeSlots(ref P_Slots);
-                MarkDPPtEncounterTypeSlots(ref Pt_Slots);
-                MarkHGSSEncounterTypeSlots(ref HG_Slots);
-                MarkHGSSEncounterTypeSlots(ref SS_Slots);
-
+                MarkDPPtEncounterTypeSlots(ref SlotsD);
+                MarkDPPtEncounterTypeSlots(ref SlotsP);
+                MarkDPPtEncounterTypeSlots(ref SlotsPt);
+                MarkHGSSEncounterTypeSlots(ref SlotsHG);
+                MarkHGSSEncounterTypeSlots(ref SlotsSS);
+                
                 Evolves4 = new EvolutionTree(new[] { Resources.evos_g4 }, GameVersion.DP, PersonalTable.DP, MaxSpeciesID_4);
 
                 // Update Personal Entries with Tutor Data

--- a/PKHeX/Legality/Tables4.cs
+++ b/PKHeX/Legality/Tables4.cs
@@ -232,6 +232,7 @@ namespace PKHeX.Core
             209, // Ruins of Alph
             210, // Union Cave
             211, // SLOWPOKE Well
+            214, // Ilex Forest
             216, // Mt. Mortar
             217, // Ice Path
             218, // Whirl Islands


### PR DESCRIPTION
Added bug contest as tail grass encounters
Illex Forest as cave encounter
Mark encounter types in the final encounter array to avoid to have none encounter in any alt slot

Also i found discrapancies with heabutt and rock smash encounters, but i need to test catching pokemon from that encounters before make any changes.

It seems it not as easy as assign none to all headbutt encounters. Headbutt have the encounter type were the player is standing when he/she catch the pokemon. That means a headbutt encounter can have none, tail grass , cave or combination of tail and none depending of the area with maybe different values for normal trees and special tress.

Also i have found a rock smash encounter in Cianwood City with building encounter, maybe rock smash also change encounter value based in the player's tile.