### PR TITLE
Add property to get a PK1's converted Gen 2 item

### DIFF
--- a/PKHeX.Core/PKM/PK1.cs
+++ b/PKHeX.Core/PKM/PK1.cs
@@ -121,6 +121,9 @@ namespace PKHeX.Core
         public override int MaxAbilityID => Legal.MaxAbilityID_1;
         public override int MaxItemID => Legal.MaxItemID_1;
 
+        // Extra
+        public int Gen2Item => ItemConverter.GetItemFuture1(Catch_Rate);
+
         public PK2 ConvertToPK2()
         {
             PK2 pk2 = new PK2(Japanese) {Species = Species};


### PR DESCRIPTION
I plan to use this property to improve Auto-Legality Mod's Generation I Tradebacks legality. Currently ItemConverter is internal and therefore cannot be interfaced with by plugins. Alternatively the scope of ItemConverter could be increased (or code could be copied, but I'd like to avoid this if possible)