### PR TITLE
ChainShinymethod for Pokeradar shiny grass patch

### DIFF
--- a/PKHeX.Core/Legality/Core.cs
+++ b/PKHeX.Core/Legality/Core.cs
@@ -789,6 +789,7 @@ namespace PKHeX.Core
                 MarkEncountersVersion(ref h_c, GameVersion.C);
 
                 var extra = AddExtraTableSlots(c, h_c, f, bcc_c, safari_c);
+                MarkSlotLocation(ref extra);
                 return Version == GameVersion.C ? extra : AddExtraTableSlots(Slots, extra);
             }
 
@@ -818,7 +819,6 @@ namespace PKHeX.Core
                 MarkG2Slots(ref SlotsGS);
                 MarkG2Slots(ref SlotsC);
                 MarkG2Slots(ref SlotsGSC);
-                MarkSlotLocation(ref SlotsC);
                 MarkEncountersGeneration(ref SlotsGS, 2);
                 MarkEncountersGeneration(ref SlotsC, 2);
                 MarkEncountersGeneration(ref SlotsGSC, 2);

--- a/PKHeX.Core/Legality/RNG/MethodFinder.cs
+++ b/PKHeX.Core/Legality/RNG/MethodFinder.cs
@@ -599,8 +599,18 @@ namespace PKHeX.Core
                     if (s.Location == 233 && s.Gift)
                         return val == PIDType.Pokewalker;
                     return s.Shiny == true ? val == PIDType.ChainShiny : val == PIDType.Method_1;
-                case EncounterSlot _:
-                    return val == PIDType.Method_1 || val == PIDType.CuteCharm;
+                case EncounterSlot sl:
+                    if (val == PIDType.Method_1)
+                        return true;
+                    if (val == PIDType.CuteCharm)
+                        // Cute charm does not work with swarms pokemon
+                        return sl.Type != SlotType.Swarm;
+                    if (val != PIDType.ChainShiny)
+                        return false;
+                    // Chain shiny with poke radar is only possible in DPPt in tall grass, safari zone do not allow pokeradar
+                    // TypeEncounter TallGrass discard any cave or city
+                    var IsDPPt = GameVersion.DP.Contains((GameVersion)pkm.Version) || (GameVersion)pkm.Version == GameVersion.Pt;
+                    return pkm.IsShiny && IsDPPt && sl.TypeEncounter == EncounterType.TallGrass && Legal.SafariZoneLocation_4.Contains(sl.Location);
                 case PGT _: // manaphy
                     return IsG4ManaphyPIDValid(val, pkm);
                 default:

--- a/PKHeX.Core/Legality/Structures/EncounterArea.cs
+++ b/PKHeX.Core/Legality/Structures/EncounterArea.cs
@@ -78,7 +78,7 @@ namespace PKHeX.Core
                     int index = i + r*slotCount;
                     slots[index].Rate = rates[r];
                     slots[index].SlotNumber = i;
-                    slots[i].Time = r == 1 ? EncounterTime.Day : EncounterTime.Night;
+                    slots[index].Time = r == 1 ? EncounterTime.Day : EncounterTime.Night;
                 }
             }
 
@@ -148,10 +148,9 @@ namespace PKHeX.Core
             var areas = new List<EncounterArea>();
             while (data[ofs] != 0xFF) // end
             {
-                int _Location = data[ofs++] << 8 | data[ofs++];
                 areas.Add(new EncounterArea
                 {
-                    Location = _Location,
+                    Location = data[ofs++] << 8 | data[ofs++],
                     Slots = GetSlots2_GW(data, ref ofs, t, slotSets, slotCount),
                 });
             }

--- a/PKHeX.Core/Legality/Structures/TreesArea.cs
+++ b/PKHeX.Core/Legality/Structures/TreesArea.cs
@@ -2,17 +2,17 @@
 
 namespace PKHeX.Core
 {
-    // Pokemon Crystal Headbutt tree encounters by trainer id, base on mechanics described in
+    // Pokemon Crystal Headbutt tree encounters by trainer id, based on mechanics described in
     // https://bulbapedia.bulbagarden.net/wiki/Headbutt_tree#Mechanics
 
     public enum TreeEncounterAvailable
     {
-        ValidTree, // Encounter is possible a reacheable tree
-        InvalidTree, // Encounter is only possible a tree reacheable only with walk-trought walls cheats
+        ValidTree, // Encounter is possible a reachable tree
+        InvalidTree, // Encounter is only possible a tree reachable only with walk-trough walls cheats
         Impossible // Encounter is not possible in any tree
     }
 
-    public class TreeCoordinates
+    internal class TreeCoordinates
     {
         internal int X { get; set; }
         internal int Y { get; set; }
@@ -72,8 +72,8 @@ namespace PKHeX.Core
 
         private void ReadAreaRawData(byte[] entrie)
         {
-            // Coordinates of trees for every are obtained with programa G2Map
-            // ValidTrees are those accesible from the player
+            // Coordinates of trees for every are obtained with the program G2Map
+            // ValidTrees are those accessible by the player
             // Invalid tress are trees that the player can not reach without cheating devices, like a tree beyond other trees
             Location = entrie[0];
             ValidTrees = new TreeCoordinates[entrie[1]];
@@ -103,14 +103,14 @@ namespace PKHeX.Core
 
         private void GenerateAreaTreeIndex()
         {
-            // For legallity purpose only the tree index is needed, group the trees data by their index, trees with the same index are indistinguible
+            // For legality purpose only the tree index is needed, group the trees data by their index, trees with the same index are indistinguishable
             ValidTreeIndex = ValidTrees.Select(t => t.Index).Distinct().OrderBy(i => i).ToArray();
             InvalidTreeIndex = InvalidTrees.Select(t => t.Index).Distinct().OrderBy(i => i).Except(ValidTreeIndex).ToArray();
         }
 
         private void GenerateAreaTrainerEncounters()
         {
-            // Check for every trainer pivot index if there is trees with low encounter and moderate encounter available in the area
+            // Check for every trainer pivot index if there are trees with low encounter and moderate encounter available in the area
             TrainerModerateEncounterTree = new TreeEncounterAvailable[10];
             TrainerLowEncounterTree = new TreeEncounterAvailable[10];
             for (int pivotindex = 0; pivotindex < 10; pivotindex++)


### PR DESCRIPTION
Added ChainShinyas valid method for pokemon found with pokeradar. Until now CuteCharm was only included as valid for static shiny encounters (red gyarados only)
A ChainShiny Pokeradar pokemon is one found in tall grass in DPPt, not including "grass" table encounters for caves, and also not including the safari zone/great marsh (you cant use pokeradar there)

Also changed CuteCharm mehtod to not allow it for swarm slots pokemon 
https://bulbapedia.bulbagarden.net/wiki/Cute_Charm_(Ability)#Outside_of_battle
"This does not affect a swarming Pokémon species or Pokémon found in Hidden Grottos. "

The other changes are typos in the treearea class, a fix for loading gen 2 encounter time data and mark the location for crystal encounter in any tables, before was marked the slot location for SlotsC but not for SlotsGSC