### PR TITLE
Fix Suggested Moves PP for < 4 Moves

### DIFF
--- a/PKHeX.WinForms/Controls/PKM Editor/PKMEditor.cs
+++ b/PKHeX.WinForms/Controls/PKM Editor/PKMEditor.cs
@@ -669,6 +669,7 @@ namespace PKHeX.WinForms.Controls
             }
 
             pkm.Moves = m;
+            pkm.FixMoves();
             pkm.SetMaximumPPCurrent(m);
             FieldsLoaded = false;
             LoadMoves(pkm);


### PR DESCRIPTION
Uses FixMoves() to zero PP if move is blank.