### PR TITLE
Fix Dex Shiny Display

### DIFF
--- a/PKHeX.Core/Saves/Substructures/PokeDex/Zukan8.cs
+++ b/PKHeX.Core/Saves/Substructures/PokeDex/Zukan8.cs
@@ -287,7 +287,7 @@ namespace PKHeX.Core
             if (!owned)
                 SetAltFormDisplayed(species, (byte)form);
 
-            if (shiny)
+            if (!owned)
                 SetDisplayShiny(species);
 
             var count = GetBattledCount(species);


### PR DESCRIPTION
Recent commit still sets Shiny displayed despite being owned. So this addresses it.