### PR TITLE
Add USUM Wormhole functions

### DIFF
--- a/PKHeX.Core/Saves/SAV7.cs
+++ b/PKHeX.Core/Saves/SAV7.cs
@@ -1533,5 +1533,104 @@ namespace PKHeX.Core
                 PadToSize = maxLength + 1;
             return StringConverter.SetString7(value, maxLength, Language, PadToSize, PadWith);
         }
+
+        // Wormhole shininess & flags found by @PP-theSLAYER
+        // https://projectpokemon.org/home/forums/topic/39433-gen-7-save-research-thread/?page=3&tab=comments#comment-239090
+        public bool WormholeShininess // 0x4535 = Misc (0x4400 in USUM) + 0x0135
+        {
+            get => Data[Misc + 0x0135] == 1;
+            set => Data[Misc + 0x0135] = (byte)(value ? 1 : 0);
+        }
+
+        // TODO: Find out if legendaries are in slots too
+        public const int WormholeSlotMax = 4;
+        public int WormholeSlot
+        {
+            get
+            {
+                //if (!InWormhole())
+                //    return -1;
+                for (int i = 0; i <= WormholeSlotMax; i++)
+                {
+                    if (GetEventFlag(i + 11) == false)
+                        return i;
+                }
+                return -1;
+            }
+            set
+            {
+                if (value < 0 || value > WormholeSlotMax)
+                    return;
+                for (int i = 0; i <= WormholeSlotMax; i++)
+                {
+                    SetEventFlag(i + 11, value != i);
+                }
+
+                // TODO: Is there a better way to set individual consts while using the API?
+                var consts = EventConsts;
+                consts[851] = (ushort)(value + 38);
+                EventConsts = consts;
+            }
+        }
+
+        public readonly int[] StandardWormholes = new[] {
+            256, // Red
+            257, // Green
+            258, // Yellow
+            259, // Blue
+        };
+
+        public readonly int[] WormholeSlotsRed = new[]
+        {
+            334, // Altaria
+            469, // Yanmega
+            561, // Sigilyph
+            581, // Swanna
+            277, // Swellow
+        };
+
+        public readonly int[] WormholeSlotsGreen = new[]
+        {
+            542, // Drapion
+            531, // Audino
+            695, // Heliolisk
+            274, // Nuzleaf
+            326, // Grumpig
+        };
+
+        public readonly int[] WormholeSlotsYellow = new[]
+        {
+            460, // Abomasnow
+            308, // Medicham
+            450, // Hippowdon
+            558, // Crustle
+            219, // Magcargo
+        };
+
+        public readonly int[] WormholeSlotsBlue = new[]
+        {
+            689, // Barbaracle
+            271, // Lombre
+            618, // Stunfisk
+            419, // Floatzel
+            195, // Quagsire
+        };
+
+        public int WormholeSlotToPokemon(int mapid, int slot)
+        {
+            if (slot < 0 || slot > WormholeSlotMax)
+                return -1;
+            //if (!StandardWormholes.Contains(mapid))
+            //    return -1;
+
+            switch (mapid)
+            {
+                case 256: return WormholeSlotsRed[slot];
+                case 257: return WormholeSlotsGreen[slot];
+                case 258: return WormholeSlotsYellow[slot];
+                case 259: return WormholeSlotsBlue[slot];
+                default: return -1;
+            }
+        }
     }
 }


### PR DESCRIPTION
The current wormhole's shiny flag & pokemon can be changed with these functions.

The flags & offsets were found by @PP-theSLAYER https://projectpokemon.org/home/forums/topic/39433-gen-7-save-research-thread/?page=3&tab=comments#comment-239090

I haven't comprehensively tested each slot and wormhole to confirm the correctness (yet). This is assuming theSLAYER's table was correct.

I didn't make a subform because I've never made GUIs in C# and because I want to see if this code needs to be changed first (like the slot base, 0, or max variable, 4). Maybe more comments too...