### PR TITLE
set gen 5 battle subway record max to 9999 + tab indexing

### DIFF
--- a/PKHeX.WinForms/Subforms/Save Editors/Gen5/SAV_Misc5.Designer.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen5/SAV_Misc5.Designer.cs
@@ -1,4 +1,4 @@
-﻿namespace PKHeX.WinForms
+namespace PKHeX.WinForms
 {
     partial class SAV_Misc5
     {
@@ -98,7 +98,34 @@
             this.CB_Areas = new System.Windows.Forms.ComboBox();
             this.LB_Slots = new System.Windows.Forms.ListBox();
             this.TAB_Subway = new System.Windows.Forms.TabPage();
+            this.GB_SuperChecks = new System.Windows.Forms.GroupBox();
+            this.CHK_SuperMulti = new System.Windows.Forms.CheckBox();
+            this.CHK_SuperDouble = new System.Windows.Forms.CheckBox();
+            this.CHK_SuperSingle = new System.Windows.Forms.CheckBox();
+            this.GB_SuperMulti = new System.Windows.Forms.GroupBox();
+            this.L_SMultiNPC = new System.Windows.Forms.Label();
+            this.L_SMultiFriends = new System.Windows.Forms.Label();
+            this.L_SMultiFriendsRecord = new System.Windows.Forms.Label();
+            this.NUD_SMultiFriendsRecord = new System.Windows.Forms.NumericUpDown();
+            this.L_SMultiFriendsPast = new System.Windows.Forms.Label();
+            this.NUD_SMultiFriendsPast = new System.Windows.Forms.NumericUpDown();
+            this.L_SMultiNpcRecord = new System.Windows.Forms.Label();
+            this.NUD_SMultiNpcRecord = new System.Windows.Forms.NumericUpDown();
+            this.L_SMultiNpcPast = new System.Windows.Forms.Label();
+            this.NUD_SMultiNpcPast = new System.Windows.Forms.NumericUpDown();
+            this.GB_SuperDoubles = new System.Windows.Forms.GroupBox();
+            this.L_SDoubleRecord = new System.Windows.Forms.Label();
+            this.NUD_SDoubleRecord = new System.Windows.Forms.NumericUpDown();
+            this.L_SDoublePast = new System.Windows.Forms.Label();
+            this.NUD_SDoublePast = new System.Windows.Forms.NumericUpDown();
+            this.GB_SuperSingles = new System.Windows.Forms.GroupBox();
+            this.L_SSingleRecord = new System.Windows.Forms.Label();
+            this.NUD_SSingleRecord = new System.Windows.Forms.NumericUpDown();
+            this.L_SSinglePast = new System.Windows.Forms.Label();
+            this.NUD_SSinglePast = new System.Windows.Forms.NumericUpDown();
             this.GB_Multi = new System.Windows.Forms.GroupBox();
+            this.L_MultiNPC = new System.Windows.Forms.Label();
+            this.L_MultiFriends = new System.Windows.Forms.Label();
             this.L_MultiFriendsRecord = new System.Windows.Forms.Label();
             this.NUD_MultiFriendsRecord = new System.Windows.Forms.NumericUpDown();
             this.L_MultiFriendsPast = new System.Windows.Forms.Label();
@@ -119,33 +146,6 @@
             this.NUD_SinglePast = new System.Windows.Forms.NumericUpDown();
             this.TipExpB = new System.Windows.Forms.ToolTip(this.components);
             this.TipExpW = new System.Windows.Forms.ToolTip(this.components);
-            this.L_MultiNPC = new System.Windows.Forms.Label();
-            this.L_MultiFriends = new System.Windows.Forms.Label();
-            this.GB_SuperSingles = new System.Windows.Forms.GroupBox();
-            this.L_SSingleRecord = new System.Windows.Forms.Label();
-            this.NUD_SSingleRecord = new System.Windows.Forms.NumericUpDown();
-            this.L_SSinglePast = new System.Windows.Forms.Label();
-            this.NUD_SSinglePast = new System.Windows.Forms.NumericUpDown();
-            this.GB_SuperDoubles = new System.Windows.Forms.GroupBox();
-            this.L_SDoubleRecord = new System.Windows.Forms.Label();
-            this.NUD_SDoubleRecord = new System.Windows.Forms.NumericUpDown();
-            this.L_SDoublePast = new System.Windows.Forms.Label();
-            this.NUD_SDoublePast = new System.Windows.Forms.NumericUpDown();
-            this.GB_SuperMulti = new System.Windows.Forms.GroupBox();
-            this.L_SMultiNPC = new System.Windows.Forms.Label();
-            this.L_SMultiFriends = new System.Windows.Forms.Label();
-            this.L_SMultiFriendsRecord = new System.Windows.Forms.Label();
-            this.NUD_SMultiFriendsRecord = new System.Windows.Forms.NumericUpDown();
-            this.L_SMultiFriendsPast = new System.Windows.Forms.Label();
-            this.NUD_SMultiFriendsPast = new System.Windows.Forms.NumericUpDown();
-            this.L_SMultiNpcRecord = new System.Windows.Forms.Label();
-            this.NUD_SMultiNpcRecord = new System.Windows.Forms.NumericUpDown();
-            this.L_SMultiNpcPast = new System.Windows.Forms.Label();
-            this.NUD_SMultiNpcPast = new System.Windows.Forms.NumericUpDown();
-            this.GB_SuperChecks = new System.Windows.Forms.GroupBox();
-            this.CHK_SuperSingle = new System.Windows.Forms.CheckBox();
-            this.CHK_SuperDouble = new System.Windows.Forms.CheckBox();
-            this.CHK_SuperMulti = new System.Windows.Forms.CheckBox();
             this.TC_Misc.SuspendLayout();
             this.TAB_Main.SuspendLayout();
             this.GB_KeySystem.SuspendLayout();
@@ -171,6 +171,18 @@
             ((System.ComponentModel.ISupportInitialize)(this.PB_SlotPreview)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_Animation)).BeginInit();
             this.TAB_Subway.SuspendLayout();
+            this.GB_SuperChecks.SuspendLayout();
+            this.GB_SuperMulti.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.NUD_SMultiFriendsRecord)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.NUD_SMultiFriendsPast)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.NUD_SMultiNpcRecord)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.NUD_SMultiNpcPast)).BeginInit();
+            this.GB_SuperDoubles.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.NUD_SDoubleRecord)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.NUD_SDoublePast)).BeginInit();
+            this.GB_SuperSingles.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.NUD_SSingleRecord)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.NUD_SSinglePast)).BeginInit();
             this.GB_Multi.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_MultiFriendsRecord)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_MultiFriendsPast)).BeginInit();
@@ -182,28 +194,15 @@
             this.GB_Singles.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_SingleRecord)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_SinglePast)).BeginInit();
-            this.GB_SuperSingles.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_SSingleRecord)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_SSinglePast)).BeginInit();
-            this.GB_SuperDoubles.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_SDoubleRecord)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_SDoublePast)).BeginInit();
-            this.GB_SuperMulti.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_SMultiFriendsRecord)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_SMultiFriendsPast)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_SMultiNpcRecord)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_SMultiNpcPast)).BeginInit();
-            this.GB_SuperChecks.SuspendLayout();
             this.SuspendLayout();
             // 
             // B_Cancel
             // 
             this.B_Cancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.B_Cancel.Location = new System.Drawing.Point(263, 415);
-            this.B_Cancel.Margin = new System.Windows.Forms.Padding(4);
+            this.B_Cancel.Location = new System.Drawing.Point(197, 337);
             this.B_Cancel.Name = "B_Cancel";
-            this.B_Cancel.Size = new System.Drawing.Size(100, 31);
-            this.B_Cancel.TabIndex = 0;
+            this.B_Cancel.Size = new System.Drawing.Size(75, 25);
+            this.B_Cancel.TabIndex = 1;
             this.B_Cancel.Text = "Cancel";
             this.B_Cancel.UseVisualStyleBackColor = true;
             this.B_Cancel.Click += new System.EventHandler(this.B_Cancel_Click);
@@ -211,11 +210,10 @@
             // B_Save
             // 
             this.B_Save.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.B_Save.Location = new System.Drawing.Point(371, 415);
-            this.B_Save.Margin = new System.Windows.Forms.Padding(4);
+            this.B_Save.Location = new System.Drawing.Point(278, 337);
             this.B_Save.Name = "B_Save";
-            this.B_Save.Size = new System.Drawing.Size(100, 31);
-            this.B_Save.TabIndex = 1;
+            this.B_Save.Size = new System.Drawing.Size(75, 25);
+            this.B_Save.TabIndex = 2;
             this.B_Save.Text = "Save";
             this.B_Save.UseVisualStyleBackColor = true;
             this.B_Save.Click += new System.EventHandler(this.B_Save_Click);
@@ -229,12 +227,11 @@
             this.TC_Misc.Controls.Add(this.TAB_Entralink);
             this.TC_Misc.Controls.Add(this.TAB_Forest);
             this.TC_Misc.Controls.Add(this.TAB_Subway);
-            this.TC_Misc.Location = new System.Drawing.Point(16, 16);
-            this.TC_Misc.Margin = new System.Windows.Forms.Padding(4);
+            this.TC_Misc.Location = new System.Drawing.Point(12, 13);
             this.TC_Misc.Name = "TC_Misc";
             this.TC_Misc.SelectedIndex = 0;
-            this.TC_Misc.Size = new System.Drawing.Size(455, 390);
-            this.TC_Misc.TabIndex = 2;
+            this.TC_Misc.Size = new System.Drawing.Size(341, 317);
+            this.TC_Misc.TabIndex = 0;
             // 
             // TAB_Main
             // 
@@ -242,11 +239,10 @@
             this.TAB_Main.Controls.Add(this.CHK_LibertyPass);
             this.TAB_Main.Controls.Add(this.GB_Roamer);
             this.TAB_Main.Controls.Add(this.GB_FlyDest);
-            this.TAB_Main.Location = new System.Drawing.Point(4, 25);
-            this.TAB_Main.Margin = new System.Windows.Forms.Padding(4);
+            this.TAB_Main.Location = new System.Drawing.Point(4, 22);
             this.TAB_Main.Name = "TAB_Main";
-            this.TAB_Main.Padding = new System.Windows.Forms.Padding(4);
-            this.TAB_Main.Size = new System.Drawing.Size(447, 361);
+            this.TAB_Main.Padding = new System.Windows.Forms.Padding(3, 3, 3, 3);
+            this.TAB_Main.Size = new System.Drawing.Size(333, 291);
             this.TAB_Main.TabIndex = 0;
             this.TAB_Main.Text = "Main";
             this.TAB_Main.UseVisualStyleBackColor = true;
@@ -255,22 +251,19 @@
             // 
             this.GB_KeySystem.Controls.Add(this.B_AllKeys);
             this.GB_KeySystem.Controls.Add(this.CLB_KeySystem);
-            this.GB_KeySystem.Location = new System.Drawing.Point(203, 9);
-            this.GB_KeySystem.Margin = new System.Windows.Forms.Padding(4);
+            this.GB_KeySystem.Location = new System.Drawing.Point(152, 7);
             this.GB_KeySystem.Name = "GB_KeySystem";
-            this.GB_KeySystem.Padding = new System.Windows.Forms.Padding(4);
-            this.GB_KeySystem.Size = new System.Drawing.Size(187, 170);
-            this.GB_KeySystem.TabIndex = 3;
+            this.GB_KeySystem.Size = new System.Drawing.Size(140, 138);
+            this.GB_KeySystem.TabIndex = 1;
             this.GB_KeySystem.TabStop = false;
             this.GB_KeySystem.Text = "Unlocked Keys";
             // 
             // B_AllKeys
             // 
-            this.B_AllKeys.Location = new System.Drawing.Point(8, 25);
-            this.B_AllKeys.Margin = new System.Windows.Forms.Padding(4);
+            this.B_AllKeys.Location = new System.Drawing.Point(6, 20);
             this.B_AllKeys.Name = "B_AllKeys";
-            this.B_AllKeys.Size = new System.Drawing.Size(100, 31);
-            this.B_AllKeys.TabIndex = 1;
+            this.B_AllKeys.Size = new System.Drawing.Size(75, 25);
+            this.B_AllKeys.TabIndex = 0;
             this.B_AllKeys.Text = "Check All";
             this.B_AllKeys.UseVisualStyleBackColor = true;
             this.B_AllKeys.Click += new System.EventHandler(this.B_AllKeys_Click);
@@ -279,20 +272,18 @@
             // 
             this.CLB_KeySystem.CheckOnClick = true;
             this.CLB_KeySystem.FormattingEnabled = true;
-            this.CLB_KeySystem.Location = new System.Drawing.Point(8, 63);
-            this.CLB_KeySystem.Margin = new System.Windows.Forms.Padding(4);
+            this.CLB_KeySystem.Location = new System.Drawing.Point(6, 51);
             this.CLB_KeySystem.Name = "CLB_KeySystem";
-            this.CLB_KeySystem.Size = new System.Drawing.Size(169, 89);
-            this.CLB_KeySystem.TabIndex = 0;
+            this.CLB_KeySystem.Size = new System.Drawing.Size(128, 64);
+            this.CLB_KeySystem.TabIndex = 1;
             // 
             // CHK_LibertyPass
             // 
             this.CHK_LibertyPass.AutoSize = true;
-            this.CHK_LibertyPass.Location = new System.Drawing.Point(8, 287);
-            this.CHK_LibertyPass.Margin = new System.Windows.Forms.Padding(4);
+            this.CHK_LibertyPass.Location = new System.Drawing.Point(6, 233);
             this.CHK_LibertyPass.Name = "CHK_LibertyPass";
-            this.CHK_LibertyPass.Size = new System.Drawing.Size(158, 21);
-            this.CHK_LibertyPass.TabIndex = 2;
+            this.CHK_LibertyPass.Size = new System.Drawing.Size(122, 17);
+            this.CHK_LibertyPass.TabIndex = 4;
             this.CHK_LibertyPass.Text = "Activate LibertyPass";
             this.CHK_LibertyPass.UseVisualStyleBackColor = true;
             // 
@@ -302,32 +293,28 @@
             this.GB_Roamer.Controls.Add(this.L_Roamer641);
             this.GB_Roamer.Controls.Add(this.CB_Roamer642);
             this.GB_Roamer.Controls.Add(this.CB_Roamer641);
-            this.GB_Roamer.Location = new System.Drawing.Point(8, 186);
-            this.GB_Roamer.Margin = new System.Windows.Forms.Padding(4);
+            this.GB_Roamer.Location = new System.Drawing.Point(6, 151);
             this.GB_Roamer.Name = "GB_Roamer";
-            this.GB_Roamer.Padding = new System.Windows.Forms.Padding(4);
-            this.GB_Roamer.Size = new System.Drawing.Size(283, 94);
-            this.GB_Roamer.TabIndex = 1;
+            this.GB_Roamer.Size = new System.Drawing.Size(212, 76);
+            this.GB_Roamer.TabIndex = 2;
             this.GB_Roamer.TabStop = false;
             this.GB_Roamer.Text = "Roamer";
             // 
             // L_Roamer642
             // 
-            this.L_Roamer642.Location = new System.Drawing.Point(8, 57);
-            this.L_Roamer642.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.L_Roamer642.Location = new System.Drawing.Point(6, 46);
             this.L_Roamer642.Name = "L_Roamer642";
-            this.L_Roamer642.Size = new System.Drawing.Size(101, 31);
-            this.L_Roamer642.TabIndex = 3;
+            this.L_Roamer642.Size = new System.Drawing.Size(76, 25);
+            this.L_Roamer642.TabIndex = 2;
             this.L_Roamer642.Text = "Thundurus";
             this.L_Roamer642.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // L_Roamer641
             // 
-            this.L_Roamer641.Location = new System.Drawing.Point(8, 21);
-            this.L_Roamer641.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.L_Roamer641.Location = new System.Drawing.Point(6, 17);
             this.L_Roamer641.Name = "L_Roamer641";
-            this.L_Roamer641.Size = new System.Drawing.Size(101, 31);
-            this.L_Roamer641.TabIndex = 2;
+            this.L_Roamer641.Size = new System.Drawing.Size(76, 25);
+            this.L_Roamer641.TabIndex = 0;
             this.L_Roamer641.Text = "Tornadus";
             this.L_Roamer641.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
@@ -336,32 +323,28 @@
             this.CB_Roamer642.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.CB_Roamer642.FormattingEnabled = true;
-            this.CB_Roamer642.Location = new System.Drawing.Point(117, 59);
-            this.CB_Roamer642.Margin = new System.Windows.Forms.Padding(4);
+            this.CB_Roamer642.Location = new System.Drawing.Point(88, 48);
             this.CB_Roamer642.Name = "CB_Roamer642";
-            this.CB_Roamer642.Size = new System.Drawing.Size(156, 24);
-            this.CB_Roamer642.TabIndex = 1;
+            this.CB_Roamer642.Size = new System.Drawing.Size(118, 21);
+            this.CB_Roamer642.TabIndex = 3;
             // 
             // CB_Roamer641
             // 
             this.CB_Roamer641.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.CB_Roamer641.FormattingEnabled = true;
-            this.CB_Roamer641.Location = new System.Drawing.Point(117, 25);
-            this.CB_Roamer641.Margin = new System.Windows.Forms.Padding(4);
+            this.CB_Roamer641.Location = new System.Drawing.Point(88, 20);
             this.CB_Roamer641.Name = "CB_Roamer641";
-            this.CB_Roamer641.Size = new System.Drawing.Size(156, 24);
-            this.CB_Roamer641.TabIndex = 0;
+            this.CB_Roamer641.Size = new System.Drawing.Size(118, 21);
+            this.CB_Roamer641.TabIndex = 1;
             // 
             // GB_FlyDest
             // 
             this.GB_FlyDest.Controls.Add(this.CLB_FlyDest);
             this.GB_FlyDest.Controls.Add(this.B_AllFlyDest);
-            this.GB_FlyDest.Location = new System.Drawing.Point(8, 9);
-            this.GB_FlyDest.Margin = new System.Windows.Forms.Padding(4);
+            this.GB_FlyDest.Location = new System.Drawing.Point(6, 7);
             this.GB_FlyDest.Name = "GB_FlyDest";
-            this.GB_FlyDest.Padding = new System.Windows.Forms.Padding(4);
-            this.GB_FlyDest.Size = new System.Drawing.Size(187, 170);
+            this.GB_FlyDest.Size = new System.Drawing.Size(140, 138);
             this.GB_FlyDest.TabIndex = 0;
             this.GB_FlyDest.TabStop = false;
             this.GB_FlyDest.Text = "Fly Destination";
@@ -370,18 +353,16 @@
             // 
             this.CLB_FlyDest.CheckOnClick = true;
             this.CLB_FlyDest.FormattingEnabled = true;
-            this.CLB_FlyDest.Location = new System.Drawing.Point(8, 63);
-            this.CLB_FlyDest.Margin = new System.Windows.Forms.Padding(4);
+            this.CLB_FlyDest.Location = new System.Drawing.Point(6, 51);
             this.CLB_FlyDest.Name = "CLB_FlyDest";
-            this.CLB_FlyDest.Size = new System.Drawing.Size(169, 89);
+            this.CLB_FlyDest.Size = new System.Drawing.Size(128, 64);
             this.CLB_FlyDest.TabIndex = 1;
             // 
             // B_AllFlyDest
             // 
-            this.B_AllFlyDest.Location = new System.Drawing.Point(8, 25);
-            this.B_AllFlyDest.Margin = new System.Windows.Forms.Padding(4);
+            this.B_AllFlyDest.Location = new System.Drawing.Point(6, 20);
             this.B_AllFlyDest.Name = "B_AllFlyDest";
-            this.B_AllFlyDest.Size = new System.Drawing.Size(100, 31);
+            this.B_AllFlyDest.Size = new System.Drawing.Size(75, 25);
             this.B_AllFlyDest.TabIndex = 0;
             this.B_AllFlyDest.Text = "Check All";
             this.B_AllFlyDest.UseVisualStyleBackColor = true;
@@ -402,61 +383,55 @@
             this.TAB_Entralink.Controls.Add(this.NUD_FMHosted);
             this.TAB_Entralink.Controls.Add(this.GB_FunfestMissions);
             this.TAB_Entralink.Controls.Add(this.GB_PassPowers);
-            this.TAB_Entralink.Location = new System.Drawing.Point(4, 25);
-            this.TAB_Entralink.Margin = new System.Windows.Forms.Padding(4);
+            this.TAB_Entralink.Location = new System.Drawing.Point(4, 22);
             this.TAB_Entralink.Name = "TAB_Entralink";
-            this.TAB_Entralink.Size = new System.Drawing.Size(447, 361);
+            this.TAB_Entralink.Size = new System.Drawing.Size(333, 291);
             this.TAB_Entralink.TabIndex = 1;
             this.TAB_Entralink.Text = "Entralink";
             this.TAB_Entralink.UseVisualStyleBackColor = true;
             // 
             // L_FMParticipants
             // 
-            this.L_FMParticipants.Location = new System.Drawing.Point(215, 319);
-            this.L_FMParticipants.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.L_FMParticipants.Location = new System.Drawing.Point(161, 259);
             this.L_FMParticipants.Name = "L_FMParticipants";
-            this.L_FMParticipants.Size = new System.Drawing.Size(152, 31);
-            this.L_FMParticipants.TabIndex = 16;
+            this.L_FMParticipants.Size = new System.Drawing.Size(114, 25);
+            this.L_FMParticipants.TabIndex = 11;
             this.L_FMParticipants.Text = "Most Participants";
             this.L_FMParticipants.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // L_FMCompleted
             // 
-            this.L_FMCompleted.Location = new System.Drawing.Point(5, 319);
-            this.L_FMCompleted.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.L_FMCompleted.Location = new System.Drawing.Point(4, 259);
             this.L_FMCompleted.Name = "L_FMCompleted";
-            this.L_FMCompleted.Size = new System.Drawing.Size(112, 31);
-            this.L_FMCompleted.TabIndex = 15;
+            this.L_FMCompleted.Size = new System.Drawing.Size(84, 25);
+            this.L_FMCompleted.TabIndex = 9;
             this.L_FMCompleted.Text = "Completed";
             this.L_FMCompleted.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // L_FMParticipated
             // 
-            this.L_FMParticipated.Location = new System.Drawing.Point(5, 286);
-            this.L_FMParticipated.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.L_FMParticipated.Location = new System.Drawing.Point(4, 232);
             this.L_FMParticipated.Name = "L_FMParticipated";
-            this.L_FMParticipated.Size = new System.Drawing.Size(112, 31);
-            this.L_FMParticipated.TabIndex = 14;
+            this.L_FMParticipated.Size = new System.Drawing.Size(84, 25);
+            this.L_FMParticipated.TabIndex = 5;
             this.L_FMParticipated.Text = "Participated";
             this.L_FMParticipated.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // L_FMHosted
             // 
-            this.L_FMHosted.Location = new System.Drawing.Point(5, 252);
-            this.L_FMHosted.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.L_FMHosted.Location = new System.Drawing.Point(4, 205);
             this.L_FMHosted.Name = "L_FMHosted";
-            this.L_FMHosted.Size = new System.Drawing.Size(112, 31);
-            this.L_FMHosted.TabIndex = 13;
+            this.L_FMHosted.Size = new System.Drawing.Size(84, 25);
+            this.L_FMHosted.TabIndex = 3;
             this.L_FMHosted.Text = "Hosted";
             this.L_FMHosted.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // L_FMTopScore
             // 
-            this.L_FMTopScore.Location = new System.Drawing.Point(211, 286);
-            this.L_FMTopScore.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.L_FMTopScore.Location = new System.Drawing.Point(158, 232);
             this.L_FMTopScore.Name = "L_FMTopScore";
-            this.L_FMTopScore.Size = new System.Drawing.Size(148, 31);
-            this.L_FMTopScore.TabIndex = 12;
+            this.L_FMTopScore.Size = new System.Drawing.Size(111, 25);
+            this.L_FMTopScore.TabIndex = 7;
             this.L_FMTopScore.Text = "Top Score";
             this.L_FMTopScore.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
@@ -468,28 +443,25 @@
             this.GB_EntreeLevel.Controls.Add(this.NUD_EntreeWhiteLV);
             this.GB_EntreeLevel.Controls.Add(this.L_EntreeBlack);
             this.GB_EntreeLevel.Controls.Add(this.L_EntreeWhite);
-            this.GB_EntreeLevel.Location = new System.Drawing.Point(8, 9);
-            this.GB_EntreeLevel.Margin = new System.Windows.Forms.Padding(4);
+            this.GB_EntreeLevel.Location = new System.Drawing.Point(6, 7);
             this.GB_EntreeLevel.Name = "GB_EntreeLevel";
-            this.GB_EntreeLevel.Padding = new System.Windows.Forms.Padding(4);
-            this.GB_EntreeLevel.Size = new System.Drawing.Size(183, 91);
-            this.GB_EntreeLevel.TabIndex = 11;
+            this.GB_EntreeLevel.Size = new System.Drawing.Size(137, 74);
+            this.GB_EntreeLevel.TabIndex = 0;
             this.GB_EntreeLevel.TabStop = false;
             this.GB_EntreeLevel.Text = "Entree Level";
             // 
             // NUD_EntreeWhiteEXP
             // 
             this.NUD_EntreeWhiteEXP.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.NUD_EntreeWhiteEXP.Location = new System.Drawing.Point(125, 58);
-            this.NUD_EntreeWhiteEXP.Margin = new System.Windows.Forms.Padding(4);
+            this.NUD_EntreeWhiteEXP.Location = new System.Drawing.Point(94, 47);
             this.NUD_EntreeWhiteEXP.Maximum = new decimal(new int[] {
             49,
             0,
             0,
             0});
             this.NUD_EntreeWhiteEXP.Name = "NUD_EntreeWhiteEXP";
-            this.NUD_EntreeWhiteEXP.Size = new System.Drawing.Size(49, 22);
-            this.NUD_EntreeWhiteEXP.TabIndex = 6;
+            this.NUD_EntreeWhiteEXP.Size = new System.Drawing.Size(37, 20);
+            this.NUD_EntreeWhiteEXP.TabIndex = 5;
             this.NUD_EntreeWhiteEXP.Value = new decimal(new int[] {
             49,
             0,
@@ -500,16 +472,15 @@
             // NUD_EntreeBlackEXP
             // 
             this.NUD_EntreeBlackEXP.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.NUD_EntreeBlackEXP.Location = new System.Drawing.Point(125, 25);
-            this.NUD_EntreeBlackEXP.Margin = new System.Windows.Forms.Padding(4);
+            this.NUD_EntreeBlackEXP.Location = new System.Drawing.Point(94, 20);
             this.NUD_EntreeBlackEXP.Maximum = new decimal(new int[] {
             49,
             0,
             0,
             0});
             this.NUD_EntreeBlackEXP.Name = "NUD_EntreeBlackEXP";
-            this.NUD_EntreeBlackEXP.Size = new System.Drawing.Size(49, 22);
-            this.NUD_EntreeBlackEXP.TabIndex = 5;
+            this.NUD_EntreeBlackEXP.Size = new System.Drawing.Size(37, 20);
+            this.NUD_EntreeBlackEXP.TabIndex = 2;
             this.NUD_EntreeBlackEXP.Value = new decimal(new int[] {
             49,
             0,
@@ -520,15 +491,14 @@
             // NUD_EntreeBlackLV
             // 
             this.NUD_EntreeBlackLV.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.NUD_EntreeBlackLV.Location = new System.Drawing.Point(60, 25);
-            this.NUD_EntreeBlackLV.Margin = new System.Windows.Forms.Padding(4);
+            this.NUD_EntreeBlackLV.Location = new System.Drawing.Point(45, 20);
             this.NUD_EntreeBlackLV.Maximum = new decimal(new int[] {
             999,
             0,
             0,
             0});
             this.NUD_EntreeBlackLV.Name = "NUD_EntreeBlackLV";
-            this.NUD_EntreeBlackLV.Size = new System.Drawing.Size(57, 22);
+            this.NUD_EntreeBlackLV.Size = new System.Drawing.Size(43, 20);
             this.NUD_EntreeBlackLV.TabIndex = 1;
             this.NUD_EntreeBlackLV.Value = new decimal(new int[] {
             999,
@@ -540,16 +510,15 @@
             // NUD_EntreeWhiteLV
             // 
             this.NUD_EntreeWhiteLV.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.NUD_EntreeWhiteLV.Location = new System.Drawing.Point(60, 58);
-            this.NUD_EntreeWhiteLV.Margin = new System.Windows.Forms.Padding(4);
+            this.NUD_EntreeWhiteLV.Location = new System.Drawing.Point(45, 47);
             this.NUD_EntreeWhiteLV.Maximum = new decimal(new int[] {
             999,
             0,
             0,
             0});
             this.NUD_EntreeWhiteLV.Name = "NUD_EntreeWhiteLV";
-            this.NUD_EntreeWhiteLV.Size = new System.Drawing.Size(57, 22);
-            this.NUD_EntreeWhiteLV.TabIndex = 0;
+            this.NUD_EntreeWhiteLV.Size = new System.Drawing.Size(43, 20);
+            this.NUD_EntreeWhiteLV.TabIndex = 4;
             this.NUD_EntreeWhiteLV.Value = new decimal(new int[] {
             999,
             0,
@@ -560,37 +529,34 @@
             // L_EntreeBlack
             // 
             this.L_EntreeBlack.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.L_EntreeBlack.Location = new System.Drawing.Point(8, 20);
-            this.L_EntreeBlack.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.L_EntreeBlack.Location = new System.Drawing.Point(6, 16);
             this.L_EntreeBlack.Name = "L_EntreeBlack";
-            this.L_EntreeBlack.Size = new System.Drawing.Size(44, 31);
-            this.L_EntreeBlack.TabIndex = 3;
+            this.L_EntreeBlack.Size = new System.Drawing.Size(33, 25);
+            this.L_EntreeBlack.TabIndex = 0;
             this.L_EntreeBlack.Text = "B";
             this.L_EntreeBlack.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // L_EntreeWhite
             // 
             this.L_EntreeWhite.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.L_EntreeWhite.Location = new System.Drawing.Point(7, 53);
-            this.L_EntreeWhite.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.L_EntreeWhite.Location = new System.Drawing.Point(5, 43);
             this.L_EntreeWhite.Name = "L_EntreeWhite";
-            this.L_EntreeWhite.Size = new System.Drawing.Size(45, 31);
-            this.L_EntreeWhite.TabIndex = 4;
+            this.L_EntreeWhite.Size = new System.Drawing.Size(34, 25);
+            this.L_EntreeWhite.TabIndex = 3;
             this.L_EntreeWhite.Text = "W";
             this.L_EntreeWhite.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // NUD_FMMostParticipants
             // 
-            this.NUD_FMMostParticipants.Location = new System.Drawing.Point(375, 322);
-            this.NUD_FMMostParticipants.Margin = new System.Windows.Forms.Padding(4);
+            this.NUD_FMMostParticipants.Location = new System.Drawing.Point(281, 262);
             this.NUD_FMMostParticipants.Maximum = new decimal(new int[] {
             255,
             0,
             0,
             0});
             this.NUD_FMMostParticipants.Name = "NUD_FMMostParticipants";
-            this.NUD_FMMostParticipants.Size = new System.Drawing.Size(57, 22);
-            this.NUD_FMMostParticipants.TabIndex = 10;
+            this.NUD_FMMostParticipants.Size = new System.Drawing.Size(43, 20);
+            this.NUD_FMMostParticipants.TabIndex = 12;
             this.NUD_FMMostParticipants.Value = new decimal(new int[] {
             255,
             0,
@@ -599,16 +565,15 @@
             // 
             // NUD_FMTopScores
             // 
-            this.NUD_FMTopScores.Location = new System.Drawing.Point(367, 289);
-            this.NUD_FMTopScores.Margin = new System.Windows.Forms.Padding(4);
+            this.NUD_FMTopScores.Location = new System.Drawing.Point(275, 235);
             this.NUD_FMTopScores.Maximum = new decimal(new int[] {
             9999,
             0,
             0,
             0});
             this.NUD_FMTopScores.Name = "NUD_FMTopScores";
-            this.NUD_FMTopScores.Size = new System.Drawing.Size(65, 22);
-            this.NUD_FMTopScores.TabIndex = 9;
+            this.NUD_FMTopScores.Size = new System.Drawing.Size(49, 20);
+            this.NUD_FMTopScores.TabIndex = 8;
             this.NUD_FMTopScores.Value = new decimal(new int[] {
             9999,
             0,
@@ -617,16 +582,15 @@
             // 
             // NUD_FMCompleted
             // 
-            this.NUD_FMCompleted.Location = new System.Drawing.Point(125, 322);
-            this.NUD_FMCompleted.Margin = new System.Windows.Forms.Padding(4);
+            this.NUD_FMCompleted.Location = new System.Drawing.Point(94, 262);
             this.NUD_FMCompleted.Maximum = new decimal(new int[] {
             9999,
             0,
             0,
             0});
             this.NUD_FMCompleted.Name = "NUD_FMCompleted";
-            this.NUD_FMCompleted.Size = new System.Drawing.Size(65, 22);
-            this.NUD_FMCompleted.TabIndex = 8;
+            this.NUD_FMCompleted.Size = new System.Drawing.Size(49, 20);
+            this.NUD_FMCompleted.TabIndex = 10;
             this.NUD_FMCompleted.Value = new decimal(new int[] {
             9999,
             0,
@@ -635,16 +599,15 @@
             // 
             // NUD_FMParticipated
             // 
-            this.NUD_FMParticipated.Location = new System.Drawing.Point(125, 289);
-            this.NUD_FMParticipated.Margin = new System.Windows.Forms.Padding(4);
+            this.NUD_FMParticipated.Location = new System.Drawing.Point(94, 235);
             this.NUD_FMParticipated.Maximum = new decimal(new int[] {
             9999,
             0,
             0,
             0});
             this.NUD_FMParticipated.Name = "NUD_FMParticipated";
-            this.NUD_FMParticipated.Size = new System.Drawing.Size(65, 22);
-            this.NUD_FMParticipated.TabIndex = 7;
+            this.NUD_FMParticipated.Size = new System.Drawing.Size(49, 20);
+            this.NUD_FMParticipated.TabIndex = 6;
             this.NUD_FMParticipated.Value = new decimal(new int[] {
             9999,
             0,
@@ -653,16 +616,15 @@
             // 
             // NUD_FMHosted
             // 
-            this.NUD_FMHosted.Location = new System.Drawing.Point(125, 256);
-            this.NUD_FMHosted.Margin = new System.Windows.Forms.Padding(4);
+            this.NUD_FMHosted.Location = new System.Drawing.Point(94, 208);
             this.NUD_FMHosted.Maximum = new decimal(new int[] {
             9999,
             0,
             0,
             0});
             this.NUD_FMHosted.Name = "NUD_FMHosted";
-            this.NUD_FMHosted.Size = new System.Drawing.Size(65, 22);
-            this.NUD_FMHosted.TabIndex = 6;
+            this.NUD_FMHosted.Size = new System.Drawing.Size(49, 20);
+            this.NUD_FMHosted.TabIndex = 4;
             this.NUD_FMHosted.Value = new decimal(new int[] {
             9999,
             0,
@@ -683,43 +645,38 @@
             this.GB_FunfestMissions.Controls.Add(this.L_FMUnlocked);
             this.GB_FunfestMissions.Controls.Add(this.B_FunfestMissions);
             this.GB_FunfestMissions.Controls.Add(this.LB_FunfestMissions);
-            this.GB_FunfestMissions.Location = new System.Drawing.Point(199, 9);
-            this.GB_FunfestMissions.Margin = new System.Windows.Forms.Padding(4);
+            this.GB_FunfestMissions.Location = new System.Drawing.Point(149, 7);
             this.GB_FunfestMissions.Name = "GB_FunfestMissions";
-            this.GB_FunfestMissions.Padding = new System.Windows.Forms.Padding(4);
-            this.GB_FunfestMissions.Size = new System.Drawing.Size(237, 273);
-            this.GB_FunfestMissions.TabIndex = 5;
+            this.GB_FunfestMissions.Size = new System.Drawing.Size(178, 222);
+            this.GB_FunfestMissions.TabIndex = 1;
             this.GB_FunfestMissions.TabStop = false;
             this.GB_FunfestMissions.Text = "Funfest Missions";
             // 
             // CHK_FMNew
             // 
-            this.CHK_FMNew.Location = new System.Drawing.Point(8, 236);
-            this.CHK_FMNew.Margin = new System.Windows.Forms.Padding(4);
+            this.CHK_FMNew.Location = new System.Drawing.Point(6, 192);
             this.CHK_FMNew.Name = "CHK_FMNew";
-            this.CHK_FMNew.Size = new System.Drawing.Size(88, 32);
-            this.CHK_FMNew.TabIndex = 9;
+            this.CHK_FMNew.Size = new System.Drawing.Size(66, 26);
+            this.CHK_FMNew.TabIndex = 6;
             this.CHK_FMNew.Text = "NEW";
             this.CHK_FMNew.UseVisualStyleBackColor = true;
             this.CHK_FMNew.CheckedChanged += new System.EventHandler(this.CHK_FMNew_CheckedChanged);
             // 
             // L_FMLocked
             // 
-            this.L_FMLocked.Location = new System.Drawing.Point(8, 170);
-            this.L_FMLocked.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.L_FMLocked.Location = new System.Drawing.Point(6, 138);
             this.L_FMLocked.Name = "L_FMLocked";
-            this.L_FMLocked.Size = new System.Drawing.Size(93, 31);
-            this.L_FMLocked.TabIndex = 8;
+            this.L_FMLocked.Size = new System.Drawing.Size(70, 25);
+            this.L_FMLocked.TabIndex = 2;
             this.L_FMLocked.Text = "Locked";
             this.L_FMLocked.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // L_FMBestScore
             // 
             this.L_FMBestScore.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.L_FMBestScore.Location = new System.Drawing.Point(87, 236);
-            this.L_FMBestScore.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.L_FMBestScore.Location = new System.Drawing.Point(65, 192);
             this.L_FMBestScore.Name = "L_FMBestScore";
-            this.L_FMBestScore.Size = new System.Drawing.Size(69, 31);
+            this.L_FMBestScore.Size = new System.Drawing.Size(52, 25);
             this.L_FMBestScore.TabIndex = 7;
             this.L_FMBestScore.Text = "Score";
             this.L_FMBestScore.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
@@ -727,42 +684,39 @@
             // L_FMBestTotal
             // 
             this.L_FMBestTotal.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.L_FMBestTotal.Location = new System.Drawing.Point(5, 203);
-            this.L_FMBestTotal.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.L_FMBestTotal.Location = new System.Drawing.Point(4, 165);
             this.L_FMBestTotal.Name = "L_FMBestTotal";
-            this.L_FMBestTotal.Size = new System.Drawing.Size(151, 31);
-            this.L_FMBestTotal.TabIndex = 6;
+            this.L_FMBestTotal.Size = new System.Drawing.Size(113, 25);
+            this.L_FMBestTotal.TabIndex = 4;
             this.L_FMBestTotal.Text = "Best Records Total";
             this.L_FMBestTotal.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // NUD_FMBestScore
             // 
             this.NUD_FMBestScore.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.NUD_FMBestScore.Location = new System.Drawing.Point(164, 240);
-            this.NUD_FMBestScore.Margin = new System.Windows.Forms.Padding(4);
+            this.NUD_FMBestScore.Location = new System.Drawing.Point(123, 195);
             this.NUD_FMBestScore.Maximum = new decimal(new int[] {
             9999,
             0,
             0,
             0});
             this.NUD_FMBestScore.Name = "NUD_FMBestScore";
-            this.NUD_FMBestScore.Size = new System.Drawing.Size(65, 22);
-            this.NUD_FMBestScore.TabIndex = 5;
+            this.NUD_FMBestScore.Size = new System.Drawing.Size(49, 20);
+            this.NUD_FMBestScore.TabIndex = 8;
             this.NUD_FMBestScore.ValueChanged += new System.EventHandler(this.NUD_FMBestScore_ValueChanged);
             // 
             // NUD_FMBestTotal
             // 
             this.NUD_FMBestTotal.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.NUD_FMBestTotal.Location = new System.Drawing.Point(164, 207);
-            this.NUD_FMBestTotal.Margin = new System.Windows.Forms.Padding(4);
+            this.NUD_FMBestTotal.Location = new System.Drawing.Point(123, 168);
             this.NUD_FMBestTotal.Maximum = new decimal(new int[] {
             9999,
             0,
             0,
             0});
             this.NUD_FMBestTotal.Name = "NUD_FMBestTotal";
-            this.NUD_FMBestTotal.Size = new System.Drawing.Size(65, 22);
-            this.NUD_FMBestTotal.TabIndex = 4;
+            this.NUD_FMBestTotal.Size = new System.Drawing.Size(49, 20);
+            this.NUD_FMBestTotal.TabIndex = 5;
             this.NUD_FMBestTotal.ValueChanged += new System.EventHandler(this.NUD_FMBestTotal_ValueChanged);
             // 
             // CB_FMLevel
@@ -771,29 +725,26 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.CB_FMLevel.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.CB_FMLevel.FormattingEnabled = true;
-            this.CB_FMLevel.Location = new System.Drawing.Point(109, 172);
-            this.CB_FMLevel.Margin = new System.Windows.Forms.Padding(4);
+            this.CB_FMLevel.Location = new System.Drawing.Point(82, 140);
             this.CB_FMLevel.Name = "CB_FMLevel";
-            this.CB_FMLevel.Size = new System.Drawing.Size(119, 24);
+            this.CB_FMLevel.Size = new System.Drawing.Size(90, 21);
             this.CB_FMLevel.TabIndex = 3;
             this.CB_FMLevel.SelectedIndexChanged += new System.EventHandler(this.CB_FMLevel_SelectedIndexChanged);
             // 
             // L_FMUnlocked
             // 
-            this.L_FMUnlocked.Location = new System.Drawing.Point(8, 170);
-            this.L_FMUnlocked.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.L_FMUnlocked.Location = new System.Drawing.Point(6, 138);
             this.L_FMUnlocked.Name = "L_FMUnlocked";
-            this.L_FMUnlocked.Size = new System.Drawing.Size(93, 31);
+            this.L_FMUnlocked.Size = new System.Drawing.Size(70, 25);
             this.L_FMUnlocked.TabIndex = 2;
             this.L_FMUnlocked.Text = "Unlocked";
             this.L_FMUnlocked.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // B_FunfestMissions
             // 
-            this.B_FunfestMissions.Location = new System.Drawing.Point(8, 25);
-            this.B_FunfestMissions.Margin = new System.Windows.Forms.Padding(4);
+            this.B_FunfestMissions.Location = new System.Drawing.Point(6, 20);
             this.B_FunfestMissions.Name = "B_FunfestMissions";
-            this.B_FunfestMissions.Size = new System.Drawing.Size(192, 31);
+            this.B_FunfestMissions.Size = new System.Drawing.Size(144, 25);
             this.B_FunfestMissions.TabIndex = 0;
             this.B_FunfestMissions.Text = "Unlock All (w/o No.0)";
             this.B_FunfestMissions.UseVisualStyleBackColor = true;
@@ -804,11 +755,9 @@
             this.LB_FunfestMissions.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.LB_FunfestMissions.FormattingEnabled = true;
-            this.LB_FunfestMissions.ItemHeight = 16;
-            this.LB_FunfestMissions.Location = new System.Drawing.Point(8, 63);
-            this.LB_FunfestMissions.Margin = new System.Windows.Forms.Padding(4);
+            this.LB_FunfestMissions.Location = new System.Drawing.Point(6, 51);
             this.LB_FunfestMissions.Name = "LB_FunfestMissions";
-            this.LB_FunfestMissions.Size = new System.Drawing.Size(220, 100);
+            this.LB_FunfestMissions.Size = new System.Drawing.Size(166, 82);
             this.LB_FunfestMissions.TabIndex = 1;
             this.LB_FunfestMissions.SelectedIndexChanged += new System.EventHandler(this.LB_FunfestMissions_SelectedIndexChanged);
             // 
@@ -817,11 +766,9 @@
             this.GB_PassPowers.Controls.Add(this.CB_PassPower3);
             this.GB_PassPowers.Controls.Add(this.CB_PassPower2);
             this.GB_PassPowers.Controls.Add(this.CB_PassPower1);
-            this.GB_PassPowers.Location = new System.Drawing.Point(8, 107);
-            this.GB_PassPowers.Margin = new System.Windows.Forms.Padding(4);
+            this.GB_PassPowers.Location = new System.Drawing.Point(6, 87);
             this.GB_PassPowers.Name = "GB_PassPowers";
-            this.GB_PassPowers.Padding = new System.Windows.Forms.Padding(4);
-            this.GB_PassPowers.Size = new System.Drawing.Size(183, 128);
+            this.GB_PassPowers.Size = new System.Drawing.Size(137, 104);
             this.GB_PassPowers.TabIndex = 2;
             this.GB_PassPowers.TabStop = false;
             this.GB_PassPowers.Text = "Pass Powers";
@@ -832,10 +779,9 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.CB_PassPower3.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.CB_PassPower3.FormattingEnabled = true;
-            this.CB_PassPower3.Location = new System.Drawing.Point(8, 94);
-            this.CB_PassPower3.Margin = new System.Windows.Forms.Padding(4);
+            this.CB_PassPower3.Location = new System.Drawing.Point(6, 76);
             this.CB_PassPower3.Name = "CB_PassPower3";
-            this.CB_PassPower3.Size = new System.Drawing.Size(165, 24);
+            this.CB_PassPower3.Size = new System.Drawing.Size(125, 21);
             this.CB_PassPower3.TabIndex = 2;
             // 
             // CB_PassPower2
@@ -844,10 +790,9 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.CB_PassPower2.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.CB_PassPower2.FormattingEnabled = true;
-            this.CB_PassPower2.Location = new System.Drawing.Point(8, 59);
-            this.CB_PassPower2.Margin = new System.Windows.Forms.Padding(4);
+            this.CB_PassPower2.Location = new System.Drawing.Point(6, 48);
             this.CB_PassPower2.Name = "CB_PassPower2";
-            this.CB_PassPower2.Size = new System.Drawing.Size(165, 24);
+            this.CB_PassPower2.Size = new System.Drawing.Size(125, 21);
             this.CB_PassPower2.TabIndex = 1;
             // 
             // CB_PassPower1
@@ -856,10 +801,9 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.CB_PassPower1.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.CB_PassPower1.FormattingEnabled = true;
-            this.CB_PassPower1.Location = new System.Drawing.Point(8, 25);
-            this.CB_PassPower1.Margin = new System.Windows.Forms.Padding(4);
+            this.CB_PassPower1.Location = new System.Drawing.Point(6, 20);
             this.CB_PassPower1.Name = "CB_PassPower1";
-            this.CB_PassPower1.Size = new System.Drawing.Size(165, 24);
+            this.CB_PassPower1.Size = new System.Drawing.Size(125, 21);
             this.CB_PassPower1.TabIndex = 0;
             // 
             // TAB_Forest
@@ -882,11 +826,10 @@
             this.TAB_Forest.Controls.Add(this.CB_Species);
             this.TAB_Forest.Controls.Add(this.CB_Areas);
             this.TAB_Forest.Controls.Add(this.LB_Slots);
-            this.TAB_Forest.Location = new System.Drawing.Point(4, 25);
-            this.TAB_Forest.Margin = new System.Windows.Forms.Padding(4);
+            this.TAB_Forest.Location = new System.Drawing.Point(4, 22);
             this.TAB_Forest.Name = "TAB_Forest";
-            this.TAB_Forest.Padding = new System.Windows.Forms.Padding(4);
-            this.TAB_Forest.Size = new System.Drawing.Size(447, 361);
+            this.TAB_Forest.Padding = new System.Windows.Forms.Padding(3, 3, 3, 3);
+            this.TAB_Forest.Size = new System.Drawing.Size(333, 291);
             this.TAB_Forest.TabIndex = 2;
             this.TAB_Forest.Text = "Forest";
             this.TAB_Forest.UseVisualStyleBackColor = true;
@@ -895,11 +838,10 @@
             // 
             this.B_RandForest.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.B_RandForest.Location = new System.Drawing.Point(189, 101);
-            this.B_RandForest.Margin = new System.Windows.Forms.Padding(4);
+            this.B_RandForest.Location = new System.Drawing.Point(142, 82);
             this.B_RandForest.Name = "B_RandForest";
-            this.B_RandForest.Size = new System.Drawing.Size(247, 28);
-            this.B_RandForest.TabIndex = 17;
+            this.B_RandForest.Size = new System.Drawing.Size(185, 23);
+            this.B_RandForest.TabIndex = 5;
             this.B_RandForest.Text = "Randomize All Areas";
             this.B_RandForest.UseVisualStyleBackColor = true;
             this.B_RandForest.Click += new System.EventHandler(this.B_RandForest_Click);
@@ -907,8 +849,7 @@
             // NUD_Unlocked
             // 
             this.NUD_Unlocked.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.NUD_Unlocked.Location = new System.Drawing.Point(387, 41);
-            this.NUD_Unlocked.Margin = new System.Windows.Forms.Padding(4);
+            this.NUD_Unlocked.Location = new System.Drawing.Point(290, 33);
             this.NUD_Unlocked.Maximum = new decimal(new int[] {
             8,
             0,
@@ -920,8 +861,8 @@
             0,
             0});
             this.NUD_Unlocked.Name = "NUD_Unlocked";
-            this.NUD_Unlocked.Size = new System.Drawing.Size(49, 22);
-            this.NUD_Unlocked.TabIndex = 16;
+            this.NUD_Unlocked.Size = new System.Drawing.Size(37, 20);
+            this.NUD_Unlocked.TabIndex = 3;
             this.NUD_Unlocked.Value = new decimal(new int[] {
             2,
             0,
@@ -932,11 +873,10 @@
             // 
             this.L_Area18.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.L_Area18.Location = new System.Drawing.Point(185, 41);
-            this.L_Area18.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.L_Area18.Location = new System.Drawing.Point(139, 33);
             this.L_Area18.Name = "L_Area18";
-            this.L_Area18.Size = new System.Drawing.Size(193, 26);
-            this.L_Area18.TabIndex = 15;
+            this.L_Area18.Size = new System.Drawing.Size(145, 21);
+            this.L_Area18.TabIndex = 2;
             this.L_Area18.Text = "Areas 1-8 Unlocked:";
             this.L_Area18.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
@@ -945,11 +885,10 @@
             this.CHK_Area9.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.CHK_Area9.AutoSize = true;
             this.CHK_Area9.CheckAlign = System.Drawing.ContentAlignment.MiddleRight;
-            this.CHK_Area9.Location = new System.Drawing.Point(297, 73);
-            this.CHK_Area9.Margin = new System.Windows.Forms.Padding(4);
+            this.CHK_Area9.Location = new System.Drawing.Point(218, 59);
             this.CHK_Area9.Name = "CHK_Area9";
-            this.CHK_Area9.Size = new System.Drawing.Size(139, 21);
-            this.CHK_Area9.TabIndex = 14;
+            this.CHK_Area9.Size = new System.Drawing.Size(109, 17);
+            this.CHK_Area9.TabIndex = 4;
             this.CHK_Area9.Text = "Area 9 Unlocked:";
             this.CHK_Area9.UseVisualStyleBackColor = true;
             // 
@@ -957,10 +896,9 @@
             // 
             this.PB_SlotPreview.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.PB_SlotPreview.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.PB_SlotPreview.Location = new System.Drawing.Point(275, 162);
-            this.PB_SlotPreview.Margin = new System.Windows.Forms.Padding(4);
+            this.PB_SlotPreview.Location = new System.Drawing.Point(206, 132);
             this.PB_SlotPreview.Name = "PB_SlotPreview";
-            this.PB_SlotPreview.Size = new System.Drawing.Size(55, 39);
+            this.PB_SlotPreview.Size = new System.Drawing.Size(42, 32);
             this.PB_SlotPreview.TabIndex = 13;
             this.PB_SlotPreview.TabStop = false;
             // 
@@ -968,11 +906,10 @@
             // 
             this.CHK_Invisible.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.CHK_Invisible.AutoSize = true;
-            this.CHK_Invisible.Location = new System.Drawing.Point(338, 334);
-            this.CHK_Invisible.Margin = new System.Windows.Forms.Padding(4);
+            this.CHK_Invisible.Location = new System.Drawing.Point(250, 271);
             this.CHK_Invisible.Name = "CHK_Invisible";
-            this.CHK_Invisible.Size = new System.Drawing.Size(80, 21);
-            this.CHK_Invisible.TabIndex = 12;
+            this.CHK_Invisible.Size = new System.Drawing.Size(64, 17);
+            this.CHK_Invisible.TabIndex = 16;
             this.CHK_Invisible.Text = "Invisible";
             this.CHK_Invisible.UseVisualStyleBackColor = true;
             this.CHK_Invisible.CheckedChanged += new System.EventHandler(this.UpdateSlotValue);
@@ -981,38 +918,35 @@
             // 
             this.L_Animation.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.L_Animation.Location = new System.Drawing.Point(185, 327);
-            this.L_Animation.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.L_Animation.Location = new System.Drawing.Point(139, 266);
             this.L_Animation.Name = "L_Animation";
-            this.L_Animation.Size = new System.Drawing.Size(81, 26);
-            this.L_Animation.TabIndex = 11;
+            this.L_Animation.Size = new System.Drawing.Size(61, 21);
+            this.L_Animation.TabIndex = 14;
             this.L_Animation.Text = "Animation:";
             this.L_Animation.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // NUD_Animation
             // 
             this.NUD_Animation.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.NUD_Animation.Location = new System.Drawing.Point(275, 330);
-            this.NUD_Animation.Margin = new System.Windows.Forms.Padding(4);
+            this.NUD_Animation.Location = new System.Drawing.Point(206, 268);
             this.NUD_Animation.Maximum = new decimal(new int[] {
             5,
             0,
             0,
             0});
             this.NUD_Animation.Name = "NUD_Animation";
-            this.NUD_Animation.Size = new System.Drawing.Size(49, 22);
-            this.NUD_Animation.TabIndex = 10;
+            this.NUD_Animation.Size = new System.Drawing.Size(37, 20);
+            this.NUD_Animation.TabIndex = 15;
             this.NUD_Animation.ValueChanged += new System.EventHandler(this.UpdateSlotValue);
             // 
             // L_Gender
             // 
             this.L_Gender.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.L_Gender.Location = new System.Drawing.Point(185, 266);
-            this.L_Gender.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.L_Gender.Location = new System.Drawing.Point(139, 216);
             this.L_Gender.Name = "L_Gender";
-            this.L_Gender.Size = new System.Drawing.Size(81, 26);
-            this.L_Gender.TabIndex = 9;
+            this.L_Gender.Size = new System.Drawing.Size(61, 21);
+            this.L_Gender.TabIndex = 10;
             this.L_Gender.Text = "Gender:";
             this.L_Gender.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
@@ -1021,22 +955,20 @@
             this.CB_Gender.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.CB_Gender.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.CB_Gender.FormattingEnabled = true;
-            this.CB_Gender.Location = new System.Drawing.Point(275, 266);
-            this.CB_Gender.Margin = new System.Windows.Forms.Padding(4);
+            this.CB_Gender.Location = new System.Drawing.Point(206, 216);
             this.CB_Gender.Name = "CB_Gender";
-            this.CB_Gender.Size = new System.Drawing.Size(160, 24);
-            this.CB_Gender.TabIndex = 8;
+            this.CB_Gender.Size = new System.Drawing.Size(121, 21);
+            this.CB_Gender.TabIndex = 11;
             this.CB_Gender.SelectedIndexChanged += new System.EventHandler(this.UpdateSlotValue);
             // 
             // L_Move
             // 
             this.L_Move.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.L_Move.Location = new System.Drawing.Point(185, 293);
-            this.L_Move.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.L_Move.Location = new System.Drawing.Point(139, 238);
             this.L_Move.Name = "L_Move";
-            this.L_Move.Size = new System.Drawing.Size(81, 26);
-            this.L_Move.TabIndex = 7;
+            this.L_Move.Size = new System.Drawing.Size(61, 21);
+            this.L_Move.TabIndex = 12;
             this.L_Move.Text = "Move:";
             this.L_Move.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
@@ -1044,11 +976,10 @@
             // 
             this.L_Form.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.L_Form.Location = new System.Drawing.Point(185, 238);
-            this.L_Form.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.L_Form.Location = new System.Drawing.Point(139, 193);
             this.L_Form.Name = "L_Form";
-            this.L_Form.Size = new System.Drawing.Size(81, 26);
-            this.L_Form.TabIndex = 6;
+            this.L_Form.Size = new System.Drawing.Size(61, 21);
+            this.L_Form.TabIndex = 8;
             this.L_Form.Text = "Form:";
             this.L_Form.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
@@ -1056,11 +987,10 @@
             // 
             this.L_Species.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.L_Species.Location = new System.Drawing.Point(185, 209);
-            this.L_Species.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            this.L_Species.Location = new System.Drawing.Point(139, 170);
             this.L_Species.Name = "L_Species";
-            this.L_Species.Size = new System.Drawing.Size(81, 26);
-            this.L_Species.TabIndex = 5;
+            this.L_Species.Size = new System.Drawing.Size(61, 21);
+            this.L_Species.TabIndex = 6;
             this.L_Species.Text = "Species:";
             this.L_Species.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
@@ -1070,11 +1000,10 @@
             this.CB_Move.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
             this.CB_Move.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Move.FormattingEnabled = true;
-            this.CB_Move.Location = new System.Drawing.Point(275, 294);
-            this.CB_Move.Margin = new System.Windows.Forms.Padding(4);
+            this.CB_Move.Location = new System.Drawing.Point(206, 239);
             this.CB_Move.Name = "CB_Move";
-            this.CB_Move.Size = new System.Drawing.Size(160, 24);
-            this.CB_Move.TabIndex = 4;
+            this.CB_Move.Size = new System.Drawing.Size(121, 21);
+            this.CB_Move.TabIndex = 13;
             this.CB_Move.SelectedIndexChanged += new System.EventHandler(this.UpdateSlotValue);
             // 
             // CB_Form
@@ -1082,11 +1011,10 @@
             this.CB_Form.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.CB_Form.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.CB_Form.FormattingEnabled = true;
-            this.CB_Form.Location = new System.Drawing.Point(275, 238);
-            this.CB_Form.Margin = new System.Windows.Forms.Padding(4);
+            this.CB_Form.Location = new System.Drawing.Point(206, 193);
             this.CB_Form.Name = "CB_Form";
-            this.CB_Form.Size = new System.Drawing.Size(160, 24);
-            this.CB_Form.TabIndex = 3;
+            this.CB_Form.Size = new System.Drawing.Size(121, 21);
+            this.CB_Form.TabIndex = 9;
             this.CB_Form.SelectedIndexChanged += new System.EventHandler(this.UpdateSlotValue);
             // 
             // CB_Species
@@ -1095,11 +1023,10 @@
             this.CB_Species.AutoCompleteMode = System.Windows.Forms.AutoCompleteMode.SuggestAppend;
             this.CB_Species.AutoCompleteSource = System.Windows.Forms.AutoCompleteSource.ListItems;
             this.CB_Species.FormattingEnabled = true;
-            this.CB_Species.Location = new System.Drawing.Point(275, 209);
-            this.CB_Species.Margin = new System.Windows.Forms.Padding(4);
+            this.CB_Species.Location = new System.Drawing.Point(206, 170);
             this.CB_Species.Name = "CB_Species";
-            this.CB_Species.Size = new System.Drawing.Size(160, 24);
-            this.CB_Species.TabIndex = 2;
+            this.CB_Species.Size = new System.Drawing.Size(121, 21);
+            this.CB_Species.TabIndex = 7;
             this.CB_Species.SelectedIndexChanged += new System.EventHandler(this.UpdateSlotValue);
             // 
             // CB_Areas
@@ -1108,10 +1035,9 @@
             | System.Windows.Forms.AnchorStyles.Right)));
             this.CB_Areas.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.CB_Areas.FormattingEnabled = true;
-            this.CB_Areas.Location = new System.Drawing.Point(189, 7);
-            this.CB_Areas.Margin = new System.Windows.Forms.Padding(4);
+            this.CB_Areas.Location = new System.Drawing.Point(142, 6);
             this.CB_Areas.Name = "CB_Areas";
-            this.CB_Areas.Size = new System.Drawing.Size(245, 24);
+            this.CB_Areas.Size = new System.Drawing.Size(185, 21);
             this.CB_Areas.TabIndex = 1;
             this.CB_Areas.SelectedIndexChanged += new System.EventHandler(this.ChangeArea);
             // 
@@ -1119,11 +1045,9 @@
             // 
             this.LB_Slots.Dock = System.Windows.Forms.DockStyle.Left;
             this.LB_Slots.FormattingEnabled = true;
-            this.LB_Slots.ItemHeight = 16;
-            this.LB_Slots.Location = new System.Drawing.Point(4, 4);
-            this.LB_Slots.Margin = new System.Windows.Forms.Padding(4);
+            this.LB_Slots.Location = new System.Drawing.Point(3, 3);
             this.LB_Slots.Name = "LB_Slots";
-            this.LB_Slots.Size = new System.Drawing.Size(176, 353);
+            this.LB_Slots.Size = new System.Drawing.Size(133, 285);
             this.LB_Slots.TabIndex = 0;
             this.LB_Slots.SelectedIndexChanged += new System.EventHandler(this.ChangeSlot);
             // 
@@ -1136,402 +1060,162 @@
             this.TAB_Subway.Controls.Add(this.GB_Multi);
             this.TAB_Subway.Controls.Add(this.GB_Doubles);
             this.TAB_Subway.Controls.Add(this.GB_Singles);
-            this.TAB_Subway.Location = new System.Drawing.Point(4, 25);
+            this.TAB_Subway.Location = new System.Drawing.Point(4, 22);
+            this.TAB_Subway.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.TAB_Subway.Name = "TAB_Subway";
-            this.TAB_Subway.Padding = new System.Windows.Forms.Padding(3);
-            this.TAB_Subway.Size = new System.Drawing.Size(447, 361);
+            this.TAB_Subway.Padding = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.TAB_Subway.Size = new System.Drawing.Size(333, 291);
             this.TAB_Subway.TabIndex = 3;
             this.TAB_Subway.Text = "Subway";
             this.TAB_Subway.UseVisualStyleBackColor = true;
             // 
-            // GB_Multi
+            // GB_SuperChecks
             // 
-            this.GB_Multi.Controls.Add(this.L_MultiNPC);
-            this.GB_Multi.Controls.Add(this.L_MultiFriends);
-            this.GB_Multi.Controls.Add(this.L_MultiFriendsRecord);
-            this.GB_Multi.Controls.Add(this.NUD_MultiFriendsRecord);
-            this.GB_Multi.Controls.Add(this.L_MultiFriendsPast);
-            this.GB_Multi.Controls.Add(this.NUD_MultiFriendsPast);
-            this.GB_Multi.Controls.Add(this.L_MultiNpcRecord);
-            this.GB_Multi.Controls.Add(this.NUD_MultiNpcRecord);
-            this.GB_Multi.Controls.Add(this.L_MultiNpcPast);
-            this.GB_Multi.Controls.Add(this.NUD_MultiNpcPast);
-            this.GB_Multi.Location = new System.Drawing.Point(6, 173);
-            this.GB_Multi.Name = "GB_Multi";
-            this.GB_Multi.Size = new System.Drawing.Size(132, 171);
-            this.GB_Multi.TabIndex = 5;
-            this.GB_Multi.TabStop = false;
-            this.GB_Multi.Text = "Multi";
+            this.GB_SuperChecks.Controls.Add(this.CHK_SuperMulti);
+            this.GB_SuperChecks.Controls.Add(this.CHK_SuperDouble);
+            this.GB_SuperChecks.Controls.Add(this.CHK_SuperSingle);
+            this.GB_SuperChecks.Location = new System.Drawing.Point(212, 6);
+            this.GB_SuperChecks.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.GB_SuperChecks.Name = "GB_SuperChecks";
+            this.GB_SuperChecks.Padding = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.GB_SuperChecks.Size = new System.Drawing.Size(118, 87);
+            this.GB_SuperChecks.TabIndex = 3;
+            this.GB_SuperChecks.TabStop = false;
+            this.GB_SuperChecks.Text = "Super Checks";
             // 
-            // L_MultiFriendsRecord
+            // CHK_SuperMulti
             // 
-            this.L_MultiFriendsRecord.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.L_MultiFriendsRecord.Location = new System.Drawing.Point(11, 143);
-            this.L_MultiFriendsRecord.Name = "L_MultiFriendsRecord";
-            this.L_MultiFriendsRecord.Size = new System.Drawing.Size(55, 17);
-            this.L_MultiFriendsRecord.TabIndex = 7;
-            this.L_MultiFriendsRecord.Text = "Record";
-            this.L_MultiFriendsRecord.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            this.CHK_SuperMulti.AutoSize = true;
+            this.CHK_SuperMulti.Location = new System.Drawing.Point(9, 63);
+            this.CHK_SuperMulti.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.CHK_SuperMulti.Name = "CHK_SuperMulti";
+            this.CHK_SuperMulti.Size = new System.Drawing.Size(85, 17);
+            this.CHK_SuperMulti.TabIndex = 2;
+            this.CHK_SuperMulti.Text = "Super Multi?";
+            this.CHK_SuperMulti.UseVisualStyleBackColor = true;
             // 
-            // NUD_MultiFriendsRecord
+            // CHK_SuperDouble
             // 
-            this.NUD_MultiFriendsRecord.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.NUD_MultiFriendsRecord.Location = new System.Drawing.Point(71, 141);
-            this.NUD_MultiFriendsRecord.Name = "NUD_MultiFriendsRecord";
-            this.NUD_MultiFriendsRecord.Size = new System.Drawing.Size(55, 22);
-            this.NUD_MultiFriendsRecord.TabIndex = 6;
+            this.CHK_SuperDouble.AutoSize = true;
+            this.CHK_SuperDouble.Location = new System.Drawing.Point(9, 41);
+            this.CHK_SuperDouble.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.CHK_SuperDouble.Name = "CHK_SuperDouble";
+            this.CHK_SuperDouble.Size = new System.Drawing.Size(102, 17);
+            this.CHK_SuperDouble.TabIndex = 1;
+            this.CHK_SuperDouble.Text = "Super Doubles?";
+            this.CHK_SuperDouble.UseVisualStyleBackColor = true;
             // 
-            // L_MultiFriendsPast
+            // CHK_SuperSingle
             // 
-            this.L_MultiFriendsPast.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.L_MultiFriendsPast.Location = new System.Drawing.Point(10, 118);
-            this.L_MultiFriendsPast.Name = "L_MultiFriendsPast";
-            this.L_MultiFriendsPast.Size = new System.Drawing.Size(55, 17);
-            this.L_MultiFriendsPast.TabIndex = 5;
-            this.L_MultiFriendsPast.Text = "Past";
-            this.L_MultiFriendsPast.TextAlign = System.Drawing.ContentAlignment.TopRight;
-            // 
-            // NUD_MultiFriendsPast
-            // 
-            this.NUD_MultiFriendsPast.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.NUD_MultiFriendsPast.Location = new System.Drawing.Point(71, 116);
-            this.NUD_MultiFriendsPast.Name = "NUD_MultiFriendsPast";
-            this.NUD_MultiFriendsPast.Size = new System.Drawing.Size(55, 22);
-            this.NUD_MultiFriendsPast.TabIndex = 4;
-            // 
-            // L_MultiNpcRecord
-            // 
-            this.L_MultiNpcRecord.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.L_MultiNpcRecord.Location = new System.Drawing.Point(11, 68);
-            this.L_MultiNpcRecord.Name = "L_MultiNpcRecord";
-            this.L_MultiNpcRecord.Size = new System.Drawing.Size(55, 17);
-            this.L_MultiNpcRecord.TabIndex = 3;
-            this.L_MultiNpcRecord.Text = "Record";
-            this.L_MultiNpcRecord.TextAlign = System.Drawing.ContentAlignment.TopRight;
-            // 
-            // NUD_MultiNpcRecord
-            // 
-            this.NUD_MultiNpcRecord.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.NUD_MultiNpcRecord.Location = new System.Drawing.Point(71, 66);
-            this.NUD_MultiNpcRecord.Name = "NUD_MultiNpcRecord";
-            this.NUD_MultiNpcRecord.Size = new System.Drawing.Size(55, 22);
-            this.NUD_MultiNpcRecord.TabIndex = 2;
-            // 
-            // L_MultiNpcPast
-            // 
-            this.L_MultiNpcPast.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.L_MultiNpcPast.Location = new System.Drawing.Point(10, 43);
-            this.L_MultiNpcPast.Name = "L_MultiNpcPast";
-            this.L_MultiNpcPast.Size = new System.Drawing.Size(55, 17);
-            this.L_MultiNpcPast.TabIndex = 1;
-            this.L_MultiNpcPast.Text = "Past";
-            this.L_MultiNpcPast.TextAlign = System.Drawing.ContentAlignment.TopRight;
-            // 
-            // NUD_MultiNpcPast
-            // 
-            this.NUD_MultiNpcPast.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.NUD_MultiNpcPast.Location = new System.Drawing.Point(71, 41);
-            this.NUD_MultiNpcPast.Name = "NUD_MultiNpcPast";
-            this.NUD_MultiNpcPast.Size = new System.Drawing.Size(55, 22);
-            this.NUD_MultiNpcPast.TabIndex = 0;
-            // 
-            // GB_Doubles
-            // 
-            this.GB_Doubles.Controls.Add(this.L_DoubleRecord);
-            this.GB_Doubles.Controls.Add(this.NUD_DoubleRecord);
-            this.GB_Doubles.Controls.Add(this.L_DoublePast);
-            this.GB_Doubles.Controls.Add(this.NUD_DoublePast);
-            this.GB_Doubles.Location = new System.Drawing.Point(6, 90);
-            this.GB_Doubles.Name = "GB_Doubles";
-            this.GB_Doubles.Size = new System.Drawing.Size(132, 77);
-            this.GB_Doubles.TabIndex = 4;
-            this.GB_Doubles.TabStop = false;
-            this.GB_Doubles.Text = "Doubles";
-            // 
-            // L_DoubleRecord
-            // 
-            this.L_DoubleRecord.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.L_DoubleRecord.Location = new System.Drawing.Point(11, 49);
-            this.L_DoubleRecord.Name = "L_DoubleRecord";
-            this.L_DoubleRecord.Size = new System.Drawing.Size(55, 17);
-            this.L_DoubleRecord.TabIndex = 3;
-            this.L_DoubleRecord.Text = "Record";
-            this.L_DoubleRecord.TextAlign = System.Drawing.ContentAlignment.TopRight;
-            // 
-            // NUD_DoubleRecord
-            // 
-            this.NUD_DoubleRecord.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.NUD_DoubleRecord.Location = new System.Drawing.Point(71, 47);
-            this.NUD_DoubleRecord.Name = "NUD_DoubleRecord";
-            this.NUD_DoubleRecord.Size = new System.Drawing.Size(55, 22);
-            this.NUD_DoubleRecord.TabIndex = 2;
-            // 
-            // L_DoublePast
-            // 
-            this.L_DoublePast.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.L_DoublePast.Location = new System.Drawing.Point(10, 24);
-            this.L_DoublePast.Name = "L_DoublePast";
-            this.L_DoublePast.Size = new System.Drawing.Size(55, 17);
-            this.L_DoublePast.TabIndex = 1;
-            this.L_DoublePast.Text = "Past";
-            this.L_DoublePast.TextAlign = System.Drawing.ContentAlignment.TopRight;
-            // 
-            // NUD_DoublePast
-            // 
-            this.NUD_DoublePast.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.NUD_DoublePast.Location = new System.Drawing.Point(71, 22);
-            this.NUD_DoublePast.Name = "NUD_DoublePast";
-            this.NUD_DoublePast.Size = new System.Drawing.Size(55, 22);
-            this.NUD_DoublePast.TabIndex = 0;
-            // 
-            // GB_Singles
-            // 
-            this.GB_Singles.Controls.Add(this.L_SingleRecord);
-            this.GB_Singles.Controls.Add(this.NUD_SingleRecord);
-            this.GB_Singles.Controls.Add(this.L_SinglePast);
-            this.GB_Singles.Controls.Add(this.NUD_SinglePast);
-            this.GB_Singles.Location = new System.Drawing.Point(6, 7);
-            this.GB_Singles.Name = "GB_Singles";
-            this.GB_Singles.Size = new System.Drawing.Size(132, 77);
-            this.GB_Singles.TabIndex = 2;
-            this.GB_Singles.TabStop = false;
-            this.GB_Singles.Text = "Singles";
-            // 
-            // L_SingleRecord
-            // 
-            this.L_SingleRecord.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.L_SingleRecord.Location = new System.Drawing.Point(10, 50);
-            this.L_SingleRecord.Name = "L_SingleRecord";
-            this.L_SingleRecord.Size = new System.Drawing.Size(55, 17);
-            this.L_SingleRecord.TabIndex = 3;
-            this.L_SingleRecord.Text = "Record";
-            this.L_SingleRecord.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-            // 
-            // NUD_SingleRecord
-            // 
-            this.NUD_SingleRecord.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.NUD_SingleRecord.Location = new System.Drawing.Point(71, 48);
-            this.NUD_SingleRecord.Name = "NUD_SingleRecord";
-            this.NUD_SingleRecord.Size = new System.Drawing.Size(55, 22);
-            this.NUD_SingleRecord.TabIndex = 2;
-            // 
-            // L_SinglePast
-            // 
-            this.L_SinglePast.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.L_SinglePast.Location = new System.Drawing.Point(10, 24);
-            this.L_SinglePast.Name = "L_SinglePast";
-            this.L_SinglePast.Size = new System.Drawing.Size(55, 17);
-            this.L_SinglePast.TabIndex = 1;
-            this.L_SinglePast.Text = "Past";
-            this.L_SinglePast.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-            // 
-            // NUD_SinglePast
-            // 
-            this.NUD_SinglePast.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.NUD_SinglePast.Location = new System.Drawing.Point(71, 22);
-            this.NUD_SinglePast.Name = "NUD_SinglePast";
-            this.NUD_SinglePast.Size = new System.Drawing.Size(55, 22);
-            this.NUD_SinglePast.TabIndex = 0;
-            // 
-            // L_MultiNPC
-            // 
-            this.L_MultiNPC.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.L_MultiNPC.Location = new System.Drawing.Point(71, 21);
-            this.L_MultiNPC.Name = "L_MultiNPC";
-            this.L_MultiNPC.Size = new System.Drawing.Size(55, 17);
-            this.L_MultiNPC.TabIndex = 6;
-            this.L_MultiNPC.Text = "NPC";
-            this.L_MultiNPC.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-            // 
-            // L_MultiFriends
-            // 
-            this.L_MultiFriends.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.L_MultiFriends.Location = new System.Drawing.Point(71, 94);
-            this.L_MultiFriends.Name = "L_MultiFriends";
-            this.L_MultiFriends.Size = new System.Drawing.Size(55, 19);
-            this.L_MultiFriends.TabIndex = 7;
-            this.L_MultiFriends.Text = "Friends";
-            this.L_MultiFriends.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
-            // 
-            // GB_SuperSingles
-            // 
-            this.GB_SuperSingles.Controls.Add(this.L_SSingleRecord);
-            this.GB_SuperSingles.Controls.Add(this.NUD_SSingleRecord);
-            this.GB_SuperSingles.Controls.Add(this.L_SSinglePast);
-            this.GB_SuperSingles.Controls.Add(this.NUD_SSinglePast);
-            this.GB_SuperSingles.Location = new System.Drawing.Point(144, 7);
-            this.GB_SuperSingles.Name = "GB_SuperSingles";
-            this.GB_SuperSingles.Size = new System.Drawing.Size(132, 77);
-            this.GB_SuperSingles.TabIndex = 4;
-            this.GB_SuperSingles.TabStop = false;
-            this.GB_SuperSingles.Text = "Super Singles";
-            // 
-            // L_SSingleRecord
-            // 
-            this.L_SSingleRecord.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.L_SSingleRecord.Location = new System.Drawing.Point(10, 50);
-            this.L_SSingleRecord.Name = "L_SSingleRecord";
-            this.L_SSingleRecord.Size = new System.Drawing.Size(55, 17);
-            this.L_SSingleRecord.TabIndex = 3;
-            this.L_SSingleRecord.Text = "Record";
-            this.L_SSingleRecord.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-            // 
-            // NUD_SSingleRecord
-            // 
-            this.NUD_SSingleRecord.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.NUD_SSingleRecord.Location = new System.Drawing.Point(71, 48);
-            this.NUD_SSingleRecord.Name = "NUD_SSingleRecord";
-            this.NUD_SSingleRecord.Size = new System.Drawing.Size(55, 22);
-            this.NUD_SSingleRecord.TabIndex = 2;
-            // 
-            // L_SSinglePast
-            // 
-            this.L_SSinglePast.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.L_SSinglePast.Location = new System.Drawing.Point(10, 24);
-            this.L_SSinglePast.Name = "L_SSinglePast";
-            this.L_SSinglePast.Size = new System.Drawing.Size(55, 17);
-            this.L_SSinglePast.TabIndex = 1;
-            this.L_SSinglePast.Text = "Past";
-            this.L_SSinglePast.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-            // 
-            // NUD_SSinglePast
-            // 
-            this.NUD_SSinglePast.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.NUD_SSinglePast.Location = new System.Drawing.Point(71, 22);
-            this.NUD_SSinglePast.Name = "NUD_SSinglePast";
-            this.NUD_SSinglePast.Size = new System.Drawing.Size(55, 22);
-            this.NUD_SSinglePast.TabIndex = 0;
-            // 
-            // GB_SuperDoubles
-            // 
-            this.GB_SuperDoubles.Controls.Add(this.L_SDoubleRecord);
-            this.GB_SuperDoubles.Controls.Add(this.NUD_SDoubleRecord);
-            this.GB_SuperDoubles.Controls.Add(this.L_SDoublePast);
-            this.GB_SuperDoubles.Controls.Add(this.NUD_SDoublePast);
-            this.GB_SuperDoubles.Location = new System.Drawing.Point(144, 90);
-            this.GB_SuperDoubles.Name = "GB_SuperDoubles";
-            this.GB_SuperDoubles.Size = new System.Drawing.Size(132, 77);
-            this.GB_SuperDoubles.TabIndex = 5;
-            this.GB_SuperDoubles.TabStop = false;
-            this.GB_SuperDoubles.Text = "Super Doubles";
-            // 
-            // L_SDoubleRecord
-            // 
-            this.L_SDoubleRecord.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.L_SDoubleRecord.Location = new System.Drawing.Point(11, 49);
-            this.L_SDoubleRecord.Name = "L_SDoubleRecord";
-            this.L_SDoubleRecord.Size = new System.Drawing.Size(55, 17);
-            this.L_SDoubleRecord.TabIndex = 3;
-            this.L_SDoubleRecord.Text = "Record";
-            this.L_SDoubleRecord.TextAlign = System.Drawing.ContentAlignment.TopRight;
-            // 
-            // NUD_SDoubleRecord
-            // 
-            this.NUD_SDoubleRecord.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.NUD_SDoubleRecord.Location = new System.Drawing.Point(71, 47);
-            this.NUD_SDoubleRecord.Name = "NUD_SDoubleRecord";
-            this.NUD_SDoubleRecord.Size = new System.Drawing.Size(55, 22);
-            this.NUD_SDoubleRecord.TabIndex = 2;
-            // 
-            // L_SDoublePast
-            // 
-            this.L_SDoublePast.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.L_SDoublePast.Location = new System.Drawing.Point(10, 24);
-            this.L_SDoublePast.Name = "L_SDoublePast";
-            this.L_SDoublePast.Size = new System.Drawing.Size(55, 17);
-            this.L_SDoublePast.TabIndex = 1;
-            this.L_SDoublePast.Text = "Past";
-            this.L_SDoublePast.TextAlign = System.Drawing.ContentAlignment.TopRight;
-            // 
-            // NUD_SDoublePast
-            // 
-            this.NUD_SDoublePast.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.NUD_SDoublePast.Location = new System.Drawing.Point(71, 22);
-            this.NUD_SDoublePast.Name = "NUD_SDoublePast";
-            this.NUD_SDoublePast.Size = new System.Drawing.Size(55, 22);
-            this.NUD_SDoublePast.TabIndex = 0;
+            this.CHK_SuperSingle.AutoSize = true;
+            this.CHK_SuperSingle.Location = new System.Drawing.Point(9, 20);
+            this.CHK_SuperSingle.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.CHK_SuperSingle.Name = "CHK_SuperSingle";
+            this.CHK_SuperSingle.Size = new System.Drawing.Size(97, 17);
+            this.CHK_SuperSingle.TabIndex = 0;
+            this.CHK_SuperSingle.Text = "Super Singles?";
+            this.CHK_SuperSingle.UseVisualStyleBackColor = true;
             // 
             // GB_SuperMulti
             // 
             this.GB_SuperMulti.Controls.Add(this.L_SMultiNPC);
             this.GB_SuperMulti.Controls.Add(this.L_SMultiFriends);
-            this.GB_SuperMulti.Controls.Add(this.L_SMultiFriendsRecord);
             this.GB_SuperMulti.Controls.Add(this.NUD_SMultiFriendsRecord);
             this.GB_SuperMulti.Controls.Add(this.L_SMultiFriendsPast);
             this.GB_SuperMulti.Controls.Add(this.NUD_SMultiFriendsPast);
-            this.GB_SuperMulti.Controls.Add(this.L_SMultiNpcRecord);
             this.GB_SuperMulti.Controls.Add(this.NUD_SMultiNpcRecord);
             this.GB_SuperMulti.Controls.Add(this.L_SMultiNpcPast);
             this.GB_SuperMulti.Controls.Add(this.NUD_SMultiNpcPast);
-            this.GB_SuperMulti.Location = new System.Drawing.Point(144, 173);
+            this.GB_SuperMulti.Controls.Add(this.L_SMultiFriendsRecord);
+            this.GB_SuperMulti.Controls.Add(this.L_SMultiNpcRecord);
+            this.GB_SuperMulti.Location = new System.Drawing.Point(108, 141);
+            this.GB_SuperMulti.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
             this.GB_SuperMulti.Name = "GB_SuperMulti";
-            this.GB_SuperMulti.Size = new System.Drawing.Size(132, 171);
-            this.GB_SuperMulti.TabIndex = 8;
+            this.GB_SuperMulti.Padding = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.GB_SuperMulti.Size = new System.Drawing.Size(99, 139);
+            this.GB_SuperMulti.TabIndex = 7;
             this.GB_SuperMulti.TabStop = false;
             this.GB_SuperMulti.Text = "Super Multi";
             // 
             // L_SMultiNPC
             // 
             this.L_SMultiNPC.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.L_SMultiNPC.Location = new System.Drawing.Point(71, 21);
+            this.L_SMultiNPC.Location = new System.Drawing.Point(53, 17);
+            this.L_SMultiNPC.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.L_SMultiNPC.Name = "L_SMultiNPC";
-            this.L_SMultiNPC.Size = new System.Drawing.Size(55, 17);
-            this.L_SMultiNPC.TabIndex = 6;
+            this.L_SMultiNPC.Size = new System.Drawing.Size(41, 14);
+            this.L_SMultiNPC.TabIndex = 0;
             this.L_SMultiNPC.Text = "NPC";
             this.L_SMultiNPC.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // L_SMultiFriends
             // 
             this.L_SMultiFriends.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.L_SMultiFriends.Location = new System.Drawing.Point(71, 94);
+            this.L_SMultiFriends.Location = new System.Drawing.Point(53, 76);
+            this.L_SMultiFriends.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.L_SMultiFriends.Name = "L_SMultiFriends";
-            this.L_SMultiFriends.Size = new System.Drawing.Size(55, 19);
-            this.L_SMultiFriends.TabIndex = 7;
+            this.L_SMultiFriends.Size = new System.Drawing.Size(41, 15);
+            this.L_SMultiFriends.TabIndex = 5;
             this.L_SMultiFriends.Text = "Friends";
             this.L_SMultiFriends.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
             // L_SMultiFriendsRecord
             // 
             this.L_SMultiFriendsRecord.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.L_SMultiFriendsRecord.Location = new System.Drawing.Point(11, 143);
+            this.L_SMultiFriendsRecord.Location = new System.Drawing.Point(8, 116);
+            this.L_SMultiFriendsRecord.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.L_SMultiFriendsRecord.Name = "L_SMultiFriendsRecord";
-            this.L_SMultiFriendsRecord.Size = new System.Drawing.Size(55, 17);
-            this.L_SMultiFriendsRecord.TabIndex = 7;
+            this.L_SMultiFriendsRecord.Size = new System.Drawing.Size(42, 14);
+            this.L_SMultiFriendsRecord.TabIndex = 8;
             this.L_SMultiFriendsRecord.Text = "Record";
             this.L_SMultiFriendsRecord.TextAlign = System.Drawing.ContentAlignment.TopRight;
             // 
             // NUD_SMultiFriendsRecord
             // 
             this.NUD_SMultiFriendsRecord.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.NUD_SMultiFriendsRecord.Location = new System.Drawing.Point(71, 141);
+            this.NUD_SMultiFriendsRecord.Location = new System.Drawing.Point(53, 115);
+            this.NUD_SMultiFriendsRecord.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.NUD_SMultiFriendsRecord.Maximum = new decimal(new int[] {
+            9999,
+            0,
+            0,
+            0});
             this.NUD_SMultiFriendsRecord.Name = "NUD_SMultiFriendsRecord";
-            this.NUD_SMultiFriendsRecord.Size = new System.Drawing.Size(55, 22);
-            this.NUD_SMultiFriendsRecord.TabIndex = 6;
+            this.NUD_SMultiFriendsRecord.Size = new System.Drawing.Size(41, 20);
+            this.NUD_SMultiFriendsRecord.TabIndex = 9;
             // 
             // L_SMultiFriendsPast
             // 
             this.L_SMultiFriendsPast.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.L_SMultiFriendsPast.Location = new System.Drawing.Point(10, 118);
+            this.L_SMultiFriendsPast.Location = new System.Drawing.Point(8, 96);
+            this.L_SMultiFriendsPast.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.L_SMultiFriendsPast.Name = "L_SMultiFriendsPast";
-            this.L_SMultiFriendsPast.Size = new System.Drawing.Size(55, 17);
-            this.L_SMultiFriendsPast.TabIndex = 5;
+            this.L_SMultiFriendsPast.Size = new System.Drawing.Size(41, 14);
+            this.L_SMultiFriendsPast.TabIndex = 6;
             this.L_SMultiFriendsPast.Text = "Past";
             this.L_SMultiFriendsPast.TextAlign = System.Drawing.ContentAlignment.TopRight;
             // 
             // NUD_SMultiFriendsPast
             // 
             this.NUD_SMultiFriendsPast.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.NUD_SMultiFriendsPast.Location = new System.Drawing.Point(71, 116);
+            this.NUD_SMultiFriendsPast.Location = new System.Drawing.Point(53, 94);
+            this.NUD_SMultiFriendsPast.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.NUD_SMultiFriendsPast.Maximum = new decimal(new int[] {
+            9999,
+            0,
+            0,
+            0});
             this.NUD_SMultiFriendsPast.Name = "NUD_SMultiFriendsPast";
-            this.NUD_SMultiFriendsPast.Size = new System.Drawing.Size(55, 22);
-            this.NUD_SMultiFriendsPast.TabIndex = 4;
+            this.NUD_SMultiFriendsPast.Size = new System.Drawing.Size(41, 20);
+            this.NUD_SMultiFriendsPast.TabIndex = 7;
             // 
             // L_SMultiNpcRecord
             // 
             this.L_SMultiNpcRecord.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.L_SMultiNpcRecord.Location = new System.Drawing.Point(11, 68);
+            this.L_SMultiNpcRecord.Location = new System.Drawing.Point(8, 55);
+            this.L_SMultiNpcRecord.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.L_SMultiNpcRecord.Name = "L_SMultiNpcRecord";
-            this.L_SMultiNpcRecord.Size = new System.Drawing.Size(55, 17);
+            this.L_SMultiNpcRecord.Size = new System.Drawing.Size(42, 14);
             this.L_SMultiNpcRecord.TabIndex = 3;
             this.L_SMultiNpcRecord.Text = "Record";
             this.L_SMultiNpcRecord.TextAlign = System.Drawing.ContentAlignment.TopRight;
@@ -1539,17 +1223,24 @@
             // NUD_SMultiNpcRecord
             // 
             this.NUD_SMultiNpcRecord.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.NUD_SMultiNpcRecord.Location = new System.Drawing.Point(71, 66);
+            this.NUD_SMultiNpcRecord.Location = new System.Drawing.Point(53, 54);
+            this.NUD_SMultiNpcRecord.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.NUD_SMultiNpcRecord.Maximum = new decimal(new int[] {
+            9999,
+            0,
+            0,
+            0});
             this.NUD_SMultiNpcRecord.Name = "NUD_SMultiNpcRecord";
-            this.NUD_SMultiNpcRecord.Size = new System.Drawing.Size(55, 22);
-            this.NUD_SMultiNpcRecord.TabIndex = 2;
+            this.NUD_SMultiNpcRecord.Size = new System.Drawing.Size(41, 20);
+            this.NUD_SMultiNpcRecord.TabIndex = 4;
             // 
             // L_SMultiNpcPast
             // 
             this.L_SMultiNpcPast.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.L_SMultiNpcPast.Location = new System.Drawing.Point(10, 43);
+            this.L_SMultiNpcPast.Location = new System.Drawing.Point(8, 35);
+            this.L_SMultiNpcPast.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.L_SMultiNpcPast.Name = "L_SMultiNpcPast";
-            this.L_SMultiNpcPast.Size = new System.Drawing.Size(55, 17);
+            this.L_SMultiNpcPast.Size = new System.Drawing.Size(41, 14);
             this.L_SMultiNpcPast.TabIndex = 1;
             this.L_SMultiNpcPast.Text = "Past";
             this.L_SMultiNpcPast.TextAlign = System.Drawing.ContentAlignment.TopRight;
@@ -1557,64 +1248,430 @@
             // NUD_SMultiNpcPast
             // 
             this.NUD_SMultiNpcPast.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.NUD_SMultiNpcPast.Location = new System.Drawing.Point(71, 41);
+            this.NUD_SMultiNpcPast.Location = new System.Drawing.Point(53, 33);
+            this.NUD_SMultiNpcPast.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.NUD_SMultiNpcPast.Maximum = new decimal(new int[] {
+            9999,
+            0,
+            0,
+            0});
             this.NUD_SMultiNpcPast.Name = "NUD_SMultiNpcPast";
-            this.NUD_SMultiNpcPast.Size = new System.Drawing.Size(55, 22);
-            this.NUD_SMultiNpcPast.TabIndex = 0;
+            this.NUD_SMultiNpcPast.Size = new System.Drawing.Size(41, 20);
+            this.NUD_SMultiNpcPast.TabIndex = 2;
             // 
-            // GB_SuperChecks
+            // GB_SuperDoubles
             // 
-            this.GB_SuperChecks.Controls.Add(this.CHK_SuperMulti);
-            this.GB_SuperChecks.Controls.Add(this.CHK_SuperDouble);
-            this.GB_SuperChecks.Controls.Add(this.CHK_SuperSingle);
-            this.GB_SuperChecks.Location = new System.Drawing.Point(283, 7);
-            this.GB_SuperChecks.Name = "GB_SuperChecks";
-            this.GB_SuperChecks.Size = new System.Drawing.Size(158, 107);
-            this.GB_SuperChecks.TabIndex = 9;
-            this.GB_SuperChecks.TabStop = false;
-            this.GB_SuperChecks.Text = "Super Checks";
+            this.GB_SuperDoubles.Controls.Add(this.NUD_SDoubleRecord);
+            this.GB_SuperDoubles.Controls.Add(this.L_SDoublePast);
+            this.GB_SuperDoubles.Controls.Add(this.NUD_SDoublePast);
+            this.GB_SuperDoubles.Controls.Add(this.L_SDoubleRecord);
+            this.GB_SuperDoubles.Location = new System.Drawing.Point(108, 73);
+            this.GB_SuperDoubles.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.GB_SuperDoubles.Name = "GB_SuperDoubles";
+            this.GB_SuperDoubles.Padding = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.GB_SuperDoubles.Size = new System.Drawing.Size(99, 63);
+            this.GB_SuperDoubles.TabIndex = 5;
+            this.GB_SuperDoubles.TabStop = false;
+            this.GB_SuperDoubles.Text = "Super Doubles";
             // 
-            // CHK_SuperSingle
+            // L_SDoubleRecord
             // 
-            this.CHK_SuperSingle.AutoSize = true;
-            this.CHK_SuperSingle.Location = new System.Drawing.Point(12, 24);
-            this.CHK_SuperSingle.Name = "CHK_SuperSingle";
-            this.CHK_SuperSingle.Size = new System.Drawing.Size(126, 21);
-            this.CHK_SuperSingle.TabIndex = 0;
-            this.CHK_SuperSingle.Text = "Super Singles?";
-            this.CHK_SuperSingle.UseVisualStyleBackColor = true;
+            this.L_SDoubleRecord.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.L_SDoubleRecord.Location = new System.Drawing.Point(8, 40);
+            this.L_SDoubleRecord.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.L_SDoubleRecord.Name = "L_SDoubleRecord";
+            this.L_SDoubleRecord.Size = new System.Drawing.Size(42, 14);
+            this.L_SDoubleRecord.TabIndex = 2;
+            this.L_SDoubleRecord.Text = "Record";
+            this.L_SDoubleRecord.TextAlign = System.Drawing.ContentAlignment.TopRight;
             // 
-            // CHK_SuperDouble
+            // NUD_SDoubleRecord
             // 
-            this.CHK_SuperDouble.AutoSize = true;
-            this.CHK_SuperDouble.Location = new System.Drawing.Point(12, 51);
-            this.CHK_SuperDouble.Name = "CHK_SuperDouble";
-            this.CHK_SuperDouble.Size = new System.Drawing.Size(132, 21);
-            this.CHK_SuperDouble.TabIndex = 1;
-            this.CHK_SuperDouble.Text = "Super Doubles?";
-            this.CHK_SuperDouble.UseVisualStyleBackColor = true;
+            this.NUD_SDoubleRecord.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.NUD_SDoubleRecord.Location = new System.Drawing.Point(53, 38);
+            this.NUD_SDoubleRecord.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.NUD_SDoubleRecord.Maximum = new decimal(new int[] {
+            9999,
+            0,
+            0,
+            0});
+            this.NUD_SDoubleRecord.Name = "NUD_SDoubleRecord";
+            this.NUD_SDoubleRecord.Size = new System.Drawing.Size(41, 20);
+            this.NUD_SDoubleRecord.TabIndex = 3;
             // 
-            // CHK_SuperMulti
+            // L_SDoublePast
             // 
-            this.CHK_SuperMulti.AutoSize = true;
-            this.CHK_SuperMulti.Location = new System.Drawing.Point(12, 78);
-            this.CHK_SuperMulti.Name = "CHK_SuperMulti";
-            this.CHK_SuperMulti.Size = new System.Drawing.Size(109, 21);
-            this.CHK_SuperMulti.TabIndex = 2;
-            this.CHK_SuperMulti.Text = "Super Multi?";
-            this.CHK_SuperMulti.UseVisualStyleBackColor = true;
+            this.L_SDoublePast.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.L_SDoublePast.Location = new System.Drawing.Point(8, 20);
+            this.L_SDoublePast.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.L_SDoublePast.Name = "L_SDoublePast";
+            this.L_SDoublePast.Size = new System.Drawing.Size(41, 14);
+            this.L_SDoublePast.TabIndex = 0;
+            this.L_SDoublePast.Text = "Past";
+            this.L_SDoublePast.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            // 
+            // NUD_SDoublePast
+            // 
+            this.NUD_SDoublePast.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.NUD_SDoublePast.Location = new System.Drawing.Point(53, 18);
+            this.NUD_SDoublePast.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.NUD_SDoublePast.Maximum = new decimal(new int[] {
+            9999,
+            0,
+            0,
+            0});
+            this.NUD_SDoublePast.Name = "NUD_SDoublePast";
+            this.NUD_SDoublePast.Size = new System.Drawing.Size(41, 20);
+            this.NUD_SDoublePast.TabIndex = 1;
+            // 
+            // GB_SuperSingles
+            // 
+            this.GB_SuperSingles.Controls.Add(this.NUD_SSingleRecord);
+            this.GB_SuperSingles.Controls.Add(this.L_SSinglePast);
+            this.GB_SuperSingles.Controls.Add(this.NUD_SSinglePast);
+            this.GB_SuperSingles.Controls.Add(this.L_SSingleRecord);
+            this.GB_SuperSingles.Location = new System.Drawing.Point(108, 6);
+            this.GB_SuperSingles.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.GB_SuperSingles.Name = "GB_SuperSingles";
+            this.GB_SuperSingles.Padding = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.GB_SuperSingles.Size = new System.Drawing.Size(99, 63);
+            this.GB_SuperSingles.TabIndex = 1;
+            this.GB_SuperSingles.TabStop = false;
+            this.GB_SuperSingles.Text = "Super Singles";
+            // 
+            // L_SSingleRecord
+            // 
+            this.L_SSingleRecord.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.L_SSingleRecord.Location = new System.Drawing.Point(8, 41);
+            this.L_SSingleRecord.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.L_SSingleRecord.Name = "L_SSingleRecord";
+            this.L_SSingleRecord.Size = new System.Drawing.Size(42, 14);
+            this.L_SSingleRecord.TabIndex = 2;
+            this.L_SSingleRecord.Text = "Record";
+            this.L_SSingleRecord.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // NUD_SSingleRecord
+            // 
+            this.NUD_SSingleRecord.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.NUD_SSingleRecord.Location = new System.Drawing.Point(53, 39);
+            this.NUD_SSingleRecord.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.NUD_SSingleRecord.Maximum = new decimal(new int[] {
+            9999,
+            0,
+            0,
+            0});
+            this.NUD_SSingleRecord.Name = "NUD_SSingleRecord";
+            this.NUD_SSingleRecord.Size = new System.Drawing.Size(41, 20);
+            this.NUD_SSingleRecord.TabIndex = 3;
+            // 
+            // L_SSinglePast
+            // 
+            this.L_SSinglePast.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.L_SSinglePast.Location = new System.Drawing.Point(8, 20);
+            this.L_SSinglePast.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.L_SSinglePast.Name = "L_SSinglePast";
+            this.L_SSinglePast.Size = new System.Drawing.Size(41, 14);
+            this.L_SSinglePast.TabIndex = 0;
+            this.L_SSinglePast.Text = "Past";
+            this.L_SSinglePast.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // NUD_SSinglePast
+            // 
+            this.NUD_SSinglePast.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.NUD_SSinglePast.Location = new System.Drawing.Point(53, 18);
+            this.NUD_SSinglePast.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.NUD_SSinglePast.Maximum = new decimal(new int[] {
+            9999,
+            0,
+            0,
+            0});
+            this.NUD_SSinglePast.Name = "NUD_SSinglePast";
+            this.NUD_SSinglePast.Size = new System.Drawing.Size(41, 20);
+            this.NUD_SSinglePast.TabIndex = 1;
+            // 
+            // GB_Multi
+            // 
+            this.GB_Multi.Controls.Add(this.L_MultiNPC);
+            this.GB_Multi.Controls.Add(this.L_MultiFriends);
+            this.GB_Multi.Controls.Add(this.NUD_MultiFriendsRecord);
+            this.GB_Multi.Controls.Add(this.L_MultiFriendsPast);
+            this.GB_Multi.Controls.Add(this.NUD_MultiFriendsPast);
+            this.GB_Multi.Controls.Add(this.NUD_MultiNpcRecord);
+            this.GB_Multi.Controls.Add(this.L_MultiNpcPast);
+            this.GB_Multi.Controls.Add(this.NUD_MultiNpcPast);
+            this.GB_Multi.Controls.Add(this.L_MultiFriendsRecord);
+            this.GB_Multi.Controls.Add(this.L_MultiNpcRecord);
+            this.GB_Multi.Location = new System.Drawing.Point(4, 141);
+            this.GB_Multi.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.GB_Multi.Name = "GB_Multi";
+            this.GB_Multi.Padding = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.GB_Multi.Size = new System.Drawing.Size(99, 139);
+            this.GB_Multi.TabIndex = 6;
+            this.GB_Multi.TabStop = false;
+            this.GB_Multi.Text = "Multi";
+            // 
+            // L_MultiNPC
+            // 
+            this.L_MultiNPC.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.L_MultiNPC.Location = new System.Drawing.Point(53, 17);
+            this.L_MultiNPC.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.L_MultiNPC.Name = "L_MultiNPC";
+            this.L_MultiNPC.Size = new System.Drawing.Size(41, 14);
+            this.L_MultiNPC.TabIndex = 0;
+            this.L_MultiNPC.Text = "NPC";
+            this.L_MultiNPC.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // L_MultiFriends
+            // 
+            this.L_MultiFriends.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.L_MultiFriends.Location = new System.Drawing.Point(53, 76);
+            this.L_MultiFriends.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.L_MultiFriends.Name = "L_MultiFriends";
+            this.L_MultiFriends.Size = new System.Drawing.Size(41, 15);
+            this.L_MultiFriends.TabIndex = 5;
+            this.L_MultiFriends.Text = "Friends";
+            this.L_MultiFriends.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
+            // 
+            // L_MultiFriendsRecord
+            // 
+            this.L_MultiFriendsRecord.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.L_MultiFriendsRecord.Location = new System.Drawing.Point(8, 116);
+            this.L_MultiFriendsRecord.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.L_MultiFriendsRecord.Name = "L_MultiFriendsRecord";
+            this.L_MultiFriendsRecord.Size = new System.Drawing.Size(42, 14);
+            this.L_MultiFriendsRecord.TabIndex = 8;
+            this.L_MultiFriendsRecord.Text = "Record";
+            this.L_MultiFriendsRecord.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            // 
+            // NUD_MultiFriendsRecord
+            // 
+            this.NUD_MultiFriendsRecord.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.NUD_MultiFriendsRecord.Location = new System.Drawing.Point(53, 115);
+            this.NUD_MultiFriendsRecord.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.NUD_MultiFriendsRecord.Maximum = new decimal(new int[] {
+            9999,
+            0,
+            0,
+            0});
+            this.NUD_MultiFriendsRecord.Name = "NUD_MultiFriendsRecord";
+            this.NUD_MultiFriendsRecord.Size = new System.Drawing.Size(41, 20);
+            this.NUD_MultiFriendsRecord.TabIndex = 9;
+            // 
+            // L_MultiFriendsPast
+            // 
+            this.L_MultiFriendsPast.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.L_MultiFriendsPast.Location = new System.Drawing.Point(8, 96);
+            this.L_MultiFriendsPast.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.L_MultiFriendsPast.Name = "L_MultiFriendsPast";
+            this.L_MultiFriendsPast.Size = new System.Drawing.Size(41, 14);
+            this.L_MultiFriendsPast.TabIndex = 6;
+            this.L_MultiFriendsPast.Text = "Past";
+            this.L_MultiFriendsPast.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            // 
+            // NUD_MultiFriendsPast
+            // 
+            this.NUD_MultiFriendsPast.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.NUD_MultiFriendsPast.Location = new System.Drawing.Point(53, 94);
+            this.NUD_MultiFriendsPast.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.NUD_MultiFriendsPast.Maximum = new decimal(new int[] {
+            9999,
+            0,
+            0,
+            0});
+            this.NUD_MultiFriendsPast.Name = "NUD_MultiFriendsPast";
+            this.NUD_MultiFriendsPast.Size = new System.Drawing.Size(41, 20);
+            this.NUD_MultiFriendsPast.TabIndex = 7;
+            // 
+            // L_MultiNpcRecord
+            // 
+            this.L_MultiNpcRecord.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.L_MultiNpcRecord.Location = new System.Drawing.Point(8, 55);
+            this.L_MultiNpcRecord.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.L_MultiNpcRecord.Name = "L_MultiNpcRecord";
+            this.L_MultiNpcRecord.Size = new System.Drawing.Size(42, 14);
+            this.L_MultiNpcRecord.TabIndex = 3;
+            this.L_MultiNpcRecord.Text = "Record";
+            this.L_MultiNpcRecord.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            // 
+            // NUD_MultiNpcRecord
+            // 
+            this.NUD_MultiNpcRecord.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.NUD_MultiNpcRecord.Location = new System.Drawing.Point(53, 54);
+            this.NUD_MultiNpcRecord.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.NUD_MultiNpcRecord.Maximum = new decimal(new int[] {
+            9999,
+            0,
+            0,
+            0});
+            this.NUD_MultiNpcRecord.Name = "NUD_MultiNpcRecord";
+            this.NUD_MultiNpcRecord.Size = new System.Drawing.Size(41, 20);
+            this.NUD_MultiNpcRecord.TabIndex = 4;
+            // 
+            // L_MultiNpcPast
+            // 
+            this.L_MultiNpcPast.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.L_MultiNpcPast.Location = new System.Drawing.Point(8, 35);
+            this.L_MultiNpcPast.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.L_MultiNpcPast.Name = "L_MultiNpcPast";
+            this.L_MultiNpcPast.Size = new System.Drawing.Size(41, 14);
+            this.L_MultiNpcPast.TabIndex = 1;
+            this.L_MultiNpcPast.Text = "Past";
+            this.L_MultiNpcPast.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            // 
+            // NUD_MultiNpcPast
+            // 
+            this.NUD_MultiNpcPast.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.NUD_MultiNpcPast.Location = new System.Drawing.Point(53, 33);
+            this.NUD_MultiNpcPast.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.NUD_MultiNpcPast.Maximum = new decimal(new int[] {
+            9999,
+            0,
+            0,
+            0});
+            this.NUD_MultiNpcPast.Name = "NUD_MultiNpcPast";
+            this.NUD_MultiNpcPast.Size = new System.Drawing.Size(41, 20);
+            this.NUD_MultiNpcPast.TabIndex = 2;
+            // 
+            // GB_Doubles
+            // 
+            this.GB_Doubles.Controls.Add(this.NUD_DoubleRecord);
+            this.GB_Doubles.Controls.Add(this.L_DoublePast);
+            this.GB_Doubles.Controls.Add(this.NUD_DoublePast);
+            this.GB_Doubles.Controls.Add(this.L_DoubleRecord);
+            this.GB_Doubles.Location = new System.Drawing.Point(4, 73);
+            this.GB_Doubles.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.GB_Doubles.Name = "GB_Doubles";
+            this.GB_Doubles.Padding = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.GB_Doubles.Size = new System.Drawing.Size(99, 63);
+            this.GB_Doubles.TabIndex = 4;
+            this.GB_Doubles.TabStop = false;
+            this.GB_Doubles.Text = "Doubles";
+            // 
+            // L_DoubleRecord
+            // 
+            this.L_DoubleRecord.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.L_DoubleRecord.Location = new System.Drawing.Point(8, 40);
+            this.L_DoubleRecord.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.L_DoubleRecord.Name = "L_DoubleRecord";
+            this.L_DoubleRecord.Size = new System.Drawing.Size(42, 14);
+            this.L_DoubleRecord.TabIndex = 2;
+            this.L_DoubleRecord.Text = "Record";
+            this.L_DoubleRecord.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            // 
+            // NUD_DoubleRecord
+            // 
+            this.NUD_DoubleRecord.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.NUD_DoubleRecord.Location = new System.Drawing.Point(53, 38);
+            this.NUD_DoubleRecord.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.NUD_DoubleRecord.Maximum = new decimal(new int[] {
+            9999,
+            0,
+            0,
+            0});
+            this.NUD_DoubleRecord.Name = "NUD_DoubleRecord";
+            this.NUD_DoubleRecord.Size = new System.Drawing.Size(41, 20);
+            this.NUD_DoubleRecord.TabIndex = 3;
+            // 
+            // L_DoublePast
+            // 
+            this.L_DoublePast.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.L_DoublePast.Location = new System.Drawing.Point(8, 20);
+            this.L_DoublePast.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.L_DoublePast.Name = "L_DoublePast";
+            this.L_DoublePast.Size = new System.Drawing.Size(41, 14);
+            this.L_DoublePast.TabIndex = 0;
+            this.L_DoublePast.Text = "Past";
+            this.L_DoublePast.TextAlign = System.Drawing.ContentAlignment.TopRight;
+            // 
+            // NUD_DoublePast
+            // 
+            this.NUD_DoublePast.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.NUD_DoublePast.Location = new System.Drawing.Point(53, 18);
+            this.NUD_DoublePast.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.NUD_DoublePast.Maximum = new decimal(new int[] {
+            9999,
+            0,
+            0,
+            0});
+            this.NUD_DoublePast.Name = "NUD_DoublePast";
+            this.NUD_DoublePast.Size = new System.Drawing.Size(41, 20);
+            this.NUD_DoublePast.TabIndex = 1;
+            // 
+            // GB_Singles
+            // 
+            this.GB_Singles.Controls.Add(this.NUD_SingleRecord);
+            this.GB_Singles.Controls.Add(this.L_SinglePast);
+            this.GB_Singles.Controls.Add(this.NUD_SinglePast);
+            this.GB_Singles.Controls.Add(this.L_SingleRecord);
+            this.GB_Singles.Location = new System.Drawing.Point(4, 6);
+            this.GB_Singles.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.GB_Singles.Name = "GB_Singles";
+            this.GB_Singles.Padding = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.GB_Singles.Size = new System.Drawing.Size(99, 63);
+            this.GB_Singles.TabIndex = 0;
+            this.GB_Singles.TabStop = false;
+            this.GB_Singles.Text = "Singles";
+            // 
+            // L_SingleRecord
+            // 
+            this.L_SingleRecord.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.L_SingleRecord.Location = new System.Drawing.Point(8, 41);
+            this.L_SingleRecord.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.L_SingleRecord.Name = "L_SingleRecord";
+            this.L_SingleRecord.Size = new System.Drawing.Size(42, 14);
+            this.L_SingleRecord.TabIndex = 2;
+            this.L_SingleRecord.Text = "Record";
+            this.L_SingleRecord.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // NUD_SingleRecord
+            // 
+            this.NUD_SingleRecord.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.NUD_SingleRecord.Location = new System.Drawing.Point(53, 39);
+            this.NUD_SingleRecord.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.NUD_SingleRecord.Maximum = new decimal(new int[] {
+            9999,
+            0,
+            0,
+            0});
+            this.NUD_SingleRecord.Name = "NUD_SingleRecord";
+            this.NUD_SingleRecord.Size = new System.Drawing.Size(41, 20);
+            this.NUD_SingleRecord.TabIndex = 3;
+            // 
+            // L_SinglePast
+            // 
+            this.L_SinglePast.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.L_SinglePast.Location = new System.Drawing.Point(8, 20);
+            this.L_SinglePast.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+            this.L_SinglePast.Name = "L_SinglePast";
+            this.L_SinglePast.Size = new System.Drawing.Size(41, 14);
+            this.L_SinglePast.TabIndex = 0;
+            this.L_SinglePast.Text = "Past";
+            this.L_SinglePast.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // NUD_SinglePast
+            // 
+            this.NUD_SinglePast.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.NUD_SinglePast.Location = new System.Drawing.Point(53, 18);
+            this.NUD_SinglePast.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+            this.NUD_SinglePast.Maximum = new decimal(new int[] {
+            9999,
+            0,
+            0,
+            0});
+            this.NUD_SinglePast.Name = "NUD_SinglePast";
+            this.NUD_SinglePast.Size = new System.Drawing.Size(41, 20);
+            this.NUD_SinglePast.TabIndex = 1;
             // 
             // SAV_Misc5
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 16F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(487, 462);
+            this.ClientSize = new System.Drawing.Size(370, 380);
             this.Controls.Add(this.TC_Misc);
             this.Controls.Add(this.B_Save);
             this.Controls.Add(this.B_Cancel);
             this.Icon = global::PKHeX.WinForms.Properties.Resources.Icon;
-            this.Margin = new System.Windows.Forms.Padding(4);
-            this.MinimumSize = new System.Drawing.Size(502, 499);
+            this.MinimumSize = new System.Drawing.Size(378, 411);
             this.Name = "SAV_Misc5";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
             this.Text = "Misc Editor";
@@ -1645,6 +1702,19 @@
             ((System.ComponentModel.ISupportInitialize)(this.PB_SlotPreview)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_Animation)).EndInit();
             this.TAB_Subway.ResumeLayout(false);
+            this.GB_SuperChecks.ResumeLayout(false);
+            this.GB_SuperChecks.PerformLayout();
+            this.GB_SuperMulti.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.NUD_SMultiFriendsRecord)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.NUD_SMultiFriendsPast)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.NUD_SMultiNpcRecord)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.NUD_SMultiNpcPast)).EndInit();
+            this.GB_SuperDoubles.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.NUD_SDoubleRecord)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.NUD_SDoublePast)).EndInit();
+            this.GB_SuperSingles.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.NUD_SSingleRecord)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.NUD_SSinglePast)).EndInit();
             this.GB_Multi.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.NUD_MultiFriendsRecord)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_MultiFriendsPast)).EndInit();
@@ -1656,19 +1726,6 @@
             this.GB_Singles.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.NUD_SingleRecord)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.NUD_SinglePast)).EndInit();
-            this.GB_SuperSingles.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_SSingleRecord)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_SSinglePast)).EndInit();
-            this.GB_SuperDoubles.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_SDoubleRecord)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_SDoublePast)).EndInit();
-            this.GB_SuperMulti.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_SMultiFriendsRecord)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_SMultiFriendsPast)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_SMultiNpcRecord)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.NUD_SMultiNpcPast)).EndInit();
-            this.GB_SuperChecks.ResumeLayout(false);
-            this.GB_SuperChecks.PerformLayout();
             this.ResumeLayout(false);
 
         }


### PR DESCRIPTION
since battle subway records has a maximum of 9999 for your record. non-super formats don't really need a maximum, but i included it anyways.

i also included some tab indexing so people can navigate the window with a keyboard, and a minor fix to the "record" labels so you can read them.