### PR TITLE
Add Route 3 -> Motostoke City crossover

### DIFF
--- a/PKHeX.Core/Legality/Areas/EncounterArea8.cs
+++ b/PKHeX.Core/Legality/Areas/EncounterArea8.cs
@@ -90,6 +90,10 @@ namespace PKHeX.Core
         // Location, and areas that it can feed encounters to.
         public static readonly IReadOnlyDictionary<int, IReadOnlyList<byte>> ConnectingArea8 = new Dictionary<int, IReadOnlyList<byte>>
         {
+            // Route 3
+            // City of Motostoke
+            {28, new byte[] {20}},
+
             // Rolling Fields
             // Dappled Grove, East Lake Axewell, West Lake Axewell
             // Also connects to South Lake Miloch but too much of a stretch


### PR DESCRIPTION
Not related to the location glitch; whistle to lead Zigzagoon.

Co-Authored-By: tehvik <40148574+tehvik@users.noreply.github.com>