### PR TITLE
Simplify foreach loops

### DIFF
--- a/PKHeX.Core/Util/DataUtil.cs
+++ b/PKHeX.Core/Util/DataUtil.cs
@@ -333,8 +333,7 @@ namespace PKHeX.Core
         public static List<ComboItem> GetCBList(IReadOnlyList<string> inStrings, IReadOnlyList<ushort> allowed)
         {
             var list = new List<ComboItem>(allowed.Count + 1) { new ComboItem(inStrings[0], 0) };
-            foreach (var index in allowed)
-                list.Add(new ComboItem(inStrings[index], index));
+            list.AddRange(allowed.Select(index => new ComboItem(inStrings[index], index)));
             list.Sort(Comparer);
             return list;
         }

--- a/PKHeX.Core/Util/Util.cs
+++ b/PKHeX.Core/Util/Util.cs
@@ -46,10 +46,8 @@ namespace PKHeX.Core
             if (string.IsNullOrEmpty(value))
                 return result;
 
-            foreach (var c in value)
+            foreach (var c in value.Where(c => IsNum(c)))
             {
-                if (!IsNum(c))
-                    continue;
                 result *= 10;
                 result += c;
                 result -= '0';


### PR DESCRIPTION
This is another attempt at using LINQ to make code clearer, however, only in places in which the resulting IL is not compromised.

For example, in the original List<ComboItem> GetCBList function, at every iteration "list.Add" was called. However, with AddRange, it is only one function call.

I hope this is good enough to consider!