### PR TITLE
Added Location ComboBox

### DIFF
--- a/PKHeX.WinForms/Subforms/Save Editors/SAV_SimpleTrainer.Designer.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/SAV_SimpleTrainer.Designer.cs
@@ -94,6 +94,8 @@
             this.LBL_BattleStyle = new System.Windows.Forms.Label();
             this.CB_BattleStyle = new System.Windows.Forms.ComboBox();
             this.CHK_BattleEffects = new System.Windows.Forms.CheckBox();
+            this.L_Location = new System.Windows.Forms.Label();
+            this.CB_Location = new System.Windows.Forms.ComboBox();
             this.GB_Adventure.SuspendLayout();
             this.GB_Map.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_Z)).BeginInit();
@@ -107,6 +109,8 @@
             // 
             // GB_Adventure
             // 
+            this.GB_Adventure.Controls.Add(this.CB_Location);
+            this.GB_Adventure.Controls.Add(this.L_Location);
             this.GB_Adventure.Controls.Add(this.L_PikaFriend);
             this.GB_Adventure.Controls.Add(this.MT_PikaFriend);
             this.GB_Adventure.Controls.Add(this.L_Started);
@@ -818,6 +822,26 @@
             this.CHK_BattleEffects.Text = "Use Battle Effects";
             this.CHK_BattleEffects.UseVisualStyleBackColor = true;
             // 
+            // L_Location
+            // 
+            this.L_Location.Location = new System.Drawing.Point(12, 81);
+            this.L_Location.Name = "L_Location";
+            this.L_Location.Size = new System.Drawing.Size(64, 20);
+            this.L_Location.TabIndex = 74;
+            this.L_Location.Text = "Location:";
+            this.L_Location.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // CB_Location
+            // 
+            this.CB_Location.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.CB_Location.FormattingEnabled = true;
+            this.CB_Location.Items.AddRange(new object[] {
+            "Default"});
+            this.CB_Location.Location = new System.Drawing.Point(82, 82);
+            this.CB_Location.Name = "CB_Location";
+            this.CB_Location.Size = new System.Drawing.Size(106, 21);
+            this.CB_Location.TabIndex = 75;
+            // 
             // SAV_SimpleTrainer
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -919,5 +943,7 @@
         private System.Windows.Forms.CheckBox CHK_BattleEffects;
         private System.Windows.Forms.Label L_PikaFriend;
         private System.Windows.Forms.MaskedTextBox MT_PikaFriend;
+        private System.Windows.Forms.ComboBox CB_Location;
+        private System.Windows.Forms.Label L_Location;
     }
 }

--- a/PKHeX.WinForms/Subforms/Save Editors/SAV_SimpleTrainer.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/SAV_SimpleTrainer.cs
@@ -32,6 +32,10 @@ namespace PKHeX.WinForms
 
             L_PikaFriend.Visible = MT_PikaFriend.Visible = SAV.Generation == 1;
 
+            L_Location.Visible = SAV.Generation == 3;
+            CB_Location.Visible = SAV.Generation == 3;
+            CB_Location.SelectedIndex = 0;
+
             TB_OTName.Text = SAV.OT;
             CB_Gender.SelectedIndex = SAV.Gender;
             MT_TID.Text = SAV.TID.ToString("00000");


### PR DESCRIPTION
Added into SimpleTrainer Dialog for Gen3.
Default = don't change current location.

I think this would be a good feature even across other generations, but with permission I would like to focus on attempting to implement this feature for Gen 3. 
The reasoning is that I am stuck on One Island and I would like to be able to get off without going through the required tasks! Also, it could give players the opportunity to explore areas earlier than allowed. 
 
![image](https://user-images.githubusercontent.com/30199063/28247701-aab41bf0-6a2d-11e7-9b0f-c309d9f2f6c1.png)
