### PR TITLE
Unban GO Shiny Tentacool

### DIFF
--- a/PKHeX.Core/Legality/Tables/Tables7b.cs
+++ b/PKHeX.Core/Legality/Tables/Tables7b.cs
@@ -291,8 +291,6 @@ namespace PKHeX.Core
             047, // Parasect
             048, // Venonat
             049, // Venomoth
-            052, // Meowth
-            053, // Persian
             069, // Bellsprout
             070, // Weepinbell
             071, // Victreebel

--- a/PKHeX.Core/Legality/Tables/Tables7b.cs
+++ b/PKHeX.Core/Legality/Tables/Tables7b.cs
@@ -296,8 +296,6 @@ namespace PKHeX.Core
             069, // Bellsprout
             070, // Weepinbell
             071, // Victreebel
-            072, // Tentacool
-            073, // Tentacruel
             079, // Slowpoke
             080, // Slowbro
             084, // Doduo


### PR DESCRIPTION
Edit: When I told you about Shiny Meowth, it was only from Team GO Rocket (non-transferable)... but a day later it got added to wild lmao