### PR TITLE
Add Gender to Gen 8 Trainer Card

### DIFF
--- a/PKHeX.Core/Saves/Substructures/Gen8/TrainerCard8.cs
+++ b/PKHeX.Core/Saves/Substructures/Gen8/TrainerCard8.cs
@@ -92,6 +92,12 @@ namespace PKHeX.Core
             set => Data[Offset + 0x30] = (byte)(value ? 1 : 0);
         }
 
+        public int Gender
+        {
+            get => Data[0x38];
+            set => Data[0x38] = (byte)value;
+        }
+
         public string Number
         {
             get => Encoding.ASCII.GetString(Data, 0x39, 3);


### PR DESCRIPTION
In other interesting news, a Block file with all available clothing was posted on PP!: https://projectpokemon.org/home/files/file/4041-fashion-block/

Maybe it could be implemented into PKHeX? I'm sure a lot of peps would love this! :)