### PR TITLE
Fix Link Gift Check if not Gen 6

### DIFF
--- a/PKHeX.Core/Legality/Encounters/EncounterGenerator.cs
+++ b/PKHeX.Core/Legality/Encounters/EncounterGenerator.cs
@@ -129,7 +129,7 @@ namespace PKHeX.Core
         private static IEnumerable<IEncounterable> GenerateRawEncounters(PKM pkm)
         {
             int ctr = 0;
-            if (pkm.WasLink)
+            if (pkm.WasLink && pkm.GenNumber == 6)
             {
                 foreach (var z in getValidLinkGifts(pkm))
                 { yield return z; ++ctr; }

--- a/PKHeX.Core/Legality/Encounters/EncounterGenerator.cs
+++ b/PKHeX.Core/Legality/Encounters/EncounterGenerator.cs
@@ -129,7 +129,7 @@ namespace PKHeX.Core
         private static IEnumerable<IEncounterable> GenerateRawEncounters(PKM pkm)
         {
             int ctr = 0;
-            if (pkm.WasLink && pkm.GenNumber == 6)
+            if (pkm.WasLink)
             {
                 foreach (var z in getValidLinkGifts(pkm))
                 { yield return z; ++ctr; }
@@ -515,7 +515,7 @@ namespace PKHeX.Core
                 case 6:
                     return LinkGifts6.Where(g => g.Species == pkm.Species && g.Level == pkm.Met_Level);
                 default:
-                    return null;
+                    return new EncounterLink[0];
             }
         }
 


### PR DESCRIPTION
Prevents NullReferenceException if location is set in other Gen. Reference: https://projectpokemon.org/forums/forums/topic/40749-beautifly-and-dustox-re-roll-pidencryption-pkhex-becomes-unresponsive/