### PR TITLE
Allow editing of Generation II held items from a Generation I save file

### DIFF
--- a/PKHeX.Core/Legality/Core.cs
+++ b/PKHeX.Core/Legality/Core.cs
@@ -833,6 +833,7 @@ namespace PKHeX.Core
         {
             switch (generation)
             {
+                case 1:
                 case 2: return ReleasedHeldItems_2;
                 case 3: return ReleasedHeldItems_3;
                 case 4: return ReleasedHeldItems_4;

--- a/PKHeX.Core/PKM/PK1.cs
+++ b/PKHeX.Core/PKM/PK1.cs
@@ -72,6 +72,11 @@ namespace PKHeX.Core
         public override int Stat_SPD { get => Stat_SPC; set { } }
         #endregion
 
+        public int GetGen2Item(int itemID)
+        {
+            return ItemConverter.GetG2ItemTransfer(itemID);
+        }
+
         private void SetSpeciesValues(int value)
         {
             var updated = (byte)SpeciesConverter.SetG1Species(value);

--- a/PKHeX.Core/PKM/PK1.cs
+++ b/PKHeX.Core/PKM/PK1.cs
@@ -94,6 +94,7 @@ namespace PKHeX.Core
                         return;
                 }
                 Catch_Rate = PersonalTable.RB[value].CatchRate;
+                HeldItem = PersonalTable.RB[value].CatchRate;
             }
         }
 

--- a/PKHeX.Core/PKM/PK1.cs
+++ b/PKHeX.Core/PKM/PK1.cs
@@ -56,6 +56,8 @@ namespace PKHeX.Core
         public override int Move2_PPUps { get => (Data[0x1E] & 0xC0) >> 6; set => Data[0x1E] = (byte)((Data[0x1E] & 0x3F) | ((value & 0x3) << 6)); }
         public override int Move3_PPUps { get => (Data[0x1F] & 0xC0) >> 6; set => Data[0x1F] = (byte)((Data[0x1F] & 0x3F) | ((value & 0x3) << 6)); }
         public override int Move4_PPUps { get => (Data[0x20] & 0xC0) >> 6; set => Data[0x20] = (byte)((Data[0x20] & 0x3F) | ((value & 0x3) << 6)); }
+        public override int HeldItem { get => ItemConverter.GetG2ItemTransfer(Data[0x7]); set => Data[0x7] = (byte)value; }
+        public override int SpriteItem => ItemConverter.GetG4Item((byte)HeldItem);
         #endregion
 
         #region Party Attributes
@@ -98,7 +100,7 @@ namespace PKHeX.Core
         public override int Version { get => (int)GameVersion.RBY; set { } }
         public override int PKRS_Strain { get => 0; set { } }
         public override int PKRS_Days { get => 0; set { } }
-        public override bool CanHoldItem(ushort[] ValidArray) => false;
+        //public override bool CanHoldItem(ushort[] ValidArray) => false;
 
         // Maximums
         public override int MaxMoveID => Legal.MaxMoveID_1;

--- a/PKHeX.Core/Saves/SAV1.cs
+++ b/PKHeX.Core/Saves/SAV1.cs
@@ -103,6 +103,8 @@ namespace PKHeX.Core
 
             if (!Exportable)
                 ClearBoxes();
+
+            HeldItems = Legal.HeldItems_GSC;
         }
 
         private readonly SAV1Offsets Offsets;

--- a/PKHeX.WinForms/Controls/PKM Editor/LoadSave.cs
+++ b/PKHeX.WinForms/Controls/PKM Editor/LoadSave.cs
@@ -162,6 +162,7 @@ namespace PKHeX.WinForms.Controls
             SaveNickname(pk);
             SaveOT(pk);
             SaveMoves(pk);
+            pk.HeldItem = WinFormsUtil.GetIndex(CB_HeldItem);
         }
 
         private void LoadMisc2(PKM pk)

--- a/PKHeX.WinForms/Controls/PKM Editor/LoadSave.cs
+++ b/PKHeX.WinForms/Controls/PKM Editor/LoadSave.cs
@@ -162,7 +162,8 @@ namespace PKHeX.WinForms.Controls
             SaveNickname(pk);
             SaveOT(pk);
             SaveMoves(pk);
-            pk.HeldItem = WinFormsUtil.GetIndex(CB_HeldItem);
+            if (pk is PK1 && WinFormsUtil.GetIndex(CB_HeldItem) != ((PK1)pk).GetGen2Item(((PK1)pk).Catch_Rate))
+                pk.HeldItem = WinFormsUtil.GetIndex(CB_HeldItem);
         }
 
         private void LoadMisc2(PKM pk)

--- a/PKHeX.WinForms/Controls/PKM Editor/LoadSave.cs
+++ b/PKHeX.WinForms/Controls/PKM Editor/LoadSave.cs
@@ -153,6 +153,7 @@ namespace PKHeX.WinForms.Controls
             LoadIVs(pk);
             LoadEVs(pk);
             LoadMoves(pk);
+            CB_HeldItem.SelectedValue = pk.HeldItem;
         }
 
         private void SaveMisc1(PKM pk)

--- a/PKHeX.WinForms/Controls/PKM Editor/PKMEditor.cs
+++ b/PKHeX.WinForms/Controls/PKM Editor/PKMEditor.cs
@@ -1651,7 +1651,7 @@ namespace PKHeX.WinForms.Controls
             CB_Form.Enabled = gen >= 3;
 
             FLP_FriendshipForm.Visible = gen >= 2;
-            FLP_HeldItem.Visible = gen >= 2;
+            FLP_HeldItem.Visible = gen >= 1;
             CHK_IsEgg.Visible = gen >= 2;
             FLP_PKRS.Visible = FLP_EggPKRSRight.Visible = gen >= 2;
             Label_OTGender.Visible = gen >= 2;
@@ -1811,6 +1811,11 @@ namespace PKHeX.WinForms.Controls
             GameInfo.Strings.SetItemDataSource(SAV.Version, SAV.Generation, SAV.MaxItemID, SAV.HeldItems, HaX);
             if (SAV.Generation > 1)
                 CB_HeldItem.DataSource = new BindingSource(GameInfo.ItemDataSource.Where(i => i.Value <= SAV.MaxItemID).ToList(), null);
+            else if (SAV.Generation == 1)
+            {
+                GameInfo.Strings.SetItemDataSource(GameVersion.GSC, 2, 255, SAV.HeldItems, HaX);
+                CB_HeldItem.DataSource = new BindingSource(GameInfo.ItemDataSource.Where(i => i.Value <= 255).ToList(), null);
+            }
 
             CB_Language.DataSource = GameInfo.LanguageDataSource(SAV.Generation);
 


### PR DESCRIPTION
Among other things, allows fixing legality of PK1 Pokemon with Generation II tradeback moves without exporting to a PK2 and reimporting.