### PR TITLE
add a check for gigantamax flag during encounter match

### DIFF
--- a/PKHeX.Core/Legality/Encounters/EncounterStatic8N.cs
+++ b/PKHeX.Core/Legality/Encounters/EncounterStatic8N.cs
@@ -64,7 +64,8 @@ namespace PKHeX.Core
                 return false;
             if (pkm is IDynamaxLevel d && d.DynamaxLevel < DynamaxLevel)
                 return false;
-
+            if (pkm is IGigantamax g && g.CanGigantamax != CanGigantamax)
+                return false;
             if (pkm.FlawlessIVCount < MinRank + 1)
                 return false;
 


### PR DESCRIPTION
Doesnt let non gmax flag encounters match when CanGigantamax is true