### PR TITLE
Fix inhabited generation 3 for Frosslass

### DIFF
--- a/PKHeX.Core/Legality/Tables3.cs
+++ b/PKHeX.Core/Legality/Tables3.cs
@@ -93,7 +93,7 @@ namespace PKHeX.Core
 
         internal static readonly int[] FutureEvolutionsGen3 =
         {
-            407,424,429,430,461,462,463,464,465,466,467,468,469,470,471,472,473,474,475,476,477,700
+            407,424,429,430,461,462,463,464,465,466,467,468,469,470,471,472,473,474,475,476,477,478,700
         };
 
         internal static readonly int[] FutureEvolutionsGen3_LevelUpGen4 = 


### PR DESCRIPTION
Added Froslass to FutureEvolutionsGen3, a gen 3 Froslass will now return true when executing function InhabitedGeneration for generation 3