### PR TITLE
Fix a couple off-by-one logic errors in early gens

### DIFF
--- a/PKHeX.Core/PKM/Shared/_K12.cs
+++ b/PKHeX.Core/PKM/Shared/_K12.cs
@@ -260,12 +260,11 @@ namespace PKHeX.Core
 
         protected static ushort GetStat(int BV, int IV, int EV, int LV)
         {
-            EV = (ushort)Math.Sqrt(EV) >> 2;
+            EV = (ushort)Math.Min(255, Math.Sqrt(EV) + 1) >> 2;
             return (ushort)((((2 * (BV + IV)) + EV) * LV / 100) + 5);
         }
 
-        public override int GetMovePP(int move, int ppup) => Math.Min(61, base.GetMovePP(move, ppup));
-
+        public override int GetMovePP(int move, int ppup) => GetBasePP(move) + ppup * Math.Min(7, GetBasePP(move) / 5)
         /// <summary>
         /// Applies <see cref="PKM.IVs"/> to the <see cref="PKM"/> to make it shiny.
         /// </summary>


### PR DESCRIPTION
PK1 and PK2 get the equivalent of 1 EV added after taking the square root

PP Ups on 40-PP moves don't just get the override of 3=>61, but also 2=>54 and 1=>47