### PR TITLE
Ultra Shiny PID generation

### DIFF
--- a/PKHeX.Core/PKM/PKM.cs
+++ b/PKHeX.Core/PKM/PKM.cs
@@ -920,7 +920,7 @@ namespace PKHeX.Core
         /// </remarks>
         public virtual void SetShiny()
         {
-            if (Gen8)
+            if (Format >= 8)
                 while (ShinyValueResult > 15 || ShinyValueResult < 1)
                     PID = PKX.GetRandomPID(Species, Gender, Version, Nature, AltForm, PID);
             else

--- a/PKHeX.WinForms/Controls/PKM Editor/PKMEditor.cs
+++ b/PKHeX.WinForms/Controls/PKM Editor/PKMEditor.cs
@@ -1345,11 +1345,12 @@ namespace PKHeX.WinForms.Controls
 
         private void UpdateShinyPID(object sender, EventArgs e)
         {
-            var ShinyPID = Entity.Format <= 2 || ModifierKeys != Keys.Control;
-            UpdateShiny(ShinyPID);
+            var ShinyPID = Entity.Format >= 3 && ModifierKeys != Keys.Control;
+            var UltraShiny = Entity.Format >= 8 && ModifierKeys == Keys.Shift;
+            UpdateShiny(ShinyPID, UltraShiny);
         }
 
-        private void UpdateShiny(bool PID)
+        private void UpdateShiny(bool PID, bool UltraShiny)
         {
             Entity.PID = Util.GetHexValue(TB_PID.Text);
             Entity.Nature = WinFormsUtil.GetIndex(CB_Nature);
@@ -1361,7 +1362,11 @@ namespace PKHeX.WinForms.Controls
             {
                 if (PID)
                 {
-                    Entity.SetShiny();
+                    if (UltraShiny)
+                        Entity.SetUltraShiny();
+                    else
+                        Entity.SetShiny();
+
                     TB_PID.Text = Entity.PID.ToString("X8");
 
                     if (Entity.GenNumber < 6 && TB_EC.Visible)

--- a/PKHeX.WinForms/Controls/PKM Editor/PKMEditor.cs
+++ b/PKHeX.WinForms/Controls/PKM Editor/PKMEditor.cs
@@ -1346,7 +1346,7 @@ namespace PKHeX.WinForms.Controls
         private void UpdateShinyPID(object sender, EventArgs e)
         {
             var ShinyPID = Entity.Format >= 3 && ModifierKeys != Keys.Control;
-            var UltraShiny = Entity.Format >= 8 && ModifierKeys == Keys.Shift;
+            var UltraShiny = Entity.SWSH && ModifierKeys == Keys.Shift;
             UpdateShiny(ShinyPID, UltraShiny);
         }
 


### PR DESCRIPTION
https://projectpokemon.org/home/forums/topic/55510-ultra-shiny-pokemon-editing-in-swsh

Allows generating Ultra Shinies/super shinies/square shinies/whatever people want to call them.

When on Gen. 8 file:
- Shift+click on the Shinytize button generates a PID where the formula equals 0 (= Ultra Shiny), only works on Pokémon of Sword/Shield origin in case Pokémon Home prevents regular shinies from becoming Ultra Shinies on transfer (like Bank did with Gen. 5 transfers.)
- Regular click generates a PID where the formula equals 1-15.

Should still generate PIDs with the full 0-15 range on Gens. 7 and lower.

I'll leave it up to you to decide how Ultra Shinies should be differentiated from regular shinies in the UI.