### PR TITLE
Do not allow backward transfer a pokemon without valid moves for destination game

### DIFF
--- a/PKHeX.Core/PKM/PKMConverter.cs
+++ b/PKHeX.Core/PKM/PKMConverter.cs
@@ -221,7 +221,7 @@ namespace PKHeX.Core
                     case nameof(PK2):
                         if (PKMType == typeof (PK1))
                         {
-                            if (pk.Species > 151)
+                            if (pk.Species > 151 || pk.Moves.All(m=> m == 0 || m > Legal.MaxMoveID_1))
                             {
                                 comment = $"Cannot convert a {PKX.getSpeciesName(pkm.Species, ((PK2)pkm).Japanese ? 1 : 2)} to {PKMType.Name}";
                                 return null;

--- a/PKHeX.Core/Saves/SaveUtil.cs
+++ b/PKHeX.Core/Saves/SaveUtil.cs
@@ -1066,7 +1066,7 @@ namespace PKHeX.Core
         /// <returns>Indication whether or not the PKM is compatible.</returns>
         public static bool checkCompatible(SaveFile SAV, PKM pk)
         {
-            if (pk.Species > SAV.MaxSpeciesID)
+            if (pk.Species > SAV.MaxSpeciesID || pk.Moves.All(m => m == 0 || m > SAV.MaxMoveID))
                 return false;
 
             if (pk.HeldItem > SAV.MaxItemID)


### PR DESCRIPTION
When a pokemon is converted from generation 2 to generation 1 any exclusive gen 2 moves are removed just like the real games do,  GSC does not allow a pokemon with gen 2 moves to enter the time capsule, but at the same time the games does not allow a pokemon to remove all the moves, it must have at least a non-empty move.

I just added the check for the case when a pokemon only have generation 2 moves, and its move list would be empy after removin all the moves, it should not be allowed to transfer because it wont have any move in generation 1