### PR TITLE
Ranked Battle Series 7

### DIFF
--- a/PKHeX.Core/Legality/Verifiers/Ribbons/RibbonVerifier.cs
+++ b/PKHeX.Core/Legality/Verifiers/Ribbons/RibbonVerifier.cs
@@ -404,16 +404,24 @@ namespace PKHeX.Core
             // Clamp to permitted species
             var spec = pkm.Species;
 
-            if (638 <= spec && spec <= 640)
+            if (Legal.SubLegends.Contains(spec))
                 return true; // Sub Legends
+
+            if (252 <= spec && spec <= 260)
+                return true; // Hoenn Starters
+
             if (722 <= spec && spec <= 730)
                 return true; // Gen7 starters
+
             var pi = (PersonalInfoSWSH)PersonalTable.SWSH[spec];
             var galarDex = pi.PokeDexIndex;
             var armorDex = pi.ArmorDexIndex;
+            var crownDex = pi.CrownDexIndex;
             if (1 <= galarDex && galarDex <= 397)
                 return true;
             if (1 <= armorDex && armorDex <= 210)
+                return true;
+            if (1 <= crownDex && crownDex <= 209)
                 return true;
 
             return false;


### PR DESCRIPTION
Ranked Battle Series 7 includes Crown Dex, Hoenn Starters and all Sub Legends now.

https://assets.pokemon.com//assets/cms2/pdf/play-pokemon/rules/play-pokemon-vg-rules-formats-and-penalty-guidelines-10232020-en.pdf