### PR TITLE
Translate Showdown Markings & Fix PT Selection

### DIFF
--- a/PKHeX.Core/Resources/text/de/lang_de.txt
+++ b/PKHeX.Core/Resources/text/de/lang_de.txt
@@ -30,6 +30,7 @@ Menu_ShowdownImportPKM = Importiere Set aus Zwischenablage
 Menu_ShowdownExportPKM = Exportiere Set in Zwischenablage
 Menu_ShowdownExportParty = Exportiere Team in Zwischenablage
 Menu_ShowdownExportBattleBox = Exportiere Kampf-Box in Zwischenablage
+Menu_ApplyMarkings = Apply Markings on Import
 Menu_Data = Daten
 Menu_LoadBoxes = Lade Boxen
 Menu_DumpBoxes = Dumpe Boxen

--- a/PKHeX.Core/Resources/text/en/lang_en.txt
+++ b/PKHeX.Core/Resources/text/en/lang_en.txt
@@ -30,6 +30,7 @@ Menu_ShowdownImportPKM = Import Set from Clipboard
 Menu_ShowdownExportPKM = Export Set to Clipboard
 Menu_ShowdownExportParty = Export Party to Clipboard
 Menu_ShowdownExportBattleBox = Export Battle Box to Clipboard
+Menu_ApplyMarkings = Apply Markings on Import
 Menu_Data = Data
 Menu_LoadBoxes = Load Boxes
 Menu_DumpBoxes = Dump Boxes

--- a/PKHeX.Core/Resources/text/es/lang_es.txt
+++ b/PKHeX.Core/Resources/text/es/lang_es.txt
@@ -30,6 +30,7 @@ Menu_ShowdownImportPKM = Importar set desde el portapapeles
 Menu_ShowdownExportPKM = Exportar set desde el portapapeles
 Menu_ShowdownExportParty = Exportar equipo desde el portapapeles
 Menu_ShowdownExportBattleBox = Exportar caja de combate desde el portapapeles
+Menu_ApplyMarkings = Apply Markings on Import
 Menu_Data = Data
 Menu_LoadBoxes = Cargar Cajas
 Menu_DumpBoxes = Exportar Cajas

--- a/PKHeX.Core/Resources/text/fr/lang_fr.txt
+++ b/PKHeX.Core/Resources/text/fr/lang_fr.txt
@@ -30,6 +30,7 @@ Menu_ShowdownImportPKM = Importer set Showdown
 Menu_ShowdownExportPKM = Exporter set Showdown
 Menu_ShowdownExportParty = Exporter équipe
 Menu_ShowdownExportBattleBox = Exporter la Boîte de Combat
+Menu_ApplyMarkings = Appliquer des marques de l'importation
 Menu_Data = Données
 Menu_LoadBoxes = Charger Boîtes
 Menu_DumpBoxes = Dumper Boîtes

--- a/PKHeX.Core/Resources/text/it/lang_it.txt
+++ b/PKHeX.Core/Resources/text/it/lang_it.txt
@@ -30,6 +30,7 @@ Menu_ShowdownImportPKM = Import Set from Clipboard
 Menu_ShowdownExportPKM = Export Set to Clipboard
 Menu_ShowdownExportParty = Export Party to Clipboard
 Menu_ShowdownExportBattleBox = Export Battle Box to Clipboard
+Menu_ApplyMarkings = Apply Markings on Import
 Menu_Data = Data
 Menu_LoadBoxes = Load Boxes
 Menu_DumpBoxes = Dump Boxes

--- a/PKHeX.Core/Resources/text/ja/lang_ja.txt
+++ b/PKHeX.Core/Resources/text/ja/lang_ja.txt
@@ -30,6 +30,7 @@ Menu_ShowdownImportPKM = クリップボードから読み込む
 Menu_ShowdownExportPKM = Export Set to Clipboard
 Menu_ShowdownExportParty = Export Party to Clipboard
 Menu_ShowdownExportBattleBox = Export Battle Box to Clipboard
+Menu_ApplyMarkings = Apply Markings on Import
 Menu_Data = データ
 Menu_LoadBoxes = ロードボックス
 Menu_DumpBoxes = ダンプボックス

--- a/PKHeX.Core/Resources/text/ko/lang_ko.txt
+++ b/PKHeX.Core/Resources/text/ko/lang_ko.txt
@@ -30,6 +30,7 @@ Menu_ShowdownImportPKM = 클립보드에서 세트 가져오기
 Menu_ShowdownExportPKM = 클립보드로 세트 내보내기
 Menu_ShowdownExportParty = 클립보드로 파티 내보내기
 Menu_ShowdownExportBattleBox = 클립보드로 배틀 박스 내보내기
+Menu_ApplyMarkings = 가져오기 중 마킹하기
 Menu_Data = 데이터
 Menu_LoadBoxes = 박스 불러오기
 Menu_DumpBoxes = 박스 덤프

--- a/PKHeX.Core/Resources/text/other/lang_pt.txt
+++ b/PKHeX.Core/Resources/text/other/lang_pt.txt
@@ -30,6 +30,7 @@ Menu_ShowdownImportPKM = Import Set from Clipboard
 Menu_ShowdownExportPKM = Export Set to Clipboard
 Menu_ShowdownExportParty = Export Party to Clipboard
 Menu_ShowdownExportBattleBox = Export Battle Box to Clipboard
+Menu_ApplyMarkings = Apply Markings on Import
 Menu_Data = Dados
 Menu_LoadBoxes = Carregar Boxes
 Menu_DumpBoxes = Despejar Boxes

--- a/PKHeX.Core/Resources/text/zh/lang_zh.txt
+++ b/PKHeX.Core/Resources/text/zh/lang_zh.txt
@@ -30,6 +30,7 @@ Menu_ShowdownImportPKM = 从剪贴板导入宝可梦
 Menu_ShowdownExportPKM = 导出宝可梦到剪贴板
 Menu_ShowdownExportParty = 导出同行队伍到剪贴板
 Menu_ShowdownExportBattleBox = 导出战斗盒子到剪贴板
+Menu_ApplyMarkings = 导入时标记
 Menu_Data = 数据
 Menu_LoadBoxes = 加载盒子信息
 Menu_DumpBoxes = 导出盒子信息

--- a/PKHeX.WinForms/MainWindow/Main.cs
+++ b/PKHeX.WinForms/MainWindow/Main.cs
@@ -921,6 +921,8 @@ namespace PKHeX.WinForms
         {
             if (CB_MainLanguage.SelectedIndex < 8)
                 CurrentLanguage = GameInfo.Language2Char((uint)CB_MainLanguage.SelectedIndex);
+            else if (CB_MainLanguage.SelectedIndex == 8)
+                CurrentLanguage = GameInfo.Language2Char((uint)9);
 
             // Set the culture (makes it easy to pass language to other forms)
             Settings.Default.Language = CurrentLanguage;


### PR DESCRIPTION
Added translation strings for Apply Showdown Markings in CHS, French, and Korean. International schools ftw.

Additionally, Portuguese was not accessible as it is Index 9 ("zh2", which I assume is CHT, is at 8), so I've just hardcoded this bit since I don't know if anything else relies on lang_val.