### PR TITLE
Correct Control Switching for G2->G7

### DIFF
--- a/PKHeX.WinForms/Controls/PKM Editor/PKMEditor.cs
+++ b/PKHeX.WinForms/Controls/PKM Editor/PKMEditor.cs
@@ -1025,10 +1025,7 @@ namespace PKHeX.WinForms.Controls
                 pkm.Version = (int)Version;
                 TID_Trainer.LoadIDValues(pkm);
             }
-            if (newTrack == GameVersion.GSC && pkm.Format >= 7)
-                newTrack = GameVersion.USUM;
-            else if (pkm.Format < 3)
-                newTrack = GameVersion.GSC;
+
             if (newTrack != origintrack)
             {
                 var met_list = GameInfo.GetLocationList(Version, pkm.Format, egg: false);


### PR DESCRIPTION
Is there a reason for having GSC newTrack as USUM? This causes `origintrack = newTrack;` not to happen and thus controls don't switch from G2->G7 correctly.