### PR TITLE
Fix edge case in GetShowdownSets

### DIFF
--- a/PKHeX.Core/Editing/ShowdownSet.cs
+++ b/PKHeX.Core/Editing/ShowdownSet.cs
@@ -533,6 +533,7 @@ namespace PKHeX.Core
                 yield return new ShowdownSet(setLines);
                 setLines.Clear();
             }
+            yield return new ShowdownSet(setLines);
         }
 
         /// <summary>


### PR DESCRIPTION
As discussed on my discord: the function will never return the last ShowdownSet as it breaks out of the foreach loop on the last line variable before the set can be yielded to the IEnumerable