### PR TITLE
Update GO Shiny banlist

### DIFF
--- a/PKHeX.Core/Legality/Tables/Tables7b.cs
+++ b/PKHeX.Core/Legality/Tables/Tables7b.cs
@@ -277,9 +277,6 @@ namespace PKHeX.Core
             060, // Poliwag
             061, // Poliwhirl
             062, // Poliwrath
-            063, // Abra
-            064, // Kadabra
-            065, // Alakazam
             069, // Bellsprout
             070, // Weepinbell
             071, // Victreebel
@@ -304,8 +301,6 @@ namespace PKHeX.Core
             113, // Chansey
             114, // Tangela
             115, // Kangaskhan
-            116, // Horsea
-            117, // Seadra
             118, // Goldeen
             119, // Seaking
             120, // Staryu


### PR DESCRIPTION
Horsea is in less than an hour, so remove that too.
https://twitter.com/PokemonGoApp/status/1138853525075746816
https://twitter.com/SerebiiNet/status/1139182713695539200