### PR TITLE
Fix sav path after exporting to new name

### DIFF
--- a/PKHeX.WinForms/MainWindow/Main.cs
+++ b/PKHeX.WinForms/MainWindow/Main.cs
@@ -1196,7 +1196,10 @@ namespace PKHeX.WinForms
         private void ClickExportSAV(object sender, EventArgs e)
         {
             if (Menu_ExportSAV.Enabled)
+            {
                 C_SAV.ExportSaveFile();
+                Text = GetProgramTitle(C_SAV.SAV);
+            }
         }
 
         private void ClickSaveFileName(object sender, EventArgs e)

--- a/PKHeX.WinForms/Util/WinFormsUtil.cs
+++ b/PKHeX.WinForms/Util/WinFormsUtil.cs
@@ -362,6 +362,7 @@ namespace PKHeX.WinForms
             {
                 File.WriteAllBytes(path, sav.Write(flags));
                 sav.Edited = false;
+                sav.SetFileInfo(path);
                 Alert(MsgSaveExportSuccessPath, path);
             }
             catch (Exception x)


### PR DESCRIPTION
If you open a file called "E.sav" and save it as "E2.sav", PKHeX will still believe the current save file is "E.sav" and will have that as the title of the program and the default filename when exporting which may lead to you overwriting the original save file accidentally. This PR will correctly update the title bar and the sav object.