### PR TITLE
add back watchtower as a legal location

### DIFF
--- a/PKHeX.Core/Legality/Areas/EncounterArea8.cs
+++ b/PKHeX.Core/Legality/Areas/EncounterArea8.cs
@@ -58,7 +58,7 @@ namespace PKHeX.Core
 
         protected override IEnumerable<EncounterSlot> GetFilteredSlots(PKM pkm, IEnumerable<EncounterSlot> slots, int minLevel) => slots;
 
-        public static bool IsWildArea8(int loc) => 122 <= loc && loc <= 154 && loc != Encounters8Nest.Watchtower; // Rolling Fields -> Lake of Outrage
+        public static bool IsWildArea8(int loc) => 122 <= loc && loc <= 154; // Rolling Fields -> Lake of Outrage
 
         // Location, and areas that can feed encounters into it.
         public static readonly IReadOnlyDictionary<int, IReadOnlyList<byte>> ConnectingArea8 = new Dictionary<int, IReadOnlyList<byte>>


### PR DESCRIPTION
made an oopsie, Watchtower Ruins also apparently includes 2 extra dens that can spawn encounters that are not 8NC. Den 17 is locked to 8NC encounters only, but location-wise there is no difference between Den 15,16,17