### PR TITLE
Update GO Shiny banlist for GO 3rd Anniversary

### DIFF
--- a/PKHeX.Core/Legality/Tables/Tables7b.cs
+++ b/PKHeX.Core/Legality/Tables/Tables7b.cs
@@ -258,7 +258,7 @@ namespace PKHeX.Core
             022, // Fearow
             023, // Ekans
             024, // Arbok
-            032, // Nidoran-M
+            032, // Nidoran♂
             033, // Nidorino
             034, // Nidoking
             037, // Vulpix
@@ -312,26 +312,6 @@ namespace PKHeX.Core
             143, // Snorlax
             150, // Mewtwo
             151, // Mew
-        };
-
-        internal static readonly HashSet<int> GoTransferSpeciesShinyBanAlola = new HashSet<int>
-        {
-            019, // Rattata
-            020, // Raticate
-            027, // Sandshrew
-            028, // Sandslash
-            037, // Vulpix
-            038, // Ninetales
-            050, // Diglett
-            051, // Dugtrio
-            052, // Meowth
-            053, // Persian
-            074, // Geodude
-            075, // Graveler
-            076, // Golem
-            088, // Grimer
-            089, // Muk
-            103, // Exeggutor
         };
     }
 }

--- a/PKHeX.Core/Legality/Verifiers/IndividualValueVerifier.cs
+++ b/PKHeX.Core/Legality/Verifiers/IndividualValueVerifier.cs
@@ -117,9 +117,11 @@ namespace PKHeX.Core
 
             if (!pkm.IsShiny)
                 return;
-            var banlist = pkm.AltForm == 1 && Legal.EvolveToAlolanForms.Contains(pkm.Species)
-                ? Legal.GoTransferSpeciesShinyBanAlola
-                : Legal.GoTransferSpeciesShinyBan;
+            var banlist = Legal.GoTransferSpeciesShinyBan;
+
+            // all Shiny Alola Forms are legal, while some of their respective Kantonian Forms are not
+            if (banlist.Contains(pkm.Species) && pkm.AltForm == 1)
+                return;
             if (banlist.Contains(pkm.Species))
                 data.AddLine(GetInvalid(LEncStaticPIDShiny, CheckIdentifier.PID));
         }

--- a/PKHeX.Core/Legality/Verifiers/IndividualValueVerifier.cs
+++ b/PKHeX.Core/Legality/Verifiers/IndividualValueVerifier.cs
@@ -119,10 +119,8 @@ namespace PKHeX.Core
                 return;
             var banlist = Legal.GoTransferSpeciesShinyBan;
 
-            // all Shiny Alola Forms are legal, while some of their respective Kantonian Forms are not
-            if (banlist.Contains(pkm.Species) && pkm.AltForm == 1)
-                return;
-            if (banlist.Contains(pkm.Species))
+            // all Shiny Alola Forms are legal, while some of their respective Kanto Forms are not
+            if (banlist.Contains(pkm.Species) && pkm.AltForm != 1)
                 data.AddLine(GetInvalid(LEncStaticPIDShiny, CheckIdentifier.PID));
         }
 


### PR DESCRIPTION
All Shiny Alola Forms are releasing; modify Verifier to allow Shiny Alola Form while still flagging the respective Kanto Form (if not released).

Changes go live at 20:00 UTC today (in just over 2 hours), getting it out of the way now.

![image](https://user-images.githubusercontent.com/17801814/60361367-004d4780-99ac-11e9-856a-486acf216dc6.png)
![image](https://user-images.githubusercontent.com/17801814/60361339-ef9cd180-99ab-11e9-89c5-c1f8e4561942.png)