### PR TITLE
Handle Exception When Adding Font File

### DIFF
--- a/PKHeX.WinForms/Util/FontUtil.cs
+++ b/PKHeX.WinForms/Util/FontUtil.cs
@@ -11,6 +11,7 @@ namespace PKHeX.WinForms
     public static class FontUtil
     {
         private static readonly PrivateFontCollection CustomFonts = new PrivateFontCollection();
+        private static readonly Dictionary<float, Font> GeneratedFonts = new Dictionary<float, Font>();
 
         static FontUtil()
         {
@@ -19,14 +20,15 @@ namespace PKHeX.WinForms
             {
                 if (!File.Exists(g6path))
                     File.WriteAllBytes(g6path, Resources.pgldings_normalregular);
+                CustomFonts.AddFontFile(g6path);
+            }
+            catch (FileNotFoundException ex){
+                Debug.WriteLine($"Unable to read font file: {ex.Message}");
             }
             catch (Exception ex)
             {
                 Debug.WriteLine($"Unable to add in-game font: {ex.Message}");
-                return;
             }
-
-            CustomFonts.AddFontFile(g6path);
         }
 
         public static Font GetPKXFont(float size = 11f)
@@ -38,7 +40,5 @@ namespace PKHeX.WinForms
             GeneratedFonts.Add(size, font);
             return font;
         }
-
-        private static readonly Dictionary<float, Font> GeneratedFonts = new Dictionary<float, Font>();
     }
 }


### PR DESCRIPTION
It appears that some users are experiencing an issue where the PrivateFontCollection cannot find the font that should have been written to the temporary path. Move the AddFontFile call into the try-catch block so that PKHex doesn't crash in this event.

Link to Issue: https://projectpokemon.org/home/forums/topic/57234-pkhex-200414-error/