### PR TITLE
Actually fix Old Chateau Encounter Type

### DIFF
--- a/PKHeX.Core/Legality/Tables4.cs
+++ b/PKHeX.Core/Legality/Tables4.cs
@@ -228,7 +228,7 @@ namespace PKHeX.Core
         };
         internal static readonly int[] DPPt_MtCoronetExteriorEncounters =
         {
-            4, 5
+            4, 5, 70
         };
         internal static readonly int[] HGSS_CaveLocations =
         {


### PR DESCRIPTION
Finally got around to actually testing this. The PKM in question is a legitimately caught Gastly in Platinum. My previous PR, as suggested by @javierhimura, was NOT the actual fix. This PR remedies this by checking for the correct Encounter Type, rather than not having one checked for at all.

Before **and** after first PR, PKHeX checked for "None", which was the bug initially brought up in #1297.
![image](https://user-images.githubusercontent.com/17801814/27875553-8c08c9da-6181-11e7-9ac7-709c422afbfd.png)

With this PR, it properly checks for "Building/Enigma Stone" and flags "None".
![image](https://user-images.githubusercontent.com/17801814/27875574-a7674d46-6181-11e7-9be9-d517a8b4a63e.png)
![image](https://user-images.githubusercontent.com/17801814/27875584-b274f68e-6181-11e7-96fb-003cc3bd8105.png)