### PR TITLE
Change Gen 1/2 Inventory count default

### DIFF
--- a/PKHeX.Core/Saves/SAV1.cs
+++ b/PKHeX.Core/Saves/SAV1.cs
@@ -337,8 +337,8 @@ namespace PKHeX.Core
                 ushort[] legalItems = LegalItems;
                 InventoryPouch[] pouch =
                 {
-                    new InventoryPouch(InventoryType.Items, legalItems, 99, Japanese ? 0x25C4 : 0x25C9, 20),
-                    new InventoryPouch(InventoryType.PCItems, legalItems, 99, Japanese ? 0x27DC : 0x27E6, 50)
+                    new InventoryPouch(InventoryType.Items, legalItems, 95, Japanese ? 0x25C4 : 0x25C9, 20),
+                    new InventoryPouch(InventoryType.PCItems, legalItems, 95, Japanese ? 0x27DC : 0x27E6, 50)
                 };
                 foreach (var p in pouch)
                 {

--- a/PKHeX.Core/Saves/SAV2.cs
+++ b/PKHeX.Core/Saves/SAV2.cs
@@ -414,22 +414,22 @@ namespace PKHeX.Core
                 {
                     pouch = new[]
                     {
-                        new InventoryPouch(InventoryType.TMHMs, LegalTMHMs, 99, Japanese ? 0x23C9 : 0x23E7, 57),
-                        new InventoryPouch(InventoryType.Items, LegalItems, 99, Japanese ? 0x2402 : 0x2420, 20),
+                        new InventoryPouch(InventoryType.TMHMs, LegalTMHMs, 95, Japanese ? 0x23C9 : 0x23E7, 57),
+                        new InventoryPouch(InventoryType.Items, LegalItems, 95, Japanese ? 0x2402 : 0x2420, 20),
                         new InventoryPouch(InventoryType.KeyItems, LegalKeyItems, 1, Japanese ? 0x242C : 0x244A, 26),
-                        new InventoryPouch(InventoryType.Balls, LegalBalls, 99, Japanese ? 0x2447 : 0x2465, 12),
-                        new InventoryPouch(InventoryType.PCItems, LegalItems.Concat(LegalKeyItems).Concat(LegalBalls).Concat(LegalTMHMs).ToArray(), 99, Japanese ? 0x2461 : 0x247F, 50)
+                        new InventoryPouch(InventoryType.Balls, LegalBalls, 95, Japanese ? 0x2447 : 0x2465, 12),
+                        new InventoryPouch(InventoryType.PCItems, LegalItems.Concat(LegalKeyItems).Concat(LegalBalls).Concat(LegalTMHMs).ToArray(), 95, Japanese ? 0x2461 : 0x247F, 50)
                     };
                 }
                 else
                 {
                     pouch = new[]
                     {
-                        new InventoryPouch(InventoryType.TMHMs, LegalTMHMs, 99, Japanese ? 0x23C7 : 0x23E6, 57),
-                        new InventoryPouch(InventoryType.Items, LegalItems, 99, Japanese ? 0x2400 : 0x241F, 20),
-                        new InventoryPouch(InventoryType.KeyItems, LegalKeyItems, 99, Japanese ? 0x242A : 0x2449, 26),
-                        new InventoryPouch(InventoryType.Balls, LegalBalls, 99, Japanese ? 0x2445 : 0x2464, 12),
-                        new InventoryPouch(InventoryType.PCItems, LegalItems.Concat(LegalKeyItems).Concat(LegalBalls).Concat(LegalTMHMs).ToArray(), 99, Japanese ? 0x245F : 0x247E, 50)
+                        new InventoryPouch(InventoryType.TMHMs, LegalTMHMs, 95, Japanese ? 0x23C7 : 0x23E6, 57),
+                        new InventoryPouch(InventoryType.Items, LegalItems, 95, Japanese ? 0x2400 : 0x241F, 20),
+                        new InventoryPouch(InventoryType.KeyItems, LegalKeyItems, 95, Japanese ? 0x242A : 0x2449, 26),
+                        new InventoryPouch(InventoryType.Balls, LegalBalls, 95, Japanese ? 0x2445 : 0x2464, 12),
+                        new InventoryPouch(InventoryType.PCItems, LegalItems.Concat(LegalKeyItems).Concat(LegalBalls).Concat(LegalTMHMs).ToArray(), 95, Japanese ? 0x245F : 0x247E, 50)
                     };
                 }
                 foreach (var p in pouch)


### PR DESCRIPTION
Changes 99 to 95 so that it can be consistent with Gen 3's 95, and Gen 4 to 7's 995 (allows player to pick up a couple extra items before having a full bag).