### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ PKHeX
 Pokémon core series save editor, programmed in [C#](https://en.wikipedia.org/wiki/C_Sharp_%28programming_language%29).
 
 Supports the following files:
-* Save files ("main", \*.sav, \*.dsv, \*.dat, \*.gci)
+* Save files ("main", \*.sav, \*.dsv, \.sa*, \*.dat, \*.gci)
 * GameCube Memory Card files (\*.raw, \*.bin) containing GC Pokémon savegames.
 * Individual Pokémon entity files (.pk\*, \*.ck3, \*.xk3, \*.bk4)
 * Mystery Gift files (\*.pgt, \*.pcd, \*.pgf, .wc\*) including conversion to .pk\*


### PR DESCRIPTION
PKHeX is capable of loading .sa1 and .sa2 file formats, which are used in some versions of the Visual Boy Advance emulator.

![image](https://user-images.githubusercontent.com/17801814/27262686-f5f26b72-5429-11e7-9cc4-954888b2328e.png)