### PR TITLE
Restrict the Excluded Pokemon in IDynamaxLevel to between Zacian and Eternatus Inclusive

### DIFF
--- a/PKHeX.Core/PKM/Shared/IDynamaxLevel.cs
+++ b/PKHeX.Core/PKM/Shared/IDynamaxLevel.cs
@@ -11,7 +11,7 @@
         {
             if (pkm.IsEgg)
                 return false;
-            if (pkm.Species >= (int)Species.Zacian)
+            if (pkm.Species >= (int)Species.Zacian && pkm.Species <= (int)Species.Eternatus)
                 return false;
             return true;
         }


### PR DESCRIPTION
Preemptively restrict the Dynamax Level check to between Zacian and Eternatus inclusive since the DLC trailer depict Urshifu as Dynamaxed.



