### PR TITLE
USUM event flag updates

### DIFF
--- a/PKHeX.Core/Resources/text/script/flags_usum_en.txt
+++ b/PKHeX.Core/Resources/text/script/flags_usum_en.txt
@@ -2,9 +2,9 @@
 0518	Received Surfing Pikachu
 0493	Received Gift Porygon
 0504	Received Gift Aerodactyl
-1476	Received Gift Cosmog
 0654	Received Gift Type: Null (1)
 1101	Received Gift Type: Null (2)
+1476	Received Gift Cosmog
 1469	Received Gift Magearna
 0269	Received Gift Poipole
 4420	Articuno Captured
@@ -44,9 +44,10 @@
 4282	Kyurem Captured
 4424	(US) Xerneas Captured
 4425	(UM) Yveltal Captured
-1627	(UM)Lunala Captured
+1627	Solgaleo/Lunala Captured
 1552	Necrozma Captured
-4370	(UM)Stakataka Appearable
+4370	(UM) Stakataka in Poni Grove
+4371	(US) Blacephalon in Poni Grove
 4545	Unlocked Lanturn 360
 4546	Unlocked Primarina Twist
 4547	Unlocked Starmie 720


### PR DESCRIPTION
- Move Cosmog below Type: Null (in accordance to National Dex order)
- Add Blacephalon
- Rename Stakataka + Lunala

After testing, unsetting flag 1627 respawned either Legendary. The exact same save file imported to both US and UM with that one flag unset had both respawn at Mahalo Trail.

Thanks @pokecal for finding Lunala and Stakataka to begin with :)