### PR TITLE
Fix Suggested Move Set

### DIFF
--- a/PKHeX.WinForms/Controls/PKM Editor/PKMEditor.cs
+++ b/PKHeX.WinForms/Controls/PKM Editor/PKMEditor.cs
@@ -669,15 +669,9 @@ namespace PKHeX.WinForms.Controls
 
             pkm.Moves = m;
             pkm.SetPPUps(m);
-            CB_Move1.SelectedIndexChanged -= ValidateMove;
-            CB_Move2.SelectedIndexChanged -= ValidateMove;
-            CB_Move3.SelectedIndexChanged -= ValidateMove;
-            CB_Move4.SelectedIndexChanged -= ValidateMove;
+            FieldsLoaded = false;
             LoadMoves(pkm);
-            CB_Move1.SelectedIndexChanged += ValidateMove;
-            CB_Move2.SelectedIndexChanged += ValidateMove;
-            CB_Move3.SelectedIndexChanged += ValidateMove;
-            CB_Move4.SelectedIndexChanged += ValidateMove;
+            FieldsLoaded = true;
             return true;
         }
         private bool SetSuggestedRelearnMoves(bool silent = false)

--- a/PKHeX.WinForms/Controls/PKM Editor/PKMEditor.cs
+++ b/PKHeX.WinForms/Controls/PKM Editor/PKMEditor.cs
@@ -669,7 +669,15 @@ namespace PKHeX.WinForms.Controls
 
             pkm.Moves = m;
             pkm.SetPPUps(m);
+            CB_Move1.SelectedIndexChanged -= ValidateMove;
+            CB_Move2.SelectedIndexChanged -= ValidateMove;
+            CB_Move3.SelectedIndexChanged -= ValidateMove;
+            CB_Move4.SelectedIndexChanged -= ValidateMove;
             LoadMoves(pkm);
+            CB_Move1.SelectedIndexChanged += ValidateMove;
+            CB_Move2.SelectedIndexChanged += ValidateMove;
+            CB_Move3.SelectedIndexChanged += ValidateMove;
+            CB_Move4.SelectedIndexChanged += ValidateMove;
             return true;
         }
         private bool SetSuggestedRelearnMoves(bool silent = false)


### PR DESCRIPTION
Remove SelectedIndexChanged EventHandler to skip ValidateMove and allow moves to populate, then set back SelectedIndexChanged EventHandler