### PR TITLE
Fix DPPt English Trade OTs

### DIFF
--- a/PKHeX.Core/Resources/text/en/text_tradedppt_en.txt
+++ b/PKHeX.Core/Resources/text/en/text_tradedppt_en.txt
@@ -2,7 +2,7 @@
 Charap
 Gaspar
 Foppa
-Hasshi
-Noburin
-Minacchi
+Hilary
+Norton
+Mindy
 Meister


### PR DESCRIPTION
Resource had translated Japanese names instead of localized English names.