### PR TITLE
Changes to suggested hyper training logic 

### DIFF
--- a/PKHeX.Core/Editing/CommonEdits.cs
+++ b/PKHeX.Core/Editing/CommonEdits.cs
@@ -202,7 +202,11 @@ namespace PKHeX.Core
             pk.IVs = Set.IVs;
             pk.EVs = Set.EVs;
 
-            pk.SetSuggestedHyperTrainingData(Set.IVs);
+            // IVs have no side effects such as hidden power type in gen 8
+            // therefore all specified IVs are deliberate and should not be HT'd over for pokemon met in gen 8
+            if (!pk.Gen8)
+                pk.SetSuggestedHyperTrainingData(Set.IVs);
+
             if (ShowdownSetIVMarkings)
                 pk.SetMarkings();
 

--- a/PKHeX.Core/PKM/Shared/IHyperTrain.cs
+++ b/PKHeX.Core/PKM/Shared/IHyperTrain.cs
@@ -91,9 +91,13 @@ namespace PKHeX.Core
             t.HT_HP = IVs[0] != 31;
             t.HT_ATK = IVs[1] != 31 && IVs[1] > 2;
             t.HT_DEF = IVs[2] != 31;
-            t.HT_SPE = IVs[3] != 31 && IVs[3] > 2;
             t.HT_SPA = IVs[4] != 31;
             t.HT_SPD = IVs[5] != 31;
+
+            // sometimes unusual speed IVs are desirable for competitive reasons
+            // if nothing else was HT'd and the IV isn't too high, it was probably intentional
+            t.HT_SPE = IVs[3] != 31 && IVs[3] > 2 &&
+                (IVs[3] > 17 || t.HT_HP || t.HT_ATK || t.HT_DEF || t.HT_SPA || t.HT_SPD);
 
             if (pkm is PB7 pb)
                 pb.ResetCP();


### PR DESCRIPTION
Now that Hidden Power is removed from the game in gen 8, IVs have no battle relevant side effects and only affect the pokemon's stats. This means that any IVs specified in the showdown format are deliberate for stat purposes and should not be hyper trained over.

The main use case for this is allowing sysbots to gen trick room pokemon with a specific amount of speed creep without bleeding into another speed tier.