### PR TITLE
Add more USUM event flags

### DIFF
--- a/PKHeX.Core/Resources/text/script/flags_usum_en.txt
+++ b/PKHeX.Core/Resources/text/script/flags_usum_en.txt
@@ -3,7 +3,10 @@
 0493	Received Gift Porygon
 0504	Received Gift Aerodactyl
 1476	Received Gift Cosmog
+0654	Received Gift Type: Null (1)
+1101	Received Gift Type: Null (2)
 1469	Received Gift Magearna
+0269	Received Gift Poipole
 4420	Articuno Captured
 4421	Zapdos Captured
 4422	Moltres Captured
@@ -41,3 +44,7 @@
 4282	Kyurem Captured
 4424	(US) Xerneas Captured
 4425	(UM) Yveltal Captured
+4545	Unlocked Lanturn 360
+4546	Unlocked Primarina Twist
+4547	Unlocked Starmie 720
+4548	Unlocked Over-the-Gyarados


### PR DESCRIPTION
In order to re-collect Type: Null, both event flags must be unset.