### PR TITLE
Fix a crash bug when loading Gen 3 saves on mono

### DIFF
--- a/PKHeX.WinForms/Subforms/Save Editors/SAV_GameSelect.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/SAV_GameSelect.cs
@@ -13,7 +13,7 @@ namespace PKHeX.WinForms
             InitializeComponent();
             CB_Game.DisplayMember = nameof(ComboItem.Text);
             CB_Game.ValueMember = nameof(ComboItem.Value);
-            CB_Game.DataSource = new BindingSource(items, null);
+            CB_Game.DataSource = new BindingSource(items.ToList(), null);
             CB_Game.SelectedIndex = 0;
             CB_Game.Focus();
         }


### PR DESCRIPTION
Bug found while trying to load a LeafGreen save on mono:

```Exception Details:
System.NotImplementedException: The method or operation is not implemented.
  at System.Linq.Enumerable+Iterator`1[TSource].System.Collections.IEnumerator.Reset () [0x00000] in <2392cff65f724abaaed9de072f62bc4a>:0 
  at System.Windows.Forms.BindingSource.GetListFromEnumerable (System.Collections.IEnumerable enumerable) [0x00066] in <2f8b04a5fbc8420bbb3895e91a62c74f>:0 
  at System.Windows.Forms.BindingSource.ResetList () [0x000a3] in <2f8b04a5fbc8420bbb3895e91a62c74f>:0 
  at System.Windows.Forms.BindingSource..ctor (System.Object dataSource, System.String dataMember) [0x0002d] in <2f8b04a5fbc8420bbb3895e91a62c74f>:0 
  at (wrapper remoting-invoke-with-check) System.Windows.Forms.BindingSource:.ctor (object,string)
  at PKHeX.WinForms.SAV_GameSelect..ctor (System.Collections.IEnumerable items) [0x00034] in <5b5073e048d946a786df2f94efb1df9a>:0 
  at (wrapper remoting-invoke-with-check) PKHeX.WinForms.SAV_GameSelect:.ctor (System.Collections.IEnumerable)
  at PKHeX.WinForms.Main.SanityCheckSAV (PKHeX.Core.SaveFile& sav) [0x0028a] in <5b5073e048d946a786df2f94efb1df9a>:0 
  at PKHeX.WinForms.Main.OpenSAV (PKHeX.Core.SaveFile sav, System.String path) [0x0002d] in <5b5073e048d946a786df2f94efb1df9a>:0 
  at PKHeX.WinForms.Main.TryLoadSAV (System.Byte[] input, System.String path) [0x0000c] in <5b5073e048d946a786df2f94efb1df9a>:0 
  at PKHeX.WinForms.Main.OpenFile (System.Byte[] input, System.String path, System.String ext) [0x0000b] in <5b5073e048d946a786df2f94efb1df9a>:0 
  at PKHeX.WinForms.Main.OpenQuick (System.String path, System.Boolean force) [0x0010a] in <5b5073e048d946a786df2f94efb1df9a>:0 

Loaded Assemblies:
--------------------
mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089
/usr/lib/mono/4.5/mscorlib.dll

PKHeX, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
/home/peter.rolph/scripts/PKHeX.exe

System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089
/usr/lib/mono/gac/System/4.0.0.0__b77a5c561934e089/System.dll

System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089
/usr/lib/mono/gac/System.Windows.Forms/4.0.0.0__b77a5c561934e089/System.Windows.Forms.dll

System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
/usr/lib/mono/gac/System.Drawing/4.0.0.0__b03f5f7f11d50a3a/System.Drawing.dll

Accessibility, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
/usr/lib/mono/gac/Accessibility/4.0.0.0__b03f5f7f11d50a3a/Accessibility.dll

Mono.Posix, Version=4.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756
/usr/lib/mono/gac/Mono.Posix/4.0.0.0__0738eb9f132ed756/Mono.Posix.dll

System.Configuration, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a
/usr/lib/mono/gac/System.Configuration/4.0.0.0__b03f5f7f11d50a3a/System.Configuration.dll

System.Xml, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089
/usr/lib/mono/gac/System.Xml/4.0.0.0__b77a5c561934e089/System.Xml.dll

Mono.Security, Version=4.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756
/usr/lib/mono/gac/Mono.Security/4.0.0.0__0738eb9f132ed756/Mono.Security.dll

PKHeX.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null
/home/peter.rolph/scripts/PKHeX.Core.dll

System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089
/usr/lib/mono/gac/System.Core/4.0.0.0__b77a5c561934e089/System.Core.dll

--------------------
User Message:
Unable to load file.
Path: /home/peter.rolph/scripts/Pokemon - Leaf Green Version (U) (V1.1).sav
```