### PR TITLE
Box Layout fixes

### DIFF
--- a/PKHeX.Core/Saves/SAV4HGSS.cs
+++ b/PKHeX.Core/Saves/SAV4HGSS.cs
@@ -80,7 +80,7 @@ namespace PKHeX.Core
 
         public override void SetBoxName(int box, string value)
         {
-            const int maxlen = BOX_NAME_LEN / 2;
+            const int maxlen = 8;
             if (value.Length > maxlen)
                 value = value.Substring(0, maxlen); // Hard cap
             int offset = GetBoxNameOffset(box);

--- a/PKHeX.Core/Saves/SAV4Sinnoh.cs
+++ b/PKHeX.Core/Saves/SAV4Sinnoh.cs
@@ -47,7 +47,7 @@ namespace PKHeX.Core
 
         public override void SetBoxName(int box, string value)
         {
-            const int maxlen = BOX_NAME_LEN / 2;
+            const int maxlen = 8;
             if (value.Length > maxlen)
                 value = value.Substring(0, maxlen); // Hard cap
             int offset = GetBoxNameOffset(box);

--- a/PKHeX.Core/Saves/Substructures/Gen7/BoxLayout7.cs
+++ b/PKHeX.Core/Saves/Substructures/Gen7/BoxLayout7.cs
@@ -47,7 +47,7 @@ namespace PKHeX.Core
         public void SetBoxName(int box, string value)
         {
             var data = SAV.SetString(value, strlen, strlen, 0);
-            var offset = GetBoxNameOffset(box) + (SAV6.LongStringLength * box);
+            var offset = GetBoxNameOffset(box - 1) + (SAV6.LongStringLength);
             SAV.SetData(data, offset);
         }
 

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen6/SAV_BoxLayout.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen6/SAV_BoxLayout.cs
@@ -28,6 +28,7 @@ namespace PKHeX.WinForms
             LoadUnlockedCount();
 
             LB_BoxSelect.SelectedIndex = box;
+            TB_BoxName.MaxLength = SAV.Generation >= 6 ? 14 : 8;
             editing = false;
         }
 


### PR DESCRIPTION
Box Name length is 8 characters in Gen. 2/3/4/5 (JPN included), and 14 in Gen. 6/7. No reason to let the user enter more characters than the game allows, just like Nickname and OT fields. This also fixes an issue that would occur in Gen. 2 when setting 9 characters-long box names, where it would wipe the name of the box after it.

I don't know how many characters Sword/Shield allow for boxes, so this may need to be adjusted for G8.

Fixes a bug in G4 where editing a box's name wiped the name of the box after it. Setting the maximum length of the string to 8 fixes this (hardcoded value bad, but this works at a glance, and can be improved later.)

Fixes a bug in G7 where editing a box's name applied it to the wrong box.