### PR TITLE
Fix false EXP threshold/EV sum fishy flags

### DIFF
--- a/PKHeX.Core/Legality/Checks.cs
+++ b/PKHeX.Core/Legality/Checks.cs
@@ -354,7 +354,7 @@ namespace PKHeX.Core
             }
 
             // Only one of the following can be true: 0, 508, and x%6!=0
-            if (sum == 0 && pkm.CurrentLevel != EncounterMatch.LevelMin)
+            if (sum == 0 && pkm.CurrentLevel != pkm.Met_Level)
                 AddLine(Severity.Fishy, V23, CheckIdentifier.EVs);
             else if (sum == 508)
                 AddLine(Severity.Fishy, V24, CheckIdentifier.EVs);
@@ -635,7 +635,7 @@ namespace PKHeX.Core
             int lvl = pkm.CurrentLevel;
             if (lvl < pkm.Met_Level)
                 AddLine(Severity.Invalid, V85, CheckIdentifier.Level);
-            else if (EncounterMatch.LevelMin != lvl && lvl != 100 && pkm.EXP == PKX.GetEXP(lvl, pkm.Species))
+            else if (pkm.Met_Level != lvl && lvl != 100 && pkm.EXP == PKX.GetEXP(lvl, pkm.Species))
                 AddLine(Severity.Fishy, V87, CheckIdentifier.Level);
             else
                 AddLine(Severity.Valid, V88, CheckIdentifier.Level);


### PR DESCRIPTION
This fixes my own issues with Drapion as described in #1259. New method proposed in this PR compares the PKM's current level with the PKM's met level, rather than the minimum possible level from encounters.

![image](https://user-images.githubusercontent.com/17801814/27416181-bdef0412-56d9-11e7-9871-46c2345a25c0.png)