### PR TITLE
Column sorting changes for ZygardeCell editor

### DIFF
--- a/PKHeX.WinForms/Subforms/Save Editors/Gen7/SAV_ZygardeCell.Designer.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen7/SAV_ZygardeCell.Designer.cs
@@ -90,6 +90,7 @@
             this.dgv_val.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.dgv_val.HeaderText = "Value";
             this.dgv_val.Name = "dgv_val";
+            this.dgv_val.SortMode = System.Windows.Forms.DataGridViewColumnSortMode.Automatic;
             // 
             // B_Cancel
             // 

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen7/SAV_ZygardeCell.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen7/SAV_ZygardeCell.cs
@@ -31,6 +31,7 @@ namespace PKHeX.WinForms
             var combo = dgv.Columns[2] as DataGridViewComboBoxColumn;
             foreach (string t in states)
                 combo.Items.Add(t); // add only the Names
+            dgv.Columns[0].ValueType = typeof(int);
 
             // Populate Grid
             dgv.Rows.Add(CellCount);
@@ -40,7 +41,7 @@ namespace PKHeX.WinForms
                 if (cells[i] > 2)
                     throw new ArgumentException();
 
-                dgv.Rows[i].Cells[0].Value = (i+1).ToString();
+                dgv.Rows[i].Cells[0].Value = (i+1);
                 dgv.Rows[i].Cells[1].Value = locations[i];
                 dgv.Rows[i].Cells[2].Value = states[cells[i]];
             }


### PR DESCRIPTION
Now you can sort the Available stickers to the top.
Also a change to have the "Ref" sort integers instead of strings.
Now it doesn't go 1\n11\n etc