### PR TITLE
Add blocks for NPC and Friend League Cards

### DIFF
--- a/PKHeX.Core/Saves/Access/SaveBlockAccessor8SWSH.cs
+++ b/PKHeX.Core/Saves/Access/SaveBlockAccessor8SWSH.cs
@@ -74,7 +74,7 @@ namespace PKHeX.Core
         private const uint KTitleScreenTeam = 0xE9BE28BF; // Title Screen Team details
         public const uint KEnteredHallOfFame = 0xE2F6E456; // U64 Unix Timestamp
         private const uint KMyStatus = 0xf25c070e; // Trainer Details
-        private const uint KFriendLeagueCards = 0x28e707f5; // League Cards received from players linked with
+        private const uint KFriendLeagueCards = 0x28e707f5; // League Cards received from other players
         private const uint KNPCLeagueCards = 0xb1c26fb0; // League Cards received from NPCs
         
         // Rental Teams - Objects (Blocks) (Incrementing internal names?) 

--- a/PKHeX.Core/Saves/Access/SaveBlockAccessor8SWSH.cs
+++ b/PKHeX.Core/Saves/Access/SaveBlockAccessor8SWSH.cs
@@ -74,7 +74,9 @@ namespace PKHeX.Core
         private const uint KTitleScreenTeam = 0xE9BE28BF; // Title Screen Team details
         public const uint KEnteredHallOfFame = 0xE2F6E456; // U64 Unix Timestamp
         private const uint KMyStatus = 0xf25c070e; // Trainer Details
-
+        private const uint KFriendLeagueCards = 0x28e707f5; // League Cards received from players linked with
+        private const uint KNPCLeagueCards = 0xb1c26fb0; // League Cards received from NPCs
+        
         // Rental Teams - Objects (Blocks) (Incrementing internal names?) 
         private const uint KRentalTeam1 = 0x149A1DD0;
       //private const uint KRentalTeam2 = 0x159A1F63; // does not exist


### PR DESCRIPTION
Here's the structure for the NPC card data. Very straightforward :)

Owned: 0 = No 1 = Yes
Date: YYMD values

Hop
Owned 0x00
Date 0x2-5

Hop (Rare)
Owned 0x08
Date 0xA-D

Marnie
Owned 0x10
Date 0x12-15

Marnie (Rare)
Owned 0x18
Date 0x1A-1D

Milo
Owned 0x20
Date 0x22-25

Milo (Rare)
Owned 0x28
Date 0x2A-2D

Nessa
Owned 0x30
Date 0x32-35

Nessa (Rare)
Owned 0x38
Date 0x3A-3D

Kabu
Owned 0x40
Date 0x42-45

Kabu (Rare)
Owned 0x48
Date 0x4A-4D

Bea
Owned 0x50
Date 0x52-55

Bea (Rare)
Owned 0x58
Date 0x5A-5D

Allister
Owned 0x60
Date 0x62-65

Allister (Rare)
Owned 0x68
Date 0x6A-6D

Opal
Owned 0x70
Date 0x72-75

Opal (Rare)
Owned 0x78
Date 0x7A-7D

Gordie
Owned 0x80
Date 0x82-85

Gordie (Rare)
Owned 0x88
Date 0x8A-8D

Melony
Owned 0x90
Date 0x92-95

Melony (Rare)
Owned 0x98
Date 0x9A-9D

Piers
Owned 0xA0
Date 0xA2-A5

Piers (Rare)
Owned 0xA8
Date 0xAA-AD

Raihan
Owned 0xB0
Date 0xB2-B5

Raihan (Rare)
Owned 0xB8
Date 0xBA-BD

Leon
Owned 0xC0
Date 0xC2-C5

Leon (Rare)
Owned 0xC8
Date 0xCA-CD

Rose
Owned 0xD0
Date 0xD2-D5

Rose (Rare)
Owned 0xD8
Date 0xDA-DD

Bede
Owned 0xE0
Date 0xE2-E5

Bede (Rare)
Owned 0xE8
Date 0xEA-ED

Ball Guy
Owned 0xF0
Date 0xF2-F5