### PR TITLE
Fix build error

### DIFF
--- a/PKHeX.WinForms/MainWindow/Main.cs
+++ b/PKHeX.WinForms/MainWindow/Main.cs
@@ -674,7 +674,7 @@ namespace PKHeX.WinForms
             if (MC.HasRSBOX) games.Add(new ComboItem { Text = "RS Box", Value = (int)GameVersion.RSBOX });
 
             WinFormsUtil.Alert("Multiple games detected", "Select a game to edit.");
-            var dialog = new SAV_GameSelect(games.ToArray());
+            var dialog = new SAV_GameSelect(games);
             dialog.ShowDialog();
             return dialog.Result;
         }

--- a/PKHeX.WinForms/Subforms/Save Editors/SAV_GameSelect.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/SAV_GameSelect.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 using System.Windows.Forms;
 using PKHeX.Core;
 
@@ -8,7 +10,7 @@ namespace PKHeX.WinForms
     public partial class SAV_GameSelect : Form
     {
         public GameVersion Result = GameVersion.Invalid;
-        public SAV_GameSelect(IEnumerable items)
+        public SAV_GameSelect(IEnumerable<ComboItem> items)
         {
             InitializeComponent();
             CB_Game.DisplayMember = nameof(ComboItem.Text);


### PR DESCRIPTION
IEnumerable doesn't support LINQ methods, only the generic variant does. So this commit changes SAV_GameSelect's parameter to a generic IEnumerable of the only type being passed into it. I didn't realize it until afterward, but this is 100% the way it should have been because the databinding members expect ComboItems.