### PR TITLE
Fix WC6/7 IV generation

### DIFF
--- a/PKHeX.Core/Legality/Checks.cs
+++ b/PKHeX.Core/Legality/Checks.cs
@@ -590,15 +590,22 @@ namespace PKHeX.Core
                 if (IVs != null)
                 {
                     var pkIVs = pkm.IVs;
-                    bool valid = true;
-                    for (int i = 0; i < 6; i++)
-                        if (IVs[i] <= 31 && IVs[i] != pkIVs[i])
-                            valid = false;
-                    if (!valid)
-                        AddLine(Severity.Invalid, V30, CheckIdentifier.IVs);
-                    bool IV3 = IVs[0] == 0xFE;
-                    if (IV3 && pkm.IVs.Count(iv => iv == 31) < 3)
-                        AddLine(Severity.Invalid, string.Format(V28, 3), CheckIdentifier.IVs);
+                    var ivflag = IVs.FirstOrDefault(iv => (byte)(iv - 0xFC) < 3);
+                    if (ivflag == 0) // Random IVs
+                    {
+                        bool valid = true;
+                        for (int i = 0; i < 6; i++)
+                            if (IVs[i] <= 31 && IVs[i] != pkIVs[i])
+                                valid = false;
+                        if (!valid)
+                            AddLine(Severity.Invalid, V30, CheckIdentifier.IVs);
+                    }
+                    else
+                    {
+                        int IVCount = ivflag - 0xFB;  // IV2/IV3
+                        if (pkIVs.Count(iv => iv == 31) < IVCount)
+                            AddLine(Severity.Invalid, string.Format(V28, IVCount), CheckIdentifier.IVs);
+                    }
                 }
             }
             if (pkm.IVs.Sum() == 0)

--- a/PKHeX.Core/MysteryGifts/WC6.cs
+++ b/PKHeX.Core/MysteryGifts/WC6.cs
@@ -381,28 +381,20 @@ namespace PKHeX.Core
             pk.IsNicknamed = IsNicknamed;
             pk.Nickname = IsNicknamed ? Nickname : PKX.GetSpeciesNameGeneration(Species, pk.Language, Format);
 
-            // More 'complex' logic to determine final values
-            
-            // Dumb way to generate random IVs.
             int[] finalIVs = new int[6];
-            switch (IVs[0])
+            var ivflag = IVs.FirstOrDefault(iv => (byte)(iv - 0xFC) < 3);
+            if (ivflag == 0) // Random IVs
             {
-                case 0xFE:
-                    do { // 3 Perfect IVs
-                    for (int i = 0; i < 6; i++)
-                        finalIVs[i] = IVs[i] > 31 ? (int)(Util.Rand32() & 0x1F) : IVs[i];
-                    } while (finalIVs.Count(r => r == 31) < 3); // 3*31
-                    break;
-                case 0xFD: 
-                    do { // 2 other 31s
-                    for (int i = 0; i < 6; i++)
-                        finalIVs[i] = IVs[i] > 31 ? (int)(Util.Rand32() & 0x1F) : IVs[i];
-                    } while (finalIVs.Count(r => r == 31) < 2); // 2*31
-                    break;
-                default: // Random IVs
-                    for (int i = 0; i < 6; i++)
-                        finalIVs[i] = IVs[i] > 31 ? (int)(Util.Rand32() & 0x1F) : IVs[i];
-                    break;
+                for (int i = 0; i < 6; i++)
+                    finalIVs[i] = IVs[i] > 31 ? (int)(Util.Rand32() & 0x1F) : IVs[i];
+            }
+            else // 1/2/3 perfect IVs
+            {
+                int IVCount = ivflag - 0xFB;
+                do { finalIVs[Util.Rand32() % 6] = 31; }
+                while (finalIVs.Count(r => r == 31) < IVCount);
+                for (int i = 0; i < 6; i++)
+                    finalIVs[i] = finalIVs[i] == 31 ? 31 : (int)(Util.Rand32() & 0x1F);
             }
             pk.IVs = finalIVs;
 

--- a/PKHeX.Core/MysteryGifts/WC7.cs
+++ b/PKHeX.Core/MysteryGifts/WC7.cs
@@ -391,28 +391,20 @@ namespace PKHeX.Core
             pk.IsNicknamed = IsNicknamed;
             pk.Nickname = IsNicknamed ? Nickname : PKX.GetSpeciesNameGeneration(Species, pk.Language, Format);
 
-            // More 'complex' logic to determine final values
-            
-            // Dumb way to generate random IVs.
             int[] finalIVs = new int[6];
-            switch (IVs[0])
+            var ivflag = IVs.FirstOrDefault(iv => (byte)(iv - 0xFC) < 3);
+            if (ivflag == 0) // Random IVs
             {
-                case 0xFE:
-                    do { // 3 Perfect IVs
-                    for (int i = 0; i < 6; i++)
-                        finalIVs[i] = IVs[i] > 31 ? (int)(Util.Rand32() & 0x1F) : IVs[i];
-                    } while (finalIVs.Count(r => r == 31) < 3); // 3*31
-                    break;
-                case 0xFD: 
-                    do { // 2 other 31s
-                    for (int i = 0; i < 6; i++)
-                        finalIVs[i] = IVs[i] > 31 ? (int)(Util.Rand32() & 0x1F) : IVs[i];
-                    } while (finalIVs.Count(r => r == 31) < 2); // 2*31
-                    break;
-                default: // Random IVs
-                    for (int i = 0; i < 6; i++)
-                        finalIVs[i] = IVs[i] > 31 ? (int)(Util.Rand32() & 0x1F) : IVs[i];
-                    break;
+                for (int i = 0; i < 6; i++)
+                    finalIVs[i] = IVs[i] > 31 ? (int)(Util.Rand32() & 0x1F) : IVs[i];
+            }
+            else // 1/2/3 perfect IVs
+            {
+                int IVCount = ivflag - 0xFB;
+                do { finalIVs[Util.Rand32() % 6] = 31; }
+                while (finalIVs.Count(r => r == 31) < IVCount);
+                for (int i = 0; i < 6; i++)
+                    finalIVs[i] = finalIVs[i] == 31 ? 31 : (int)(Util.Rand32() & 0x1F);
             }
             pk.IVs = finalIVs;
 


### PR DESCRIPTION
IV lock doesn't work for IV3 case (Issue happens in Shiny Poipole WC7, all IVs besides HP are 31)
General WC  IVs check for [PGL Pikachu](https://github.com/projectpokemon/EventsGallery/blob/master/Released/Gen%206/Wondercards/JPN/1510%20ORAS%20-%20PGL%20Pikachu%20(JPN).wc6full) 
Source: ORAS: sub_45FB84 UMv1.2: sub_454408  https://pastebin.com/bbpS6svw 