### PR TITLE
Add *.fla files to file dialogs

### DIFF
--- a/PKHeX.Core/Saves/SAV3.cs
+++ b/PKHeX.Core/Saves/SAV3.cs
@@ -10,7 +10,7 @@ namespace PKHeX.Core
     public sealed class SAV3 : SaveFile
     {
         public override string BAKName => $"{FileName} [{OT} ({Version}) - {PlayTimeString}].bak";
-        public override string Filter => "SAV File|*.sav|All Files|*.*";
+        public override string Filter => "SAV File|*.sav|EDGBA Save File|*.fla|All Files|*.*";
         public override string Extension => ".sav";
 
         /* SAV3 Structure:

--- a/PKHeX.WinForms/Util/WinFormsUtil.cs
+++ b/PKHeX.WinForms/Util/WinFormsUtil.cs
@@ -124,9 +124,9 @@ namespace PKHeX.WinForms
             OpenFileDialog ofd = new OpenFileDialog
             {
                 Filter = "All Files|*.*" +
-                         $"|Supported Files|main;*.sav;*.dat;*.gci;*.bin;{supported};*.bak" +
+                         $"|Supported Files|main;*.sav;*.fla;*.dat;*.gci;*.bin;{supported};*.bak" +
                          "|3DS Main Files|main" +
-                         "|Save Files|*.sav;*.dat;*.gci" +
+                         "|Save Files|*.sav;*.fla;*.dat;*.gci" +
                          "|Decrypted PKM File|" + supported +
                          "|Binary File|*.bin" +
                          "|Backup File|*.bak"


### PR DESCRIPTION
This adds .fla save files created by the Everdrive GBA flashcard to the list of supported files to make handling these files a little more convenient.