### PR TITLE
Mark OT Female trainer from Gamecube and VC pokemon as invalid.

### DIFF
--- a/PKHeX.Core/Legality/Checks.cs
+++ b/PKHeX.Core/Legality/Checks.cs
@@ -422,8 +422,20 @@ namespace PKHeX.Core
             else if (pkm.SID == 0)
                 AddLine(Severity.Fishy, V37, CheckIdentifier.Trainer);
 
+            if (pkm.OT_Gender == 1)
+                verifyOTFemale();
+
             if (pkm.VC)
                 verifyG1OT();
+        }
+        private void verifyOTFemale()
+        {
+            if (pkm.Format < 3) // Format 2 pkm with ot gender stored are from crystal, female player is allowed
+                return;
+            if (pkm.Version == 15)
+                AddLine(Severity.Invalid, V407, CheckIdentifier.Trainer);
+            else if (pkm.VC) // If VC2 is realease probably more checks will be needed
+                AddLine(Severity.Invalid, V407, CheckIdentifier.Trainer);
         }
         private void verifyG1OT()
         {

--- a/PKHeX.Core/Legality/LegalityCheckStrings.cs
+++ b/PKHeX.Core/Legality/LegalityCheckStrings.cs
@@ -400,6 +400,8 @@ namespace PKHeX.Core
         public static string V402 {get; set;} = "Incorrect Stadium OT.";
         public static string V405 {get; set;} = "Outsider {0} should have evolved into {1}.";
         public static string V406 {get; set;} = "Non japanese Shadow E-reader Pokémon. Unreleased encounter.";
+        public static string V407 {get; set;} = "OT Trainer from Colloseum/XD could not be female.";
+        public static string V408 {get; set;} = "OT Trainer from generation 1 could not be female.";
         #endregion
 
     }

--- a/PKHeX.Core/Resources/text/en/LegalityCheckStrings_en.txt
+++ b/PKHeX.Core/Resources/text/en/LegalityCheckStrings_en.txt
@@ -337,3 +337,5 @@ V401 = In-game trade {0} should have evolved into {1}.
 V402 = Incorrect Stadium OT.
 V405 = Outsider {0} should have evolved into {1}.
 V406 = Non japanese Shadow E-reader Pokémon. Unreleased encounter.
+V407 = OT Trainer from Colloseum/XD could not be female.
+V408 = OT Trainer from generation 1 could not be female.

--- a/PKHeX.Core/Resources/text/ko/LegalityCheckStrings_ko.txt
+++ b/PKHeX.Core/Resources/text/ko/LegalityCheckStrings_ko.txt
@@ -338,3 +338,5 @@ V401 = In-game trade {0} should have evolved into {1}.
 V402 = Incorrect Stadium OT.
 V405 = Outsider {0} should have evolved into {1}.
 V406 = Non japanese Shadow E-reader Pokémon. Unreleased encounter.
+V407 = OT Trainer from Colloseum/XD could not be female.
+V408 = OT Trainer from generation 1 could not be female.

--- a/PKHeX.Core/Resources/text/zh/LegalityCheckStrings_zh.txt
+++ b/PKHeX.Core/Resources/text/zh/LegalityCheckStrings_zh.txt
@@ -337,3 +337,5 @@ V401 = 游戏内交换{0}应当进化为{1}.
 V402 = 不正确竞技场初训家。
 V405 = 外来的{0}应当进化为{1}.
 V406 = 非日版黑暗E-reader宝可梦。未解禁遇见方式。
+V407 = OT Trainer from Colloseum/XD could not be female.
+V408 = OT Trainer from generation 1 could not be female.


### PR DESCRIPTION
A small check for ot gender in GC and GB pokemon.

Gamecube games and generation 1 games do not have female player character.

Also generation 2 is not checked because if the pokemon is in format 2 and have met location data stored that means it was caught in crystal where female player is allowed, checks are not included for generation VC2 pokemon, we do not know how the bank will transfer ot gender of crystal pokemon if VC2 games are released