### PR TITLE
Fix Showdown Imports for Nidoran

### DIFF
--- a/PKHeX.Core/PKM/ShowdownSet.cs
+++ b/PKHeX.Core/PKM/ShowdownSet.cs
@@ -281,10 +281,10 @@ namespace PKHeX.Core
                 return true;
 
             // failure to parse, check edge cases
-            var edge = new[] {784, 250}; // all species with dashes in English Name (Kommo-o & Ho-Oh)
+            var edge = new[] {784, 250, 032, 029}; // all species with dashes in English Name (Kommo-o, Ho-Oh, Nidoran-M, Nidoran-F)
             foreach (var e in edge)
             {
-                if (!spec.StartsWith(species[e]))
+                if (!spec.StartsWith(species[e].Replace("♂", "-M").Replace("♀", "-F")))
                     continue;
                 Species = e;
                 Form = spec.Substring(species[e].Length);


### PR DESCRIPTION
Showdown Set imports for Nidoran are of the format: `Nidoran-G (G)` or `Nidoran-G`  where G is the gender represented by M/F. The current logic for handling edge cases with species that have a `-` in their name does not account for the Nidorans.

The string replace on line `287` is needed because we cannot simply trim the gender symbols since that would not properly specify the gender in species. So the cases when a showdown set is imported without specified gender (i.e. `Nidoran-G` format and not `Nidoran-G (G)` format) then the code would not be able to differentiate between the genders of either nidoran and so will just default to the male nidoran (032) even though the intended Showdown imports specify female nidoran since the male one comes before in the `var edge` list. This is why I decided to go for string replace over string trim!!

Hopefully this helps! And as always thanks for all your work on PKHeX!