### PR TITLE
Activate illegal mode with command-line arg

### DIFF
--- a/PKHeX.WinForms/MainWindow/Main.cs
+++ b/PKHeX.WinForms/MainWindow/Main.cs
@@ -149,8 +149,7 @@ namespace PKHeX.WinForms
             #endregion
             #region Localize & Populate Fields
             string[] args = Environment.GetCommandLineArgs();
-            string filename = args.Length > 0 ? Path.GetFileNameWithoutExtension(args[0])?.ToLower() : "";
-            HaX = filename?.IndexOf("hax", StringComparison.Ordinal) >= 0;
+            HaX = args.Any(x => x.Trim('-').ToLower() == "hax");
 
             bool showChangelog = false;
             bool BAKprompt = false;


### PR DESCRIPTION
Workaround for PKHaX being broken. Trimming each argument allows "hax", "-hax", and "--hax" to all work for activating illegal mode. Case insensitivity is because case sensitivity is annoying.

Original issue [here](https://projectpokemon.org/forums/forums/topic/40651-illegal-mode-issue/). Additional binding information:
```
=== Pre-bind state information ===
LOG: DisplayName = System.IO.FileSystem, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
 (Fully-specified)
LOG: Appbase = file:///<path>/PKHeX.WinForms/bin/x86/Release/
LOG: Initial PrivatePath = NULL
Calling assembly : PKHeX.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null.
===
LOG: This bind starts in default load context.
LOG: No application configuration file found.
LOG: Using host configuration file: 
LOG: Using machine configuration file from C:\Windows\Microsoft.NET\Framework\v4.0.30319\config\machine.config.
LOG: Post-policy reference: System.IO.FileSystem, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
LOG: Attempting download of new URL file:///<path>/PKHeX.WinForms/bin/x86/Release/System.IO.FileSystem.DLL.
WRN: Comparing the assembly name resulted in the mismatch: Build Number
ERR: Failed to complete setup of assembly (hr = 0x80131040). Probing terminated.
```

Debugging steps:
- Remove version, culture, and public key token from every .Net Core DLL referenced by PKHeX.WinForms
- Set PKHeX.WinForms from `Embed manifest with default settings` to `Create application without a manifest`
- Both of the above at once and each individually

I do not know why the error remains, and I believe this PR is the simplest solution.