### PR TITLE
Fix Hidden Power Power calculations (and add to UI)

### DIFF
--- a/PKHeX.Core/PKM/PKM.cs
+++ b/PKHeX.Core/PKM/PKM.cs
@@ -491,15 +491,19 @@ namespace PKHeX.Core
 
         protected static int GetHiddenPowerBitVal(int[] ivs)
         {
+            return GetHiddenPowerBitVal(ivs, 0);
+        }
+        protected static int GetHiddenPowerBitVal(int[] ivs, int bit)
+        {
             int sum = 0;
             for (int i = 0; i < ivs.Length; i++)
-                sum |= (ivs[i] & 1) << i;
+                sum |= (ivs[i] >> bit & 1) << i;
             return sum;
         }
 
         private int HPVal => GetHiddenPowerBitVal(IVs);
-        public virtual int HPPower => Format < 6 ? (40 *HPVal/63) + 30 : 60;
-
+        private int HPPowerVal => GetHiddenPowerBitVal(IVs, 1);
+        public virtual int HPPower => Format < 6 ? (40 * HPPowerVal/63) + 30 : 60;
         public virtual int HPType
         {
             get => 15 * HPVal / 63;

--- a/PKHeX.Core/PKM/PKM.cs
+++ b/PKHeX.Core/PKM/PKM.cs
@@ -497,7 +497,7 @@ namespace PKHeX.Core
         {
             int sum = 0;
             for (int i = 0; i < ivs.Length; i++)
-                sum |= (ivs[i] >> bit & 1) << i;
+                sum |= ((ivs[i] >> bit) & 1) << i;
             return sum;
         }
 

--- a/PKHeX.Core/PKM/PKM.cs
+++ b/PKHeX.Core/PKM/PKM.cs
@@ -489,24 +489,14 @@ namespace PKHeX.Core
             }
         }
 
-        protected static int GetHiddenPowerBitVal(int[] ivs)
-        {
-            return GetHiddenPowerBitVal(ivs, 0);
-        }
-        protected static int GetHiddenPowerBitVal(int[] ivs, int bit)
-        {
-            int sum = 0;
-            for (int i = 0; i < ivs.Length; i++)
-                sum |= ((ivs[i] >> bit) & 1) << i;
-            return sum;
-        }
+        private int HPBitValPower => ((IV_HP & 2) >> 1) | ((IV_ATK & 2) >> 0) | ((IV_DEF & 2) << 1) | ((IV_SPE & 2) << 2) | ((IV_SPA & 2) << 3) | ((IV_SPD & 2) << 4);
+        public virtual int HPPower => Format < 6 ? ((40 * HPBitValPower) / 63) + 30 : 60;
 
-        private int HPVal => GetHiddenPowerBitVal(IVs);
-        private int HPPowerVal => GetHiddenPowerBitVal(IVs, 1);
-        public virtual int HPPower => Format < 6 ? (40 * HPPowerVal/63) + 30 : 60;
+        private int HPBitValType =>  ((IV_HP & 1) >> 0) | ((IV_ATK & 1) << 1) | ((IV_DEF & 1) << 2) | ((IV_SPE & 1) << 3) | ((IV_SPA & 1) << 4) | ((IV_SPD & 1) << 5);
+
         public virtual int HPType
         {
-            get => 15 * HPVal / 63;
+            get => 15 * HPBitValType / 63;
             set
             {
                 IV_HP =  (IV_HP  & ~1) + HiddenPower.DefaultLowBits[value, 0];

--- a/PKHeX.Core/PKM/Shared/GBPKM.cs
+++ b/PKHeX.Core/PKM/Shared/GBPKM.cs
@@ -175,7 +175,8 @@ namespace PKHeX.Core
 
         public sealed override bool IsShiny => IV_DEF == 10 && IV_SPE == 10 && IV_SPC == 10 && (IV_ATK & 2) == 2;
         private int HPVal => GetHiddenPowerBitVal(new[] { IV_SPC, IV_SPE, IV_DEF, IV_ATK });
-        public sealed override int HPPower => (((5 * HPVal) + (IV_SPC % 4)) / 2) + 31;
+        private int HPPowerVal => GetHiddenPowerBitVal(new[] { IV_SPC, IV_SPE, IV_DEF, IV_ATK }, 3);
+        public sealed override int HPPower => (((5 * HPPowerVal) + (IV_SPC % 4)) / 2) + 31;
 
         public sealed override int HPType
         {

--- a/PKHeX.Core/PKM/Shared/GBPKM.cs
+++ b/PKHeX.Core/PKM/Shared/GBPKM.cs
@@ -174,13 +174,13 @@ namespace PKHeX.Core
         #endregion
 
         public sealed override bool IsShiny => IV_DEF == 10 && IV_SPE == 10 && IV_SPC == 10 && (IV_ATK & 2) == 2;
-        private int HPVal => GetHiddenPowerBitVal(new[] { IV_SPC, IV_SPE, IV_DEF, IV_ATK });
-        private int HPPowerVal => GetHiddenPowerBitVal(new[] { IV_SPC, IV_SPE, IV_DEF, IV_ATK }, 3);
-        public sealed override int HPPower => (((5 * HPPowerVal) + (IV_SPC % 4)) / 2) + 31;
+        private int HPBitValPower => ((IV_ATK & 8) >> 0) | ((IV_DEF & 8) >> 1) | ((IV_SPE & 8) >> 2) | ((IV_SPC & 8) >> 3);
+        public sealed override int HPPower => (((5 * HPBitValPower) + (IV_SPC & 3)) >> 1) + 31;
 
         public sealed override int HPType
         {
-            get => ((IV_ATK & 3) << 2) | (IV_DEF & 3); set
+            get => ((IV_ATK & 3) << 2) | (IV_DEF & 3);
+            set
             {
                 IV_DEF = ((IV_DEF >> 2) << 2) | (value & 3);
                 IV_DEF = ((IV_ATK >> 2) << 2) | ((value >> 2) & 3);

--- a/PKHeX.WinForms/Controls/PKM Editor/StatEditor.Designer.cs
+++ b/PKHeX.WinForms/Controls/PKM Editor/StatEditor.Designer.cs
@@ -98,8 +98,11 @@
             this.TB_AVTotal = new System.Windows.Forms.TextBox();
             this.L_Potential = new System.Windows.Forms.Label();
             this.FLP_HPType = new System.Windows.Forms.FlowLayoutPanel();
+            this.FLP_HPPower = new System.Windows.Forms.FlowLayoutPanel();
             this.Label_HiddenPowerPrefix = new System.Windows.Forms.Label();
             this.CB_HPType = new System.Windows.Forms.ComboBox();
+            this.Label_HiddenPowerPowerPrefix = new System.Windows.Forms.Label();
+            this.Label_HiddenPowerPower = new System.Windows.Forms.Label();
             this.FLP_Characteristic = new System.Windows.Forms.FlowLayoutPanel();
             this.Label_CharacteristicPrefix = new System.Windows.Forms.Label();
             this.L_Characteristic = new System.Windows.Forms.Label();
@@ -132,6 +135,7 @@
             this.FLP_StatsTotal.SuspendLayout();
             this.FLP_StatsTotalRight.SuspendLayout();
             this.FLP_HPType.SuspendLayout();
+            this.FLP_HPPower.SuspendLayout();
             this.FLP_Characteristic.SuspendLayout();
             this.PAN_BTN.SuspendLayout();
             this.FLP_DynamaxLevel.SuspendLayout();
@@ -148,6 +152,7 @@
             this.FLP_Stats.Controls.Add(this.FLP_Spe);
             this.FLP_Stats.Controls.Add(this.FLP_StatsTotal);
             this.FLP_Stats.Controls.Add(this.FLP_HPType);
+            this.FLP_Stats.Controls.Add(this.FLP_HPPower);
             this.FLP_Stats.Controls.Add(this.FLP_Characteristic);
             this.FLP_Stats.Controls.Add(this.PAN_BTN);
             this.FLP_Stats.Controls.Add(this.FLP_DynamaxLevel);
@@ -1035,6 +1040,37 @@
             this.CB_HPType.TabIndex = 44;
             this.CB_HPType.SelectedIndexChanged += new System.EventHandler(this.UpdateHPType);
             // 
+            // FLP_HPPower
+            // 
+            this.FLP_HPPower.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.FLP_HPPower.Controls.Add(this.Label_HiddenPowerPowerPrefix);
+            this.FLP_HPPower.Controls.Add(this.Label_HiddenPowerPower);
+            this.FLP_HPPower.Location = new System.Drawing.Point(0, 169);
+            this.FLP_HPPower.Margin = new System.Windows.Forms.Padding(0);
+            this.FLP_HPPower.Name = "FLP_HPPower";
+            this.FLP_HPPower.Size = new System.Drawing.Size(272, 21);
+            this.FLP_HPPower.TabIndex = 130;
+            // 
+            // Label_HiddenPowerPowerPrefix
+            // 
+            this.Label_HiddenPowerPowerPrefix.Location = new System.Drawing.Point(0, 0);
+            this.Label_HiddenPowerPowerPrefix.Margin = new System.Windows.Forms.Padding(0);
+            this.Label_HiddenPowerPowerPrefix.Name = "Label_HiddenPowerPowerPrefix";
+            this.Label_HiddenPowerPowerPrefix.Size = new System.Drawing.Size(174, 21);
+            this.Label_HiddenPowerPowerPrefix.TabIndex = 29;
+            this.Label_HiddenPowerPowerPrefix.Text = "Hidden Power Power:";
+            this.Label_HiddenPowerPowerPrefix.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // Label_HiddenPowerPower
+            // 
+            this.Label_HiddenPowerPower.Location = new System.Drawing.Point(174, 0);
+            this.Label_HiddenPowerPower.Margin = new System.Windows.Forms.Padding(0);
+            this.Label_HiddenPowerPower.Name = "Label_HiddenPowerPower";
+            this.Label_HiddenPowerPower.Size = new System.Drawing.Size(174, 21);
+            this.Label_HiddenPowerPower.TabIndex = 29;
+            this.Label_HiddenPowerPower.Text = "60";
+            this.Label_HiddenPowerPower.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
             // FLP_Characteristic
             // 
             this.FLP_Characteristic.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
@@ -1194,6 +1230,7 @@
             this.FLP_StatsTotalRight.ResumeLayout(false);
             this.FLP_StatsTotalRight.PerformLayout();
             this.FLP_HPType.ResumeLayout(false);
+            this.FLP_HPPower.ResumeLayout(false);
             this.FLP_Characteristic.ResumeLayout(false);
             this.PAN_BTN.ResumeLayout(false);
             this.FLP_DynamaxLevel.ResumeLayout(false);
@@ -1257,7 +1294,10 @@
         private System.Windows.Forms.TextBox TB_EVTotal;
         private System.Windows.Forms.Label L_Potential;
         private System.Windows.Forms.FlowLayoutPanel FLP_HPType;
+        private System.Windows.Forms.FlowLayoutPanel FLP_HPPower;
         private System.Windows.Forms.Label Label_HiddenPowerPrefix;
+        private System.Windows.Forms.Label Label_HiddenPowerPowerPrefix;
+        private System.Windows.Forms.Label Label_HiddenPowerPower;
         private System.Windows.Forms.ComboBox CB_HPType;
         private System.Windows.Forms.FlowLayoutPanel FLP_Characteristic;
         private System.Windows.Forms.Label Label_CharacteristicPrefix;

--- a/PKHeX.WinForms/Controls/PKM Editor/StatEditor.Designer.cs
+++ b/PKHeX.WinForms/Controls/PKM Editor/StatEditor.Designer.cs
@@ -98,9 +98,9 @@
             this.TB_AVTotal = new System.Windows.Forms.TextBox();
             this.L_Potential = new System.Windows.Forms.Label();
             this.FLP_HPType = new System.Windows.Forms.FlowLayoutPanel();
-            this.FLP_HPPower = new System.Windows.Forms.FlowLayoutPanel();
             this.Label_HiddenPowerPrefix = new System.Windows.Forms.Label();
             this.CB_HPType = new System.Windows.Forms.ComboBox();
+            this.FLP_HPPower = new System.Windows.Forms.FlowLayoutPanel();
             this.Label_HiddenPowerPowerPrefix = new System.Windows.Forms.Label();
             this.Label_HiddenPowerPower = new System.Windows.Forms.Label();
             this.FLP_Characteristic = new System.Windows.Forms.FlowLayoutPanel();
@@ -110,11 +110,11 @@
             this.BTN_RandomAVs = new System.Windows.Forms.Button();
             this.BTN_RandomIVs = new System.Windows.Forms.Button();
             this.BTN_RandomEVs = new System.Windows.Forms.Button();
-            this.EVTip = new System.Windows.Forms.ToolTip(this.components);
             this.FLP_DynamaxLevel = new System.Windows.Forms.FlowLayoutPanel();
             this.L_DynamaxLevel = new System.Windows.Forms.Label();
-            this.CHK_Gigantamax = new System.Windows.Forms.CheckBox();
             this.CB_DynamaxLevel = new System.Windows.Forms.ComboBox();
+            this.CHK_Gigantamax = new System.Windows.Forms.CheckBox();
+            this.EVTip = new System.Windows.Forms.ToolTip(this.components);
             this.FLP_Stats.SuspendLayout();
             this.FLP_StatHeader.SuspendLayout();
             this.FLP_HackedStats.SuspendLayout();
@@ -1045,7 +1045,7 @@
             this.FLP_HPPower.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.FLP_HPPower.Controls.Add(this.Label_HiddenPowerPowerPrefix);
             this.FLP_HPPower.Controls.Add(this.Label_HiddenPowerPower);
-            this.FLP_HPPower.Location = new System.Drawing.Point(0, 169);
+            this.FLP_HPPower.Location = new System.Drawing.Point(0, 190);
             this.FLP_HPPower.Margin = new System.Windows.Forms.Padding(0);
             this.FLP_HPPower.Name = "FLP_HPPower";
             this.FLP_HPPower.Size = new System.Drawing.Size(272, 21);
@@ -1063,10 +1063,12 @@
             // 
             // Label_HiddenPowerPower
             // 
+            this.Label_HiddenPowerPower.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.Label_HiddenPowerPower.Location = new System.Drawing.Point(174, 0);
             this.Label_HiddenPowerPower.Margin = new System.Windows.Forms.Padding(0);
             this.Label_HiddenPowerPower.Name = "Label_HiddenPowerPower";
-            this.Label_HiddenPowerPower.Size = new System.Drawing.Size(174, 21);
+            this.Label_HiddenPowerPower.Size = new System.Drawing.Size(98, 21);
             this.Label_HiddenPowerPower.TabIndex = 29;
             this.Label_HiddenPowerPower.Text = "60";
             this.Label_HiddenPowerPower.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
@@ -1076,7 +1078,7 @@
             this.FLP_Characteristic.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.FLP_Characteristic.Controls.Add(this.Label_CharacteristicPrefix);
             this.FLP_Characteristic.Controls.Add(this.L_Characteristic);
-            this.FLP_Characteristic.Location = new System.Drawing.Point(0, 190);
+            this.FLP_Characteristic.Location = new System.Drawing.Point(0, 211);
             this.FLP_Characteristic.Margin = new System.Windows.Forms.Padding(0);
             this.FLP_Characteristic.Name = "FLP_Characteristic";
             this.FLP_Characteristic.Size = new System.Drawing.Size(272, 21);
@@ -1108,7 +1110,7 @@
             this.PAN_BTN.Controls.Add(this.BTN_RandomAVs);
             this.PAN_BTN.Controls.Add(this.BTN_RandomIVs);
             this.PAN_BTN.Controls.Add(this.BTN_RandomEVs);
-            this.PAN_BTN.Location = new System.Drawing.Point(3, 214);
+            this.PAN_BTN.Location = new System.Drawing.Point(3, 235);
             this.PAN_BTN.Name = "PAN_BTN";
             this.PAN_BTN.Size = new System.Drawing.Size(267, 31);
             this.PAN_BTN.TabIndex = 132;
@@ -1149,7 +1151,7 @@
             this.FLP_DynamaxLevel.Controls.Add(this.L_DynamaxLevel);
             this.FLP_DynamaxLevel.Controls.Add(this.CB_DynamaxLevel);
             this.FLP_DynamaxLevel.Controls.Add(this.CHK_Gigantamax);
-            this.FLP_DynamaxLevel.Location = new System.Drawing.Point(0, 248);
+            this.FLP_DynamaxLevel.Location = new System.Drawing.Point(0, 269);
             this.FLP_DynamaxLevel.Margin = new System.Windows.Forms.Padding(0);
             this.FLP_DynamaxLevel.Name = "FLP_DynamaxLevel";
             this.FLP_DynamaxLevel.Size = new System.Drawing.Size(272, 21);
@@ -1165,17 +1167,7 @@
             this.L_DynamaxLevel.Text = "Dynamax Level:";
             this.L_DynamaxLevel.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
-            // checkBox1
-            // 
-            this.CHK_Gigantamax.AutoSize = true;
-            this.CHK_Gigantamax.Location = new System.Drawing.Point(163, 3);
-            this.CHK_Gigantamax.Name = "CHK_Gigantamax";
-            this.CHK_Gigantamax.Size = new System.Drawing.Size(82, 17);
-            this.CHK_Gigantamax.TabIndex = 44;
-            this.CHK_Gigantamax.Text = "Gigantamax";
-            this.CHK_Gigantamax.UseVisualStyleBackColor = true;
-            // 
-            // comboBox1
+            // CB_DynamaxLevel
             // 
             this.CB_DynamaxLevel.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.CB_DynamaxLevel.FormattingEnabled = true;
@@ -1196,6 +1188,16 @@
             this.CB_DynamaxLevel.Name = "CB_DynamaxLevel";
             this.CB_DynamaxLevel.Size = new System.Drawing.Size(40, 21);
             this.CB_DynamaxLevel.TabIndex = 44;
+            // 
+            // CHK_Gigantamax
+            // 
+            this.CHK_Gigantamax.AutoSize = true;
+            this.CHK_Gigantamax.Location = new System.Drawing.Point(163, 3);
+            this.CHK_Gigantamax.Name = "CHK_Gigantamax";
+            this.CHK_Gigantamax.Size = new System.Drawing.Size(82, 17);
+            this.CHK_Gigantamax.TabIndex = 44;
+            this.CHK_Gigantamax.Text = "Gigantamax";
+            this.CHK_Gigantamax.UseVisualStyleBackColor = true;
             // 
             // StatEditor
             // 

--- a/PKHeX.WinForms/Controls/PKM Editor/StatEditor.cs
+++ b/PKHeX.WinForms/Controls/PKM Editor/StatEditor.cs
@@ -477,6 +477,7 @@ namespace PKHeX.WinForms.Controls
             FLP_StatsTotal.Visible = gen >= 3;
             FLP_Characteristic.Visible = gen >= 3;
             FLP_HPType.Visible = gen <= 7;
+            FLP_HPPower.Visible = gen <= 5;
             FLP_DynamaxLevel.Visible = gen >= 8;
 
             switch (gen)

--- a/PKHeX.WinForms/Controls/PKM Editor/StatEditor.cs
+++ b/PKHeX.WinForms/Controls/PKM Editor/StatEditor.cs
@@ -152,6 +152,7 @@ namespace PKHeX.WinForms.Controls
             {
                 ChangingFields = true;
                 CB_HPType.SelectedValue = Entity.HPType;
+                Label_HiddenPowerPower.Text = Entity.HPPower.ToString();
                 ChangingFields = false;
             }
 

--- a/Tests/PKHeX.Core.Tests/PKM/HiddenPowerTests.cs
+++ b/Tests/PKHeX.Core.Tests/PKM/HiddenPowerTests.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using FluentAssertions;
+using PKHeX.Core;
+using Xunit;
+
+namespace PKHeX.Tests.PKM
+{
+    public class HiddenPowerTests
+    {
+        [Theory]
+        [InlineData(14, 15, 15, 14, 14, 15, MoveType.Dark, 69, typeof(PK2))]
+        [InlineData(30, 31, 31, 30, 31, 31, MoveType.Grass, 70, typeof(PK3))]
+        [InlineData(26, 31, 31, 30, 31, 31, MoveType.Grass, 70, typeof(PK3))]
+        public void HiddenPowerTest(int h, int a, int b, int c, int d, int s, MoveType type, int power, Type pkmType)
+        {
+            var pkm = PKMConverter.GetBlank(pkmType);
+            pkm.IV_HP = h;
+            pkm.IV_ATK = a;
+            pkm.IV_DEF = b;
+            pkm.IV_SPA = c;
+            pkm.IV_SPD = d;
+            pkm.IV_SPE = s;
+
+            pkm.HPType.Should().Be((int)type - 1); // no normal type, down-shift by 1
+            pkm.HPPower.Should().Be(power);
+        }
+    }
+}


### PR DESCRIPTION
The power calculations for Hidden Power used the incorrect bit. Fixed for both Gen II and Gen III-V. Added Power calculations to UI for Gens 1-5 where they are applicable