### PR TITLE
Update GO minimum Level requirements

### DIFF
--- a/PKHeX.Core/Legality/Encounters/Data/Encounters7b.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Encounters7b.cs
@@ -122,19 +122,18 @@ namespace PKHeX.Core
                 088, // Grimer
                 089, // Muk
                 103, // Exeggutor
-
-                // Level 20+
-                026, // Raichu
                 105, // Marowak
+
+                // Level 15+
+                026, // Raichu
             };
 
             var regular = obtainable.Select(z => GetSlot(z, 0));
             var alolan = AlolanKanto.Select(z => GetSlot(z, 1));
             var slots = regular.Concat(alolan).ToArray();
 
-            slots[slots.Length - 2].LevelMin = 20; // Raichu
-            slots[slots.Length - 1].LevelMin = 20; // Marowak
-            slots[(int)Species.Mewtwo - 1].LevelMin = 20;
+            slots[slots.Length - 1].LevelMin = 15; // Raichu
+            slots[(int)Species.Mewtwo - 1].LevelMin = 15;
             slots[(int)Species.Articuno - 1].LevelMin = 15;
             slots[(int)Species.Zapdos - 1].LevelMin = 15;
             slots[(int)Species.Moltres - 1].LevelMin = 15;


### PR DESCRIPTION
This'll probably end up being deprecated in the future when we have GO->HOME transfer checks, in addition to IV checking, but update this for now since I don't think we'll get that functionality until the second coming of Christ.