### PR TITLE
Enable nullable for winforms csproj

### DIFF
--- a/PKHeX.Core/Legality/Analysis.cs
+++ b/PKHeX.Core/Legality/Analysis.cs
@@ -456,7 +456,7 @@ namespace PKHeX.Core
                 return Info.RelearnBase;
 
             List<int> window = new List<int>(Info.RelearnBase.Where(z => z != 0));
-            window.AddRange(pkm.Moves.Where((z, i) => z != 0 && !Info.Moves[i].Valid || Info.Moves[i].Flag));
+            window.AddRange(pkm.Moves.Where((z, i) => z != 0 && (!Info.Moves[i].Valid || Info.Moves[i].Flag)));
             window = window.Distinct().ToList();
             int[] moves = new int[4];
             int start = Math.Max(0, window.Count - 4);

--- a/PKHeX.Core/Saves/Util/SaveExtensions.cs
+++ b/PKHeX.Core/Saves/Util/SaveExtensions.cs
@@ -51,7 +51,7 @@ namespace PKHeX.Core
         /// </summary>
         /// <param name="sav">SaveFile to be exported</param>
         /// <param name="ext">Selected export extension</param>
-        public static ExportFlags GetSuggestedFlags(this SaveFile sav, string ext)
+        public static ExportFlags GetSuggestedFlags(this SaveFile sav, string? ext = null)
         {
             var flags = ExportFlags.None;
             if (ext == ".dsv")

--- a/PKHeX.WinForms/Controls/PKM Editor/CatchRate.cs
+++ b/PKHeX.WinForms/Controls/PKM Editor/CatchRate.cs
@@ -6,7 +6,7 @@ namespace PKHeX.WinForms.Controls
 {
     public partial class CatchRate : UserControl
     {
-        private PK1 pk1;
+        private PK1 pk1 = new PK1();
         public CatchRate() => InitializeComponent();
 
         public void LoadPK1(PK1 pk) => NUD_CatchRate.Value = (pk1 = pk).Catch_Rate;
@@ -15,7 +15,9 @@ namespace PKHeX.WinForms.Controls
 
         private void Reset(object sender, EventArgs e)
         {
-            var sav = WinFormsUtil.FindFirstControlOfType<IMainEditor>(this).RequestSaveFile;
+            var sav = WinFormsUtil.FindFirstControlOfType<IMainEditor>(this)?.RequestSaveFile;
+            if (sav == null)
+                return;
             NUD_CatchRate.Value = CatchRateApplicator.GetSuggestedCatchRate(pk1, sav);
         }
     }

--- a/PKHeX.WinForms/Controls/PKM Editor/ContextMenuPKM.cs
+++ b/PKHeX.WinForms/Controls/PKM Editor/ContextMenuPKM.cs
@@ -7,9 +7,9 @@ namespace PKHeX.WinForms.Controls
     {
         public ContextMenuPKM() => InitializeComponent();
 
-        public event EventHandler RequestEditorLegality;
-        public event EventHandler RequestEditorQR;
-        public event EventHandler RequestEditorSaveAs;
+        public event EventHandler? RequestEditorLegality;
+        public event EventHandler? RequestEditorQR;
+        public event EventHandler? RequestEditorSaveAs;
         private void ClickShowLegality(object sender, EventArgs e) => RequestEditorLegality?.Invoke(sender, e);
         private void ClickShowQR(object sender, EventArgs e) => RequestEditorQR?.Invoke(sender, e);
         private void ClickSaveAs(object sender, EventArgs e) => RequestEditorSaveAs?.Invoke(sender, e);

--- a/PKHeX.WinForms/Controls/PKM Editor/DrawConfig.cs
+++ b/PKHeX.WinForms/Controls/PKM Editor/DrawConfig.cs
@@ -118,7 +118,7 @@ namespace PKHeX.WinForms
                     continue;
 
                 var name = p.Name;
-                var value = p.PropertyType == typeof(Color) ? ((Color)p.GetValue(this)).ToArgb() : p.GetValue(this);
+                var value = p.PropertyType == typeof(Color) ? ((Color)p.GetValue(this)!).ToArgb() : p.GetValue(this);
                 lines.Add($"{name}\t{value}");
             }
             return string.Join("\n", lines);
@@ -171,11 +171,11 @@ namespace PKHeX.WinForms
 
     public sealed class BrushSet : IDisposable
     {
-        public Brush Text { get; set; }
-        public Brush BackLegal { get; set; }
-        public Brush BackDefault { get; set; }
-        public Brush TextHighlighted { get; set; }
-        public Brush BackHighlighted { get; set; }
+        public Brush Text { get; set; } = Brushes.Black;
+        public Brush BackLegal { get; set; } = Brushes.DarkSeaGreen;
+        public Brush BackDefault { get; set; } = Brushes.White;
+        public Brush TextHighlighted { get; set; } = Brushes.White;
+        public Brush BackHighlighted { get; set; } = Brushes.Blue;
 
         public Brush GetText(bool highlight) => highlight ? TextHighlighted : Text;
         public Brush GetBackground(bool legal, bool highlight) => highlight ? BackHighlighted : (legal ? BackLegal : BackDefault);

--- a/PKHeX.WinForms/Controls/PKM Editor/SizeCP.cs
+++ b/PKHeX.WinForms/Controls/PKM Editor/SizeCP.cs
@@ -6,8 +6,8 @@ namespace PKHeX.WinForms.Controls
 {
     public partial class SizeCP : UserControl
     {
-        private IScaledSize ss;
-        private PB7 pkm;
+        private IScaledSize? ss;
+        private PB7? pkm;
         private bool Loading;
 
         public SizeCP()
@@ -60,31 +60,37 @@ namespace PKHeX.WinForms.Controls
             if (!CHK_Auto.Checked)
                 return;
 
-            pkm.ResetCalculatedValues();
+            pkm?.ResetCalculatedValues();
             LoadStoredValues();
         }
 
         private void MT_CP_TextChanged(object sender, EventArgs e)
         {
-            if (int.TryParse(MT_CP.Text, out var cp))
+            if (int.TryParse(MT_CP.Text, out var cp) && pkm != null)
                 pkm.Stat_CP = Math.Min(65535, cp);
         }
 
         private void NUD_HeightScalar_ValueChanged(object sender, EventArgs e)
         {
-            ss.HeightScalar = (byte) NUD_HeightScalar.Value;
-            L_SizeH.Text = SizeClass[(int)PokeSizeUtil.GetSizeRating(ss.HeightScalar)];
+            if (ss != null)
+            {
+                ss.HeightScalar = (byte) NUD_HeightScalar.Value;
+                L_SizeH.Text = SizeClass[(int)PokeSizeUtil.GetSizeRating(ss.HeightScalar)];
+            }
 
             if (!CHK_Auto.Checked || Loading || pkm == null)
                 return;
             pkm.ResetHeight();
-            TB_HeightAbs.Text = pkm.HeightAbsolute.ToString();
+            TB_HeightAbs.Text = pkm.HeightAbsolute.ToString("F8");
         }
 
         private void NUD_WeightScalar_ValueChanged(object sender, EventArgs e)
         {
-            ss.WeightScalar = (byte) NUD_WeightScalar.Value;
-            L_SizeW.Text = SizeClass[(int)PokeSizeUtil.GetSizeRating(ss.WeightScalar)];
+            if (ss != null)
+            {
+                ss.WeightScalar = (byte) NUD_WeightScalar.Value;
+                L_SizeW.Text = SizeClass[(int)PokeSizeUtil.GetSizeRating(ss.WeightScalar)];
+            }
 
             if (!CHK_Auto.Checked || Loading || pkm == null)
                 return;
@@ -94,6 +100,8 @@ namespace PKHeX.WinForms.Controls
 
         private void TB_HeightAbs_TextChanged(object sender, EventArgs e)
         {
+            if (pkm == null)
+                return;
             if (CHK_Auto.Checked)
                 pkm.ResetHeight();
             else if (float.TryParse(TB_HeightAbs.Text, out var result))
@@ -102,6 +110,8 @@ namespace PKHeX.WinForms.Controls
 
         private void TB_WeightAbs_TextChanged(object sender, EventArgs e)
         {
+            if (pkm == null)
+                return;
             if (CHK_Auto.Checked)
                 pkm.ResetWeight();
             else if (float.TryParse(TB_WeightAbs.Text, out var result))

--- a/PKHeX.WinForms/Controls/PKM Editor/StatEditor.cs
+++ b/PKHeX.WinForms/Controls/PKM Editor/StatEditor.cs
@@ -31,7 +31,7 @@ namespace PKHeX.WinForms.Controls
         public Color StatDecreased { get; set; } = Color.Blue;
         public Color StatHyperTrained { get; set; } = Color.LightGreen;
 
-        public IMainEditor MainEditor { private get; set; }
+        public IMainEditor MainEditor { private get; set; } = null!;
         public bool HaX { set => CHK_HackedStats.Enabled = CHK_HackedStats.Visible = value; }
 
         public bool Valid
@@ -138,14 +138,14 @@ namespace PKHeX.WinForms.Controls
             UpdateStats();
         }
 
-        private void RefreshDerivedValues(object sender)
+        private void RefreshDerivedValues(object _)
         {
             if (Entity.Format < 3)
             {
                 TB_IVHP.Text = Entity.IV_HP.ToString();
                 TB_IVSPD.Text = Entity.IV_SPD.ToString();
 
-                MainEditor.UpdateIVsGB(sender == null);
+                MainEditor.UpdateIVsGB(false);
             }
 
             if (!ChangingFields)
@@ -216,7 +216,7 @@ namespace PKHeX.WinForms.Controls
             bool zero = (ModifierKeys & Keys.Control) != 0;
             var evs = zero ? new int[6] : PKX.GetRandomEVs(Entity.Format);
             LoadEVs(evs);
-            UpdateEVs(null, EventArgs.Empty);
+            UpdateEVs(sender, EventArgs.Empty);
         }
 
         private void UpdateHackedStats(object sender, EventArgs e)

--- a/PKHeX.WinForms/Controls/PKM Editor/TrainerID.cs
+++ b/PKHeX.WinForms/Controls/PKM Editor/TrainerID.cs
@@ -8,10 +8,10 @@ namespace PKHeX.WinForms.Controls
     public partial class TrainerID : UserControl
     {
         public TrainerID() => InitializeComponent();
-        public event EventHandler UpdatedID;
+        public event EventHandler? UpdatedID;
 
         private int Format = -1;
-        private ITrainerID Trainer;
+        private ITrainerID Trainer = null!;
 
         public void UpdateTSV()
         {

--- a/PKHeX.WinForms/Controls/SAV Editor/BitmapAnimator.cs
+++ b/PKHeX.WinForms/Controls/SAV Editor/BitmapAnimator.cs
@@ -16,13 +16,13 @@ namespace PKHeX.WinForms.Controls
 
         private int imgWidth;
         private int imgHeight;
-        private byte[] GlowData;
-        private Image ExtraLayer;
-        private Image[] GlowCache;
-        public Image OriginalBackground;
+        private byte[]? GlowData;
+        private Image? ExtraLayer;
+        private Image?[]? GlowCache;
+        public Image? OriginalBackground;
         private readonly object Lock = new object();
 
-        private PictureBox pb;
+        private PictureBox? pb;
         private int GlowInterval;
         private int GlowCounter;
 
@@ -44,6 +44,8 @@ namespace PKHeX.WinForms.Controls
             }
 
             // reset logic
+            if (GlowCache == null)
+                throw new ArgumentNullException(nameof(GlowCache));
             GlowCounter = 0;
             for (int i = 0; i < GlowCache.Length; i++)
                 GlowCache[i] = null;
@@ -79,6 +81,9 @@ namespace PKHeX.WinForms.Controls
             {
                 if (!Enabled)
                     return;
+
+                if (pb == null)
+                    return;
                 try { pb.BackgroundImage = GetFrame(frameIndex); } // drawing GDI can be silly sometimes #2072
                 catch (AccessViolationException ex) { System.Diagnostics.Debug.WriteLine(ex.Message); }
             }
@@ -86,12 +91,17 @@ namespace PKHeX.WinForms.Controls
 
         private Image GetFrame(int frameIndex)
         {
+            if (GlowCache == null)
+                throw new ArgumentNullException(nameof(GlowCache));
             var frame = GlowCache[frameIndex];
             if (frame != null)
                 return frame;
 
             var elapsedFraction = (double)frameIndex / GlowInterval;
             var frameColor = GetFrameColor(elapsedFraction);
+
+            if (GlowData == null)
+                throw new ArgumentNullException(nameof(GlowData));
             var frameData = (byte[])GlowData.Clone();
             ImageUtil.ChangeAllColorTo(frameData, frameColor);
 

--- a/PKHeX.WinForms/Controls/SAV Editor/ContextMenuSAV.cs
+++ b/PKHeX.WinForms/Controls/SAV Editor/ContextMenuSAV.cs
@@ -11,10 +11,10 @@ namespace PKHeX.WinForms.Controls
     {
         public ContextMenuSAV() => InitializeComponent();
 
-        public SaveDataEditor<PictureBox> Editor { private get; set; }
-        public SlotChangeManager Manager { get; set; }
+        public SaveDataEditor<PictureBox> Editor { private get; set; } = null!;
+        public SlotChangeManager Manager { get; set; } = null!;
 
-        public event LegalityRequest RequestEditorLegality;
+        public event LegalityRequest? RequestEditorLegality;
         public delegate void LegalityRequest(object sender, EventArgs e, PKM pkm);
 
         public void OmniClick(object sender, EventArgs e, Keys z)
@@ -132,7 +132,11 @@ namespace PKHeX.WinForms.Controls
         private static SlotViewInfo<PictureBox> GetSenderInfo(ref object sender)
         {
             var pb = WinFormsUtil.GetUnderlyingControl<PictureBox>(sender);
+            if (pb == null)
+                throw new ArgumentNullException(nameof(pb));
             var view = WinFormsUtil.FindFirstControlOfType<ISlotViewer<PictureBox>>(pb);
+            if (view == null)
+                throw new ArgumentNullException(nameof(view));
             var loc = view.GetSlotData(pb);
             sender = pb;
             return new SlotViewInfo<PictureBox>(loc, view);

--- a/PKHeX.WinForms/Controls/SAV Editor/PartyEditor.cs
+++ b/PKHeX.WinForms/Controls/SAV Editor/PartyEditor.cs
@@ -8,11 +8,11 @@ namespace PKHeX.WinForms.Controls
 {
     public partial class PartyEditor : UserControl, ISlotViewer<PictureBox>
     {
-        public IList<PictureBox> SlotPictureBoxes { get; private set; }
-        public SaveFile SAV => M?.SE.SAV;
+        public IList<PictureBox> SlotPictureBoxes { get; private set; } = Array.Empty<PictureBox>();
+        public SaveFile SAV => M?.SE.SAV ?? throw new ArgumentNullException(nameof(SAV));
 
         public int BoxSlotCount { get; private set; }
-        public SlotChangeManager M { get; set; }
+        public SlotChangeManager? M { get; set; }
         public bool FlagIllegal { get; set; }
 
         public PartyEditor()
@@ -39,8 +39,8 @@ namespace PKHeX.WinForms.Controls
             BoxSlotCount = SlotPictureBoxes.Count;
             foreach (var pb in SlotPictureBoxes)
             {
-                pb.MouseEnter += BoxSlot_MouseEnter;
-                pb.MouseLeave += BoxSlot_MouseLeave;
+                pb.MouseEnter += (o, args) => BoxSlot_MouseEnter(pb, args);
+                pb.MouseLeave += (o, args) => BoxSlot_MouseLeave(pb, args);
                 pb.MouseClick += BoxSlot_MouseClick;
                 pb.MouseMove += BoxSlot_MouseMove;
                 pb.MouseDown += BoxSlot_MouseDown;
@@ -104,7 +104,7 @@ namespace PKHeX.WinForms.Controls
         public void ResetSlots()
         {
             //pokeGrid1.SetBackground(SAV.WallpaperImage(0));
-            M.Hover.Stop();
+            M?.Hover.Stop();
 
             foreach (var pb in SlotPictureBoxes)
             {
@@ -112,7 +112,7 @@ namespace PKHeX.WinForms.Controls
                 SlotUtil.UpdateSlot(pb, slot, slot.Read(SAV), SAV, FlagIllegal);
             }
 
-            if (M.Env.Slots.Publisher.Previous is SlotInfoParty p)
+            if (M?.Env.Slots.Publisher.Previous is SlotInfoParty p)
                 SlotPictureBoxes[p.Slot].BackgroundImage = SlotUtil.GetTouchTypeBackground(M.Env.Slots.Publisher.PreviousType);
         }
 

--- a/PKHeX.WinForms/Controls/SAV Editor/SAVEditor.Designer.cs
+++ b/PKHeX.WinForms/Controls/SAV Editor/SAVEditor.Designer.cs
@@ -20,6 +20,8 @@
             base.Dispose(disposing);
             SortMenu?.Dispose();
             menu?.Dispose();
+            Menu_Undo = null;
+            Menu_Redo = null;
         }
 
         #region Component Designer generated code

--- a/PKHeX.WinForms/Controls/Slots/DragManager.cs
+++ b/PKHeX.WinForms/Controls/Slots/DragManager.cs
@@ -5,16 +5,18 @@ namespace PKHeX.WinForms.Controls
 {
     public sealed class DragManager
     {
-        public SlotChangeInfo<Cursor, PictureBox> Info { get; private set; }
-        public event DragEventHandler RequestExternalDragDrop;
+        public SlotChangeInfo<Cursor, PictureBox> Info { get; private set; } = new SlotChangeInfo<Cursor, PictureBox>();
+        public event DragEventHandler? RequestExternalDragDrop;
         public void RequestDD(object sender, DragEventArgs e) => RequestExternalDragDrop?.Invoke(sender, e);
 
-        public void SetCursor(Form f, Cursor z)
+        public void SetCursor(Form? f, Cursor? z)
         {
-            Info.Cursor = f.Cursor = z;
+            if (f != null)
+                f.Cursor = z;
+            Info.Cursor = z;
         }
 
-        public void ResetCursor(Form sender)
+        public void ResetCursor(Form? sender)
         {
             SetCursor(sender, Cursors.Default);
         }

--- a/PKHeX.WinForms/Controls/Slots/SlotChangeInfo.cs
+++ b/PKHeX.WinForms/Controls/Slots/SlotChangeInfo.cs
@@ -2,16 +2,16 @@
 
 namespace PKHeX.WinForms.Controls
 {
-    public sealed class SlotChangeInfo<TCursor, TImageSource>
+    public sealed class SlotChangeInfo<TCursor, TImageSource> where TCursor : class
     {
         public bool LeftMouseIsDown { get; set; }
         public bool DragDropInProgress { get; set; }
 
-        public TCursor Cursor { get; set; }
-        public string CurrentPath { get; set; }
+        public TCursor? Cursor { get; set; }
+        public string? CurrentPath { get; set; }
 
-        public SlotViewInfo<TImageSource> Source { get; set; }
-        public SlotViewInfo<TImageSource> Destination { get; set; }
+        public SlotViewInfo<TImageSource>? Source { get; set; }
+        public SlotViewInfo<TImageSource>? Destination { get; set; }
 
         public SlotChangeInfo()
         {
@@ -25,7 +25,7 @@ namespace PKHeX.WinForms.Controls
             Cursor = default;
         }
 
-        public bool SameLocation => Source?.Equals(Destination) ?? false;
+        public bool SameLocation => (Destination != null) && (Source?.Equals(Destination) ?? false);
         public bool DragIsParty => Source?.Slot is SlotInfoParty || Destination?.Slot is SlotInfoParty;
     }
 }

--- a/PKHeX.WinForms/Controls/Slots/SlotHoverHandler.cs
+++ b/PKHeX.WinForms/Controls/Slots/SlotHoverHandler.cs
@@ -12,7 +12,7 @@ namespace PKHeX.WinForms.Controls
     /// </summary>
     public sealed class SlotHoverHandler : IDisposable
     {
-        public DrawConfig Draw { private get; set; }
+        public DrawConfig Draw { private get; set; } = new DrawConfig();
         public bool GlowHover { private get; set; } = true;
 
         public static readonly CryPlayer CryPlayer = new CryPlayer();
@@ -21,12 +21,14 @@ namespace PKHeX.WinForms.Controls
 
         private readonly BitmapAnimator HoverWorker = new BitmapAnimator();
 
-        private PictureBox Slot;
-        private SlotTrackerImage LastSlot;
+        private PictureBox? Slot;
+        private SlotTrackerImage? LastSlot;
 
         public void Start(PictureBox pb, SlotTrackerImage lastSlot)
         {
             var view = WinFormsUtil.FindFirstControlOfType<ISlotViewer<PictureBox>>(pb);
+            if (view == null)
+                throw new ArgumentNullException(nameof(view));
             var data = view.GetSlotData(pb);
             var pk = data.Read(view.SAV);
             Slot = pb;
@@ -67,7 +69,7 @@ namespace PKHeX.WinForms.Controls
                 if (HoverWorker.Enabled)
                     HoverWorker.Stop();
                 else
-                    Slot.BackgroundImage = LastSlot.OriginalBackground;
+                    Slot.BackgroundImage = LastSlot?.OriginalBackground;
                 Slot = null;
                 LastSlot = null;
             }
@@ -77,9 +79,9 @@ namespace PKHeX.WinForms.Controls
 
         public void Dispose()
         {
-            HoverWorker?.Dispose();
-            Slot?.Dispose();
-            Draw?.Dispose();
+            HoverWorker.Dispose();
+            Slot = null;
+            Draw.Dispose();
         }
     }
 }

--- a/PKHeX.WinForms/Controls/Slots/SlotList.cs
+++ b/PKHeX.WinForms/Controls/Slots/SlotList.cs
@@ -12,7 +12,7 @@ namespace PKHeX.WinForms.Controls
         private readonly List<PictureBox> slots = new List<PictureBox>();
         private List<SlotInfoMisc> SlotOffsets = new List<SlotInfoMisc>();
         public int SlotCount { get; private set; }
-        public SaveFile SAV { get; set; }
+        public SaveFile SAV { get; set; } = null!;
         public bool FlagIllegal { get; set; }
 
         public SlotList()
@@ -36,7 +36,7 @@ namespace PKHeX.WinForms.Controls
         /// <summary>
         /// Hides all slots from the <see cref="SlotList"/>.
         /// </summary>
-        public void HideAllSlots() => LoadSlots(0, null);
+        public void HideAllSlots() => LoadSlots(0, _ => { });
 
         public void NotifySlotOld(ISlotInfo previous)
         {
@@ -71,7 +71,15 @@ namespace PKHeX.WinForms.Controls
         public ISlotInfo GetSlotData(int slot) => SlotOffsets[slot];
 
         public IList<PictureBox> SlotPictureBoxes => slots;
-        public int GetSlot(PictureBox sender) => slots.IndexOf(WinFormsUtil.GetUnderlyingControl<PictureBox>(sender));
+
+        public int GetSlot(PictureBox sender)
+        {
+            var view = WinFormsUtil.GetUnderlyingControl<PictureBox>(sender);
+            if (view == null)
+                return -1;
+            return slots.IndexOf(view);
+        }
+
         public int GetSlotOffset(int slot) => SlotOffsets[slot].Offset;
         public int ViewIndex { get; set; } = -1;
 

--- a/PKHeX.WinForms/Controls/Slots/SlotTrackerImage.cs
+++ b/PKHeX.WinForms/Controls/Slots/SlotTrackerImage.cs
@@ -4,8 +4,8 @@ namespace PKHeX.WinForms.Controls
 {
     public sealed class SlotTrackerImage
     {
-        public Image OriginalBackground { get; set; }
-        public Image CurrentBackground { get; set; }
+        public Image? OriginalBackground { get; set; }
+        public Image? CurrentBackground { get; set; }
 
         public void Reset()
         {

--- a/PKHeX.WinForms/MainWindow/PluginLoader.cs
+++ b/PKHeX.WinForms/MainWindow/PluginLoader.cs
@@ -8,7 +8,7 @@ namespace PKHeX.WinForms
 {
     public static class PluginLoader
     {
-        public static IEnumerable<T> LoadPlugins<T>(string pluginPath)
+        public static IEnumerable<T> LoadPlugins<T>(string pluginPath) where T : class
         {
             var dllFileNames = !Directory.Exists(pluginPath)
                 ? Enumerable.Empty<string>()
@@ -18,9 +18,14 @@ namespace PKHeX.WinForms
             return LoadPlugins<T>(pluginTypes);
         }
 
-        private static IEnumerable<T> LoadPlugins<T>(IEnumerable<Type> pluginTypes)
+        private static IEnumerable<T> LoadPlugins<T>(IEnumerable<Type> pluginTypes) where T : class
         {
-            return pluginTypes.Select(type => (T)Activator.CreateInstance(type));
+            foreach (var t in pluginTypes)
+            {
+                var activate = (T?) Activator.CreateInstance(t);
+                if (activate != null)
+                    yield return activate;
+            }
         }
 
         private static IEnumerable<Assembly> GetAssemblies(IEnumerable<string> dllFileNames)
@@ -63,7 +68,10 @@ namespace PKHeX.WinForms
         {
             if (type.IsInterface || type.IsAbstract)
                 return false;
-            if (type.GetInterface(pluginType.FullName) == null)
+            var name = pluginType.FullName;
+            if (name == null)
+                return false;
+            if (type.GetInterface(name) == null)
                 return false;
             return true;
         }

--- a/PKHeX.WinForms/Misc/ErrorWindow.cs
+++ b/PKHeX.WinForms/Misc/ErrorWindow.cs
@@ -52,11 +52,11 @@ namespace PKHeX.WinForms
             set => L_Message.Text = value;
         }
 
-        private Exception _error;
+        private Exception? _error;
 
         public Exception Error
         {
-            get => _error;
+            get => _error ?? throw new ArgumentNullException(nameof(_error));
             set
             {
                 _error = value;

--- a/PKHeX.WinForms/Misc/QR.cs
+++ b/PKHeX.WinForms/Misc/QR.cs
@@ -10,12 +10,12 @@ namespace PKHeX.WinForms
 {
     public partial class QR : Form
     {
-        private readonly PKM pkm;
+        private readonly PKM? pkm;
         private readonly Image icon;
         private Image qr;
 
         private readonly string[] Lines;
-        private string extraText;
+        private string extraText = string.Empty;
 
         public QR(Image qr, Image icon, params string[] lines)
         {

--- a/PKHeX.WinForms/PKHeX.WinForms.csproj
+++ b/PKHeX.WinForms/PKHeX.WinForms.csproj
@@ -14,6 +14,7 @@
     <AssemblyName>PKHeX</AssemblyName>
     <Version>20.10.10</Version>
     <LangVersion>8</LangVersion>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/PKHeX.WinForms/Subforms/Misc/SortableBindingList.cs
+++ b/PKHeX.WinForms/Subforms/Misc/SortableBindingList.cs
@@ -4,12 +4,12 @@ using System.ComponentModel;
 
 namespace PKHeX.WinForms
 {
-    public abstract class SortableBindingList<T> : BindingList<T>
+    public abstract class SortableBindingList<T> : BindingList<T> where T : class
     {
         private readonly Dictionary<Type, PropertyComparer<T>> comparers;
         private bool isSorted;
         private ListSortDirection listSortDirection;
-        private PropertyDescriptor propertyDescriptor;
+        private PropertyDescriptor? propertyDescriptor;
 
         protected SortableBindingList() : base(new List<T>())
         {
@@ -20,7 +20,7 @@ namespace PKHeX.WinForms
 
         protected override bool IsSortedCore => isSorted;
 
-        protected override PropertyDescriptor SortPropertyCore => propertyDescriptor;
+        protected override PropertyDescriptor? SortPropertyCore => propertyDescriptor;
 
         protected override ListSortDirection SortDirectionCore => listSortDirection;
 
@@ -31,7 +31,7 @@ namespace PKHeX.WinForms
             List<T> itemsList = (List<T>)Items;
 
             Type propertyType = prop.PropertyType;
-            if (!comparers.TryGetValue(propertyType, out PropertyComparer<T> comparer))
+            if (!comparers.TryGetValue(propertyType, out var comparer))
             {
                 comparer = new PropertyComparer<T>(prop, direction);
                 comparers.Add(propertyType, comparer);

--- a/PKHeX.WinForms/Subforms/PKM Editors/BatchEditor.cs
+++ b/PKHeX.WinForms/Subforms/PKM Editors/BatchEditor.cs
@@ -137,7 +137,7 @@ namespace PKHeX.WinForms
                     return;
             }
 
-            string destPath = null;
+            string? destPath = null;
             if (RB_Path.Checked)
             {
                 WinFormsUtil.Alert(MsgExportFolder, MsgExportFolderAdvice);
@@ -159,7 +159,7 @@ namespace PKHeX.WinForms
             RunBatchEdit(sets, TB_Folder.Text, destPath);
         }
 
-        private void RunBatchEdit(StringInstructionSet[] sets, string source, string destination)
+        private void RunBatchEdit(StringInstructionSet[] sets, string source, string? destination)
         {
             editor = new Core.BatchEditor();
             bool finished = false, displayed = false; // hack cuz DoWork event isn't cleared after completion
@@ -171,7 +171,7 @@ namespace PKHeX.WinForms
                     RunBatchEditSaveFile(sets, boxes: true);
                 else if (RB_Party.Checked)
                     RunBatchEditSaveFile(sets, party: true);
-                else
+                else if (destination != null)
                     RunBatchEditFolder(sets, source, destination);
                 finished = true;
             };
@@ -245,22 +245,25 @@ namespace PKHeX.WinForms
         {
             for (int i = 0; i < files.Count; i++)
             {
-                string file = files[i];
-                var fi = new FileInfo(file);
-                if (!PKX.IsPKM(fi.Length))
-                {
-                    b.ReportProgress(i);
-                    continue;
-                }
-
-                int format = PKX.GetPKMFormatFromExtension(fi.Extension, SAV.Generation);
-                byte[] data = File.ReadAllBytes(file);
-                var pk = PKMConverter.GetPKMfromBytes(data, prefer: format);
-                if (editor.Process(pk, Filters, Instructions))
-                    File.WriteAllBytes(Path.Combine(destPath, Path.GetFileName(file)), pk.DecryptedPartyData);
-
+                TryProcess(Filters, Instructions, files[i], destPath);
                 b.ReportProgress(i);
             }
+        }
+
+        private void TryProcess(IReadOnlyList<StringInstruction> Filters, IReadOnlyList<StringInstruction> Instructions, string source, string dest)
+        {
+            var fi = new FileInfo(source);
+            if (!PKX.IsPKM(fi.Length))
+                return;
+
+            int format = PKX.GetPKMFormatFromExtension(fi.Extension, SAV.Generation);
+            byte[] data = File.ReadAllBytes(source);
+            var pk = PKMConverter.GetPKMfromBytes(data, prefer: format);
+            if (pk == null)
+                return;
+
+            if (editor.Process(pk, Filters, Instructions))
+                File.WriteAllBytes(Path.Combine(dest, Path.GetFileName(source)), pk.DecryptedPartyData);
         }
     }
 }

--- a/PKHeX.WinForms/Subforms/PKM Editors/MemoryAmie.cs
+++ b/PKHeX.WinForms/Subforms/PKM Editors/MemoryAmie.cs
@@ -358,18 +358,18 @@ namespace PKHeX.WinForms
             public TextMarkup(string[] args)
             {
                 Array.Resize(ref args, 10);
-                if (args[0] != null) Disabled = args[0];
-                if (args[1] != null) NeverLeft = args[1];
-                if (args[2] != null) OT = args[2];
-                if (args[3] != null) PastGen = args[3];
-                if (args[4] != null) MemoriesWith = args[4];
+                if (!string.IsNullOrWhiteSpace(args[0])) Disabled = args[0];
+                if (!string.IsNullOrWhiteSpace(args[1])) NeverLeft = args[1];
+                if (!string.IsNullOrWhiteSpace(args[2])) OT = args[2];
+                if (!string.IsNullOrWhiteSpace(args[3])) PastGen = args[3];
+                if (!string.IsNullOrWhiteSpace(args[4])) MemoriesWith = args[4];
 
                 // Pokémon ; Area ; Item(s) ; Move ; Location
-                if (args[5] != null) Species = args[5] + ":";
-                if (args[6] != null) Area = args[6] + ":";
-                if (args[7] != null) Item = args[7] + ":";
-                if (args[8] != null) Move = args[8] + ":";
-                if (args[9] != null) Location = args[9] + ":";
+                if (!string.IsNullOrWhiteSpace(args[5])) Species = args[5] + ":";
+                if (!string.IsNullOrWhiteSpace(args[6])) Area = args[6] + ":";
+                if (!string.IsNullOrWhiteSpace(args[7])) Item = args[7] + ":";
+                if (!string.IsNullOrWhiteSpace(args[8])) Move = args[8] + ":";
+                if (!string.IsNullOrWhiteSpace(args[9])) Location = args[9] + ":";
             }
 
             public string GetMemoryCategory(MemoryArgType type, int format)

--- a/PKHeX.WinForms/Subforms/PKM Editors/RibbonEditor.cs
+++ b/PKHeX.WinForms/Subforms/PKM Editors/RibbonEditor.cs
@@ -55,9 +55,9 @@ namespace PKHeX.WinForms
                 AddRibbonChoice(rib);
 
             // Force auto-size
-            foreach (RowStyle style in TLP_Ribbons.RowStyles)
+            foreach (var style in TLP_Ribbons.RowStyles.OfType<RowStyle>())
                 style.SizeType = SizeType.AutoSize;
-            foreach (ColumnStyle style in TLP_Ribbons.ColumnStyles)
+            foreach (var style in TLP_Ribbons.ColumnStyles.OfType<ColumnStyle>())
                 style.SizeType = SizeType.AutoSize;
         }
 
@@ -66,7 +66,7 @@ namespace PKHeX.WinForms
             var name = rib.Name;
             var pb = new PictureBox { AutoSize = false, Size = new Size(40,40), BackgroundImageLayout = ImageLayout.Center, Visible = false, Name = PrefixPB + name };
             var img = SpriteUtil.GetRibbonSprite(name);
-            pb.BackgroundImage = (Bitmap)img;
+            pb.BackgroundImage = img;
 
             var display = RibbonStrings.GetName(name);
             pb.MouseEnter += (s, e) => tipName.SetToolTip(pb, display);

--- a/PKHeX.WinForms/Subforms/PKM Editors/SuperTrainingEditor.cs
+++ b/PKHeX.WinForms/Subforms/PKM Editors/SuperTrainingEditor.cs
@@ -40,7 +40,7 @@ namespace PKHeX.WinForms
                 NUD_BagHits.Value = pk6.TrainingBagHits;
 
                 if (!CHK_SecretUnlocked.Checked) // force update to disable checkboxes
-                    CHK_Secret_CheckedChanged(null, EventArgs.Empty);
+                    CHK_Secret_CheckedChanged(this, EventArgs.Empty);
             }
             else
             {
@@ -74,9 +74,9 @@ namespace PKHeX.WinForms
                 AddRegimenChoice(reg, TLP);
 
             // Force auto-size
-            foreach (RowStyle style in TLP.RowStyles)
+            foreach (var style in TLP.RowStyles.OfType<RowStyle>())
                 style.SizeType = SizeType.AutoSize;
-            foreach (ColumnStyle style in TLP.ColumnStyles)
+            foreach (var style in TLP.ColumnStyles.OfType<ColumnStyle>())
                 style.SizeType = SizeType.AutoSize;
         }
 

--- a/PKHeX.WinForms/Subforms/PKM Editors/Text.cs
+++ b/PKHeX.WinForms/Subforms/PKM Editors/Text.cs
@@ -10,6 +10,8 @@ namespace PKHeX.WinForms
     {
         private readonly SaveFile SAV;
 
+        public TrashEditor(TextBoxBase TB_NN, SaveFile sav) : this(TB_NN, Array.Empty<byte>(), sav) { }
+
         public TrashEditor(TextBoxBase TB_NN, byte[] raw, SaveFile sav)
         {
             InitializeComponent();
@@ -20,7 +22,7 @@ namespace PKHeX.WinForms
             Raw = FinalBytes = raw;
 
             editing = true;
-            if (raw != null)
+            if (raw.Length != 0)
                 AddTrashEditing(raw.Length);
 
             var f = FontUtil.GetPKXFont();
@@ -46,7 +48,7 @@ namespace PKHeX.WinForms
 
         private readonly List<NumericUpDown> Bytes = new List<NumericUpDown>();
         public string FinalString;
-        public byte[] FinalBytes { get; private set; }
+        public byte[] FinalBytes { get; private set; } = Array.Empty<byte>();
         private readonly byte[] Raw;
         private bool editing;
         private void B_Cancel_Click(object sender, EventArgs e) => Close();
@@ -54,7 +56,7 @@ namespace PKHeX.WinForms
         private void B_Save_Click(object sender, EventArgs e)
         {
             FinalString = TB_Text.Text;
-            if (FinalBytes != null)
+            if (FinalBytes.Length == 0)
                 FinalBytes = Raw;
             Close();
         }
@@ -96,13 +98,13 @@ namespace PKHeX.WinForms
                     }
                 };
                 n.Value = Raw[i];
-                n.ValueChanged += UpdateNUD;
+                n.ValueChanged += (o, args) => UpdateNUD(n, args);
 
                 FLP_Hex.Controls.Add(l);
                 FLP_Hex.Controls.Add(n);
                 Bytes.Add(n);
             }
-            TB_Text.TextChanged += UpdateString;
+            TB_Text.TextChanged += (o, args) => UpdateString(TB_Text, args);
 
             CB_Species.InitializeBinding();
             CB_Species.DataSource = new BindingSource(GameInfo.SpeciesDataSource, null);
@@ -117,7 +119,8 @@ namespace PKHeX.WinForms
                 return;
             editing = true;
             // build bytes
-            var nud = sender as NumericUpDown;
+            if (!(sender is NumericUpDown nud))
+                throw new Exception();
             int index = Bytes.IndexOf(nud);
             Raw[index] = (byte)nud.Value;
 

--- a/PKHeX.WinForms/Subforms/ReportGrid.cs
+++ b/PKHeX.WinForms/Subforms/ReportGrid.cs
@@ -49,7 +49,7 @@ namespace PKHeX.WinForms
             dgData.ContextMenuStrip = mnu;
         }
 
-        private sealed class PokemonList<T> : SortableBindingList<T> { }
+        private sealed class PokemonList<T> : SortableBindingList<T> where T : class { }
 
         public void PopulateData(IList<PKM> Data)
         {
@@ -84,7 +84,7 @@ namespace PKHeX.WinForms
                 dgData.Columns[i].Width = w;
             }
             dgData.AutoSizeColumnsMode = DataGridViewAutoSizeColumnsMode.None;
-            Data_Sorted(null, EventArgs.Empty); // trigger row resizing
+            Data_Sorted(this, EventArgs.Empty); // trigger row resizing
 
             ResumeLayout();
         }

--- a/PKHeX.WinForms/Subforms/SAV_MysteryGiftDB.cs
+++ b/PKHeX.WinForms/Subforms/SAV_MysteryGiftDB.cs
@@ -78,10 +78,10 @@ namespace PKHeX.WinForms
 
         private readonly PictureBox[] PKXBOXES;
         private readonly string DatabasePath = Main.MGDatabasePath;
-        private List<MysteryGift> Results;
-        private List<MysteryGift> RawDB;
+        private List<MysteryGift> Results = new List<MysteryGift>();
+        private List<MysteryGift> RawDB = new List<MysteryGift>();
         private int slotSelected = -1; // = null;
-        private Image slotColor;
+        private Image? slotColor;
         private const int RES_MAX = 66;
         private const int RES_MIN = 6;
         private readonly string Counter;
@@ -172,7 +172,7 @@ namespace PKHeX.WinForms
             }
 
             // Trigger a Reset
-            ResetFilters(null, EventArgs.Empty);
+            ResetFilters(this, EventArgs.Empty);
             B_Search.Enabled = true;
         }
 
@@ -186,7 +186,7 @@ namespace PKHeX.WinForms
             CB_Move1.SelectedIndex = CB_Move2.SelectedIndex = CB_Move3.SelectedIndex = CB_Move4.SelectedIndex = 0;
             RTB_Instructions.Clear();
 
-            if (sender != null)
+            if (sender != this)
                 System.Media.SystemSounds.Asterisk.Play();
         }
 
@@ -224,7 +224,7 @@ namespace PKHeX.WinForms
 
         private void Menu_Export_Click(object sender, EventArgs e)
         {
-            if (Results == null || Results.Count == 0)
+            if (Results.Count == 0)
             { WinFormsUtil.Alert(MsgDBCreateReportFail); return; }
 
             if (DialogResult.Yes != WinFormsUtil.Prompt(MessageBoxButtons.YesNo, MsgDBExportResultsPrompt))
@@ -315,10 +315,13 @@ namespace PKHeX.WinForms
 
         private void FillPKXBoxes(int start)
         {
-            if (Results == null)
+            if (Results.Count == 0)
             {
                 for (int i = 0; i < RES_MAX; i++)
+                {
                     PKXBOXES[i].Image = null;
+                    PKXBOXES[i].BackgroundImage = null;
+                }
                 return;
             }
             int begin = start * RES_MIN;

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen3/SAV_Misc3.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen3/SAV_Misc3.cs
@@ -156,6 +156,8 @@ namespace PKHeX.WinForms
                 tickets = tickets.Take(tickets.Length - 1).ToArray(); // remove old sea map
 
             var p = Array.Find(Pouches, z => z.Type == InventoryType.KeyItems);
+            if (p == null)
+                throw new ArgumentException(nameof(InventoryPouch.Type));
 
             // check for missing tickets
             var missing = tickets.Where(z => !p.Items.Any(item => item.Index == z && item.Count == 1)).ToList();
@@ -232,20 +234,20 @@ namespace PKHeX.WinForms
         #endregion
 
         #region BattleFrontier
-        private int[] Symbols;
+        private int[] Symbols = null!;
         private int ofsSymbols;
-        private Color[] SymbolColorA;
-        private Button[] SymbolButtonA;
+        private Color[] SymbolColorA = null!;
+        private Button[] SymbolButtonA = null!;
         private bool editingcont;
         private bool editingval;
-        private RadioButton[] StatRBA;
-        private NumericUpDown[] StatNUDA;
-        private Label[] StatLabelA;
+        private RadioButton[] StatRBA = null!;
+        private NumericUpDown[] StatNUDA = null!;
+        private Label[] StatLabelA = null!;
         private bool loading;
-        private int[][] BFF;
-        private string[][] BFT;
-        private int[][] BFV;
-        private string[] BFN;
+        private int[][] BFF = null!;
+        private string[]?[] BFT = null!;
+        private int[][] BFV = null!;
+        private string[] BFN = null!;
 
         private void ChangeStat1(object sender, EventArgs e)
         {
@@ -259,15 +261,17 @@ namespace PKHeX.WinForms
             foreach (RadioButton rb in StatRBA)
                 rb.Checked = false;
 
-            if (BFT[BFF[facility][1]] == null)
+            var bft = BFT[BFF[facility][1]];
+            if (bft == null)
             {
                 CB_Stats2.Visible = false;
             }
             else
             {
                 CB_Stats2.Visible = true;
-                for (int i = 0; i < BFT[BFF[facility][1]].Length; i++)
-                    CB_Stats2.Items.Add(BFT[BFF[facility][1]][i]);
+                foreach (var t in bft)
+                    CB_Stats2.Items.Add(t);
+
                 CB_Stats2.SelectedIndex = 0;
             }
 
@@ -292,11 +296,12 @@ namespace PKHeX.WinForms
                 return;
 
             int BattleType = CB_Stats2.SelectedIndex;
-            if (BFT[BFF[Facility][1]] == null)
+            var bft = BFT[BFF[Facility][1]];
+            if (bft == null)
                 BattleType = 0;
             else if (BattleType < 0)
                 return;
-            else if (BattleType >= BFT[BFF[Facility][1]].Length)
+            else if (BattleType >= bft.Length)
                 return;
 
             int RBi = -1;
@@ -486,11 +491,11 @@ namespace PKHeX.WinForms
                 NUD_BPEarned.Visible = L_BPEarned.Visible = false;
             }
 
-            NUD_FameH.ValueChanged += (s, e) => ChangeFame();
-            NUD_FameM.ValueChanged += (s, e) => ChangeFame();
-            NUD_FameS.ValueChanged += (s, e) => ChangeFame();
+            NUD_FameH.ValueChanged += (s, e) => ChangeFame(records);
+            NUD_FameM.ValueChanged += (s, e) => ChangeFame(records);
+            NUD_FameS.ValueChanged += (s, e) => ChangeFame(records);
 
-            void ChangeFame() => records.SetRecord(1, (uint)(NUD_RecordValue.Value = GetFameTime()));
+            void ChangeFame(Record3 r3) => r3.SetRecord(1, (uint)(NUD_RecordValue.Value = GetFameTime()));
             void LoadRecordID(int index) => NUD_RecordValue.Value = records.GetRecord(index);
             void LoadFame(uint val) => SetFameTime(val);
         }

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen4/PoffinCase4Editor.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen4/PoffinCase4Editor.cs
@@ -7,7 +7,7 @@ namespace PKHeX.WinForms
     public partial class PoffinCase4Editor : UserControl
     {
         public PoffinCase4Editor() => InitializeComponent();
-        private PoffinCase4 Case;
+        private PoffinCase4 Case = null!; // initialized on load
         private int CurrentIndex = -1;
         private bool Updating;
 

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen4/PokeGear4Editor.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen4/PokeGear4Editor.cs
@@ -7,8 +7,8 @@ namespace PKHeX.WinForms
     public partial class PokeGear4Editor : UserControl
     {
         public PokeGear4Editor() => InitializeComponent();
-        private PokegearNumber[] Rolodex;
-        private SAV4HGSS SAV;
+        private PokegearNumber[] Rolodex = null!;
+        private SAV4HGSS SAV = null!;
 
         public void Initialize(SAV4HGSS sav)
         {

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen4/SAV_HoneyTree.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen4/SAV_HoneyTree.cs
@@ -16,10 +16,12 @@ namespace PKHeX.WinForms
             WinFormsUtil.TranslateInterface(this, Main.CurrentLanguage);
             SAV = (SAV4Sinnoh)(Origin = sav).Clone();
 
-            if (SAV is SAV4DP)
-                Table = HoneyTree.TableDP;
-            else if (SAV is SAV4Pt)
-                Table = HoneyTree.TablePt;
+            Table = SAV switch
+            {
+                SAV4DP _ => HoneyTree.TableDP,
+                SAV4Pt _ => HoneyTree.TablePt,
+                _ => throw new Exception()
+            };
 
             // Get Munchlax tree for this savegame in screen
             MunchlaxTrees = SAV.GetMunchlaxTrees();
@@ -34,7 +36,7 @@ namespace PKHeX.WinForms
         private readonly int[][] Table;
         private int entry;
         private bool loading;
-        private HoneyTree Tree;
+        private HoneyTree? Tree;
 
         private int TreeSpecies => Table[(int)NUD_Group.Value][(int)NUD_Slot.Value];
         private void B_Catchable_Click(object sender, EventArgs e) => NUD_Time.Value = 1080;
@@ -71,7 +73,7 @@ namespace PKHeX.WinForms
             NUD_Group.Value = Math.Min(NUD_Group.Maximum, Tree.Group);
             NUD_Slot.Value = Math.Min(NUD_Slot.Maximum, Tree.Slot);
 
-            ChangeGroupSlot(null, EventArgs.Empty);
+            ChangeGroupSlot(this, EventArgs.Empty);
             loading = false;
         }
 

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen4/SAV_Misc4.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen4/SAV_Misc4.cs
@@ -106,7 +106,7 @@ namespace PKHeX.WinForms
         private readonly int ofsBP;
         private readonly int ofsMap = -1;
         private readonly int ofsUGFlagCount = -1;
-        private int[] FlyDestC;
+        private int[] FlyDestC = null!;
 
         private void ReadMain()
         {
@@ -206,8 +206,8 @@ namespace PKHeX.WinForms
         }
 
         #region Poketch
-        private byte[] DotArtistByte;
-        private byte[] ColorTable;
+        private byte[] DotArtistByte = null!;
+        private byte[] ColorTable = null!;
 
         private void ReadPoketch(SAV4Sinnoh s)
         {
@@ -419,19 +419,19 @@ namespace PKHeX.WinForms
         #endregion
 
         #region BattleFrontier
-        private int[] Prints;
+        private int[] Prints = null!;
         private readonly int ofsPrints = -1;
-        private Color[] PrintColorA;
-        private Button[] PrintButtonA;
+        private Color[] PrintColorA = null!;
+        private Button[] PrintButtonA = null!;
         private bool editing;
-        private RadioButton[] StatRBA;
-        private NumericUpDown[] StatNUDA;
-        private Label[] StatLabelA;
-        private readonly int[][] BFF;
-        private string[][] BFT;
-        private int[][] BFV;
-        private string[] BFN;
-        private NumericUpDown[] HallNUDA;
+        private RadioButton[] StatRBA = null!;
+        private NumericUpDown[] StatNUDA = null!;
+        private Label[] StatLabelA = null!;
+        private readonly int[][] BFF = null!;
+        private string[][] BFT = null!;
+        private int[][] BFV = null!;
+        private string[] BFN = null!;
+        private NumericUpDown[] HallNUDA = null!;
         private bool HallStatUpdated;
         private int ofsHallStat = -1;
 

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen4/SAV_Underground.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen4/SAV_Underground.cs
@@ -11,8 +11,11 @@ namespace PKHeX.WinForms
         private readonly SAV4Sinnoh SAV;
 
         private const int MAX_SIZE = SAV4Sinnoh.UG_POUCH_SIZE;
-        private string[] ugGoods, ugSpheres, ugTraps, ugTreasures;
-        private string[] ugGoodsSorted, ugTrapsSorted, ugTreasuresSorted;
+        private readonly string[] ugGoods, ugSpheres, ugTraps, ugTreasures;
+
+        private readonly string[] ugGoodsSorted;
+        private readonly string[] ugTrapsSorted;
+        private readonly string[] ugTreasuresSorted;
 
         public SAV_Underground(SaveFile sav)
         {
@@ -20,21 +23,23 @@ namespace PKHeX.WinForms
             WinFormsUtil.TranslateInterface(this, Main.CurrentLanguage);
             SAV = (SAV4Sinnoh)(Origin = sav).Clone();
 
-            InitializeDGV();
+            ugGoods = GameInfo.Strings.uggoods;
+            ugSpheres = GameInfo.Strings.ugspheres;
+            ugTraps = GameInfo.Strings.ugtraps;
+            ugTreasures = GameInfo.Strings.ugtreasures;
 
+            ugGoodsSorted = SanitizeList(ugGoods);
+            ugTrapsSorted = SanitizeList(ugTraps);
+            ugTreasuresSorted = SanitizeList(ugTreasures);
+
+            InitializeDGV();
             GetUGScores();
             ReadUGData();
         }
 
         private void InitializeDGV()
         {
-            ugGoods = GameInfo.Strings.uggoods;
-            ugSpheres = GameInfo.Strings.ugspheres;
-            ugTraps = GameInfo.Strings.ugtraps;
-            ugTreasures = GameInfo.Strings.ugtreasures;
-
             // Goods
-            ugGoodsSorted = SanitizeList(ugGoods);
             DGV_UGGoods.Rows.Add(SAV4Sinnoh.UG_POUCH_SIZE);
 
             Item_Goods.DataSource = new BindingSource(ugGoodsSorted, null);
@@ -49,7 +54,6 @@ namespace PKHeX.WinForms
             DGV_UGSpheres.CancelEdit();
 
             // Traps
-            ugTrapsSorted = SanitizeList(ugTraps);
             DGV_UGTraps.Rows.Add(MAX_SIZE);
 
             Item_Traps.DataSource = new BindingSource(ugTrapsSorted, null);
@@ -57,7 +61,6 @@ namespace PKHeX.WinForms
             DGV_UGTraps.CancelEdit();
 
             // Treasures
-            ugTreasuresSorted = SanitizeList(ugTreasures);
             DGV_UGTreasures.Rows.Add(MAX_SIZE);
 
             Item_Treasures.DataSource = new BindingSource(ugTreasuresSorted, null);

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen5/SAV_Misc5.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen5/SAV_Misc5.cs
@@ -41,9 +41,9 @@ namespace PKHeX.WinForms
             Close();
         }
 
-        private ComboBox[] cbr;
+        private ComboBox[] cbr = null!;
         private int ofsFly;
-        private int[] FlyDestC;
+        private int[] FlyDestC = null!;
         private const int ofsRoamer = 0x21B00;
         private const int ofsLibPass = 0x212BC;
         private const uint keyLibPass = 0x0132B536;
@@ -59,12 +59,12 @@ namespace PKHeX.WinForms
             0x93389, 0x22843, 0x34771, 0xAB031, 0xB3818 // Unlocked(EasyMode, Challenge, City, Iron, Iceberg)
         };
 
-        private uint[] valKS;
-        private bool[] bKS;
+        private uint[] valKS = null!;
+        private bool[] bKS = null!;
 
         private void ReadMain()
         {
-            string[] FlyDestA = null;
+            string[]? FlyDestA = null;
             switch (SAV.Version)
             {
                 case GameVersion.B:
@@ -249,7 +249,7 @@ namespace PKHeX.WinForms
                 CLB_KeySystem.SetItemChecked(i, true);
         }
 
-        private readonly int[][] FMUnlockConditions = {
+        private readonly int[]?[] FMUnlockConditions = {
             null, // 00
             null, // 01
             new[] { 2444 }, // 02
@@ -293,9 +293,9 @@ namespace PKHeX.WinForms
 
         private bool editing;
         private const int ofsFM = 0x25900;
-        private NumericUpDown[] nudaE, nudaF;
-        private ComboBox[] cba;
-        private ToolTip[] ta;
+        private NumericUpDown[] nudaE = null!, nudaF = null!;
+        private ComboBox[] cba = null!;
+        private ToolTip[] ta = null!;
 
         private void ReadEntralink()
         {
@@ -524,10 +524,12 @@ namespace PKHeX.WinForms
         {
             const int FunfestFlag = 2438;
             SAV.Data[0x2025E + (FunfestFlag >> 3)] |= 1 << (FunfestFlag & 7);
-            foreach (int[] ia in FMUnlockConditions)
+            foreach (var ia in FMUnlockConditions)
             {
-                for (int i = 0; i < ia?.Length; i++)
-                    SAV.Data[0x2025E + (ia[i] >> 3)] |= (byte)(1 << (ia[i] & 7));
+                if (ia == null)
+                    continue;
+                foreach (var index in ia)
+                    SAV.Data[0x2025E + (index >> 3)] |= (byte)(1 << (index & 7));
             }
 
             L_FMUnlocked.Visible = true;
@@ -560,8 +562,8 @@ namespace PKHeX.WinForms
             SetEntreeExpTooltip(isBlack: false);
         }
 
-        private EntreeForest Forest;
-        private IList<EntreeSlot> AllSlots;
+        private EntreeForest Forest = null!;
+        private IList<EntreeSlot> AllSlots = null!;
 
         private void LoadForest()
         {
@@ -591,7 +593,7 @@ namespace PKHeX.WinForms
             SAV.EntreeData = Forest;
         }
 
-        private IList<EntreeSlot> CurrentSlots;
+        private IList<EntreeSlot> CurrentSlots = null!;
         private int currentIndex = -1;
 
         private void ChangeArea(object sender, EventArgs e)
@@ -620,7 +622,7 @@ namespace PKHeX.WinForms
             SetSprite(current);
         }
 
-        private EntreeSlot CurrentSlot;
+        private EntreeSlot? CurrentSlot;
 
         private void UpdateSlotValue(object sender, EventArgs e)
         {
@@ -683,7 +685,7 @@ namespace PKHeX.WinForms
                 s.Move = slot.Moves.Count > 0 ? slot.Moves[rnd.Next(slot.Moves.Count)] : 0;
                 s.Gender = slot.Gender == -1 ? PersonalTable.B2W2[slot.Species].RandomGender() : slot.Gender;
             }
-            ChangeArea(null, EventArgs.Empty); // refresh
+            ChangeArea(this, EventArgs.Empty); // refresh
             NUD_Unlocked.Value = 8;
             CHK_Area9.Checked = true;
             System.Media.SystemSounds.Asterisk.Play();
@@ -717,7 +719,7 @@ namespace PKHeX.WinForms
         }
 
         // Subway
-        private BattleSubway5 sw;
+        private BattleSubway5 sw = null!;
 
         private void ReadSubway()
         {

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen6/SAV_BoxLayout.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen6/SAV_BoxLayout.cs
@@ -206,7 +206,7 @@ namespace PKHeX.WinForms
             }
             else
             {
-                ChangeBox(null, EventArgs.Empty);
+                ChangeBox(sender, EventArgs.Empty);
             }
 
             editing = renamingBox = false;

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen6/SAV_HallOfFame.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen6/SAV_HallOfFame.cs
@@ -23,7 +23,7 @@ namespace PKHeX.WinForms
             Array.Copy(SAV.Data, SAV.HoF, data, 0, data.Length); //Copy HoF section of save into Data
             Setup();
             LB_DataEntry.SelectedIndex = 0;
-            NUP_PartyIndex_ValueChanged(null, EventArgs.Empty);
+            NUP_PartyIndex_ValueChanged(this, EventArgs.Empty);
             TB_Nickname.Font = TB_OT.Font = FontUtil.GetPKXFont();
             editing = true;
         }
@@ -100,7 +100,7 @@ namespace PKHeX.WinForms
                 groupBox1.Enabled = true;
                 var moncount = AddEntries(offset, s, year, month, day);
 
-                if (sender != null)
+                if (sender != this)
                 {
                     NUP_PartyIndex.Maximum = moncount == 0 ? 1 : moncount;
                     NUP_PartyIndex.Value = 1;
@@ -290,7 +290,7 @@ namespace PKHeX.WinForms
             var gender = PKX.GetGenderFromString(Label_Gender.Text);
             var item = WinFormsUtil.GetIndex(CB_HeldItem);
             bpkx.Image = SpriteUtil.GetSprite(spec, form, gender, 0, item, false, CHK_Shiny.Checked);
-            DisplayEntry(null, EventArgs.Empty); // refresh text view
+            DisplayEntry(this, EventArgs.Empty); // refresh text view
         }
 
         private void Validate_TextBoxes()
@@ -319,7 +319,7 @@ namespace PKHeX.WinForms
             }
             TB_Nickname.ReadOnly = !CHK_Nicknamed.Checked;
 
-            Write_Entry(null, EventArgs.Empty);
+            Write_Entry(this, EventArgs.Empty);
         }
 
         private void SetForms()
@@ -335,7 +335,7 @@ namespace PKHeX.WinForms
         private void UpdateSpecies(object sender, EventArgs e)
         {
             SetForms();
-            UpdateNickname(null, EventArgs.Empty);
+            UpdateNickname(this, EventArgs.Empty);
         }
 
         private void UpdateShiny(object sender, EventArgs e)
@@ -349,7 +349,7 @@ namespace PKHeX.WinForms
             var item = WinFormsUtil.GetIndex(CB_HeldItem);
             bpkx.Image = SpriteUtil.GetSprite(spec, form, gender, 0, item, false, CHK_Shiny.Checked);
 
-            Write_Entry(null, EventArgs.Empty);
+            Write_Entry(this, EventArgs.Empty);
         }
 
         private void UpdateGender(object sender, EventArgs e)
@@ -379,7 +379,7 @@ namespace PKHeX.WinForms
             if (species == (int)Species.Pyroar)
                 CB_Form.SelectedIndex = PKX.GetGenderFromString(Label_Gender.Text);
 
-            Write_Entry(null, EventArgs.Empty);
+            Write_Entry(this, EventArgs.Empty);
         }
 
         private void SetGenderLabel(int gender)
@@ -391,7 +391,7 @@ namespace PKHeX.WinForms
             else
                 Label_Gender.Text = gendersymbols[2];    // Genderless
 
-            Write_Entry(null, EventArgs.Empty);
+            Write_Entry(this, EventArgs.Empty);
         }
 
         private void B_CopyText_Click(object sender, EventArgs e)
@@ -410,7 +410,7 @@ namespace PKHeX.WinForms
             if (index != 15) Array.Copy(data, offset + 0x1B4, data, offset, 0x1B4 * (15 - index));
             // Ensure Last Entry is Cleared
             Array.Copy(new byte[0x1B4], 0, data, 0x1B4 * 15, 0x1B4);
-            DisplayEntry(LB_DataEntry, null);
+            DisplayEntry(LB_DataEntry, EventArgs.Empty);
         }
 
         private void ChangeNickname(object sender, MouseEventArgs e)

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen6/SAV_Pokepuff.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen6/SAV_Pokepuff.cs
@@ -105,7 +105,7 @@ namespace PKHeX.WinForms
             var puffs = new List<byte>();
             for (int i = 0; i < dgv.Rows.Count; i++)
             {
-                string puff = dgv.Rows[i].Cells[1].Value.ToString();
+                var puff = dgv.Rows[i].Cells[1].Value?.ToString();
                 int index = (byte)Array.IndexOf(pfa, puff);
                 puffs.Add((byte)index);
             }

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen6/SAV_SecretBase.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen6/SAV_SecretBase.cs
@@ -12,6 +12,9 @@ namespace PKHeX.WinForms
         private readonly SaveFile Origin;
         private readonly SAV6AO SAV;
 
+        private byte[,] objdata;
+        private byte[,] pkmdata;
+
         public SAV_SecretBase(SaveFile sav)
         {
             InitializeComponent();
@@ -27,7 +30,11 @@ namespace PKHeX.WinForms
 
             LB_Favorite.SelectedIndex = 0;
             MT_Flags.Text = SAV.Records.GetRecord(080).ToString(); // read counter; also present in the Secret Base data block
-            B_SAV2FAV(null, EventArgs.Empty);
+
+            var offset = GetSecretBaseOffset(0);
+            objdata = LoadObjectArray(offset);
+            pkmdata = LoadPKMData(0, offset);
+            B_SAV2FAV(this, EventArgs.Empty);
         }
 
         private bool editing;
@@ -99,36 +106,48 @@ namespace PKHeX.WinForms
             TB_FSay4.Text = bdata.Saying4;
 
             // Gather data for Object Array
-            byte[] data = SAV.Data;
-            objdata = new byte[25, 12];
-            for (int i = 0; i < 25; i++)
-            {
-                for (int z = 0; z < 12; z++)
-                    objdata[i, z] = data[offset + 2 + (12 * i) + z];
-            }
+            objdata = LoadObjectArray(offset);
 
             NUD_FObject.Value = 1; // Trigger Update
-            ChangeObjectIndex(null, EventArgs.Empty);
+            ChangeObjectIndex(this, EventArgs.Empty);
 
             GB_PKM.Enabled = index > 0;
 
             // Trainer Pokemon
-            pkmdata = new byte[3, 0x34];
-            if (index > 0)
-            {
-                for (int i = 0; i < 3; i++)
-                {
-                    for (int z = 0; z < 0x34; z++)
-                        pkmdata[i, z] = SAV.Data[offset + 0x32E + (0x34 * i) + z];
-                }
-            }
+            pkmdata = LoadPKMData(index, offset);
 
             NUD_FPKM.Value = 1;
-            ChangeFavPKM(null, EventArgs.Empty); // Trigger Update
+            ChangeFavPKM(this, EventArgs.Empty); // Trigger Update
 
             loading = false;
             B_Import.Enabled = B_Export.Enabled = index > 0;
             currentIndex = index;
+        }
+
+        private byte[,] LoadPKMData(int index, int offset)
+        {
+            var result = new byte[3, 0x34];
+            if (index <= 0)
+                return result;
+            for (int i = 0; i < 3; i++)
+            {
+                for (int z = 0; z < 0x34; z++)
+                    result[i, z] = SAV.Data[offset + 0x32E + (0x34 * i) + z];
+            }
+            return result;
+        }
+
+        private byte[,] LoadObjectArray(int offset)
+        {
+            byte[] data = SAV.Data;
+            var result = new byte[25, 12];
+            for (int i = 0; i < 25; i++)
+            {
+                for (int z = 0; z < 12; z++)
+                    result[i, z] = data[offset + 2 + (12 * i) + z];
+            }
+
+            return result;
         }
 
         private int GetSecretBaseOffset(int index)
@@ -141,9 +160,6 @@ namespace PKHeX.WinForms
             // Received
             return SAV.SecretBase + 0x63A + (index * SecretBase6.SIZE);
         }
-
-        private byte[,] objdata;
-        private byte[,] pkmdata;
 
         private void B_FAV2SAV(object sender, EventArgs e)
         {

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen6/SAV_SuperTrain.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen6/SAV_SuperTrain.cs
@@ -125,7 +125,7 @@ namespace PKHeX.WinForms
             int emptyslots = 0;
             for (int i = 0; i < 12; i++)
             {
-                string bag = dataGridView1.Rows[i].Cells[1].Value.ToString();
+                var bag = dataGridView1.Rows[i].Cells[1].Value.ToString();
                 if (Array.IndexOf(trba, bag) == 0)
                 {
                     emptyslots++;

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen6/SAV_Trainer.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen6/SAV_Trainer.cs
@@ -283,7 +283,7 @@ namespace PKHeX.WinForms
             if (ModifierKeys != Keys.Control)
                 return;
 
-            var d = new TrashEditor(tb, null, SAV);
+            var d = new TrashEditor(tb, SAV);
             d.ShowDialog();
             tb.Text = d.FinalString;
         }
@@ -352,7 +352,7 @@ namespace PKHeX.WinForms
             PB_Sprite.Image = SAV.Sprite();
         }
 
-        private string UpdateTip(int index)
+        private string? UpdateTip(int index)
         {
             switch (index)
             {

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen7/SAV_FestivalPlaza.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen7/SAV_FestivalPlaza.cs
@@ -377,7 +377,7 @@ namespace PKHeX.WinForms
             if (ModifierKeys != Keys.Control)
                 return;
 
-            var d = new TrashEditor(tb, null, SAV);
+            var d = new TrashEditor(tb, SAV);
             d.ShowDialog();
             tb.Text = d.FinalString;
         }

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen7/SAV_Trainer7.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen7/SAV_Trainer7.cs
@@ -48,7 +48,7 @@ namespace PKHeX.WinForms
         private static readonly string[] AllStyles = Enum.GetNames(typeof(PlayerBattleStyle7));
         private readonly List<string> BattleStyles = new List<string>(AllStyles);
 
-        private int[] FlyDestFlagOfs, MapUnmaskFlagOfs;
+        private int[] FlyDestFlagOfs = null!, MapUnmaskFlagOfs = null!;
         private int SkipFlag => SAV is SAV7USUM ? 4160 : 3200; // FlagMax - 768
 
         private void GetComboBoxes()
@@ -117,6 +117,8 @@ namespace PKHeX.WinForms
                 CB_AlolaTime.Enabled = false; // alola time doesn't exist yet
             else
                 CB_AlolaTime.SelectedValue = (int)timeA;
+
+            // ReSharper disable once ConditionIsAlwaysTrueOrFalse
             if (CB_AlolaTime.SelectedValue == null)
                 CB_AlolaTime.Enabled = false;
 
@@ -392,8 +394,8 @@ namespace PKHeX.WinForms
             // Skin changed && (gender matches || override)
             int gender = CB_Gender.SelectedIndex & 1;
             int skin = CB_SkinColor.SelectedIndex & 1;
-            string gStr = CB_Gender.Items[gender].ToString();
-            string sStr = CB_Gender.Items[skin].ToString();
+            var gStr = CB_Gender.Items[gender].ToString();
+            var sStr = CB_Gender.Items[skin].ToString();
 
             if (SAV.MyStatus.DressUpSkinColor == CB_SkinColor.SelectedIndex)
                 return;
@@ -473,7 +475,7 @@ namespace PKHeX.WinForms
             if (ModifierKeys != Keys.Control)
                 return;
 
-            var d = new TrashEditor(tb, null, SAV);
+            var d = new TrashEditor(tb, SAV);
             d.ShowDialog();
             tb.Text = d.FinalString;
         }
@@ -546,7 +548,7 @@ namespace PKHeX.WinForms
             System.Media.SystemSounds.Asterisk.Play();
         }
 
-        private string UpdateTip(int index)
+        private string? UpdateTip(int index)
         {
             switch (index)
             {

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen7/SAV_Trainer7GG.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen7/SAV_Trainer7GG.cs
@@ -43,7 +43,7 @@ namespace PKHeX.WinForms
 
         private void Main_DragDrop(object sender, DragEventArgs e)
         {
-            string[] files = (string[])e.Data.GetData(DataFormats.FileDrop);
+            var files = (string[]?)e.Data.GetData(DataFormats.FileDrop);
             if (files == null || files.Length == 0)
                 return;
             ImportGP1From(files[0]);
@@ -108,7 +108,7 @@ namespace PKHeX.WinForms
             TextBox tb = sender as TextBox ?? TB_OTName;
 
             // Special Character Form
-            var d = new TrashEditor(tb, null, SAV);
+            var d = new TrashEditor(tb, SAV);
             d.ShowDialog();
             tb.Text = d.FinalString;
         }

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen7/SAV_ZygardeCell.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen7/SAV_ZygardeCell.cs
@@ -28,7 +28,7 @@ namespace PKHeX.WinForms
             NUD_Cells.Value = cellCount;
             NUD_Collected.Value = cellCollected;
 
-            var combo = dgv.Columns[2] as DataGridViewComboBoxColumn;
+            var combo = (DataGridViewComboBoxColumn)dgv.Columns[2];
             foreach (string t in states)
                 combo.Items.Add(t); // add only the Names
             dgv.Columns[0].ValueType = typeof(int);

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen8/SAV_BlockDump8.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen8/SAV_BlockDump8.cs
@@ -14,7 +14,7 @@ namespace PKHeX.WinForms
         private readonly SAV8SWSH SAV;
         private readonly SCBlockMetadata Metadata;
 
-        private SCBlock CurrentBlock;
+        private SCBlock CurrentBlock = null!;
 
         public SAV_BlockDump8(SaveFile sav)
         {
@@ -38,7 +38,9 @@ namespace PKHeX.WinForms
             CB_TypeToggle.InitializeBinding();
             CB_TypeToggle.DataSource = boolToggle;
 
-            CB_TypeToggle.SelectedIndexChanged += CB_TypeToggle_SelectedIndexChanged;
+            CB_TypeToggle.SelectedIndexChanged += (o, args) => CB_TypeToggle_SelectedIndexChanged(CB_TypeToggle, args);
+
+            CB_Key.SelectedIndex = 0;
         }
 
         private void CB_Key_SelectedIndexChanged(object sender, EventArgs e)
@@ -63,7 +65,7 @@ namespace PKHeX.WinForms
             L_Detail_R.Text = GetBlockSummary(block);
             RTB_Hex.Text = string.Join(" ", block.Data.Select(z => $"{z:X2}"));
 
-            string blockName = Metadata.GetBlockName(block, out SaveBlock obj);
+            var blockName = Metadata.GetBlockName(block, out var obj);
             if (blockName != null)
             {
                 L_BlockName.Visible = true;
@@ -101,11 +103,12 @@ namespace PKHeX.WinForms
 
         private void CB_TypeToggle_SelectedIndexChanged(object sender, EventArgs e)
         {
-            var cType = CurrentBlock.Type;
+            var block = CurrentBlock;
+            var cType = block.Type;
             var cValue = (SCTypeCode)WinFormsUtil.GetIndex(CB_TypeToggle);
             if (cType == cValue)
                 return;
-            CurrentBlock.Type = cValue;
+            block.Type = cValue;
             UpdateBlockSummaryControls();
         }
 

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen8/SAV_Trainer8.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen8/SAV_Trainer8.cs
@@ -36,8 +36,8 @@ namespace PKHeX.WinForms
 
             TC_Editor.TabPages.Remove(Tab_BadgeMap); // needs more work
 
-            ChangeTitleScreenIndex(null, EventArgs.Empty);
-            ChangeTrainerCardIndex(null, EventArgs.Empty);
+            ChangeTitleScreenIndex(this, EventArgs.Empty);
+            ChangeTrainerCardIndex(this, EventArgs.Empty);
 
             //Loading = false;
         }
@@ -182,7 +182,7 @@ namespace PKHeX.WinForms
             if (ModifierKeys != Keys.Control)
                 return;
 
-            var d = new TrashEditor(tb, null, SAV);
+            var d = new TrashEditor(tb, SAV);
             d.ShowDialog();
             tb.Text = d.FinalString;
         }
@@ -228,14 +228,14 @@ namespace PKHeX.WinForms
         {
             SAV.Blocks.TrainerCard.SetPartyData();
             System.Media.SystemSounds.Asterisk.Play();
-            ChangeTrainerCardIndex(null, EventArgs.Empty);
+            ChangeTrainerCardIndex(this, EventArgs.Empty);
         }
 
         private void B_CopyFromPartyToTitleScreen_Click(object sender, EventArgs e)
         {
             SAV.Blocks.TitleScreen.SetPartyData();
             System.Media.SystemSounds.Asterisk.Play();
-            ChangeTitleScreenIndex(null, EventArgs.Empty);
+            ChangeTitleScreenIndex(this, EventArgs.Empty);
         }
 
         //private string UpdateTip(int index)

--- a/PKHeX.WinForms/Subforms/Save Editors/Misc/SAV_Accessor.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Misc/SAV_Accessor.cs
@@ -6,7 +6,7 @@ using PKHeX.Core;
 
 namespace PKHeX.WinForms
 {
-    public partial class SAV_Accessor<T> : Form where T : ISaveBlockAccessor<BlockInfo>
+    public partial class SAV_Accessor<T> : Form where T : class, ISaveBlockAccessor<BlockInfo>
     {
         private readonly SaveBlockMetadata<BlockInfo> Metadata;
 

--- a/PKHeX.WinForms/Subforms/Save Editors/SAV_BoxList.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/SAV_BoxList.cs
@@ -33,7 +33,7 @@ namespace PKHeX.WinForms
             {
                 foreach (var b in Boxes)
                 {
-                    b.M.Boxes.Remove(b);
+                    b.M?.Boxes.Remove(b);
                     m.Env.Slots.Publisher.Subscribers.Remove(b);
                 }
             };
@@ -77,12 +77,16 @@ namespace PKHeX.WinForms
                 box.ClearEvents();
                 box.B_BoxLeft.Click += (s, e) =>
                 {
+                    if (s == null)
+                        return;
                     int index = Array.FindIndex(Boxes, z => z == ((Button)s).Parent);
                     int other = (index + Boxes.Length - 1) % Boxes.Length;
                     m.SwapBoxes(index, other, p.SAV);
                 };
                 box.B_BoxRight.Click += (s, e) =>
                 {
+                    if (s == null)
+                        return;
                     int index = Array.FindIndex(Boxes, z => z == ((Button)s).Parent);
                     int other = (index + 1) % Boxes.Length;
                     m.SwapBoxes(index, other, p.SAV);

--- a/PKHeX.WinForms/Subforms/Save Editors/SAV_BoxViewer.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/SAV_BoxViewer.cs
@@ -65,7 +65,7 @@ namespace PKHeX.WinForms
         private void SAV_BoxViewer_FormClosing(object sender, FormClosingEventArgs e)
         {
             // Remove viewer from manager list
-            Box.M.Boxes.Remove(Box);
+            Box.M?.Boxes.Remove(Box);
             parent.EditEnv.Slots.Publisher.Subscribers.Remove(Box);
         }
     }

--- a/PKHeX.WinForms/Subforms/Save Editors/SAV_EventFlags.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/SAV_EventFlags.cs
@@ -84,7 +84,7 @@ namespace PKHeX.WinForms
             SAV.EventFlags = flags;
 
             // Copy back Constants
-            ChangeConstantIndex(null, EventArgs.Empty); // Trigger Saving
+            ChangeConstantIndex(sender, EventArgs.Empty); // Trigger Saving
             SAV.EventConsts = Constants;
 
             HandleSpecialFlags();
@@ -129,7 +129,7 @@ namespace PKHeX.WinForms
 
         private void AddFlagList(string[] list)
         {
-            if (list == null || list.Length == 0)
+            if (list.Length == 0)
             {
                 TLP_Flags.Controls.Add(new Label { Text = MsgResearchRequired, Name = "TLP_Flags_Research", ForeColor = Color.Red, AutoSize = true }, 0, 0);
                 return;
@@ -182,7 +182,7 @@ namespace PKHeX.WinForms
                     Checked = flags[num[i]],
                     AutoSize = true
                 };
-                chk.CheckStateChanged += ToggleFlag;
+                chk.CheckStateChanged += (o, args) => ToggleFlag(chk, args);
                 lbl.Click += (sender, e) => chk.Checked ^= true;
                 TLP_Flags.Controls.Add(chk, 0, i);
                 TLP_Flags.Controls.Add(lbl, 1, i);
@@ -199,7 +199,7 @@ namespace PKHeX.WinForms
 
         private void AddConstList(string[] list)
         {
-            if (list == null || list.Length == 0)
+            if (list.Length == 0)
             {
                 TLP_Const.Controls.Add(new Label { Text = MsgResearchRequired, Name = "TLP_Const_Research", ForeColor = Color.Red, AutoSize = true }, 0, 0);
                 return;
@@ -278,8 +278,8 @@ namespace PKHeX.WinForms
                 cb.InitializeBinding();
                 cb.DataSource = map;
                 cb.SelectedIndex = 0;
-                cb.SelectedValueChanged += ToggleConst;
-                mtb.TextChanged += ToggleConst;
+                cb.SelectedValueChanged += (o, args) => ToggleConst(cb, args);
+                mtb.TextChanged += (o, args) => ToggleConst(mtb, args);
                 TLP_Const.Controls.Add(lbl, 0, i);
                 TLP_Const.Controls.Add(cb, 1, i);
                 TLP_Const.Controls.Add(mtb, 2, i);
@@ -333,10 +333,7 @@ namespace PKHeX.WinForms
             }
         }
 
-        private void ChangeCustomFlag(object sender, KeyEventArgs e)
-        {
-            ChangeCustomFlag(null, (EventArgs)e);
-        }
+        private void ChangeCustomFlag(object sender, KeyEventArgs e) => ChangeCustomFlag(sender, (EventArgs)e);
 
         private void ToggleFlag(object sender, EventArgs e)
         {

--- a/PKHeX.WinForms/Subforms/Save Editors/SAV_EventWork.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/SAV_EventWork.cs
@@ -9,20 +9,17 @@ namespace PKHeX.WinForms
 {
     public sealed partial class SAV_EventWork : Form
     {
-        private readonly SaveFile Origin;
+        private readonly SAV7b Origin;
         private readonly IEventWork<int> SAV;
         private readonly SplitEventEditor<int> Editor;
 
-        public SAV_EventWork(SaveFile sav)
+        public SAV_EventWork(SAV7b sav)
         {
             InitializeComponent();
 
             WinFormsUtil.TranslateInterface(this, Main.CurrentLanguage);
 
-            if (sav is SAV7b s7b)
-                SAV = s7b.Blocks.EventWork;
-            //else if (sav is SAV8SWSH s8ss)
-            //    SAV = s8ss.Blocks.EventWork;
+            SAV = sav.Blocks.EventWork;
             Origin = sav;
 
             DragEnter += Main_DragEnter;

--- a/PKHeX.WinForms/Subforms/Save Editors/SAV_GameSelect.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/SAV_GameSelect.cs
@@ -32,9 +32,9 @@ namespace PKHeX.WinForms
         private void SAV_GameSelect_KeyDown(object sender, KeyEventArgs e)
         {
             if (e.KeyCode == Keys.Enter)
-                B_OK_Click(null, EventArgs.Empty);
+                B_OK_Click(sender, EventArgs.Empty);
             if (e.KeyCode == Keys.Escape)
-                B_Cancel_Click(null, EventArgs.Empty);
+                B_Cancel_Click(sender, EventArgs.Empty);
         }
     }
 }

--- a/PKHeX.WinForms/Subforms/Save Editors/SAV_GroupViewer.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/SAV_GroupViewer.cs
@@ -37,8 +37,8 @@ namespace PKHeX.WinForms
 
             foreach (PictureBox pb in Box.Entries)
             {
-                pb.Click += OmniClick;
-                pb.MouseHover += HoverSlot;
+                pb.Click += (o, args) => OmniClick(pb, args);
+                pb.MouseHover += (o, args) => HoverSlot(pb, args);
                 pb.ContextMenuStrip = mnu;
             }
         }
@@ -142,6 +142,8 @@ namespace PKHeX.WinForms
         private void ClickView(object sender, EventArgs e)
         {
             var pb = WinFormsUtil.GetUnderlyingControl<PictureBox>(sender);
+            if (pb == null)
+                return;
             int index = Box.Entries.IndexOf(pb);
 
             var group = Groups[CurrentGroup];

--- a/PKHeX.WinForms/Subforms/Save Editors/SAV_MailBox.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/SAV_MailBox.cs
@@ -236,7 +236,7 @@ namespace PKHeX.WinForms
             editing = false;
         }
 
-        private readonly Mail[] m;
+        private readonly Mail[] m = null!;
         private bool editing;
         private int entry;
         private readonly NumericUpDown[][] Messages;
@@ -246,9 +246,9 @@ namespace PKHeX.WinForms
         private readonly int Gen;
         private readonly byte ResetVer, ResetLang;
         private readonly int PartyBoxCount;
-        private string loadedLBItemLabel;
+        private string loadedLBItemLabel = null!;
         private bool LabelValue_GenderF;
-        private readonly int[] MailItemID;
+        private readonly int[] MailItemID = null!;
         private readonly IList<PKM> p;
 
         private void Save()
@@ -292,6 +292,7 @@ namespace PKHeX.WinForms
             mail.AuthorName = TB_AuthorName.Text;
             mail.AuthorTID = (ushort)NUD_AuthorTID.Value;
             mail.MailType = CBIndexToMailType(CB_MailType.SelectedIndex);
+            // ReSharper disable once ConstantNullCoalescingCondition
             int v = (int?)CB_AppearPKM1.SelectedValue ?? 0;
             if (Gen == 2)
             {
@@ -310,8 +311,13 @@ namespace PKHeX.WinForms
                 mail.AppearPKM = v < 252 ? v : HoennListMixed[v - 252];
                 return;
             }
+
+            // ReSharper disable once ConstantNullCoalescingCondition
             mail.AuthorVersion = (byte)((int?)CB_AuthorVersion.SelectedValue ?? 0);
+
+            // ReSharper disable once ConstantNullCoalescingCondition
             mail.AuthorLanguage = (byte)((int?)CB_AuthorLang.SelectedValue ?? 0);
+
             mail.AuthorGender = (byte)((mail.AuthorGender & 0xFE) | (LabelValue_GenderF ? 1 : 0));
             switch (mail)
             {
@@ -427,7 +433,7 @@ namespace PKHeX.WinForms
 
         private string GetSpeciesNameFromCB(int index)
         {
-            foreach (ComboItem i in CB_AppearPKM1.Items)
+            foreach (var i in CB_AppearPKM1.Items.OfType<ComboItem>())
             {
                 if (index == i.Value)
                     return i.Text;
@@ -446,14 +452,14 @@ namespace PKHeX.WinForms
             ret = WinFormsUtil.Prompt(MessageBoxButtons.YesNoCancel, msg);
             if (ret != DialogResult.Yes)
                 return ret;
-            foreach (PKM pkm in s)
+            foreach (var pkm in s)
             {
-                if (pkm != null)
-                {
-                    pkm.HeldItem = 0;
-                    if (Gen == 3)
-                        ((PK3)pkm).HeldMailID = -1;
-                }
+                if (pkm == null)
+                    continue;
+
+                pkm.HeldItem = 0;
+                if (Gen == 3)
+                    ((PK3)pkm).HeldMailID = -1;
             }
             LoadPKM(false);
             return ret;

--- a/PKHeX.WinForms/Subforms/Save Editors/SAV_Wondercard.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/SAV_Wondercard.cs
@@ -15,7 +15,7 @@ namespace PKHeX.WinForms
         private readonly SaveFile Origin;
         private readonly SaveFile SAV;
 
-        public SAV_Wondercard(SaveFile sav, DataMysteryGift g = null)
+        public SAV_Wondercard(SaveFile sav, DataMysteryGift? g = null)
         {
             InitializeComponent();
             WinFormsUtil.TranslateInterface(this, Main.CurrentLanguage);
@@ -55,13 +55,13 @@ namespace PKHeX.WinForms
             DragDrop += Main_DragDrop;
 
             if (g == null)
-                ClickView(pba[0], null);
+                ClickView(pba[0], EventArgs.Empty);
             else
                 ViewGiftData(g);
         }
 
         private readonly MysteryGiftAlbum mga;
-        private DataMysteryGift mg;
+        private DataMysteryGift? mg;
         private readonly PictureBox[] pba;
 
         // Repopulation Functions
@@ -143,6 +143,8 @@ namespace PKHeX.WinForms
 
         private void B_Output_Click(object sender, EventArgs e)
         {
+            if (mg == null)
+                return;
             WinFormsUtil.ExportMGDialog(mg, SAV.Version);
         }
 
@@ -170,6 +172,9 @@ namespace PKHeX.WinForms
 
         private void ClickSet(object sender, EventArgs e)
         {
+            if (mg == null)
+                return;
+
             if (!mg.IsCardCompatible(SAV, out var msg))
             {
                 WinFormsUtil.Alert(MsgMysteryGiftSlotFail, msg);
@@ -239,7 +244,13 @@ namespace PKHeX.WinForms
             // Make sure all of the Received Flags are flipped!
             bool[] flags = new bool[mga.Flags.Length];
             foreach (var o in LB_Received.Items)
-                flags[Util.ToUInt32(o.ToString())] = true;
+            {
+                var value = o?.ToString();
+                if (value == null)
+                    continue;
+                var flag = Util.ToUInt32(value);
+                flags[flag] = true;
+            }
 
             flags.CopyTo(mga.Flags, 0);
             SAV.GiftAlbum = mga;
@@ -323,6 +334,8 @@ namespace PKHeX.WinForms
 
         private void ExportQRFromView()
         {
+            if (mg == null)
+                return;
             if (mg.Empty)
             {
                 WinFormsUtil.Alert(MsgMysteryGiftSlotNone);
@@ -356,6 +369,9 @@ namespace PKHeX.WinForms
 
             string[] types = mga.Gifts.Select(g => g.Type).Distinct().ToArray();
             var gift = MysteryGift.GetMysteryGift(data);
+            if (gift == null)
+                return;
+
             string giftType = gift.Type;
 
             if (mga.Gifts.All(card => card.Data.Length != data.Length))
@@ -406,6 +422,9 @@ namespace PKHeX.WinForms
 
         private void BoxSlot_DragDrop(object sender, DragEventArgs e)
         {
+            if (mg == null)
+                return;
+
             int index = Array.IndexOf(pba, sender);
 
             // Hijack to the latest unfilled slot if index creates interstitial empty slots.
@@ -415,7 +434,7 @@ namespace PKHeX.WinForms
 
             if (wc_slot == -1) // dropped
             {
-                var files = (string[])e.Data.GetData(DataFormats.FileDrop);
+                var files = (string[]?)e.Data.GetData(DataFormats.FileDrop);
                 if (files == null || files.Length == 0)
                     return;
 
@@ -453,7 +472,7 @@ namespace PKHeX.WinForms
                 {
                     // set the PGT to the PGT slot instead
                     ViewGiftData(s2);
-                    ClickSet(pba[index], null);
+                    ClickSet(pba[index], EventArgs.Empty);
                     { WinFormsUtil.Alert(string.Format(MsgMysteryGiftSlotAlternate, s2.Type, s1.Type)); return; }
                 }
                 if (s1.Type != s2.Type)

--- a/PKHeX.WinForms/Subforms/Save Editors/TrainerStat.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/TrainerStat.cs
@@ -15,9 +15,9 @@ namespace PKHeX.WinForms.Subforms.Save_Editors
         }
 
         private bool Editing;
-        private ITrainerStatRecord SAV;
-        private Dictionary<int, string> RecordList; // index, description
-        public Func<int, string> GetToolTipText { private get; set; }
+        private ITrainerStatRecord SAV = null!;
+        private Dictionary<int, string> RecordList = null!; // index, description
+        public Func<int, string?>? GetToolTipText { private get; set; }
 
         public void LoadRecords(ITrainerStatRecord sav, Dictionary<int, string> records)
         {
@@ -26,7 +26,7 @@ namespace PKHeX.WinForms.Subforms.Save_Editors
             CB_Stats.Items.Clear();
             for (int i = 0; i < sav.RecordCount; i++)
             {
-                if (!RecordList.TryGetValue(i, out string name))
+                if (!RecordList.TryGetValue(i, out var name))
                     name = $"{i:D3}";
 
                 CB_Stats.Items.Add(name);
@@ -67,7 +67,7 @@ namespace PKHeX.WinForms.Subforms.Save_Editors
 
         private void UpdateToolTipSpecial(int index, bool updateStats)
         {
-            var str = GetToolTipText(index);
+            var str = GetToolTipText?.Invoke(index);
             if (str != null)
             {
                 Tip.SetToolTip(NUD_Stat, str);
@@ -78,7 +78,7 @@ namespace PKHeX.WinForms.Subforms.Save_Editors
 
         private void UpdateToolTipDefault(int index, bool updateStats)
         {
-            if (!updateStats || !RecordList.TryGetValue(index, out string tip))
+            if (!updateStats || !RecordList.TryGetValue(index, out var tip))
             {
                 Tip.RemoveAll();
                 return;

--- a/PKHeX.WinForms/Subforms/SettingsEditor.cs
+++ b/PKHeX.WinForms/Subforms/SettingsEditor.cs
@@ -13,7 +13,7 @@ namespace PKHeX.WinForms
 {
     public partial class SettingsEditor : Form
     {
-        public SettingsEditor(object obj, params string[] blacklist)
+        public SettingsEditor(object? obj, params string[] blacklist)
         {
             InitializeComponent();
             SettingsObject = obj ?? Settings.Default;
@@ -88,7 +88,7 @@ namespace PKHeX.WinForms
             return control switch
             {
                 CheckBox cb => cb.Checked,
-                _ => null
+                _ => throw new Exception(nameof(control)),
             };
         }
 

--- a/PKHeX.WinForms/Util/ConfigUtil.cs
+++ b/PKHeX.WinForms/Util/ConfigUtil.cs
@@ -14,7 +14,7 @@ namespace PKHeX.WinForms
             }
             catch (ConfigurationErrorsException e)
             {
-                string path = (e.InnerException as ConfigurationErrorsException)?.Filename;
+                var path = (e.InnerException as ConfigurationErrorsException)?.Filename;
                 if (path != null && File.Exists(path))
                     File.Delete(path);
                 return false;

--- a/PKHeX.WinForms/Util/WinFormsTranslator.cs
+++ b/PKHeX.WinForms/Util/WinFormsTranslator.cs
@@ -68,7 +68,7 @@ namespace PKHeX.WinForms
 
             if (Util.IsStringListCached(file, out var result))
                 return result;
-            var txt = (string)Properties.Resources.ResourceManager.GetObject(file);
+            var txt = (string?)Properties.Resources.ResourceManager.GetObject(file);
             return Util.LoadStringList(file, txt);
         }
 
@@ -105,7 +105,7 @@ namespace PKHeX.WinForms
 
         private static IEnumerable<T> GetChildrenOfType<T>(this Control control) where T : class
         {
-            foreach (Control child in control.Controls)
+            foreach (var child in control.Controls.OfType<Control>())
             {
                 if (child is T childOfT)
                     yield return childOfT;
@@ -174,7 +174,7 @@ namespace PKHeX.WinForms
                 var argCount = constructors[0].GetParameters().Length;
                 try
                 {
-                    var _ = (Form)System.Activator.CreateInstance(t, new object[argCount]);
+                    var _ = (Form?)System.Activator.CreateInstance(t, new object[argCount]);
                 }
 #pragma warning disable CA1031 // Do not catch general exception types
                 // This is a debug utility method, will always be logging. Shouldn't ever fail.
@@ -225,7 +225,7 @@ namespace PKHeX.WinForms
                 Translation.Add(kvp[0], kvp[1]);
         }
 
-        public string GetTranslatedText(string val, string fallback)
+        public string? GetTranslatedText(string val, string? fallback)
         {
             if (RemoveUsedKeys)
                 Translation.Remove(val);


### PR DESCRIPTION
Handle all warnings
obviously the usage of null! could potentially be avoided if the object init wasn't such garbage, but here we are with years of old junk and lack of abstraction in the GUI project