### PR TITLE
Add missing package for MemeCrypto in .Net Framework

### DIFF
--- a/PKHeX.WinForms/PKHeX.WinForms.csproj
+++ b/PKHeX.WinForms/PKHeX.WinForms.csproj
@@ -140,8 +140,8 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
-    <Reference Include="System.Console, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Console.4.3.0\lib\net46\System.Console.dll</HintPath>
+    <Reference Include="System.Console, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Console.4.0.0\lib\net46\System.Console.dll</HintPath>
     </Reference>
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
@@ -152,6 +152,12 @@
       <HintPath>..\packages\System.IO.FileSystem.Primitives.4.3.0\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime" />
+    <Reference Include="System.Security.Cryptography.Algorithms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net46\System.Security.Cryptography.Algorithms.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
+    </Reference>
     <Reference Include="System.Web" />
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>

--- a/PKHeX.WinForms/packages.config
+++ b/PKHeX.WinForms/packages.config
@@ -1,6 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Console" version="4.3.0" targetFramework="net46" />
+  <package id="System.Console" version="4.0.0" targetFramework="net46" />
   <package id="System.IO.FileSystem" version="4.3.0" targetFramework="net46" />
   <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net46" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net46" />
+  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net46" />
 </packages>

--- a/Tests/PKHeX.Tests/PKHeX.Tests.csproj
+++ b/Tests/PKHeX.Tests/PKHeX.Tests.csproj
@@ -58,14 +58,20 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Console, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\System.Console.4.3.0\lib\net46\System.Console.dll</HintPath>
+    <Reference Include="System.Console, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Console.4.0.0\lib\net46\System.Console.dll</HintPath>
     </Reference>
     <Reference Include="System.IO.FileSystem, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.IO.FileSystem.4.3.0\lib\net46\System.IO.FileSystem.dll</HintPath>
     </Reference>
     <Reference Include="System.IO.FileSystem.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.IO.FileSystem.Primitives.4.3.0\lib\net46\System.IO.FileSystem.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Algorithms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Security.Cryptography.Algorithms.4.3.0\lib\net46\System.Security.Cryptography.Algorithms.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Choose>
@@ -84,6 +90,7 @@
     <Compile Include="PKM\DateTestPKM.cs" />
     <Compile Include="PKM\PKMTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Saves\Substructures\MemeCryptoTests.cs" />
     <Compile Include="Util\DateUtilTests.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -99,6 +106,7 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup />
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
       <ItemGroup>

--- a/Tests/PKHeX.Tests/Saves/Substructures/MemeCryptoTests.cs
+++ b/Tests/PKHeX.Tests/Saves/Substructures/MemeCryptoTests.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PKHeX.Core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PKHeX.Tests.Saves.Substructures
+{
+    [TestClass]
+    public class MemeCryptoTests
+    {
+        [TestMethod]
+        public void CanUseMemeCrypto()
+        {
+            Assert.IsTrue(MemeCrypto.CanUseMemeCrypto());
+        }
+    }
+}

--- a/Tests/PKHeX.Tests/packages.config
+++ b/Tests/PKHeX.Tests/packages.config
@@ -1,6 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="System.Console" version="4.3.0" targetFramework="net46" />
+  <package id="System.Console" version="4.0.0" targetFramework="net46" />
   <package id="System.IO.FileSystem" version="4.3.0" targetFramework="net46" />
   <package id="System.IO.FileSystem.Primitives" version="4.3.0" targetFramework="net46" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.0" targetFramework="net46" />
+  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
Closes #1123 

This should also fix the Team City test build.