### PR TITLE
Removed Special Funfest Poliwag & updated min Lvl.

### DIFF
--- a/PKHeX.Core/Legality/Encounters/Data/Encounters5.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Encounters5.cs
@@ -912,21 +912,21 @@ namespace PKHeX.Core
             new EncounterSlot{ Species = 507, LevelMin = 10, LevelMax = 15, }, // Herdier
             // Funfest Missions
             // todo : check the level
-            new EncounterSlot{Species = 133, LevelMin = 10, LevelMax = 60, }, //Eevee
-            new EncounterSlot{Species = 134, LevelMin = 10, LevelMax = 60, },
-            new EncounterSlot{Species = 135, LevelMin = 10, LevelMax = 60, },
-            new EncounterSlot{Species = 136, LevelMin = 10, LevelMax = 60, },
-            new EncounterSlot{Species = 196, LevelMin = 10, LevelMax = 60, },
-            new EncounterSlot{Species = 197, LevelMin = 10, LevelMax = 60, },
-            new EncounterSlot{Species = 470, LevelMin = 10, LevelMax = 60, },
-            new EncounterSlot{Species = 471, LevelMin = 10, LevelMax = 60, },
+            new EncounterSlot{Species = 133, LevelMin = 15, LevelMax = 60, }, //Eevee
+            new EncounterSlot{Species = 134, LevelMin = 15, LevelMax = 60, },
+            new EncounterSlot{Species = 135, LevelMin = 15, LevelMax = 60, },
+            new EncounterSlot{Species = 136, LevelMin = 15, LevelMax = 60, },
+            new EncounterSlot{Species = 196, LevelMin = 15, LevelMax = 60, },
+            new EncounterSlot{Species = 197, LevelMin = 15, LevelMax = 60, },
+            new EncounterSlot{Species = 470, LevelMin = 15, LevelMax = 60, },
+            new EncounterSlot{Species = 471, LevelMin = 15, LevelMax = 60, },
             // Funfest Week 3
-            new EncounterSlot{Species = 60, LevelMin = 10, LevelMax = 60, }, // Poliwag
-            new EncounterSlot{Species = 113, LevelMin = 10, LevelMax = 60, }, // Chansey
-            new EncounterSlot{Species = 176, LevelMin = 10, LevelMax = 60, }, // Togetic
-            new EncounterSlot{Species = 82, LevelMin = 10, LevelMax = 60, }, // Magneton
-            new EncounterSlot{Species = 148, LevelMin = 10, LevelMax = 60, }, // Dragonair
-            new EncounterSlot{Species = 372, LevelMin = 10, LevelMax = 60, }, // Shelgon                      
+            // new EncounterSlot{Species = 60, LevelMin = 15, LevelMax = 60, }, // Poliwag
+            new EncounterSlot{Species = 113, LevelMin = 15, LevelMax = 60, }, // Chansey
+            new EncounterSlot{Species = 176, LevelMin = 15, LevelMax = 60, }, // Togetic
+            new EncounterSlot{Species = 82, LevelMin = 15, LevelMax = 60, }, // Magneton
+            new EncounterSlot{Species = 148, LevelMin = 15, LevelMax = 60, }, // Dragonair
+            new EncounterSlot{Species = 372, LevelMin = 15, LevelMax = 60, }, // Shelgon                      
         };
 
         private static readonly EncounterArea[] SlotsB2_HiddenGrotto =
@@ -936,7 +936,7 @@ namespace PKHeX.Core
                 Location = 143, // HiddenGrotto
                 Slots = SlotsB2W2_HiddenGrottoEncounterSlots.Concat(new[]{
                     new EncounterSlot{Species = 015, LevelMin = 55, LevelMax = 60 }, // Beedrill @ Pinwheel Forest
-                    new EncounterSlot{Species = 434, LevelMin = 10, LevelMax = 60 }, // Stunky from Funfest Missions
+                    new EncounterSlot{Species = 434, LevelMin = 15, LevelMax = 60 }, // Stunky from Funfest Missions
                 }).ToArray(),
             }
         };
@@ -948,7 +948,7 @@ namespace PKHeX.Core
                 Location = 143, // HiddenGrotto
                 Slots = SlotsB2W2_HiddenGrottoEncounterSlots.Concat(new[]{
                     new EncounterSlot{Species = 012, LevelMin = 55, LevelMax = 60 }, // Butterfree @ Pinwheel Forest
-                    new EncounterSlot{Species = 431, LevelMin = 10, LevelMax = 60 }, // Glameow from Funfest Missions
+                    new EncounterSlot{Species = 431, LevelMin = 15, LevelMax = 60 }, // Glameow from Funfest Missions
                 }).ToArray(),
             }
         };


### PR DESCRIPTION
According to the link below, the official page states that Poliwag's announcement was a mistake, and they clarified it would not be appearing.
This message was echoed across various pages (Sapporo, Fukuoka, Tohoku), not just the Yokohama one.
https://voice.pokemon.co.jp/stv/yokohama/2013/08/post-2286.html

Additionally, based on tests from me and jojo, Funfest missions forces the grotto encounters to be max level (of the individual grottoes).
https://projectpokemon.org/home/forums/topic/39810-unlock-all-funfiesta-missions/?do=findComment&comment=245303