### PR TITLE
Update GO shiny banlist

### DIFF
--- a/PKHeX.Core/Legality/Tables/Tables7b.cs
+++ b/PKHeX.Core/Legality/Tables/Tables7b.cs
@@ -272,8 +272,6 @@ namespace PKHeX.Core
             047, // Parasect
             048, // Venonat
             049, // Venomoth
-            050, // Diglett
-            051, // Dugtrio
             052, // Meowth
             053, // Persian
             060, // Poliwag
@@ -328,7 +326,6 @@ namespace PKHeX.Core
         {
             019, // Rattata
             020, // Raticate
-            026, // Raichu
             027, // Sandshrew
             028, // Sandslash
             037, // Vulpix


### PR DESCRIPTION
https://twitter.com/PokemonGoApp/status/1122954828483846144

Also, apparently Shiny Alolan Raichu has been available since November (oops?)