### PR TITLE
VC1 pokemon with VC2 tradeback

### DIFF
--- a/PKHeX.Core/Legality/Analysis.cs
+++ b/PKHeX.Core/Legality/Analysis.cs
@@ -224,16 +224,11 @@ namespace PKHeX.Core
                 else
                     pkm.TradebackStatus = TradebackType.Any;
             }
-            else if (pkm.VC1)
-            {
-                // If VC2 is ever released, we can assume it will be TradebackType.Any.
-                // Met date cannot be used definitively as the player can change their system clock.
-                pkm.TradebackStatus = TradebackType.Gen1_NotTradeback;
-            }
-            else
-            {
-                pkm.TradebackStatus = TradebackType.Any;
-            }
+
+            // VC2 is released, we can assume it will be TradebackType.Any.
+            // Met date cannot be used definitively as the player can change their system clock.
+            // Is impossible to difference between a VC1 pokemon trade to gen7 after or before VC2 release.
+            pkm.TradebackStatus = TradebackType.Any;
         }
         private void UpdateTypeInfo()
         {

--- a/PKHeX.Core/Legality/Core.cs
+++ b/PKHeX.Core/Legality/Core.cs
@@ -1459,7 +1459,7 @@ namespace PKHeX.Core
         {
             var CompleteEvoChain = GetEvolutionChain(pkm, Encounter).ToArray();
             int maxgen = pkm.Format == 1 && !pkm.Gen1_NotTradeback ? 2 : pkm.Format;
-            int mingen = pkm.Format == 2 && !pkm.Gen2_NotTradeback || pkm.Format >= 7 && pkm.GenNumber < 3 ? 1 : pkm.GenNumber;
+            int mingen = (pkm.Format == 2 || pkm.VC2) && !pkm.Gen2_NotTradeback ? 1 : pkm.GenNumber;
             DexLevel[][] GensEvoChains = new DexLevel[maxgen + 1][];
             for (int i = 0; i <= maxgen; i++)
                 GensEvoChains[i] = new DexLevel[0];

--- a/PKHeX.Core/Legality/Core.cs
+++ b/PKHeX.Core/Legality/Core.cs
@@ -1494,6 +1494,8 @@ namespace PKHeX.Core
                 }
 
                 int maxspeciesgen = GetMaxSpeciesOrigin(gen);
+                if (gen == 2 && pkm.VC1)
+                    maxspeciesgen = MaxSpeciesID_1;
 
                 // Remove future gen evolutions after a few special considerations, 
                 // it the pokemon origin is illegal like a "gen 3" Infernape the list will be emptied, it didnt existed in gen 3 in any evolution phase

--- a/PKHeX.Core/Legality/Core.cs
+++ b/PKHeX.Core/Legality/Core.cs
@@ -1530,8 +1530,16 @@ namespace PKHeX.Core
                     GensEvoChains[gen] = GensEvoChains[gen].Where(e => e.Level >= GetMinLevelGeneration(pkm, gen)).ToArray();
 
                 if (gen == 1 && GensEvoChains[gen].LastOrDefault()?.Species > MaxSpeciesID_1)
+                {
                     // Remove generation 2 pre-evolutions
                     GensEvoChains[gen] = GensEvoChains[gen].Take(GensEvoChains[gen].Length - 1).ToArray();
+                    if (pkm.VC1)
+                    {
+                        // Remove generation 2 pre-evolutions from gen 7 and future generations
+                        for ( int fgen = 7; fgen <= maxgen; fgen++)
+                            GensEvoChains[fgen] = GensEvoChains[fgen].Take(GensEvoChains[fgen].Length - 1).ToArray();
+                    }
+                }
             }
             return GensEvoChains;
         }


### PR DESCRIPTION
Change VC1 pokemon tradeback initial status to TradebackStatus.Any. With the release of VC2 there is no way to know if a VC1 pokemon was traded to gen7 after or before VC2 release (user can change clock date). That means VC1 pokemon should be TradebackStatus.Any by default, to allow VC2 encounters and moves.

The only exception are female shiny pokemon impossible with VC2 formula, those pokemon are only legal with TradebackStatus.Gen1NonTradeback, but if we let the status to Any it will change to WasTradeback if there is a gen2 only data, and PKHex will flag the pokemon as illegal.

Also do not allow gen1 evolutions for VC2 pokemon without gen1 evolutions or preevolutions, like gen2 starters.