### PR TITLE
Fix Nihilist flag

### DIFF
--- a/PKHeX.Core/Resources/text/script/flags_usum_en.txt
+++ b/PKHeX.Core/Resources/text/script/flags_usum_en.txt
@@ -7,7 +7,7 @@
 0654	Received Gift Type: Null (1)
 1101	Received Gift Type: Null (2)
 0503	Received Gift Cosmog
-0276	Received Gift Magearna
+4447	Received Gift Magearna
 0269	Received Gift Poipole
 4420	Articuno Captured
 4421	Zapdos Captured
@@ -62,4 +62,4 @@
 4444	Battle Style Learned: Left-Handed 
 4445	Battle Style Learned: Passionate 
 4446	Battle Style Learned: Idol 
-4447	Battle Style Learned: Nihilist
+4453	Battle Style Learned: Nihilist


### PR DESCRIPTION
Apparently I received Magearna in between my before/after saves for Nihilist. Thank you @SciresM for pointing out the Magearna event flag to me! Strange how 0276, 1469, and 4447 do the same thing, and that all Battle Styles but one are consecutive.