### PR TITLE
Revert PKHaX utility back to the old days

### DIFF
--- a/PKHeX.WinForms/MainWindow/Main.cs
+++ b/PKHeX.WinForms/MainWindow/Main.cs
@@ -102,7 +102,7 @@ namespace PKHeX.WinForms
             // Set up Language Selection
             foreach (var cbItem in main_langlist)
                 CB_MainLanguage.Items.Add(cbItem);
-            C_SAV.HaX = PKME_Tabs.HaX = HaX = AppDomain.CurrentDomain.FriendlyName.ToLower().Contains("pkhax");
+            C_SAV.HaX = PKME_Tabs.HaX = HaX = AppDomain.CurrentDomain.FriendlyName.ToLower().Contains("pkhax") || args.Any(x => string.Equals(x.Trim('-'), nameof(HaX), StringComparison.CurrentCultureIgnoreCase));
             PB_Legal.Visible = !HaX;
 
             int languageID = 1; // English

--- a/PKHeX.WinForms/MainWindow/Main.cs
+++ b/PKHeX.WinForms/MainWindow/Main.cs
@@ -102,7 +102,7 @@ namespace PKHeX.WinForms
             // Set up Language Selection
             foreach (var cbItem in main_langlist)
                 CB_MainLanguage.Items.Add(cbItem);
-            C_SAV.HaX = PKME_Tabs.HaX = HaX = args.Any(x => string.Equals(x.Trim('-'), nameof(HaX), StringComparison.CurrentCultureIgnoreCase));
+            C_SAV.HaX = PKME_Tabs.HaX = HaX = AppDomain.CurrentDomain.FriendlyName.ToLower().Contains("pkhax");
             PB_Legal.Visible = !HaX;
 
             int languageID = 1; // English


### PR DESCRIPTION
Using executable name as a trigger for illegal mode would be more intuitive for normal users than writing and running a cmd/bash line (or creating a batch file)