### PR TITLE
Update legal raid counts

### DIFF
--- a/PKHeX.Core/Saves/Substructures/Gen8/RaidSpawnList8.cs
+++ b/PKHeX.Core/Saves/Substructures/Gen8/RaidSpawnList8.cs
@@ -14,8 +14,8 @@ namespace PKHeX.Core
             CountUsed = legal;
         }
 
-        public const int RaidCountLegal_O0 = 93;
-        public const int RaidCountLegal_R1 = 59;
+        public const int RaidCountLegal_O0 = 100;
+        public const int RaidCountLegal_R1 = 90;
 
         public RaidSpawnDetail GetRaid(int entry) => new RaidSpawnDetail(Data, entry * RaidSpawnDetail.SIZE);
 


### PR DESCRIPTION
the normal raids have 100 before and the raids count of armor area should be 90?