### PR TITLE
Fix Cosmog/Magearna flags

### DIFF
--- a/PKHeX.Core/Resources/text/script/flags_usum_en.txt
+++ b/PKHeX.Core/Resources/text/script/flags_usum_en.txt
@@ -1,4 +1,4 @@
-4060	Is Alolan Champion/Can Receive Magearna Gift
+4060	Is Alolan Champion/Can Receive Gift Magearna
 4562	Been to Akala Island/Can Receive Partner Cap Pikachu
 4563	Received Partner Cap Pikachu
 0518	Received Surfing Pikachu
@@ -6,8 +6,8 @@
 0504	Received Gift Aerodactyl
 0654	Received Gift Type: Null (1)
 1101	Received Gift Type: Null (2)
-1476	Received Gift Cosmog
-4447	Received Gift Magearna
+0503	Received Gift Cosmog
+0276	Received Gift Magearna
 0269	Received Gift Poipole
 4420	Articuno Captured
 4421	Zapdos Captured


### PR DESCRIPTION
As discussed on IRC. For reference...

Cosmog: after receiving, sets flags 0503 and 1471. Setting 0503 respawns Cosmog with the Solgaleo/Lunala cutscene, while setting 1471 also respawns Cosmog but *without* aforementioned cutscene. 0503 is not re-used, but 1471 is.

Magearna: after receiving, sets flags 0276, 1469, and 4447. Setting any of the 3 will respawn Magearna, but 0276 isn't re-used like the latter two (1469 unknown, 4447 Nihilist Battle Style).