### PR TITLE
Set Shiny SID

### DIFF
--- a/PKHeX.Core/Legality/Tables4.cs
+++ b/PKHeX.Core/Legality/Tables4.cs
@@ -282,8 +282,9 @@ namespace PKHeX.Core
             227, // Safari Zone Gate
         };
         internal static readonly int[] HGSS_SurfingHeadbutt_Locations =
-        {   // Locations with headbutt trees adjacent  to water tiles
+        {   // Locations with headbutt trees adjacent to water tiles
             126, // New Bark Town 
+            127, // Cherrygrove City
             128, // Violet City 
             133, // Ecruteak City 
             135, // Lake of Rage 
@@ -306,7 +307,7 @@ namespace PKHeX.Core
             214, // Ilex Forest 
         };
         internal static readonly int[] HGSS_GrassHeadbutt_Locations =
-        {   // Locations with headbutt trees adjacent  to tall grass tiles
+        {   // Locations with headbutt trees adjacent to tall grass tiles
             137, // Mt. Silver 
             149, // Route 1
             150, // Route 2

--- a/PKHeX.Core/PKM/PKM.cs
+++ b/PKHeX.Core/PKM/PKM.cs
@@ -767,6 +767,14 @@ namespace PKHeX.Core
                 EncryptionConstant = PID;
         }
         /// <summary>
+        /// Applies a shiny SID to the <see cref="PKM"/>.
+        /// </summary>
+        public void setShinySID()
+        {
+            if (IsShiny) return;
+            do SID = Util.rnd16(); while (!IsShiny);
+        }
+        /// <summary>
         /// Applies a PID to the <see cref="PKM"/> according to the specified <see cref="Gender"/>.
         /// </summary>
         /// <remarks>

--- a/PKHeX.Core/Util/RandUtil.cs
+++ b/PKHeX.Core/Util/RandUtil.cs
@@ -9,6 +9,10 @@ namespace PKHeX.Core
         {
             return (uint)rand.Next(1 << 30) << 2 | (uint)rand.Next(1 << 2);
         }
+        internal static ushort rnd16()
+        {
+            return (ushort)rand.Next(ushort.MaxValue);
+        }
         public static void Shuffle<T>(T[] array)
         {
             int n = array.Length;

--- a/PKHeX.WinForms/Controls/PKM Editor/PKMEditor.cs
+++ b/PKHeX.WinForms/Controls/PKM Editor/PKMEditor.cs
@@ -1472,6 +1472,11 @@ namespace PKHeX.WinForms.Controls
         }
         private void updateShinyPID(object sender, EventArgs e)
         {
+            var ShinyPID = pkm.Format <= 2 || ModifierKeys != Keys.Control;
+            updateShiny(ShinyPID);
+        }
+        private void updateShiny(bool PID)
+        {
             pkm.TID = Util.ToInt32(TB_TID.Text);
             pkm.SID = Util.ToInt32(TB_SID.Text);
             pkm.PID = Util.getHEXval(TB_PID.Text);
@@ -1481,7 +1486,21 @@ namespace PKHeX.WinForms.Controls
             pkm.Version = WinFormsUtil.getIndex(CB_GameOrigin);
 
             if (pkm.Format > 2)
-                pkm.setShinyPID();
+            { 
+                if(PID)
+                {
+                    pkm.setShinyPID();
+                    TB_PID.Text = pkm.PID.ToString("X8");
+
+                    if (pkm.GenNumber < 6 && TB_EC.Visible)
+                        TB_EC.Text = TB_PID.Text;
+                }
+                else
+                {
+                    pkm.setShinySID();
+                    TB_SID.Text = pkm.SID.ToString();
+                }
+            }
             else
             {
                 // IVs determine shininess
@@ -1502,10 +1521,6 @@ namespace PKHeX.WinForms.Controls
                 TB_SPAIV.Text = "10";
                 updateIVs(null, null);
             }
-            TB_PID.Text = pkm.PID.ToString("X8");
-
-            if (pkm.GenNumber < 6 && TB_EC.Visible)
-                TB_EC.Text = TB_PID.Text;
 
             setIsShiny(null);
             UpdatePreviewSprite?.Invoke(this, null);
@@ -1926,7 +1941,7 @@ namespace PKHeX.WinForms.Controls
             for (int i = 0; i < 4; i++)
                 p[i].SelectedIndex = m[i].SelectedIndex != 0 ? 3 : 0; // max PP
 
-            if (Set.Shiny) updateShinyPID(null, null);
+            if (Set.Shiny) updateShiny(true);
             pkm = preparePKM();
             updateLegality();
         }


### PR DESCRIPTION
Set Shiny button will make any gen 3/4 pokemon illegal because the PID find wont match a PID/IV relation.
But Shiny can be obtained also changing the TID/SID of the pokemon instead of the PID and in most cases this wont make the pokemon illegal. Used SID instead of TID because the first data is ont visible in-game.

Changed shiny button to turn pokemon into shiny changin the SID instead of the PID if ctrl+click is used. The user can choose what data to change to make it shiny, normal click for the PID or ctrl+click for the SID.

Of course this change will make the pokemon foreign for its original trainer.

