### PR TITLE
Add more USUM event flags/constants

### DIFF
--- a/PKHeX.Core/Resources/text/script/const_usum_en.txt
+++ b/PKHeX.Core/Resources/text/script/const_usum_en.txt
@@ -3,3 +3,5 @@
 433	Tapu Lele	01:Battleable,02:Defeated,03:Captured
 434	Tapu Bulu	01:Battleable,02:Defeated,03:Captured
 404	Tapu Fini	03:Battleable,04:Defeated,05:Captured
+755	Zygarde	01:Battleable,02:Defeated,05:Captured
+867	Totem-Sized Gifts	00:None Received,01:One Received,02:Two Received,03:Three Received,04:Four Received,05:Five Received,06:All Received

--- a/PKHeX.Core/Resources/text/script/flags_usum_en.txt
+++ b/PKHeX.Core/Resources/text/script/flags_usum_en.txt
@@ -1,5 +1,8 @@
+4563	Received Partner Cap Pikachu
 0493	Received Gift Porygon
 0504	Received Gift Aerodactyl
+1476	Received Gift Cosmog
+1469	Received Gift Magearna
 4420	Articuno Captured
 4421	Zapdos Captured
 4422	Moltres Captured


### PR DESCRIPTION
Adds:
- Partner Cap Pikachu
- Cosmog
- Magearna
- Zygarde
- Totem-Sized Gifts

Flags from SM relating to Cosmog and Magearna aren't used for them in USUM. The flags from USUM that are used for them, however, are re-used elsewhere, but un-setting them does in fact allow you to re-collect both of them (did quite a few tests in-game).

Found how to re-collect Type: Null at Aether Paradise, but it involves re-setting 2 separate event flags and I don't know a good way of implementing that. For your own reference, you need to set these 2 flags:

- 0654
- 1101

Also an interesting thing: immediately catching Zygarde sets the constant value to 3, but over time it automatically gets changed to 5; I just left `05:Captured` in since you're hardly ever gonna see it be 3 after capturing Zygarde.