### PR TITLE
Breeding ball legality fixes

### DIFF
--- a/PKHeX.Core/Legality/Tables6.cs
+++ b/PKHeX.Core/Legality/Tables6.cs
@@ -304,7 +304,9 @@ namespace PKHeX.Core
             032, // Via Nidoran-F
             313, // Via Illumise
 
+            172, // Via Pikachu
             173, // Via Clefairy
+            174, // Via Jigglypuff
             239, // Via Electabuzz
             240, // Via Magmar
             298, // Via Marill
@@ -313,6 +315,8 @@ namespace PKHeX.Core
             433, // Via Chimecho
             439, // Via Mr. Mime
             440, // Via Chansey
+
+            287, // Via Vigoroth
         };
         internal static readonly HashSet<int> Inherit_Dream = new HashSet<int>
         {

--- a/PKHeX.Core/Legality/Tables7.cs
+++ b/PKHeX.Core/Legality/Tables7.cs
@@ -199,7 +199,7 @@ namespace PKHeX.Core
             276, 277, // Swellow
             451, 452, // Drapion
             531, // Audino
-            695, // Heliolisk
+            694, 695, // Heliolisk
             273, 274, 275, // Nuzleaf
             325, 326, // Gumpig
             459, 460, // Abomasnow
@@ -333,7 +333,7 @@ namespace PKHeX.Core
             714,
 
             // Wormhole
-            333, 468, 561, 580, 276, 451, 531, 694, 273, 325,
+            333, 193, 561, 580, 276, 451, 531, 694, 273, 325,
             459, 307, 449, 557, 218, 688, 270, 618, 418, 194,
         };
         internal static readonly HashSet<int> AlolanCaptureNoHeavyBall = new HashSet<int> { 374, 785, 786, 787, 788}; // Beldum & Tapus


### PR DESCRIPTION
Unban safari ball Slakoth, Pichu and Igglybuff, beast ball Helioptile.