### PR TITLE
Connecting Areas Check

### DIFF
--- a/PKHeX.Core/Legality/Areas/EncounterArea8.cs
+++ b/PKHeX.Core/Legality/Areas/EncounterArea8.cs
@@ -35,7 +35,7 @@ namespace PKHeX.Core
         {
             if (!IsWildArea8(loc))
             {
-                return new int[] { }; // Empty
+                return new int[] { loc }; // Single
             }
 
             switch (loc)
@@ -108,10 +108,10 @@ namespace PKHeX.Core
                     return new int[] { 144, 150 };
 
                 case 154: // Lake of Outrage
-                    return new int[] { }; // Empty
+                    return new int[] { loc }; // Single
 
                 default:
-                    return new int[] { }; // Empty
+                    return new int[] { loc }; // Single
             }
         }
     }

--- a/PKHeX.Core/Legality/Areas/EncounterArea8.cs
+++ b/PKHeX.Core/Legality/Areas/EncounterArea8.cs
@@ -30,5 +30,89 @@ namespace PKHeX.Core
         protected override IEnumerable<EncounterSlot> GetFilteredSlots(PKM pkm, IEnumerable<EncounterSlot> slots, int minLevel) => slots;
 
         public static bool IsWildArea8(int loc) => 120 <= loc && loc <= 154;
+
+        public static int[] ConnectingArea8(int loc)
+        {
+            if (!IsWildArea8(loc))
+            {
+                return new int[] { }; // Empty
+            }
+
+            switch (loc)
+            {
+                case 122: // Rolling Fields
+                    // Dappled Grove, East Lake Axewell, West Lake Axewell
+                    // Also connects to South Lake Miloch but too much of a stretch
+                    return new int[] { 124, 128, 130 };
+
+                case 124: // Dappled Grove
+                    // Dappled Grove, Watchtower Ruins
+                    return new int[] { 122, 126 };
+
+                case 126: // Watchtower Ruins
+                    // Dappled Grove, West Lake Axewell
+                    return new int[] { 124, 130 };
+
+                case 128: // East Lake Axewell
+                    // Rolling Fields, West Lake Axewell, Axew's Eye, North Lake Miloch
+                    return new int[] { 122, 130, 132, 138 };
+
+                case 130: // West Lake Axewell
+                    // Rolling Fields, Watchtower Ruins, East Lake Axewell, Axew's Eye
+                    return new int[] { 122, 126, 128, 132 };
+
+                case 132: // Axew's Eye
+                    // East Lake Axewell, West Lake Axewell
+                    return new int[] { 128, 130 };
+
+                case 134: // South Lake Miloch
+                    // Giant's Seat, North Lake Miloch
+                    return new int[] { 136, 138 };
+
+                case 136: // Giant's Seat
+                    // South Lake Miloch, North Lake Miloch
+                    return new int[] { 134, 138 };
+
+                case 138: // North Lake Miloch
+                    // East Lake Axewell, South Lake Miloch, Giant's Seat
+                    // Also connects to Motostoke Riverbank but too much of a stretch
+                    return new int[] { 128, 134, 136 };
+
+                case 140: // Motostoke Riverbank
+                    // Bridge Field
+                    return new int[] { 142 };
+
+                case 142: // Bridge Field
+                    // Motostoke Riverbank, Stony Wilderness
+                    return new int[] { 140, 144 };
+
+                case 144: // Stony Wilderness
+                    // Bridge Field, Dusty Bowl, Giant's Mirror, Giant's Cap
+                    return new int[] { 142, 146, 148, 152 };
+
+                case 146: // Dusty Bowl
+                    // Stony Wilderness, Giant's Mirror, Hammerlocke Hills
+                    return new int[] { 144, 148, 150 };
+
+                case 148: // Giant's Mirror
+                    // Stony Wilderness, Dusty Bowl, Hammerlocke Hills
+                    return new int[] { 144, 146, 148 };
+
+                case 150: // Hammerlocke Hills
+                    // Dusty Bowl, Giant's Mirror, Giant's Cap
+                    return new int[] { 146, 148, 152 };
+
+                case 152: // Giant's Cap
+                    // Stony Wilderness, Giant's Cap
+                    // Also connects to Lake of Outrage but too much of a stretch
+                    return new int[] { 144, 150 };
+
+                case 154: // Lake of Outrage
+                    return new int[] { }; // Empty
+
+                default:
+                    return new int[] { }; // Empty
+            }
+        }
     }
 }

--- a/PKHeX.Core/Legality/Encounters/Generator/EncounterSlotGenerator.cs
+++ b/PKHeX.Core/Legality/Encounters/Generator/EncounterSlotGenerator.cs
@@ -153,6 +153,10 @@ namespace PKHeX.Core
 
             var slots = GetEncounterSlots(pkm, gameSource: gameSource);
             bool noMet = !pkm.HasOriginalMetLocation || (pkm.Format == 2 && gameSource != GameVersion.C);
+            if (gameSource == GameVersion.SW || gameSource == GameVersion.SH)
+            {
+                return noMet ? slots : slots.Where(area => EncounterArea8.ConnectingArea8(pkm.Met_Location).Contains(area.Location));
+            }
             return noMet ? slots : slots.Where(area => area.Location == pkm.Met_Location);
         }
 


### PR DESCRIPTION
Like LGPE, SWSH's Wild Area has Pokemon that can bleed over routes. I've checked areas where this can happen and have made a method that returns other areas the Pokemon could have originated from.