### PR TITLE
Enhance Invalid Convert Error

### DIFF
--- a/PKHeX.Core/Resources/text/de/MessageStrings_de.txt
+++ b/PKHeX.Core/Resources/text/de/MessageStrings_de.txt
@@ -50,6 +50,7 @@ MsgFileWriteProtected = File's location is write protected:
 MsgFileWriteProtectedAdvice = If the file is on a removable disk (SD card), please ensure the write protection switch is not set.
 MsgFileInUse = Unable to load file. It could be in use by another program.
 MsgFileUnsupported = Attempted to load an unsupported file type/size. This could mean PKHeX doesn't support your save file or your save file is corrupt.
+MsgPKMUnsupported = Attempted to load an unsupported file type/size. This could be caused by loading a different generation Pokemon file on an unsupported generation or your file is corrupt.
 MsgPKMConvertSuccess = Converted from {0} to {1}.
 MsgPKMConvertFail = Conversion failed.
 MsgPKMMysteryGiftFail = Mystery Gift is not a Pokémon.

--- a/PKHeX.Core/Resources/text/en/MessageStrings_en.txt
+++ b/PKHeX.Core/Resources/text/en/MessageStrings_en.txt
@@ -50,6 +50,7 @@ MsgFileWriteProtected = File's location is write protected:
 MsgFileWriteProtectedAdvice = If the file is on a removable disk (SD card), please ensure the write protection switch is not set.
 MsgFileInUse = Unable to load file. It could be in use by another program.
 MsgFileUnsupported = Attempted to load an unsupported file type/size. This could mean PKHeX doesn't support your save file or your save file is corrupt.
+MsgPKMUnsupported = Attempted to load an unsupported file type/size. This could be caused by loading a different generation Pokemon file on an unsupported generation or your file is corrupt.
 MsgPKMConvertSuccess = Converted from {0} to {1}.
 MsgPKMConvertFail = Conversion failed.
 MsgPKMMysteryGiftFail = Mystery Gift is not a Pokémon.

--- a/PKHeX.Core/Resources/text/es/MessageStrings_es.txt
+++ b/PKHeX.Core/Resources/text/es/MessageStrings_es.txt
@@ -50,6 +50,7 @@ MsgFileWriteProtected = La localización del archivo está protegida contra escr
 MsgFileWriteProtectedAdvice = Si el archivo está en un disco extraíble (tarjeta SD), por favor asegúrate de que el interroptur de protección contra escritura no esté activado.
 MsgFileInUse = No se ha podido cargar el archivo. Puede que esté siendo usado por otro programa.
 MsgFileUnsupported = Se ha intentado cargar un tipo/tamaño de archivo no soportado.
+MsgPKMUnsupported = Attempted to load an unsupported file type/size. This could be caused by loading a different generation Pokemon file on an unsupported generation or your file is corrupt.
 MsgPKMConvertSuccess = Convertido de {0} a {1}.
 MsgPKMConvertFail = Conversión fallida.
 MsgPKMMysteryGiftFail = El Regalo Misterioso no es un Pokémon.

--- a/PKHeX.Core/Resources/text/fr/MessageStrings_fr.txt
+++ b/PKHeX.Core/Resources/text/fr/MessageStrings_fr.txt
@@ -50,6 +50,7 @@ MsgFileWriteProtected = L'emplacement du fichier est en lecture seulement:
 MsgFileWriteProtectedAdvice = Si le fichier est dans un disque amovible (ex: Carte SD), s'assurer que l'écriture dans le disque est permise.
 MsgFileInUse = Fichier non chargé. Il se peut qu'il soit utilisé par un autre programme.
 MsgFileUnsupported = Chargement de fichier de type / taille incompatible. Soit PKHeX ne prend pas votre fichier en charge, soit ce dernier est corrompu.
+MsgPKMUnsupported = Attempted to load an unsupported file type/size. This could be caused by loading a different generation Pokemon file on an unsupported generation or your file is corrupt.
 MsgPKMConvertSuccess = Conversion réussie de {0} à {1}.
 MsgPKMConvertFail = Conversion ratée.
 MsgPKMMysteryGiftFail = Le Cadeau Mystère n'est pas un Pokémon.

--- a/PKHeX.Core/Resources/text/it/MessageStrings_it.txt
+++ b/PKHeX.Core/Resources/text/it/MessageStrings_it.txt
@@ -50,6 +50,7 @@ MsgFileWriteProtected = File's location is write protected:
 MsgFileWriteProtectedAdvice = If the file is on a removable disk (SD card), please ensure the write protection switch is not set.
 MsgFileInUse = Unable to load file. It could be in use by another program.
 MsgFileUnsupported = Attempted to load an unsupported file type/size. This could mean PKHeX doesn't support your save file or your save file is corrupt.
+MsgPKMUnsupported = Attempted to load an unsupported file type/size. This could be caused by loading a different generation Pokemon file on an unsupported generation or your file is corrupt.
 MsgPKMConvertSuccess = Converted from {0} to {1}.
 MsgPKMConvertFail = Conversion failed.
 MsgPKMMysteryGiftFail = Mystery Gift is not a Pokémon.

--- a/PKHeX.Core/Resources/text/ja/MessageStrings_ja.txt
+++ b/PKHeX.Core/Resources/text/ja/MessageStrings_ja.txt
@@ -50,6 +50,7 @@ MsgFileWriteProtected = File's location is write protected:
 MsgFileWriteProtectedAdvice = If the file is on a removable disk (SD card), please ensure the write protection switch is not set.
 MsgFileInUse = Unable to load file. It could be in use by another program.
 MsgFileUnsupported = Attempted to load an unsupported file type/size. This could mean PKHeX doesn't support your save file or your save file is corrupt.
+MsgPKMUnsupported = Attempted to load an unsupported file type/size. This could be caused by loading a different generation Pokemon file on an unsupported generation or your file is corrupt.
 MsgPKMConvertSuccess = Converted from {0} to {1}.
 MsgPKMConvertFail = Conversion failed.
 MsgPKMMysteryGiftFail = Mystery Gift is not a Pokémon.

--- a/PKHeX.Core/Resources/text/ko/MessageStrings_ko.txt
+++ b/PKHeX.Core/Resources/text/ko/MessageStrings_ko.txt
@@ -50,6 +50,7 @@ MsgFileWriteProtected = File's location is write protected:
 MsgFileWriteProtectedAdvice = If the file is on a removable disk (SD card), please ensure the write protection switch is not set.
 MsgFileInUse = Unable to load file. It could be in use by another program.
 MsgFileUnsupported = Attempted to load an unsupported file type/size. This could mean PKHeX doesn't support your save file or your save file is corrupt.
+MsgPKMUnsupported = Attempted to load an unsupported file type/size. This could be caused by loading a different generation Pokemon file on an unsupported generation or your file is corrupt.
 MsgPKMConvertSuccess = Converted from {0} to {1}.
 MsgPKMConvertFail = Conversion failed.
 MsgPKMMysteryGiftFail = Mystery Gift is not a Pokémon.

--- a/PKHeX.Core/Resources/text/zh/MessageStrings_zh.txt
+++ b/PKHeX.Core/Resources/text/zh/MessageStrings_zh.txt
@@ -50,6 +50,7 @@ MsgFileWriteProtected = 文件路径有写入保护:
 MsgFileWriteProtectedAdvice = 如果文件在移动硬盘(SD卡)上，请确认没有打开写入保护。
 MsgFileInUse = 无法加载文件。可能被其他程序占用中。
 MsgFileUnsupported = 无法加载一个不支持的类型或大小的文件。
+MsgPKMUnsupported = Attempted to load an unsupported file type/size. This could be caused by loading a different generation Pokemon file on an unsupported generation or your file is corrupt.
 MsgPKMConvertSuccess = Converted from {0} to {1}.
 MsgPKMConvertFail = 格式转换失败。
 MsgPKMMysteryGiftFail = 神秘礼物不是一个宝可梦。

--- a/PKHeX.Core/Util/MessageStrings.cs
+++ b/PKHeX.Core/Util/MessageStrings.cs
@@ -73,6 +73,7 @@ namespace PKHeX.Core
         public static string MsgFileWriteProtectedAdvice { get; set; } = "If the file is on a removable disk (SD card), please ensure the write protection switch is not set.";
         public static string MsgFileInUse { get; set; } = "Unable to load file. It could be in use by another program.";
         public static string MsgFileUnsupported { get; set; } = "Attempted to load an unsupported file type/size. This could mean PKHeX doesn't support your save file or your save file is corrupt.";
+        public static string MsgPKMUnsupported { get; set; } = "Attempted to load an unsupported file type/size. This could be caused by loading a different generation Pokemon file on an unsupported generation or your file is corrupt.";
 
         public static string MsgPKMConvertSuccess { get; set; } = "Converted from {0} to {1}.";
         public static string MsgPKMConvertFail { get; set; } = "Conversion failed.";

--- a/PKHeX.WinForms/MainWindow/Main.cs
+++ b/PKHeX.WinForms/MainWindow/Main.cs
@@ -584,7 +584,8 @@ namespace PKHeX.WinForms
             if (obj != null && LoadFile(obj, path))
                 return;
 
-            WinFormsUtil.Error(MsgFileUnsupported,
+            string[] savTypes = { "", ".sav", ".dsv", ".dat", ".gci", ".bin" };
+            WinFormsUtil.Error(savTypes.Contains(Path.GetExtension(path)) ? MsgFileUnsupported : MsgPKMUnsupported,
                 $"{MsgFileLoad}{Environment.NewLine}{path}",
                 $"{string.Format(MsgFileSize, input.Length)}{Environment.NewLine}{input.Length} bytes (0x{input.Length:X4})");
         }


### PR DESCRIPTION
Makes it clearer for conversion failure with Pokemon files - prevent confusion with save files.