### PR TITLE
Clean up Gen 2 PCNY Events

### DIFF
--- a/PKHeX.Core/Legality/Encounters/Data/Encounters2.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Encounters2.cs
@@ -168,232 +168,233 @@ namespace PKHeX.Core
             //New York Pokémon Center Events
 
             // Legendary Beasts (November 22 to 29, 2001)
-            new EncounterStatic2E(243, 40, GS) {OT_Names = PCNYx, Shiny = Shiny.Always, Language = International}, // Shiny Raikou
-            new EncounterStatic2E(244, 40, GS) {OT_Names = PCNYx, Shiny = Shiny.Always, Language = International}, // Shiny Entei
-            new EncounterStatic2E(245, 40, GS) {OT_Names = PCNYx, Shiny = Shiny.Always, Language = International}, // Shiny Suicune
+            new EncounterStatic2E(243, 05, GS) {OT_Names = PCNYx, CurrentLevel = 40, Shiny = Shiny.Always, Location = 127, Language = International}, // Shiny Raikou
+            new EncounterStatic2E(244, 05, GS) {OT_Names = PCNYx, CurrentLevel = 40, Shiny = Shiny.Always, Location = 127, Language = International}, // Shiny Entei
+            new EncounterStatic2E(245, 05, GS) {OT_Names = PCNYx, CurrentLevel = 40, Shiny = Shiny.Always, Location = 127, Language = International}, // Shiny Suicune
 
             // Legendary Birds (November 30 to December 6, 2001)
-            new EncounterStatic2E(144, 50, GS) {OT_Names = PCNYx, Shiny = Shiny.Always, Language = International}, // Shiny Articuno
-            new EncounterStatic2E(145, 50, GS) {OT_Names = PCNYx, Shiny = Shiny.Always, Language = International}, // Shiny Zapdos
-            new EncounterStatic2E(146, 50, GS) {OT_Names = PCNYx, Shiny = Shiny.Always, Language = International}, // Shiny Moltres
+            new EncounterStatic2E(144, 05, GS) {OT_Names = PCNYx, CurrentLevel = 50, Shiny = Shiny.Always, Location = 127, Language = International}, // Shiny Articuno
+            new EncounterStatic2E(145, 05, GS) {OT_Names = PCNYx, CurrentLevel = 50, Shiny = Shiny.Always, Location = 127, Language = International}, // Shiny Zapdos
+            new EncounterStatic2E(146, 05, GS) {OT_Names = PCNYx, CurrentLevel = 50, Shiny = Shiny.Always, Location = 127, Language = International}, // Shiny Moltres
 
             // Christmas Week (December 21 to 27, 2001)
-            new EncounterStatic2E(225, 05, GSC) {Moves = new[] {006}, EggLocation = 256, Language = International}, // Pay Day Delibird
-            new EncounterStatic2E(251, 5, GS) {OT_Names = PCNYx, Language = International}, // Celebi
+            new EncounterStatic2E(225, 05, GSC) {Moves = new[] {006}, EggLocation = 256, EggCycles = 10, Language = International}, // Pay Day Delibird
+            new EncounterStatic2E(251, 05, GS) {OT_Names = PCNYx, Location = 127, Language = International}, // Celebi
 
             // The Initial Three Set (December 28, 2001 to January 31, 2002)
-            new EncounterStatic2E(001, 05, GSC) {Moves = new[] {246}, EggLocation = 256, Language = International}, // Bulbasaur Ancientpower
-            new EncounterStatic2E(004, 05, GSC) {Moves = new[] {242}, EggLocation = 256, Language = International}, // Charmander Crunch
-            new EncounterStatic2E(007, 05, GSC) {Moves = new[] {192}, EggLocation = 256, Language = International}, // Squirtle Zap Cannon
-            new EncounterStatic2E(152, 05, GSC) {Moves = new[] {080}, EggLocation = 256, Language = International}, // Chikorita Petal Dance
-            new EncounterStatic2E(155, 05, GSC) {Moves = new[] {038}, EggLocation = 256, Language = International}, // Cyndaquil Double-Edge
-            new EncounterStatic2E(158, 05, GSC) {Moves = new[] {066}, EggLocation = 256, Language = International}, // Totodile Submission
+            new EncounterStatic2E(001, 05, GSC) {Moves = new[] {246}, EggLocation = 256, EggCycles = 10, Language = International}, // Bulbasaur Ancientpower
+            new EncounterStatic2E(004, 05, GSC) {Moves = new[] {242}, EggLocation = 256, EggCycles = 10, Language = International}, // Charmander Crunch
+            new EncounterStatic2E(007, 05, GSC) {Moves = new[] {192}, EggLocation = 256, EggCycles = 10, Language = International}, // Squirtle Zap Cannon
+            new EncounterStatic2E(152, 05, GSC) {Moves = new[] {080}, EggLocation = 256, EggCycles = 10, Language = International}, // Chikorita Petal Dance
+            new EncounterStatic2E(155, 05, GSC) {Moves = new[] {038}, EggLocation = 256, EggCycles = 10, Language = International}, // Cyndaquil Double-Edge
+            new EncounterStatic2E(158, 05, GSC) {Moves = new[] {066}, EggLocation = 256, EggCycles = 10, Language = International}, // Totodile Submission
 
             // Valentine Week (February 1 to 14, 2002)
-            new EncounterStatic2E(029, 05, GSC) {Moves = new[] {142}, EggLocation = 256, Language = International}, // Nidoran (F) Lovely Kiss
-            new EncounterStatic2E(029, 05, GSC) {Moves = new[] {186}, EggLocation = 256, Language = International}, // Nidoran (F) Sweet Kiss
-            new EncounterStatic2E(032, 05, GSC) {Moves = new[] {142}, EggLocation = 256, Language = International}, // Nidoran (M) Lovely Kiss
-            new EncounterStatic2E(032, 05, GSC) {Moves = new[] {186}, EggLocation = 256, Language = International}, // Nidoran (M) Sweet Kiss
-            new EncounterStatic2E(069, 05, GSC) {Moves = new[] {142}, EggLocation = 256, Language = International}, // Bellsprout Lovely Kiss
-            new EncounterStatic2E(069, 05, GSC) {Moves = new[] {186}, EggLocation = 256, Language = International}, // Bellsprout Sweet Kiss
+            new EncounterStatic2E(029, 05, GSC) {Moves = new[] {142}, EggLocation = 256, EggCycles = 10, Language = International}, // Nidoran (F) Lovely Kiss
+            new EncounterStatic2E(029, 05, GSC) {Moves = new[] {186}, EggLocation = 256, EggCycles = 10, Language = International}, // Nidoran (F) Sweet Kiss
+            new EncounterStatic2E(032, 05, GSC) {Moves = new[] {142}, EggLocation = 256, EggCycles = 10, Language = International}, // Nidoran (M) Lovely Kiss
+            new EncounterStatic2E(032, 05, GSC) {Moves = new[] {186}, EggLocation = 256, EggCycles = 10, Language = International}, // Nidoran (M) Sweet Kiss
+            new EncounterStatic2E(069, 05, GSC) {Moves = new[] {142}, EggLocation = 256, EggCycles = 10, Language = International}, // Bellsprout Lovely Kiss
+            new EncounterStatic2E(069, 05, GSC) {Moves = new[] {186}, EggLocation = 256, EggCycles = 10, Language = International}, // Bellsprout Sweet Kiss
 
             // Swarm Week (February 22 to March 14, 2002)
-            new EncounterStatic2E(183, 05, GSC) {Moves = new[] {056}, EggLocation = 256, Language = International}, // Marill Hydro Pump
-            new EncounterStatic2E(193, 05, GSC) {Moves = new[] {211}, EggLocation = 256, Language = International}, // Yanma Steel Wing
-            new EncounterStatic2E(206, 05, GSC) {Moves = new[] {032}, EggLocation = 256, Language = International}, // Dunsparce Horn Drill
-            new EncounterStatic2E(209, 05, GSC) {Moves = new[] {142}, EggLocation = 256, Language = International}, // Snubbull Lovely Kiss
-            new EncounterStatic2E(211, 05, GSC) {Moves = new[] {038}, EggLocation = 256, Language = International}, // Qwilfish Double-Edge
-            new EncounterStatic2E(223, 05, GSC) {Moves = new[] {133}, EggLocation = 256, Language = International}, // Remoraid Amnesia
+            new EncounterStatic2E(183, 05, GSC) {Moves = new[] {056}, EggLocation = 256, EggCycles = 10, Language = International}, // Marill Hydro Pump
+            new EncounterStatic2E(193, 05, GSC) {Moves = new[] {211}, EggLocation = 256, EggCycles = 10, Language = International}, // Yanma Steel Wing
+            new EncounterStatic2E(206, 05, GSC) {Moves = new[] {032}, EggLocation = 256, EggCycles = 10, Language = International}, // Dunsparce Horn Drill
+            new EncounterStatic2E(209, 05, GSC) {Moves = new[] {142}, EggLocation = 256, EggCycles = 10, Language = International}, // Snubbull Lovely Kiss
+            new EncounterStatic2E(211, 05, GSC) {Moves = new[] {038}, EggLocation = 256, EggCycles = 10, Language = International}, // Qwilfish Double-Edge
+            new EncounterStatic2E(223, 05, GSC) {Moves = new[] {133}, EggLocation = 256, EggCycles = 10, Language = International}, // Remoraid Amnesia
 
             // Shiny RBY Starters (March 15 to 21, 2002)
-            new EncounterStatic2E(003, 40, GS) {OT_Names = PCNYx, Shiny = Shiny.Always, Language = International}, // Shiny Venusaur
-            new EncounterStatic2E(006, 40, GS) {OT_Names = PCNYx, Shiny = Shiny.Always, Language = International}, // Shiny Charizard
-            new EncounterStatic2E(009, 40, GS) {OT_Names = PCNYx, Shiny = Shiny.Always, Language = International}, // Shiny Blastoise
+            new EncounterStatic2E(003, 05, GS) {OT_Names = PCNYx, CurrentLevel = 40, Shiny = Shiny.Always, Location = 127, Language = International}, // Shiny Venusaur
+            new EncounterStatic2E(006, 05, GS) {OT_Names = PCNYx, CurrentLevel = 40, Shiny = Shiny.Always, Location = 127, Language = International}, // Shiny Charizard
+            new EncounterStatic2E(009, 05, GS) {OT_Names = PCNYx, CurrentLevel = 40, Shiny = Shiny.Always, Location = 127, Language = International}, // Shiny Blastoise
 
             // Babies Week (March 22 to April 11, 2002)
-            new EncounterStatic2E(172, 05, GSC) {Moves = new[] {047}, EggLocation = 256, Language = International}, // Pichu Sing
-            new EncounterStatic2E(173, 05, GSC) {Moves = new[] {129}, EggLocation = 256, Language = International}, // Cleffa Swift
-            new EncounterStatic2E(174, 05, GSC) {Moves = new[] {102}, EggLocation = 256, Language = International}, // Igglybuff Mimic
-            new EncounterStatic2E(238, 05, GSC) {Moves = new[] {118}, EggLocation = 256, Language = International}, // Smoochum Metronome
-            new EncounterStatic2E(239, 05, GSC) {Moves = new[] {228}, EggLocation = 256, Language = International}, // Elekid Pursuit
-            new EncounterStatic2E(240, 05, GSC) {Moves = new[] {185}, EggLocation = 256, Language = International}, // Magby Faint Attack
+            new EncounterStatic2E(172, 05, GSC) {Moves = new[] {047}, EggLocation = 256, EggCycles = 10, Language = International}, // Pichu Sing
+            new EncounterStatic2E(173, 05, GSC) {Moves = new[] {129}, EggLocation = 256, EggCycles = 10, Language = International}, // Cleffa Swift
+            new EncounterStatic2E(174, 05, GSC) {Moves = new[] {102}, EggLocation = 256, EggCycles = 10, Language = International}, // Igglybuff Mimic
+            new EncounterStatic2E(238, 05, GSC) {Moves = new[] {118}, EggLocation = 256, EggCycles = 10, Language = International}, // Smoochum Metronome
+            new EncounterStatic2E(239, 05, GSC) {Moves = new[] {228}, EggLocation = 256, EggCycles = 10, Language = International}, // Elekid Pursuit
+            new EncounterStatic2E(240, 05, GSC) {Moves = new[] {185}, EggLocation = 256, EggCycles = 10, Language = International}, // Magby Faint Attack
 
             // Spring Into Spring (April 12 to May 4, 2002)
-            new EncounterStatic2E(054, 05, GSC) {Moves = new[] {080}, EggLocation = 256, Language = International}, // Psyduck Petal Dance
-            new EncounterStatic2E(152, 05, GSC) {Moves = new[] {080}, EggLocation = 256, Language = International}, // Chikorita Petal Dance
-            new EncounterStatic2E(172, 05, GSC) {Moves = new[] {080}, EggLocation = 256, Language = International}, // Pichu Petal Dance
-            new EncounterStatic2E(173, 05, GSC) {Moves = new[] {080}, EggLocation = 256, Language = International}, // Cleffa Petal Dance
-            new EncounterStatic2E(174, 05, GSC) {Moves = new[] {080}, EggLocation = 256, Language = International}, // Igglybuff Petal Dance
-            new EncounterStatic2E(238, 05, GSC) {Moves = new[] {080}, EggLocation = 256, Language = International}, // Smoochum Petal Dance
+            new EncounterStatic2E(054, 05, GSC) {Moves = new[] {080}, EggLocation = 256, EggCycles = 10, Language = International}, // Psyduck Petal Dance
+            new EncounterStatic2E(152, 05, GSC) {Moves = new[] {080}, EggLocation = 256, EggCycles = 10, Language = International}, // Chikorita Petal Dance
+            new EncounterStatic2E(172, 05, GSC) {Moves = new[] {080}, EggLocation = 256, EggCycles = 10, Language = International}, // Pichu Petal Dance
+            new EncounterStatic2E(173, 05, GSC) {Moves = new[] {080}, EggLocation = 256, EggCycles = 10, Language = International}, // Cleffa Petal Dance
+            new EncounterStatic2E(174, 05, GSC) {Moves = new[] {080}, EggLocation = 256, EggCycles = 10, Language = International}, // Igglybuff Petal Dance
+            new EncounterStatic2E(238, 05, GSC) {Moves = new[] {080}, EggLocation = 256, EggCycles = 10, Language = International}, // Smoochum Petal Dance
 
             // Baby Weeks (May 5 to June 7, 2002)
-            new EncounterStatic2E(194, 05, GSC) {Moves = new[] {187}, EggLocation = 256, Language = International}, // Wooper Belly Drum
+            new EncounterStatic2E(194, 05, GSC) {Moves = new[] {187}, EggLocation = 256, EggCycles = 10, Language = International}, // Wooper Belly Drum
 
             // Tropical Promotion to Summer Festival 1 (June 8 to 21, 2002)
-            new EncounterStatic2E(060, 05, GSC) {Moves = new[] {074}, EggLocation = 256, Language = International}, // Poliwag Growth
-            new EncounterStatic2E(116, 05, GSC) {Moves = new[] {114}, EggLocation = 256, Language = International}, // Horsea Haze
-            new EncounterStatic2E(118, 05, GSC) {Moves = new[] {014}, EggLocation = 256, Language = International}, // Goldeen Swords Dance
-            new EncounterStatic2E(129, 05, GSC) {Moves = new[] {179}, EggLocation = 256, Language = International}, // Magikarp Reversal
-            new EncounterStatic2E(183, 05, GSC) {Moves = new[] {146}, EggLocation = 256, Language = International}, // Marill Dizzy Punch
+            new EncounterStatic2E(060, 05, GSC) {Moves = new[] {074}, EggLocation = 256, EggCycles = 10, Language = International}, // Poliwag Growth
+            new EncounterStatic2E(116, 05, GSC) {Moves = new[] {114}, EggLocation = 256, EggCycles = 10, Language = International}, // Horsea Haze
+            new EncounterStatic2E(118, 05, GSC) {Moves = new[] {014}, EggLocation = 256, EggCycles = 10, Language = International}, // Goldeen Swords Dance
+            new EncounterStatic2E(129, 05, GSC) {Moves = new[] {179}, EggLocation = 256, EggCycles = 10, Language = International}, // Magikarp Reversal
+            new EncounterStatic2E(183, 05, GSC) {Moves = new[] {146}, EggLocation = 256, EggCycles = 10, Language = International}, // Marill Dizzy Punch
 
             // Tropical Promotion to Summer Festival 2 (July 12 to August 8, 2002)
-            new EncounterStatic2E(054, 05, GSC) {Moves = new[] {161}, EggLocation = 256, Language = International}, // Psyduck Tri Attack
-            new EncounterStatic2E(072, 05, GSC) {Moves = new[] {109}, EggLocation = 256, Language = International}, // Tentacool Confuse Ray
-            new EncounterStatic2E(131, 05, GSC) {Moves = new[] {044}, EggLocation = 256, Language = International}, // Lapras Bite
-            new EncounterStatic2E(170, 05, GSC) {Moves = new[] {113}, EggLocation = 256, Language = International}, // Chinchou Light Screen
-            new EncounterStatic2E(223, 05, GSC) {Moves = new[] {054}, EggLocation = 256, Language = International}, // Remoraid Mist
-            new EncounterStatic2E(226, 05, GSC) {Moves = new[] {016}, EggLocation = 256, Language = International}, // Mantine Gust
+            new EncounterStatic2E(054, 05, GSC) {Moves = new[] {161}, EggLocation = 256, EggCycles = 10, Language = International}, // Psyduck Tri Attack
+            new EncounterStatic2E(072, 05, GSC) {Moves = new[] {109}, EggLocation = 256, EggCycles = 10, Language = International}, // Tentacool Confuse Ray
+            new EncounterStatic2E(131, 05, GSC) {Moves = new[] {044}, EggLocation = 256, EggCycles = 10, Language = International}, // Lapras Bite
+            new EncounterStatic2E(170, 05, GSC) {Moves = new[] {113}, EggLocation = 256, EggCycles = 10, Language = International}, // Chinchou Light Screen
+            new EncounterStatic2E(223, 05, GSC) {Moves = new[] {054}, EggLocation = 256, EggCycles = 10, Language = International}, // Remoraid Mist
+            new EncounterStatic2E(226, 05, GSC) {Moves = new[] {016}, EggLocation = 256, EggCycles = 10, Language = International}, // Mantine Gust
 
             // Safari Week (August 9 to 29, 2002)
-            new EncounterStatic2E(029, 05, GSC) {Moves = new[] {236}, EggLocation = 256, Language = International}, // Nidoran (F) Moonlight
-            new EncounterStatic2E(032, 05, GSC) {Moves = new[] {234}, EggLocation = 256, Language = International}, // Nidoran (M) Morning Sun
-            new EncounterStatic2E(113, 05, GSC) {Moves = new[] {230}, EggLocation = 256, Language = International}, // Chansey Sweet Scent
-            new EncounterStatic2E(115, 05, GSC) {Moves = new[] {185}, EggLocation = 256, Language = International}, // Kangaskhan Faint Attack
-            new EncounterStatic2E(128, 05, GSC) {Moves = new[] {098}, EggLocation = 256, Language = International}, // Tauros Quick Attack
-            new EncounterStatic2E(147, 05, GSC) {Moves = new[] {056}, EggLocation = 256, Language = International}, // Dratini Hydro Pump
+            new EncounterStatic2E(029, 05, GSC) {Moves = new[] {236}, EggLocation = 256, EggCycles = 10, Language = International}, // Nidoran (F) Moonlight
+            new EncounterStatic2E(032, 05, GSC) {Moves = new[] {234}, EggLocation = 256, EggCycles = 10, Language = International}, // Nidoran (M) Morning Sun
+            new EncounterStatic2E(113, 05, GSC) {Moves = new[] {230}, EggLocation = 256, EggCycles = 10, Language = International}, // Chansey Sweet Scent
+            new EncounterStatic2E(115, 05, GSC) {Moves = new[] {185}, EggLocation = 256, EggCycles = 10, Language = International}, // Kangaskhan Faint Attack
+            new EncounterStatic2E(128, 05, GSC) {Moves = new[] {098}, EggLocation = 256, EggCycles = 10, Language = International}, // Tauros Quick Attack
+            new EncounterStatic2E(147, 05, GSC) {Moves = new[] {056}, EggLocation = 256, EggCycles = 10, Language = International}, // Dratini Hydro Pump
 
             // Sky Week (August 30 to September 26, 2002)
-            new EncounterStatic2E(021, 05, GSC) {Moves = new[] {049}, EggLocation = 256, Language = International}, // Spearow SonicBoom
-            new EncounterStatic2E(083, 05, GSC) {Moves = new[] {210}, EggLocation = 256, Language = International}, // Farfetch'd Fury Cutter
-            new EncounterStatic2E(084, 05, GSC) {Moves = new[] {067}, EggLocation = 256, Language = International}, // Doduo Low Kick
-            new EncounterStatic2E(177, 05, GSC) {Moves = new[] {219}, EggLocation = 256, Language = International}, // Natu Safeguard
-            new EncounterStatic2E(198, 05, GSC) {Moves = new[] {251}, EggLocation = 256, Language = International}, // Murkrow Beat Up
-            new EncounterStatic2E(227, 05, GSC) {Moves = new[] {210}, EggLocation = 256, Language = International}, // Skarmory Fury Cutter
+            new EncounterStatic2E(021, 05, GSC) {Moves = new[] {049}, EggLocation = 256, EggCycles = 10, Language = International}, // Spearow SonicBoom
+            new EncounterStatic2E(083, 05, GSC) {Moves = new[] {210}, EggLocation = 256, EggCycles = 10, Language = International}, // Farfetch'd Fury Cutter
+            new EncounterStatic2E(084, 05, GSC) {Moves = new[] {067}, EggLocation = 256, EggCycles = 10, Language = International}, // Doduo Low Kick
+            new EncounterStatic2E(177, 05, GSC) {Moves = new[] {219}, EggLocation = 256, EggCycles = 10, Language = International}, // Natu Safeguard
+            new EncounterStatic2E(198, 05, GSC) {Moves = new[] {251}, EggLocation = 256, EggCycles = 10, Language = International}, // Murkrow Beat Up
+            new EncounterStatic2E(227, 05, GSC) {Moves = new[] {210}, EggLocation = 256, EggCycles = 10, Language = International}, // Skarmory Fury Cutter
 
             // The Kanto Initial Three Pokémon (September 27 to October 3, 2002)
-            new EncounterStatic2E(150, 70, GS) {OT_Names = PCNYx, Shiny = Shiny.Always, Language = International}, // Shiny Mewtwo
+            new EncounterStatic2E(150, 05, GS) {OT_Names = PCNYx, CurrentLevel = 70, Shiny = Shiny.Always, Location = 127, Language = International}, // Shiny Mewtwo
 
             // Power Plant Pokémon (October 4 to October 10, 2002)
-            new EncounterStatic2E(172, 05, GSC) {Moves = new[] {146}, EggLocation = 256, Language = International}, // Pichu Dizzy Punch
-            new EncounterStatic2E(081, 05, GSC) {Moves = new[] {097}, EggLocation = 256, Language = International}, // Magnemite Agility
-            new EncounterStatic2E(239, 05, GSC) {Moves = new[] {146}, EggLocation = 256, Language = International}, // Elekid Dizzy Punch
-            new EncounterStatic2E(100, 05, GSC) {Moves = new[] {097}, EggLocation = 256, Language = International}, // Voltorb Agility
+            new EncounterStatic2E(172, 05, GSC) {Moves = new[] {146}, EggLocation = 256, EggCycles = 10, Language = International}, // Pichu Dizzy Punch
+            new EncounterStatic2E(081, 05, GSC) {Moves = new[] {097}, EggLocation = 256, EggCycles = 10, Language = International}, // Magnemite Agility
+            new EncounterStatic2E(239, 05, GSC) {Moves = new[] {146}, EggLocation = 256, EggCycles = 10, Language = International}, // Elekid Dizzy Punch
+            new EncounterStatic2E(100, 05, GSC) {Moves = new[] {097}, EggLocation = 256, EggCycles = 10, Language = International}, // Voltorb Agility
 
             // Scary Face Pokémon (October 25 to October 31, 2002)
-            new EncounterStatic2E(173, 05, GSC) {Moves = new[] {184}, EggLocation = 256, Language = International}, // Cleffa Scary Face
-            new EncounterStatic2E(174, 05, GSC) {Moves = new[] {184}, EggLocation = 256, Language = International}, // Igglybuff Scary Face
-            new EncounterStatic2E(183, 05, GSC) {Moves = new[] {184}, EggLocation = 256, Language = International}, // Marill Scary Face
-            new EncounterStatic2E(172, 05, GSC) {Moves = new[] {184}, EggLocation = 256, Language = International}, // Pichu Scary Face
-            new EncounterStatic2E(194, 05, GSC) {Moves = new[] {184}, EggLocation = 256, Language = International}, // Wooper Scary Face
+            new EncounterStatic2E(173, 05, GSC) {Moves = new[] {184}, EggLocation = 256, EggCycles = 10, Language = International}, // Cleffa Scary Face
+            new EncounterStatic2E(174, 05, GSC) {Moves = new[] {184}, EggLocation = 256, EggCycles = 10, Language = International}, // Igglybuff Scary Face
+            new EncounterStatic2E(183, 05, GSC) {Moves = new[] {184}, EggLocation = 256, EggCycles = 10, Language = International}, // Marill Scary Face
+            new EncounterStatic2E(172, 05, GSC) {Moves = new[] {184}, EggLocation = 256, EggCycles = 10, Language = International}, // Pichu Scary Face
+            new EncounterStatic2E(194, 05, GSC) {Moves = new[] {184}, EggLocation = 256, EggCycles = 10, Language = International}, // Wooper Scary Face
 
             // Silver Cave (November 1 to November 7, 2002)
-            new EncounterStatic2E(114, 05, GSC) {Moves = new[] {235}, EggLocation = 256, Language = International}, // Tangela Synthesis
-            new EncounterStatic2E(077, 05, GSC) {Moves = new[] {067}, EggLocation = 256, Language = International}, // Ponyta Low Kick
-            new EncounterStatic2E(200, 05, GSC) {Moves = new[] {095}, EggLocation = 256, Language = International}, // Misdreavus Hypnosis
-            new EncounterStatic2E(246, 05, GSC) {Moves = new[] {099}, EggLocation = 256, Language = International}, // Larvitar Rage
+            new EncounterStatic2E(114, 05, GSC) {Moves = new[] {235}, EggLocation = 256, EggCycles = 10, Language = International}, // Tangela Synthesis
+            new EncounterStatic2E(077, 05, GSC) {Moves = new[] {067}, EggLocation = 256, EggCycles = 10, Language = International}, // Ponyta Low Kick
+            new EncounterStatic2E(200, 05, GSC) {Moves = new[] {095}, EggLocation = 256, EggCycles = 10, Language = International}, // Misdreavus Hypnosis
+            new EncounterStatic2E(246, 05, GSC) {Moves = new[] {099}, EggLocation = 256, EggCycles = 10, Language = International}, // Larvitar Rage
 
             // Union Cave Pokémon (November 8 to 14, 2002)
-            new EncounterStatic2E(120, 05, GSC) {Moves = new[] {239}, EggLocation = 256, Language = International}, // Staryu Twister
-            new EncounterStatic2E(098, 05, GSC) {Moves = new[] {232}, EggLocation = 256, Language = International}, // Krabby Metal Claw
-            new EncounterStatic2E(095, 05, GSC) {Moves = new[] {159}, EggLocation = 256, Language = International}, // Onix Sharpen
-            new EncounterStatic2E(131, 05, GSC) {Moves = new[] {248}, EggLocation = 256, Language = International}, // Lapras Future Sight
+            new EncounterStatic2E(120, 05, GSC) {Moves = new[] {239}, EggLocation = 256, EggCycles = 10, Language = International}, // Staryu Twister
+            new EncounterStatic2E(098, 05, GSC) {Moves = new[] {232}, EggLocation = 256, EggCycles = 10, Language = International}, // Krabby Metal Claw
+            new EncounterStatic2E(095, 05, GSC) {Moves = new[] {159}, EggLocation = 256, EggCycles = 10, Language = International}, // Onix Sharpen
+            new EncounterStatic2E(131, 05, GSC) {Moves = new[] {248}, EggLocation = 256, EggCycles = 10, Language = International}, // Lapras Future Sight
 
             // Johto Legendary (November 15 to 21, 2002)
-            new EncounterStatic2E(250, 40, GS) {OT_Names = PCNYx, Shiny = Shiny.Always, Language = International}, // Shiny Ho-Oh
-            new EncounterStatic2E(249, 40, GS) {OT_Names = PCNYx, Shiny = Shiny.Always, Language = International}, // Shiny Lugia
+            new EncounterStatic2E(250, 05, GS) {OT_Names = PCNYx, CurrentLevel = 40, Shiny = Shiny.Always, Location = 127, Language = International}, // Shiny Ho-Oh
+            new EncounterStatic2E(249, 05, GS) {OT_Names = PCNYx, CurrentLevel = 40, Shiny = Shiny.Always, Location = 127, Language = International}, // Shiny Lugia
 
             // Celebi Present SP (November 22 to 28, 2002)
-            new EncounterStatic2E(151, 05, GS) {OT_Names = PCNYx, Shiny = Shiny.Always, Language = International}, // Shiny Mew
+            new EncounterStatic2E(151, 05, GS) {OT_Names = PCNYx, Shiny = Shiny.Always, Location = 127, Language = International}, // Shiny Mew
 
             // Psychic Type Pokémon (November 29 to December 5, 2002)
-            new EncounterStatic2E(063, 05, GSC) {Moves = new[] {193}, EggLocation = 256, Language = International}, // Abra Foresight
-            new EncounterStatic2E(096, 05, GSC) {Moves = new[] {133}, EggLocation = 256, Language = International}, // Drowzee Amnesia
-            new EncounterStatic2E(102, 05, GSC) {Moves = new[] {230}, EggLocation = 256, Language = International}, // Exeggcute Sweet Scent
-            new EncounterStatic2E(122, 05, GSC) {Moves = new[] {170}, EggLocation = 256, Language = International}, // Mr. Mime Mind Reader
+            new EncounterStatic2E(063, 05, GSC) {Moves = new[] {193}, EggLocation = 256, EggCycles = 10, Language = International}, // Abra Foresight
+            new EncounterStatic2E(096, 05, GSC) {Moves = new[] {133}, EggLocation = 256, EggCycles = 10, Language = International}, // Drowzee Amnesia
+            new EncounterStatic2E(102, 05, GSC) {Moves = new[] {230}, EggLocation = 256, EggCycles = 10, Language = International}, // Exeggcute Sweet Scent
+            new EncounterStatic2E(122, 05, GSC) {Moves = new[] {170}, EggLocation = 256, EggCycles = 10, Language = International}, // Mr. Mime Mind Reader
 
             // The Johto Initial Three Pokémon (December 6 to 12, 2002)
-            new EncounterStatic2E(154, 40, GS) {OT_Names = PCNYx, Shiny = Shiny.Always, Language = International}, // Shiny Meganium
-            new EncounterStatic2E(157, 40, GS) {OT_Names = PCNYx, Shiny = Shiny.Always, Language = International}, // Shiny Typhlosion
-            new EncounterStatic2E(160, 40, GS) {OT_Names = PCNYx, Shiny = Shiny.Always, Language = International}, // Shiny Feraligatr
+            new EncounterStatic2E(154, 05, GS) {OT_Names = PCNYx, CurrentLevel = 40, Shiny = Shiny.Always, Location = 127, Language = International}, // Shiny Meganium
+            new EncounterStatic2E(157, 05, GS) {OT_Names = PCNYx, CurrentLevel = 40, Shiny = Shiny.Always, Location = 127, Language = International}, // Shiny Typhlosion
+            new EncounterStatic2E(160, 05, GS) {OT_Names = PCNYx, CurrentLevel = 40, Shiny = Shiny.Always, Location = 127, Language = International}, // Shiny Feraligatr
 
             // Rock Tunnel Pokémon (December 13 to December 19, 2002)
-            new EncounterStatic2E(074, 05, GSC) {Moves = new[] {229}, EggLocation = 256, Language = International}, // Geodude Rapid Spin
-            new EncounterStatic2E(041, 05, GSC) {Moves = new[] {175}, EggLocation = 256, Language = International}, // Zubat Flail
-            new EncounterStatic2E(066, 05, GSC) {Moves = new[] {037}, EggLocation = 256, Language = International}, // Machop Thrash
-            new EncounterStatic2E(104, 05, GSC) {Moves = new[] {031}, EggLocation = 256, Language = International}, // Cubone Fury Attack
+            new EncounterStatic2E(074, 05, GSC) {Moves = new[] {229}, EggLocation = 256, EggCycles = 10, Language = International}, // Geodude Rapid Spin
+            new EncounterStatic2E(041, 05, GSC) {Moves = new[] {175}, EggLocation = 256, EggCycles = 10, Language = International}, // Zubat Flail
+            new EncounterStatic2E(066, 05, GSC) {Moves = new[] {037}, EggLocation = 256, EggCycles = 10, Language = International}, // Machop Thrash
+            new EncounterStatic2E(104, 05, GSC) {Moves = new[] {031}, EggLocation = 256, EggCycles = 10, Language = International}, // Cubone Fury Attack
 
             // Ice Type Pokémon (December 20 to 26, 2002)
-            new EncounterStatic2E(225, 05, GSC) {Moves = new[] {191}, EggLocation = 256, Language = International}, // Delibird Spikes
-            new EncounterStatic2E(086, 05, GSC) {Moves = new[] {175}, EggLocation = 256, Language = International}, // Seel Flail
-            new EncounterStatic2E(220, 05, GSC) {Moves = new[] {018}, EggLocation = 256, Language = International}, // Swinub Whirlwind
+            new EncounterStatic2E(225, 05, GSC) {Moves = new[] {191}, EggLocation = 256, EggCycles = 10, Language = International}, // Delibird Spikes
+            new EncounterStatic2E(086, 05, GSC) {Moves = new[] {175}, EggLocation = 256, EggCycles = 10, Language = International}, // Seel Flail
+            new EncounterStatic2E(220, 05, GSC) {Moves = new[] {018}, EggLocation = 256, EggCycles = 10, Language = International}, // Swinub Whirlwind
 
             // Pokémon that Appear at Night only (December 27, 2002 to January 2, 2003)
-            new EncounterStatic2E(163, 05, GSC) {Moves = new[] {101}, EggLocation = 256, Language = International}, // Hoothoot Night Shade
-            new EncounterStatic2E(215, 05, GSC) {Moves = new[] {236}, EggLocation = 256, Language = International}, // Sneasel Moonlight
+            new EncounterStatic2E(163, 05, GSC) {Moves = new[] {101}, EggLocation = 256, EggCycles = 10, Language = International}, // Hoothoot Night Shade
+            new EncounterStatic2E(215, 05, GSC) {Moves = new[] {236}, EggLocation = 256, EggCycles = 10, Language = International}, // Sneasel Moonlight
 
             // Grass Type ( January 3 to 9, 2003)
-            new EncounterStatic2E(191, 05, GSC) {Moves = new[] {150}, EggLocation = 256, Language = International}, // Sunkern Splash
-            new EncounterStatic2E(046, 05, GSC) {Moves = new[] {235}, EggLocation = 256, Language = International}, // Paras Synthesis
-            new EncounterStatic2E(187, 05, GSC) {Moves = new[] {097}, EggLocation = 256, Language = International}, // Hoppip Agility
-            new EncounterStatic2E(043, 05, GSC) {Moves = new[] {073}, EggLocation = 256, Language = International}, // Oddish Leech Seed
+            new EncounterStatic2E(191, 05, GSC) {Moves = new[] {150}, EggLocation = 256, EggCycles = 10, Language = International}, // Sunkern Splash
+            new EncounterStatic2E(046, 05, GSC) {Moves = new[] {235}, EggLocation = 256, EggCycles = 10, Language = International}, // Paras Synthesis
+            new EncounterStatic2E(187, 05, GSC) {Moves = new[] {097}, EggLocation = 256, EggCycles = 10, Language = International}, // Hoppip Agility
+            new EncounterStatic2E(043, 05, GSC) {Moves = new[] {073}, EggLocation = 256, EggCycles = 10, Language = International}, // Oddish Leech Seed
 
             // Normal Pokémon (January 10 to 16, 2003)
-            new EncounterStatic2E(161, 05, GSC) {Moves = new[] {146}, EggLocation = 256, Language = International}, // Sentret Dizzy Punch
-            new EncounterStatic2E(234, 05, GSC) {Moves = new[] {219}, EggLocation = 256, Language = International}, // Stantler Safeguard
-            new EncounterStatic2E(241, 05, GSC) {Moves = new[] {025}, EggLocation = 256, Language = International}, // Miltank Mega Kick
-            new EncounterStatic2E(190, 05, GSC) {Moves = new[] {102}, EggLocation = 256, Language = International}, // Aipom Mimic
-            new EncounterStatic2E(108, 05, GSC) {Moves = new[] {003}, EggLocation = 256, Language = International}, // Lickitung DoubleSlap
-            new EncounterStatic2E(143, 05, GSC) {Moves = new[] {150}, EggLocation = 256, Language = International}, // Snorlax Splash
+            new EncounterStatic2E(161, 05, GSC) {Moves = new[] {146}, EggLocation = 256, EggCycles = 10, Language = International}, // Sentret Dizzy Punch
+            new EncounterStatic2E(234, 05, GSC) {Moves = new[] {219}, EggLocation = 256, EggCycles = 10, Language = International}, // Stantler Safeguard
+            new EncounterStatic2E(241, 05, GSC) {Moves = new[] {025}, EggLocation = 256, EggCycles = 10, Language = International}, // Miltank Mega Kick
+            new EncounterStatic2E(190, 05, GSC) {Moves = new[] {102}, EggLocation = 256, EggCycles = 10, Language = International}, // Aipom Mimic
+            new EncounterStatic2E(108, 05, GSC) {Moves = new[] {003}, EggLocation = 256, EggCycles = 10, Language = International}, // Lickitung DoubleSlap
+            new EncounterStatic2E(143, 05, GSC) {Moves = new[] {150}, EggLocation = 256, EggCycles = 10, Language = International}, // Snorlax Splash
 
             // Mt. Mortar (January 24 to 30, 2003)
-            new EncounterStatic2E(066, 05, GSC) {Moves = new[] {206}, EggLocation = 256, Language = International}, // Machop False Swipe
-            new EncounterStatic2E(129, 05, GSC) {Moves = new[] {145}, EggLocation = 256, Language = International}, // Magikarp Bubble
-            new EncounterStatic2E(236, 05, GSC) {Moves = new[] {099}, EggLocation = 256, Language = International}, // Tyrogue Rage
+            new EncounterStatic2E(066, 05, GSC) {Moves = new[] {206}, EggLocation = 256, EggCycles = 10, Language = International}, // Machop False Swipe
+            new EncounterStatic2E(129, 05, GSC) {Moves = new[] {145}, EggLocation = 256, EggCycles = 10, Language = International}, // Magikarp Bubble
+            new EncounterStatic2E(236, 05, GSC) {Moves = new[] {099}, EggLocation = 256, EggCycles = 10, Language = International}, // Tyrogue Rage
 
             // Dark Cave Pokémon (January 31 to February 6, 2003)
-            new EncounterStatic2E(206, 05, GSC) {Moves = new[] {031}, EggLocation = 256, Language = International}, // Dunsparce Fury Attack
-            new EncounterStatic2E(202, 05, GSC) {Moves = new[] {102}, EggLocation = 256, Language = International}, // Wobbuffet Mimic
-            new EncounterStatic2E(231, 05, GSC) {Moves = new[] {071}, EggLocation = 256, Language = International}, // Phanpy Absorb
-            new EncounterStatic2E(216, 05, GSC) {Moves = new[] {230}, EggLocation = 256, Language = International}, // Teddiursa Sweet Scent
+            new EncounterStatic2E(206, 05, GSC) {Moves = new[] {031}, EggLocation = 256, EggCycles = 10, Language = International}, // Dunsparce Fury Attack
+            new EncounterStatic2E(202, 05, GSC) {Moves = new[] {102}, EggLocation = 256, EggCycles = 10, Language = International}, // Wobbuffet Mimic
+            new EncounterStatic2E(231, 05, GSC) {Moves = new[] {071}, EggLocation = 256, EggCycles = 10, Language = International}, // Phanpy Absorb
+            new EncounterStatic2E(216, 05, GSC) {Moves = new[] {230}, EggLocation = 256, EggCycles = 10, Language = International}, // Teddiursa Sweet Scent
 
             // Valentine's Day Special (February 7 to 13, 2003)
-            new EncounterStatic2E(060, 05, GSC) {Moves = new[] {186}, EggLocation = 256, Language = International}, // Poliwag Sweet Kiss
-            new EncounterStatic2E(060, 05, GSC) {Moves = new[] {142}, EggLocation = 256, Language = International}, // Poliwag Lovely Kiss
-            new EncounterStatic2E(143, 05, GSC) {Moves = new[] {186}, EggLocation = 256, Language = International}, // Snorlax Sweet Kiss
-            new EncounterStatic2E(143, 05, GSC) {Moves = new[] {142}, EggLocation = 256, Language = International}, // Snorlax Lovely Kiss
+            new EncounterStatic2E(060, 05, GSC) {Moves = new[] {186}, EggLocation = 256, EggCycles = 10, Language = International}, // Poliwag Sweet Kiss
+            new EncounterStatic2E(060, 05, GSC) {Moves = new[] {142}, EggLocation = 256, EggCycles = 10, Language = International}, // Poliwag Lovely Kiss
+            new EncounterStatic2E(143, 05, GSC) {Moves = new[] {186}, EggLocation = 256, EggCycles = 10, Language = International}, // Snorlax Sweet Kiss
+            new EncounterStatic2E(143, 05, GSC) {Moves = new[] {142}, EggLocation = 256, EggCycles = 10, Language = International}, // Snorlax Lovely Kiss
 
             // Rare Pokémon (February 21 to 27, 2003)
-            new EncounterStatic2E(140, 05, GSC) {Moves = new[] {088}, EggLocation = 256, Language = International}, // Kabuto Rock Throw
-            new EncounterStatic2E(138, 05, GSC) {Moves = new[] {088}, EggLocation = 256, Language = International}, // Omanyte Rock Throw
-            new EncounterStatic2E(142, 05, GSC) {Moves = new[] {088}, EggLocation = 256, Language = International}, // Aerodactyl Rock Throw
-            new EncounterStatic2E(137, 05, GSC) {Moves = new[] {112}, EggLocation = 256, Language = International}, // Porygon Barrier
-            new EncounterStatic2E(133, 05, GSC) {Moves = new[] {074}, EggLocation = 256, Language = International}, // Eevee Growth
-            new EncounterStatic2E(143, 05, GSC) {Moves = new[] {164}, EggLocation = 256, Language = International}, // Sudowoodo Substitute
+            new EncounterStatic2E(140, 05, GSC) {Moves = new[] {088}, EggLocation = 256, EggCycles = 10, Language = International}, // Kabuto Rock Throw
+            new EncounterStatic2E(138, 05, GSC) {Moves = new[] {088}, EggLocation = 256, EggCycles = 10, Language = International}, // Omanyte Rock Throw
+            new EncounterStatic2E(142, 05, GSC) {Moves = new[] {088}, EggLocation = 256, EggCycles = 10, Language = International}, // Aerodactyl Rock Throw
+            new EncounterStatic2E(137, 05, GSC) {Moves = new[] {112}, EggLocation = 256, EggCycles = 10, Language = International}, // Porygon Barrier
+            new EncounterStatic2E(133, 05, GSC) {Moves = new[] {074}, EggLocation = 256, EggCycles = 10, Language = International}, // Eevee Growth
+            new EncounterStatic2E(185, 05, GSC) {Moves = new[] {164}, EggLocation = 256, EggCycles = 10, Language = International}, // Sudowoodo Substitute
 
             // Bug Type Pokémon (February 28 to March 6, 2003)
-            new EncounterStatic2E(123, 05, GSC) {Moves = new[] {049}, EggLocation = 256, Language = International}, // Scyther SonicBoom
-            new EncounterStatic2E(214, 05, GSC) {Moves = new[] {069}, EggLocation = 256, Language = International}, // Heracross Seismic Toss
-            new EncounterStatic2E(127, 05, GSC) {Moves = new[] {088}, EggLocation = 256, Language = International}, // Pinsir Rock Throw
-            new EncounterStatic2E(165, 05, GSC) {Moves = new[] {112}, EggLocation = 256, Language = International}, // Ledyba Barrier
-            new EncounterStatic2E(167, 05, GSC) {Moves = new[] {074}, EggLocation = 256, Language = International}, // Spinarak Growth
-            new EncounterStatic2E(193, 05, GSC) {Moves = new[] {186}, EggLocation = 256, Language = International}, // Yanma Sweet Kiss
-            new EncounterStatic2E(204, 05, GSC) {Moves = new[] {164}, EggLocation = 256, Language = International}, // Pineco Substitute
+            new EncounterStatic2E(123, 05, GSC) {Moves = new[] {049}, EggLocation = 256, EggCycles = 10, Language = International}, // Scyther SonicBoom
+            new EncounterStatic2E(214, 05, GSC) {Moves = new[] {069}, EggLocation = 256, EggCycles = 10, Language = International}, // Heracross Seismic Toss
+            new EncounterStatic2E(127, 05, GSC) {Moves = new[] {088}, EggLocation = 256, EggCycles = 10, Language = International}, // Pinsir Rock Throw
+            new EncounterStatic2E(165, 05, GSC) {Moves = new[] {112}, EggLocation = 256, EggCycles = 10, Language = International}, // Ledyba Barrier
+            new EncounterStatic2E(167, 05, GSC) {Moves = new[] {074}, EggLocation = 256, EggCycles = 10, Language = International}, // Spinarak Growth
+            new EncounterStatic2E(193, 05, GSC) {Moves = new[] {186}, EggLocation = 256, EggCycles = 10, Language = International}, // Yanma Sweet Kiss
+            new EncounterStatic2E(204, 05, GSC) {Moves = new[] {164}, EggLocation = 256, EggCycles = 10, Language = International}, // Pineco Substitute
 
             // Japanese Only (all below)
             new EncounterStatic2E(251, 30, GSC) {Location = 014}, // Celebi @ Ilex Forest (GBC)
 
             // Gen2 Events
+            // Egg Cycles Subject to Change
             // Pokémon Center Mystery Egg #1 (December 15, 2001 to January 14, 2002)
-            new EncounterStatic2E(152, 05, GSC) {Moves = new[] {080}, EggLocation = 256}, // Chikorita Petal Dance
-            new EncounterStatic2E(172, 05, GSC) {Moves = new[] {047}, EggLocation = 256}, // Pichu Sing
-            new EncounterStatic2E(173, 05, GSC) {Moves = new[] {129}, EggLocation = 256}, // Cleffa Swift
-            new EncounterStatic2E(194, 05, GSC) {Moves = new[] {187}, EggLocation = 256}, // Wooper Belly Drum
-            new EncounterStatic2E(231, 05, GSC) {Moves = new[] {227}, EggLocation = 256}, // Phanpy Encore
-            new EncounterStatic2E(238, 05, GSC) {Moves = new[] {118}, EggLocation = 256}, // Smoochum Metronome
+            new EncounterStatic2E(152, 05, GSC) {Moves = new[] {080}, EggLocation = 256, EggCycles = 10,}, // Chikorita Petal Dance
+            new EncounterStatic2E(172, 05, GSC) {Moves = new[] {047}, EggLocation = 256, EggCycles = 10,}, // Pichu Sing
+            new EncounterStatic2E(173, 05, GSC) {Moves = new[] {129}, EggLocation = 256, EggCycles = 10,}, // Cleffa Swift
+            new EncounterStatic2E(194, 05, GSC) {Moves = new[] {187}, EggLocation = 256, EggCycles = 10,}, // Wooper Belly Drum
+            new EncounterStatic2E(231, 05, GSC) {Moves = new[] {227}, EggLocation = 256, EggCycles = 10,}, // Phanpy Encore
+            new EncounterStatic2E(238, 05, GSC) {Moves = new[] {118}, EggLocation = 256, EggCycles = 10,}, // Smoochum Metronome
 
             // Pokémon Center Mystery Egg #2 (March 16 to April 7, 2002)
-            new EncounterStatic2E(054, 05, GSC) {Moves = new[] {080}, EggLocation = 256}, // Psyduck Petal Dance
-            new EncounterStatic2E(152, 05, GSC) {Moves = new[] {080}, EggLocation = 256}, // Chikorita Petal Dance
-            new EncounterStatic2E(172, 05, GSC) {Moves = new[] {080}, EggLocation = 256}, // Pichu Petal Dance
-            new EncounterStatic2E(173, 05, GSC) {Moves = new[] {080}, EggLocation = 256}, // Cleffa Petal Dance
-            new EncounterStatic2E(174, 05, GSC) {Moves = new[] {080}, EggLocation = 256}, // Igglybuff Petal Dance
-            new EncounterStatic2E(238, 05, GSC) {Moves = new[] {080}, EggLocation = 256}, // Smoochum Petal Dance
+            new EncounterStatic2E(054, 05, GSC) {Moves = new[] {080}, EggLocation = 256, EggCycles = 10,}, // Psyduck Petal Dance
+            new EncounterStatic2E(152, 05, GSC) {Moves = new[] {080}, EggLocation = 256, EggCycles = 10,}, // Chikorita Petal Dance
+            new EncounterStatic2E(172, 05, GSC) {Moves = new[] {080}, EggLocation = 256, EggCycles = 10,}, // Pichu Petal Dance
+            new EncounterStatic2E(173, 05, GSC) {Moves = new[] {080}, EggLocation = 256, EggCycles = 10,}, // Cleffa Petal Dance
+            new EncounterStatic2E(174, 05, GSC) {Moves = new[] {080}, EggLocation = 256, EggCycles = 10,}, // Igglybuff Petal Dance
+            new EncounterStatic2E(238, 05, GSC) {Moves = new[] {080}, EggLocation = 256, EggCycles = 10,}, // Smoochum Petal Dance
 
             // Pokémon Center Mystery Egg #3 (April 27 to May 12, 2002)
-            new EncounterStatic2E(001, 05, GSC) {Moves = new[] {246}, EggLocation = 256}, // Bulbasaur Ancientpower
-            new EncounterStatic2E(004, 05, GSC) {Moves = new[] {242}, EggLocation = 256}, // Charmander Crunch
-            new EncounterStatic2E(158, 05, GSC) {Moves = new[] {066}, EggLocation = 256}, // Totodile Submission
-            new EncounterStatic2E(163, 05, GSC) {Moves = new[] {101}, EggLocation = 256}, // Hoot-Hoot Night Shade
+            new EncounterStatic2E(001, 05, GSC) {Moves = new[] {246}, EggLocation = 256, EggCycles = 10,}, // Bulbasaur Ancientpower
+            new EncounterStatic2E(004, 05, GSC) {Moves = new[] {242}, EggLocation = 256, EggCycles = 10,}, // Charmander Crunch
+            new EncounterStatic2E(158, 05, GSC) {Moves = new[] {066}, EggLocation = 256, EggCycles = 10,}, // Totodile Submission
+            new EncounterStatic2E(163, 05, GSC) {Moves = new[] {101}, EggLocation = 256, EggCycles = 10,}, // Hoot-Hoot Night Shade
         };
     }
 }


### PR DESCRIPTION
Met + Current level data for non-Egg PCNY Pokémon and Egg legality for PCNY Pokémon fixed.