### PR TITLE
Unban Diancite

### DIFF
--- a/PKHeX.Core/Legality/Tables7.cs
+++ b/PKHeX.Core/Legality/Tables7.cs
@@ -1146,7 +1146,6 @@ namespace PKHeX.Core
             710, // Jaw Fossil
             711, // Sail Fossil
             715, // Fairy Gem
-            764, // Diancite
         };
         #endregion
         internal static readonly bool[] ReleasedHeldItems_7 = Enumerable.Range(0, MaxItemID_7+1).Select(i => HeldItems_SM.Contains((ushort)i) && !UnreleasedHeldItems_7.Contains(i)).ToArray();


### PR DESCRIPTION
Now all Mega Stones are legal in Gen 7.

https://twitter.com/PokemonLegality/status/895525097745678337