### PR TITLE
set gigantamax flag from showdown set

### DIFF
--- a/PKHeX.Core/Editing/CommonEdits.cs
+++ b/PKHeX.Core/Editing/CommonEdits.cs
@@ -367,6 +367,9 @@ namespace PKHeX.Core
                     b.ResetCalculatedValues();
                 }
             }
+            
+            if (pk is IGigantamax c)
+                c.CanGigantamax = Set.CanGigantamax;
 
             var legal = new LegalityAnalysis(pk);
             if (legal.Parsed && legal.Info.Relearn.Any(z => !z.Valid))


### PR DESCRIPTION
When using showdown import, the `CanGigantamax` boolean was being set for the ShowdownSet object but it was not being set when applying details to a pkm object