### PR TITLE
Implement IsDaycareOccupied for SAV1

### DIFF
--- a/PKHeX.Core/Saves/SAV1.cs
+++ b/PKHeX.Core/Saves/SAV1.cs
@@ -409,7 +409,10 @@ namespace PKHeX.Core
         }
         public override bool? IsDaycareOccupied(int loc, int slot)
         {
-            return null;
+            if (loc == 0 && slot == 0)
+                return Data[Japanese ? 0x2CA7 : 0x2CF4] == 0x01;
+            else
+                return null;
         }
         public override void SetDaycareEXP(int loc, int slot, uint EXP)
         {


### PR DESCRIPTION
This commit implements `IsDaycareOccupied` for generation 1 saves. The
byte which tracks if the daycare is occupied should normally only be
0x01 or 0x00, so I decided that all other values mean that the daycare
is probably corrupted and thus not occupied. `SetDaycareOccupied` is not
implemented, since I am not sure what other flags the game normally sets
in this scenario and the daycare is read-only anyway.

The GUI displays the Pokemon's index to the right for some reason, but I
don't have saves to test this for other generations, so it might be
unrelated to this change.