### PR TITLE
Fix error in transfer legality G4.

### DIFF
--- a/PKHeX/Legality/Checks.cs
+++ b/PKHeX/Legality/Checks.cs
@@ -1021,7 +1021,7 @@ namespace PKHeX.Core
                 WildEncounter = (EncounterSlot[])EncounterMatch;
             }
 
-            if (Gen4Result == null && null != (EncounterStaticMatch = Legal.getValidStaticEncounter(pkm)))
+            if (Gen4Result == null && pkm.Ball != 5 && pkm.Ball != 0x18 && null != (EncounterStaticMatch = Legal.getValidStaticEncounter(pkm)))
             {
                 EncounterMatch = EncounterStaticMatch.First();
                 var result = verifyEncounterStatic();


### PR DESCRIPTION
Transfer legality is not checked if the pokemon is a valid static encounter

Also an Entei with invalid encounter is returning null as check encounter making the analysis to throw an exception, reported in the forum. 

Changed to do not return checkresult until the end to add invalid values if Gen4Result is null.