### PR TITLE
Fixes a unit test that gets Pokémon names

### DIFF
--- a/Tests/PKHeX.Tests/Util/DataUtilTests.cs
+++ b/Tests/PKHeX.Tests/Util/DataUtilTests.cs
@@ -12,7 +12,7 @@ namespace PKHeX.Tests.Util
         public void TestGetPokemonNames()
         {
             var names = PKHeX.Core.Util.GetSpeciesList("en");
-            Assert.AreEqual(808, names.Length);
+            Assert.AreEqual(810, names.Length);
         }
     }
 }


### PR DESCRIPTION
There were additional Pokémon names added, but the test was never updated :(

After some infrastructure changes, I re-enabled automatically building pull requests, which should give more visibility on this in the future (hopefully).