### PR TITLE
handle smogon sets with multiple moves

### DIFF
--- a/PKHeX.Core/Editing/ShowdownSet.cs
+++ b/PKHeX.Core/Editing/ShowdownSet.cs
@@ -554,7 +554,7 @@ namespace PKHeX.Core
         private string ParseLineMove(string line)
         {
             const int hiddenPower = 237;
-            string moveString = line.Substring(line[1] == ' ' ? 2 : 1).Trim();
+            string moveString = line.Substring(line[1] == ' ' ? 2 : 1).Split('/')[0].Trim();
             if (!moveString.StartsWith(Strings.Move[hiddenPower])) // Hidden Power
                 return moveString; // regular move
 


### PR DESCRIPTION
sometimes competitive sets have multiple moves in one slot as optional coverage moves. Handle these cases by splitting and trimming over '/'.  Example: https://pastebin.com/raw/jvPziRdC (The dusk mane set)