### PR TITLE
Make Poffin names match in-game text

### DIFF
--- a/PKHeX.WinForms/Subforms/Save Editors/Gen4/PoffinCase4Editor.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen4/PoffinCase4Editor.cs
@@ -30,7 +30,7 @@ namespace PKHeX.WinForms
             Updating = false;
         }
 
-        private string GetPoffinText(int i) => $"{i + 1:000} - {Case.Poffins[i].Type.ToString().Replace('_', '/')}";
+        private string GetPoffinText(int i) => $"{i + 1:000} - {Case.Poffins[i].Type.ToString().Replace('_', '-')}";
 
         public void Save()
         {


### PR DESCRIPTION
Poffin names are hyphen separated.