### PR TITLE
Document weather for static encounters

### DIFF
--- a/PKHeX.Core/Legality/Areas/EncounterArea8.cs
+++ b/PKHeX.Core/Legality/Areas/EncounterArea8.cs
@@ -277,6 +277,12 @@ namespace PKHeX.Core
         Heavy_Fog = 1 << 8,
 
         All = Normal | Overcast | Raining | Thunderstorm | Intense_Sun | Snowing | Snowstorm | Sandstorm | Heavy_Fog,
+        Stormy = Raining | Thunderstorm,
+        Icy = Snowing | Snowstorm,
+        All_IoA = Normal | Overcast | Stormy | Intense_Sun | Sandstorm | Heavy_Fog,         // IoA can have everything but snow
+        All_CT = Normal | Overcast | Stormy | Intense_Sun | Icy | Heavy_Fog,                // CT can have everything but sand
+        No_Sun_Sand = Normal | Overcast | Stormy | Icy | Heavy_Fog,                         // Everything but sand and sun
+        All_Ballimere = Normal | Overcast | Stormy | Intense_Sun | Snowing | Heavy_Fog,     // All Ballimere Lake weather
 
         Shaking_Trees = 1 << 9,
         Fishing = 1 << 10,

--- a/PKHeX.Core/Legality/Encounters/Data/Encounters8.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Encounters8.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using static PKHeX.Core.EncounterUtil;
 using static PKHeX.Core.Shiny;
 using static PKHeX.Core.GameVersion;
+using static PKHeX.Core.AreaWeather8;
 
 using static PKHeX.Core.Encounters8Nest;
 using System.Linq;
@@ -50,25 +51,25 @@ namespace PKHeX.Core
             var ssl = ss.Length;
             Array.Resize(ref ss, ssl + 2);
             Array.Copy(bridge.Slots, start, ss, ssl, 2);
-            Debug.Assert(((EncounterSlot8)ss[ssl]).Weather == AreaWeather8.Shaking_Trees);
-            Debug.Assert(((EncounterSlot8)ss[ssl+1]).Weather == AreaWeather8.Shaking_Trees);
+            Debug.Assert(((EncounterSlot8)ss[ssl]).Weather == Shaking_Trees);
+            Debug.Assert(((EncounterSlot8)ss[ssl+1]).Weather == Shaking_Trees);
             stony.Slots = ss;
         }
 
         private static readonly EncounterStatic8[] Encounter_SWSH =
         {
             // gifts
-            new(SWSH) { Gift = true, Species = 810, Shiny = Never, Level = 05, Location = 006, }, // Grookey
-            new(SWSH) { Gift = true, Species = 813, Shiny = Never, Level = 05, Location = 006, }, // Scorbunny
-            new(SWSH) { Gift = true, Species = 816, Shiny = Never, Level = 05, Location = 006, }, // Sobble
+            new(SWSH) { Gift = true, Species = 810, Shiny = Never, Level = 05, Location = 006 }, // Grookey
+            new(SWSH) { Gift = true, Species = 813, Shiny = Never, Level = 05, Location = 006 }, // Scorbunny
+            new(SWSH) { Gift = true, Species = 816, Shiny = Never, Level = 05, Location = 006 }, // Sobble
 
             new(SWSH) { Gift = true, Species = 772, Shiny = Never, Level = 50, Location = 158, FlawlessIVCount = 3, }, // Type: Null
             new(SWSH) { Gift = true, Species = 848, Shiny = Never, Level = 01, Location = 040, IVs = new[]{-1,31,-1,-1,31,-1}, Ball = 11 }, // Toxel, Attack flawless
 
-            new(SWSH) { Gift = true, Species = 880, FlawlessIVCount = 3, Level = 10, Location = 068, }, // Dracozolt @ Route 6
-            new(SWSH) { Gift = true, Species = 881, FlawlessIVCount = 3, Level = 10, Location = 068, }, // Arctozolt @ Route 6
-            new(SWSH) { Gift = true, Species = 882, FlawlessIVCount = 3, Level = 10, Location = 068, }, // Dracovish @ Route 6
-            new(SWSH) { Gift = true, Species = 883, FlawlessIVCount = 3, Level = 10, Location = 068, }, // Arctovish @ Route 6
+            new(SWSH) { Gift = true, Species = 880, FlawlessIVCount = 3, Level = 10, Location = 068 }, // Dracozolt @ Route 6
+            new(SWSH) { Gift = true, Species = 881, FlawlessIVCount = 3, Level = 10, Location = 068 }, // Arctozolt @ Route 6
+            new(SWSH) { Gift = true, Species = 882, FlawlessIVCount = 3, Level = 10, Location = 068 }, // Dracovish @ Route 6
+            new(SWSH) { Gift = true, Species = 883, FlawlessIVCount = 3, Level = 10, Location = 068 }, // Arctovish @ Route 6
 
             new(SWSH) { Gift = true, Species = 004, Shiny = Never, Level = 05, Location = 006, FlawlessIVCount = 3, CanGigantamax = true, Ability = 1 }, // Charmander
             new(SWSH) { Gift = true, Species = 025, Shiny = Never, Level = 10, Location = 156, FlawlessIVCount = 6, CanGigantamax = true }, // Pikachu
@@ -106,9 +107,9 @@ namespace PKHeX.Core
             new(SWSH) { Species = 890, Level = 60, Location = 66, ScriptedNoMarks = true, Moves = new[] {440,406,053,744}, Shiny = Never, Ability = 1, FlawlessIVCount = 3 }, // Eternatus-1 (reverts to form 0)
 
             // Motostoke Stadium Static Encounters
-            new(SWSH) { Species = 037, Level = 24, Location = 24, }, // Vulpix at Motostoke Stadium
-            new(  SH) { Species = 058, Level = 24, Location = 24, }, // Growlithe at Motostoke Stadium
-            new(SWSH) { Species = 607, Level = 25, Location = 24, }, // Litwick at Motostoke Stadium
+            new(SWSH) { Species = 037, Level = 24, Location = 24 }, // Vulpix at Motostoke Stadium
+          //new(  SH) { Species = 058, Level = 24, Location = 24 }, // Growlithe at Motostoke Stadium (both versions have Vulpix)
+            new(SWSH) { Species = 607, Level = 25, Location = 24 }, // Litwick at Motostoke Stadium
             new(SWSH) { Species = 850, Level = 25, Location = 24, FlawlessIVCount = 3 }, // Sizzlipede at Motostoke Stadium
 
             new(SWSH) { Species = 618, Level = 25, Location = 054, Moves = new[] {389,319,279,341}, Form = 01, Ability = 1 }, // Stunfisk in Galar Mine No. 2
@@ -117,8 +118,8 @@ namespace PKHeX.Core
             new(SWSH) { Species = 838, Level = 18, Location = 030, Moves = new[] {488,397,229,033} }, // Carkol in Galar Mine
             new(SWSH) { Species = 834, Level = 24, Location = 054, Moves = new[] {317,029,055,044} }, // Drednaw in Galar Mine No. 2
             new(SWSH) { Species = 423, Level = 50, Location = 054, Moves = new[] {240,414,330,246}, FlawlessIVCount = 3, Form = 01 }, // Gastrodon in Galar Mine No. 2
-            new(SWSH) { Species = 859, Level = 31, Location = 076, Moves = new[] {259,389,207,372} }, // Impidimp in Glimwood Tangle
-            new(SWSH) { Species = 860, Level = 38, Location = 076, Moves = new[] {793,399,259,389} }, // Morgrem in Glimwood Tangle
+            new(SWSH) { Species = 859, Level = 31, Location = 076, ScriptedNoMarks = true, Moves = new[] {259,389,207,372} }, // Impidimp in Glimwood Tangle
+            new(SWSH) { Species = 860, Level = 38, Location = 076, ScriptedNoMarks = true, Moves = new[] {793,399,259,389} }, // Morgrem in Glimwood Tangle
             new(SWSH) { Species = 835, Level = 08, Location = 018, Moves = new[] {039,033,609,000} }, // Yamper on Route 2
             new(SWSH) { Species = 834, Level = 50, Location = 018, Moves = new[] {710,746,068,317}, FlawlessIVCount = 3 }, // Drednaw on Route 2
             new(SWSH) { Species = 833, Level = 08, Location = 018, Moves = new[] {044,055,000,000} }, // Chewtle on Route 2
@@ -129,448 +130,475 @@ namespace PKHeX.Core
             new(SWSH) { Species = 830, Level = 22, Location = 040, Moves = new[] {178,496,075,047} }, // Eldegoss on Route 5
             new(SWSH) { Species = 558, Level = 40, Location = 086, Moves = new[] {404,350,446,157} }, // Crustle on Route 8
             new(SWSH) { Species = 870, Level = 40, Location = 086, Moves = new[] {748,660,179,203} }, // Falinks on Route 8
-            new(SWSH) { Species = 362, Level = 55, Location = 090, Moves = new[] {573,329,104,182}, FlawlessIVCount = 3 }, // Glalie on Route 9
-            new(SWSH) { Species = 853, Level = 50, Location = 092, Moves = new[] {753,576,276,179} }, // Grapploct on Route 9 (in Circhester Bay)
+            new(SWSH) { Species = 362, Level = 55, Location = 090, Moves = new[] {573,329,104,182}, FlawlessIVCount = 3, Weather = Snowing }, // Glalie on Route 9
+            new(SWSH) { Species = 853, Level = 50, Location = 092, Moves = new[] {753,576,276,179}, Weather = Snowing }, // Grapploct on Route 9 (in Circhester Bay)
             new(SWSH) { Species = 822, Level = 35, Location =  -1, Moves = new[] {065,184,269,365} }, // Corvisquire
-            new(SWSH) { Species = 614, Level = 55, Location = 106, Moves = new[] {276,059,156,329} }, // Beartic on Route 10
-            new(SWSH) { Species = 460, Level = 55, Location = 106, Moves = new[] {008,059,452,275} }, // Abomasnow on Route 10
+            new(SWSH) { Species = 614, Level = 55, Location = 106, Moves = new[] {276,059,156,329}, Weather = Snowstorm }, // Beartic on Route 10
+            new(SWSH) { Species = 460, Level = 55, Location = 106, Moves = new[] {008,059,452,275}, Weather = Snowstorm }, // Abomasnow on Route 10
             new(SWSH) { Species = 342, Level = 50, Location = 034, Moves = new[] {242,014,534,400}, FlawlessIVCount = 3 }, // Crawdaunt in the town of Turffield
             #endregion
 
             #region Static Part 2
             // Some of these may be crossover cases. For now, just log the locations they can show up in and re-categorize later.
-            new(SWSH) { Species = 095, Level = 26, Location = 122, }, // Onix in the Rolling Fields (in a Wild Area)
-            new(SWSH) { Species = 416, Level = 26, Location = 122, }, // Vespiquen in the Rolling Fields (in a Wild Area)
-            new EncounterStatic8S(SWSH) { Species = 675, Level = 32, Locations = new[] {122, 124}}, // Pangoro in the Rolling Fields, in the Dappled Grove (in a Wild Area)
-            new(SWSH) { Species = 291, Level = 15, Location = 122, }, // Ninjask in the Rolling Fields (in a Wild Area)
-            new(SWSH) { Species = 315, Level = 15, Location = 122, }, // Roselia in the Rolling Fields (in a Wild Area)
-            new(SWSH) { Species = 045, Level = 36, Location = 124, }, // Vileplume in the Dappled Grove (in a Wild Area)
-            new(SWSH) { Species = 760, Level = 34, Location = 124, }, // Bewear in the Dappled Grove (in a Wild Area)
-            new(SWSH) { Species = 275, Level = 34, Location = 124, }, // Shiftry in the Dappled Grove (in a Wild Area)
-            new(SWSH) { Species = 272, Level = 34, Location = 124, }, // Ludicolo in the Dappled Grove (in a Wild Area)
-            new(SWSH) { Species = 426, Level = 34, Location = 126, }, // Drifblim at Watchtower Ruins (in a Wild Area)
-            new EncounterStatic8S(SWSH)  { Species = 623, Level = 40, Locations = new[]{126, 130}, }, // Golurk at Watchtower Ruins and West Lake Axewell (in a Wild Area) 
-            new(SWSH) { Species = 195, Level = 15, Location = 130, }, // Quagsire at West Lake Axewell (in a Wild Area)
-            new(SWSH) { Species = 099, Level = 28, Location = 130, }, // Kingler at West Lake Axewell (in a Wild Area)
-            new EncounterStatic8S(SWSH) { Species = 660, Level = 15, Locations = new [] {122, 130}, }, // Diggersby in the Rolling Fields, West Lake Axewell (in a Wild Area)
-            new EncounterStatic8S(SWSH) { Species = 178, Level = 26, Locations = new[] {128, 138}}, // Xatu at East Lake Axewell, North Lake Miloch (in a Wild Area)
-            new(SWSH) { Species = 569, Level = 36, Location = 128, }, // Garbodor at East Lake Axewell (in a Wild Area)
-            new(SWSH) { Species = 510, Level = 28, Location = 138, }, // Liepard at North Lake Miloch (in a Wild Area)
-            new(SWSH) { Species = 750, Level = 31, Location = 122, }, // Mudsdale in the Rolling Fields (in a Wild Area)
-            new(SWSH) { Species = 067, Level = 26, Location = 134, }, // Machoke at South Lake Miloch (in a Wild Area)
-            new(SWSH) { Species = 435, Level = 34, Location = 134, }, // Skuntank at South Lake Miloch (in a Wild Area)
-            new(SWSH) { Species = 099, Level = 31, Location = 134, }, // Kingler at South Lake Miloch (in a Wild Area)
-            new(SWSH) { Species = 342, Level = 31, Location = 134, }, // Crawdaunt at South Lake Miloch (in a Wild Area)
-            new(SWSH) { Species = 208, Level = 50, Location = 136, }, // Steelix near the Giant’s Seat (in a Wild Area)
-            new EncounterStatic8S(SWSH) { Species = 823, Level = 50, Locations = new[] {138, 150} }, // Corviknight at North Lake Miloch & on the Hammerlocke Hills (in a Wild Area)
-            new(SWSH) { Species = 448, Level = 36, Location = 138, }, // Lucario at North Lake Miloch (in a Wild Area)
-            new EncounterStatic8S(SWSH) { Species = 112, Level = 46, Locations = new[] {136, 142}, }, // Rhydon near the Giant’s Seat & in Bridge Field (in a Wild Area)
-            new EncounterStatic8S(SWSH) { Species = 625, Level = 52, Locations = new[] {136, 140} }, // Bisharp near the Giant’s Seat, Motostoke Riverbank (in a Wild Area)
-            new(SWSH) { Species = 738, Level = 46, Location = 136, }, // Vikavolt near the Giant’s Seat (in a Wild Area)
-            new EncounterStatic8S(SWSH) { Species = 091, Level = 46, Locations = new[] {128, 130}, }, // Cloyster at East/West Lake Axewell (in a Wild Area)
-            new EncounterStatic8S(SWSH) { Species = 131, Level = 56, Locations = new[] {128, 130, 134, 138, 154 }, }, // Lapras at North/East/South/West Lake Miloch/Axwell, the Lake of Outrage (in a Wild Area)
-            new EncounterStatic8S(SWSH) { Species = 119, Level = 46, Locations = new[] {128, 130, 134, 138, 142, 154 }, }, // Seaking in Bridge Field, at North/East/South/West Lake Miloch/Axwell, at the Lake of Outrage (in a Wild Area)
-            new EncounterStatic8S(SWSH) { Species = 130, Level = 56, Locations = new[] {128, 142, 146}, }, // Gyarados in East Lake Axewell, in Bridge Field, Dusty Bowl (in a Wild Area)
-            new EncounterStatic8S(SWSH) { Species = 279, Level = 46, Locations = new[] {128, 142}, }, // Pelipper in East Lake Axewell, Bridge Field (in a Wild Area)
-            new(SWSH) { Species = 853, Level = 56, Location = 130, }, // Grapploct at West Lake Axewell (in a Wild Area)
-            new EncounterStatic8S(SWSH) { Species = 593, Level = 46, Locations = new[] {128, 130, 134, 138, 142, 154 }, }, // Jellicent at North/East/South/West Lake Miloch/Axwell, the Lake of Outrage, Bridge Field (in a Wild Area)
-            new EncounterStatic8S(SWSH) { Species = 171, Level = 46, Locations = new[] {128,      134,      154 }, }, // Lanturn at East Lake Axewell & South Lake Miloch (in a Wild Area), the Lake of Outrage
-            new EncounterStatic8S(SWSH) { Species = 340, Level = 46, Locations = new[] {128, 130, 134, 138, 154 }, }, // Whiscash at North/East/South/West Lake Miloch/Axwell (in a Wild Area)
-            new EncounterStatic8S(SWSH) { Species = 426, Level = 46, Locations = new[] {128, 130, 134, 138, 154 }, }, // Drifblim at North/East/South/West Lake Miloch/Axwell (in a Wild Area)
-            new(SWSH) { Species = 224, Level = 46, Location = 134, }, // Octillery at South Lake Miloch (in a Wild Area)
-            new(SWSH) { Species = 612, Level = 60, Location = 132, Ability = 1, }, // Haxorus on Axew’s Eye (in a Wild Area)
-            new(SWSH) { Species = 143, Level = 36, Location = 140, }, // Snorlax at the Motostoke Riverbank (in a Wild Area)
-            new(SWSH) { Species = 452, Level = 40, Location = 140, }, // Drapion at the Motostoke Riverbank (in a Wild Area)
-            new(SWSH) { Species = 561, Level = 36, Location = 140, }, // Sigilyph at the Motostoke Riverbank (in a Wild Area)
-            new(SWSH) { Species = 534, Level = 55, Location = 140, Ability = 1, }, // Conkeldurr at the Motostoke Riverbank (in a Wild Area)
-            new(SWSH) { Species = 320, Level = 56, Location = 140, }, // Wailmer at the Motostoke Riverbank (in a Wild Area)
-            new(SWSH) { Species = 561, Level = 40, Location = 140, }, // Sigilyph at the Motostoke Riverbank (in a Wild Area)
-            new(SWSH) { Species = 569, Level = 40, Location = 142, }, // Garbodor in Bridge Field (in a Wild Area)
-            new(SWSH) { Species = 743, Level = 40, Location = 142, }, // Ribombee in Bridge Field (in a Wild Area)
-            new(SWSH) { Species = 475, Level = 60, Location = 142, }, // Gallade in Bridge Field (in a Wild Area)
-            new EncounterStatic8S(SWSH) { Species = 264, Level = 40, Locations = new[] {140, 142}, Form = 01, }, // Linoone at the Motostoke Riverbank & in Bridge Field (in a Wild Area)
-            new(SWSH) { Species = 606, Level = 42, Location = 142, }, // Beheeyem in Bridge Field (in a Wild Area)
-            new(SWSH) { Species = 715, Level = 50, Location = 142, }, // Noivern in Bridge Field (in a Wild Area)
-            new(SWSH) { Species = 537, Level = 46, Location = 142, }, // Seismitoad in Bridge Field (in a Wild Area)
-            new(SWSH) { Species = 768, Level = 50, Location = 142, }, // Golisopod in Bridge Field (in a Wild Area)
-            new(SWSH) { Species = 760, Level = 42, Location = 142, }, // Bewear in Bridge Field (in a Wild Area)
-            new(SWSH) { Species = 820, Level = 42, Location = 142, }, // Greedent in Bridge Field (in a Wild Area)
-            new EncounterStatic8S(SWSH) { Species = 598, Level = 40, Locations = new[] {142, 144}, }, // Ferrothorn in Bridge Field (in a Wild Area)
-            new(SWSH) { Species = 344, Level = 42, Location = 144, }, // Claydol in the Stony Wilderness (in a Wild Area)
-            new(SWSH) { Species = 477, Level = 60, Location = 144, }, // Dusknoir in the Stony Wilderness (in a Wild Area)
-            new(SWSH) { Species = 623, Level = 43, Location = 144, }, // Golurk in the Stony Wilderness (in a Wild Area)
-            new(SWSH) { Species = 561, Level = 40, Location = 144, }, // Sigilyph in the Stony Wilderness (in a Wild Area)
-            new(SWSH) { Species = 558, Level = 34, Location = 144, }, // Crustle in the Stony Wilderness (in a Wild Area)
-            new(SWSH) { Species = 112, Level = 41, Location = 144, }, // Rhydon in the Stony Wilderness (in a Wild Area)
-            new(SWSH) { Species = 763, Level = 36, Location = 144, }, // Tsareena in the Stony Wilderness (in a Wild Area)
-            new(SWSH) { Species = 750, Level = 41, Location = 146, }, // Mudsdale in Dusty Bowl (in a Wild Area)
-            new(SWSH) { Species = 185, Level = 41, Location = 146, }, // Sudowoodo in Dusty Bowl (in a Wild Area)
-            new(SWSH) { Species = 437, Level = 41, Location = 146, }, // Bronzong in Dusty Bowl (in a Wild Area)
-            new(SWSH) { Species = 248, Level = 60, Location = 146, }, // Tyranitar in Dusty Bowl (in a Wild Area)
-            new(SWSH) { Species = 784, Level = 60, Location = 146, Ability = 1, }, // Kommo-o in Dusty Bowl (in a Wild Area)
-            new(SWSH) { Species = 213, Level = 34, Location = 146, }, // Shuckle in Dusty Bowl (in a Wild Area)
-            new(SWSH) { Species = 330, Level = 51, Location = 146, }, // Flygon in Dusty Bowl (in a Wild Area)
-            new(SWSH) { Species = 526, Level = 51, Location = 146, }, // Gigalith in Dusty Bowl (in a Wild Area)
-            new EncounterStatic8S(SWSH) { Species = 423, Level = 56, Locations = new[] {146, 148}, Form = 01, }, // Gastrodon in Dusty Bowl (in a Wild Area) and the Giant’s Mirror
-            new(SWSH) { Species = 208, Level = 50, Location = 148, }, // Steelix around the Giant’s Mirror (in a Wild Area)
-            new(SWSH) { Species = 068, Level = 60, Location = 148, Ability = 1, }, // Machamp around the Giant’s Mirror (in a Wild Area)
-            new(SWSH) { Species = 182, Level = 41, Location = 148, }, // Bellossom around the Giant’s Mirror (in a Wild Area)
-            new(SWSH) { Species = 521, Level = 41, Location = 148, }, // Unfezant around the Giant’s Mirror (in a Wild Area)
-            new(SWSH) { Species = 701, Level = 36, Location = 150, }, // Hawlucha on the Hammerlocke Hills (in a Wild Area)
-            new(SWSH) { Species = 094, Level = 60, Location = 152, }, // Gengar near the Giant’s Cap (in a Wild Area)
-            new(SWSH) { Species = 823, Level = 39, Location = 152, }, // Corviknight near the Giant’s Cap (in a Wild Area)
-            new(SWSH) { Species = 573, Level = 46, Location = 152, }, // Cinccino near the Giant’s Cap (in a Wild Area)
-            new(SWSH) { Species = 826, Level = 41, Location = 152, }, // Orbeetle near the Giant’s Cap (in a Wild Area)
-            new(SWSH) { Species = 834, Level = 36, Location = 152, }, // Drednaw near the Giant’s Cap (in a Wild Area)
-            new(SWSH) { Species = 680, Level = 56, Location = 152, }, // Doublade near the Giant’s Cap (in a Wild Area)
-            new(SWSH) { Species = 711, Level = 41, Location = 150, }, // Gourgeist on the Hammerlocke Hills (in a Wild Area)
-            new(SWSH) { Species = 600, Level = 46, Location = 150, }, // Klang on the Hammerlocke Hills (in a Wild Area)
-            new(SWSH) { Species = 045, Level = 41, Location = 148, }, // Vileplume around the Giant’s Mirror (in a Wild Area)
-            new(SWSH) { Species = 823, Level = 38, Location = 150, }, // Corviknight on the Hammerlocke Hills (in a Wild Area)
-            new EncounterStatic8S(SWSH) { Species = 130, Level = 60, Locations = new[] {128, 130, 134, 138, 154 }, }, // Gyarados at North/East/South/West Lake Miloch/Axwell, the Lake of Outrage (in a Wild Area)
-            new(SWSH) { Species = 853, Level = 56, Location = 154, }, // Grapploct at the Lake of Outrage (in a Wild Area)
-            new(SWSH) { Species = 282, Level = 60, Location = 154, }, // Gardevoir at the Lake of Outrage (in a Wild Area)
-            new(SWSH) { Species = 470, Level = 56, Location = 154, }, // Leafeon at the Lake of Outrage (in a Wild Area)
+            new(SWSH) { Species = 095, Level = 26, Location = 122, Weather = All }, // Onix in the Rolling Fields
+            new(SWSH) { Species = 416, Level = 26, Location = 122 }, // Vespiquen in the Rolling Fields
+            new(SWSH) { Species = 675, Level = 32, Location = 122, Weather = Normal | Overcast | Stormy | Intense_Sun }, // Pangoro in the Rolling Fields
+            new(SWSH) { Species = 675, Level = 32, Location = 124, Weather = Intense_Sun | Icy | Sandstorm }, // Pangoro in the Dappled Grove
+            new(SWSH) { Species = 291, Level = 15, Location = 122, Weather = All }, // Ninjask in the Rolling Fields
+            new(SWSH) { Species = 315, Level = 15, Location = 122, Weather = Normal | Overcast | Raining | Intense_Sun | Snowing | Sandstorm | Heavy_Fog }, // Roselia in the Rolling Fields
+            new(SWSH) { Species = 045, Level = 36, Location = 124, Weather = Normal | Overcast | Heavy_Fog }, // Vileplume in the Dappled Grove
+            new(SWSH) { Species = 760, Level = 34, Location = 124, Weather = All }, // Bewear in the Dappled Grove
+            new(SW  ) { Species = 275, Level = 34, Location = 124, Weather = Normal | Overcast | Stormy | Heavy_Fog }, // Shiftry in the Dappled Grove
+            new(  SH) { Species = 272, Level = 34, Location = 124, Weather = Normal | Overcast | Stormy | Heavy_Fog }, // Ludicolo in the Dappled Grove
+            new(SWSH) { Species = 426, Level = 34, Location = 126, Weather = Normal | Intense_Sun | Snowing }, // Drifblim at Watchtower Ruins
+            new EncounterStatic8S(SWSH)  { Species = 623, Level = 40, Locations = new[] {126, 130}, Weather = Normal | Intense_Sun | Sandstorm }, // Golurk at Watchtower Ruins, West Lake Axewell 
+            new(SWSH) { Species = 195, Level = 15, Location = 130, Weather = Normal | Overcast | Stormy | Heavy_Fog }, // Quagsire at West Lake Axewell
+            new(SWSH) { Species = 099, Level = 28, Location = 130 }, // Kingler at West Lake Axewell
+            new(SWSH) { Species = 660, Level = 15, Location = 122, Weather = All }, // Diggersby in the Rolling Fields
+            new(SWSH) { Species = 660, Level = 15, Location = 130, Weather = Intense_Sun | Icy | Sandstorm }, // Diggersby at West Lake Axewell
+            new EncounterStatic8S(SWSH) { Species = 178, Level = 26, Locations = new[] {128, 138}, Weather = Normal | Overcast | Intense_Sun | Icy | Sandstorm | Heavy_Fog }, // Xatu at East Lake Axewell, North Lake Miloch
+            new(SWSH) { Species = 569, Level = 36, Location = 128, Weather = Normal | Overcast | Stormy }, // Garbodor at East Lake Axewell
+            new(SWSH) { Species = 510, Level = 28, Location = 138, Weather = All }, // Liepard at North Lake Miloch
+            new(SWSH) { Species = 750, Level = 31, Location = 122, Weather = Normal | Overcast | Intense_Sun | Sandstorm | Heavy_Fog }, // Mudsdale in the Rolling Fields
+            new(SWSH) { Species = 067, Level = 26, Location = 134, Weather = All }, // Machoke at South Lake Miloch
+            new(SWSH) { Species = 435, Level = 34, Location = 134, Weather = Normal | Overcast | Icy | Sandstorm | Heavy_Fog }, // Skuntank at South Lake Miloch
+            new(SWSH) { Species = 099, Level = 31, Location = 134, Weather = Normal | Thunderstorm }, // Kingler at South Lake Miloch
+            new(SWSH) { Species = 342, Level = 31, Location = 134, Weather = Normal | Thunderstorm }, // Crawdaunt at South Lake Miloch
+            new(SWSH) { Species = 208, Level = 50, Location = 136, Weather = All }, // Steelix near the Giant’s Seat
+            new(SWSH) { Species = 823, Level = 50, Location = 138, Weather = All }, // Corviknight at North Lake Miloch
+            new(SWSH) { Species = 448, Level = 36, Location = 138 }, // Lucario at North Lake Miloch
+            new(SWSH) { Species = 112, Level = 46, Location = 136 }, // Rhydon near the Giant’s Seat
+            new(SWSH) { Species = 625, Level = 52, Location = 136, Weather = All }, // Bisharp near the Giant’s Seat
+            new(SWSH) { Species = 625, Level = 52, Location = 140, Weather = Snowstorm }, // Bisharp at the Motostoke Riverbank
+            new(SWSH) { Species = 738, Level = 46, Location = 136, Weather = Normal | Overcast | Intense_Sun | Sandstorm }, // Vikavolt near the Giant’s Seat
+            new EncounterStatic8S(SWSH) { Species = 091, Level = 46, Locations = new[] {128, 130}, Weather = Normal | Heavy_Fog }, // Cloyster at East/West Lake Axewell
+            new EncounterStatic8S(SWSH) { Species = 131, Level = 56, Locations = new[] {130, 134, 138, 154}, Weather = Normal | Stormy | Icy | Heavy_Fog }, // Lapras at North/East/South Lake Miloch/Axewell, the Lake of Outrage
+            new(SWSH) { Species = 119, Level = 46, Location = 128, Weather = Normal | Overcast | Intense_Sun | Sandstorm }, // Seaking at East Lake Axewell
+            new(SWSH) { Species = 119, Level = 46, Location = 154, Weather = Overcast | Intense_Sun | Sandstorm }, // Seaking at Lake of Outrage
+            new EncounterStatic8S(SWSH) { Species = 119, Level = 46, Locations = new[] {130, 142}, Weather = Normal | Overcast | Sandstorm }, // Seaking at West Lake Axewell, Bridge Field
+            new(SWSH) { Species = 119, Level = 46, Location = 134, Weather = Normal | Overcast | Stormy | Sandstorm }, // Seaking at South Lake Miloch
+            new(SWSH) { Species = 119, Level = 46, Location = 138, Weather = Stormy | Sandstorm }, // Seaking at North Lake Miloch
+            new EncounterStatic8S(SWSH) { Species = 130, Level = 56, Locations = new[] {128, 130, 142, 146}, Weather = All }, // Gyarados in East/West Lake Axewell, in Bridge Field, Dusty Bowl
+            new EncounterStatic8S(SWSH) { Species = 130, Level = 56, Locations = new[] {138, 154}, Weather = Overcast | Intense_Sun | Sandstorm }, // Gyarados in North Lake Miloch, Lake of Outrage
+            new(SWSH) { Species = 279, Level = 46, Location = 128, Weather = Normal | Overcast | Stormy | Intense_Sun }, // Pelipper at East Lake Axewell
+            new(SWSH) { Species = 279, Level = 46, Location = 142, Weather = Intense_Sun }, // Pelipper in Bridge Field
+            new(SWSH) { Species = 853, Level = 56, Location = 130, Weather = Normal | Overcast | Intense_Sun | Icy | Sandstorm | Heavy_Fog }, // Grapploct at West Lake Axewell
+            new EncounterStatic8S(SWSH) { Species = 593, Level = 46, Locations = new[] {128, 138, 154}, Weather = Normal | Overcast | Stormy | Heavy_Fog }, // Jellicent at East Lake Axewell, North Lake Miloch, Lake of Outrage
+            new(SWSH) { Species = 593, Level = 46, Location = 130, Weather = Overcast | Raining | Heavy_Fog }, // Jellicent at West Lake Axewell
+            new EncounterStatic8S(SWSH) { Species = 593, Level = 46, Locations = new[] {134, 142}, Weather = Raining | Heavy_Fog }, // Jellicent at South Lake Miloch, Bridge Field
+            new(SWSH) { Species = 171, Level = 46, Location = 134, Weather = Thunderstorm }, // Lanturn at South Lake Miloch
+            new EncounterStatic8S(SWSH) { Species = 171, Level = 46, Locations = new[] {128, 154}, Weather = Normal | Thunderstorm | Heavy_Fog }, // Lanturn at East Lake Axewell, the Lake of Outrage
+            new(SWSH) { Species = 340, Level = 46, Location = 134, Weather = Normal | Thunderstorm | Intense_Sun | Sandstorm }, // Whiscash at South Lake Miloch
+            new(SWSH) { Species = 340, Level = 46, Location = 138, Weather = Normal | Overcast | Thunderstorm | Intense_Sun | Sandstorm }, // Whiscash at North Lake Miloch
+            new EncounterStatic8S(SWSH) { Species = 426, Level = 46, Locations = new[] {134, 138}, Weather = Normal | Overcast | Snowstorm | Heavy_Fog }, // Drifblim at North/South Lake Miloch
+            new(SWSH) { Species = 224, Level = 46, Location = 134, Weather = Normal | Intense_Sun | Sandstorm | Heavy_Fog }, // Octillery at South Lake Miloch
+            new(SWSH) { Species = 612, Level = 60, Location = 132, Ability = 1, Weather = Normal | Overcast | Raining | Intense_Sun | Sandstorm | Heavy_Fog }, // Haxorus on Axew’s Eye
+            new(SWSH) { Species = 143, Level = 36, Location = 140, Weather = Normal | Overcast | Stormy | Intense_Sun | Icy | Sandstorm }, // Snorlax at the Motostoke Riverbank
+            new(SWSH) { Species = 452, Level = 40, Location = 140, Weather = Normal | Stormy | Intense_Sun | Sandstorm }, // Drapion at the Motostoke Riverbank
+            new(SWSH) { Species = 561, Level = 36, Location = 140, Weather = All }, // Sigilyph at the Motostoke Riverbank
+            new(SWSH) { Species = 534, Level = 55, Location = 140, Ability = 1, Weather = Normal | Overcast | Stormy | Snowing | Heavy_Fog }, // Conkeldurr at the Motostoke Riverbank
+            new(SWSH) { Species = 320, Level = 56, Location = 140, Weather = All }, // Wailmer at the Motostoke Riverbank
+            new(SWSH) { Species = 561, Level = 40, Location = 140, Weather = Normal | Overcast | Heavy_Fog }, // Sigilyph at the Motostoke Riverbank
+            new(SWSH) { Species = 569, Level = 40, Location = 142, Weather = All }, // Garbodor in Bridge Field
+            new(SWSH) { Species = 743, Level = 40, Location = 142, Weather = Normal | Overcast | Intense_Sun | Heavy_Fog }, // Ribombee in Bridge Field
+            new(SWSH) { Species = 475, Level = 60, Location = 142, Weather = Normal | Overcast | Stormy | Intense_Sun | Sandstorm }, // Gallade in Bridge Field
+            new EncounterStatic8S(SWSH) { Species = 264, Level = 40, Locations = new[] {140, 142}, Form = 01, Weather = All }, // Linoone at the Motostoke Riverbank, Bridge Field
+            new(SWSH) { Species = 606, Level = 42, Location = 142, Weather = Normal | Overcast | Icy | Heavy_Fog }, // Beheeyem in Bridge Field
+            new(SWSH) { Species = 715, Level = 50, Location = 142, Weather = Normal | Overcast | Stormy | Intense_Sun | Snowstorm  | Sandstorm | Heavy_Fog }, // Noivern in Bridge Field
+            new(SWSH) { Species = 537, Level = 46, Location = 142, Weather = Normal | Overcast | Stormy | Heavy_Fog }, // Seismitoad in Bridge Field
+            new(SWSH) { Species = 768, Level = 50, Location = 142, Weather = Normal | Stormy }, // Golisopod in Bridge Field
+            new(SWSH) { Species = 760, Level = 42, Location = 142, Weather = Normal | Stormy | Icy | Sandstorm | Heavy_Fog }, // Bewear in Bridge Field
+            new(SWSH) { Species = 820, Level = 42, Location = 142, Weather = All }, // Greedent in Bridge Field
+            new EncounterStatic8S(SWSH) { Species = 598, Level = 40, Locations = new[] {142, 144}, Weather = All }, // Ferrothorn in Bridge Field, Stony Wilderness
+            new(SWSH) { Species = 344, Level = 42, Location = 144, Weather = Normal | Overcast | Intense_Sun | Sandstorm }, // Claydol in the Stony Wilderness
+            new(SWSH) { Species = 477, Level = 60, Location = 144, Weather = All }, // Dusknoir in the Stony Wilderness
+            new(SWSH) { Species = 623, Level = 43, Location = 144, Weather = All }, // Golurk in the Stony Wilderness
+            new(SWSH) { Species = 561, Level = 40, Location = 144, Weather = Normal | Stormy | Intense_Sun | Icy | Sandstorm | Heavy_Fog }, // Sigilyph in the Stony Wilderness
+            new(SWSH) { Species = 558, Level = 34, Location = 144, Weather = Normal | Overcast | Intense_Sun | Icy | Sandstorm | Heavy_Fog }, // Crustle in the Stony Wilderness
+            new(SWSH) { Species = 112, Level = 41, Location = 144, Weather = All }, // Rhydon in the Stony Wilderness
+            new(SWSH) { Species = 763, Level = 36, Location = 144, Weather = Normal | Overcast | Intense_Sun | Icy | Sandstorm | Heavy_Fog }, // Tsareena in the Stony Wilderness
+            new(SWSH) { Species = 750, Level = 41, Location = 146, Weather = Normal | Intense_Sun | Sandstorm }, // Mudsdale in Dusty Bowl
+            new(SWSH) { Species = 185, Level = 41, Location = 146, Weather = Normal | Overcast | Intense_Sun | Icy | Sandstorm | Heavy_Fog }, // Sudowoodo in Dusty Bowl
+            new(SWSH) { Species = 437, Level = 41, Location = 146, Weather = Normal | Stormy | Icy | Heavy_Fog }, // Bronzong in Dusty Bowl
+            new(  SH) { Species = 248, Level = 60, Location = 146, Weather = Normal | Intense_Sun | Icy | Sandstorm | Heavy_Fog }, // Tyranitar in Dusty Bowl
+            new(SW  ) { Species = 784, Level = 60, Location = 146, Ability = 1, Weather = Normal | Intense_Sun | Icy | Sandstorm | Heavy_Fog }, // Kommo-o in Dusty Bowl
+            new(SWSH) { Species = 213, Level = 34, Location = 146, Weather = All }, // Shuckle in Dusty Bowl
+            new(SWSH) { Species = 330, Level = 51, Location = 146, Weather = Normal | Sandstorm }, // Flygon in Dusty Bowl
+            new(SWSH) { Species = 526, Level = 51, Location = 146, Weather = Normal | Intense_Sun }, // Gigalith in Dusty Bowl
+            new EncounterStatic8S(SWSH) { Species = 423, Level = 56, Locations = new[] {146, 148}, Form = 01, Weather = All }, // Gastrodon in Dusty Bowl, Giant’s Mirror
+            new(SWSH) { Species = 208, Level = 50, Location = 148, Weather = All }, // Steelix around the Giant’s Mirror
+            new(SWSH) { Species = 068, Level = 60, Location = 148, Ability = 1, Weather = All }, // Machamp around the Giant’s Mirror
+            new(SWSH) { Species = 182, Level = 41, Location = 148, Weather = Normal | Intense_Sun | Heavy_Fog }, // Bellossom around the Giant’s Mirror
+            new(SWSH) { Species = 521, Level = 41, Location = 148, Weather = Normal | Overcast | Intense_Sun }, // Unfezant around the Giant’s Mirror
+            new(SWSH) { Species = 701, Level = 36, Location = 150, Weather = All }, // Hawlucha on the Hammerlocke Hills
+            new(SWSH) { Species = 094, Level = 60, Location = 152, Weather = Normal | Overcast | Thunderstorm | Intense_Sun | Snowstorm  | Sandstorm | Heavy_Fog }, // Gengar near the Giant’s Cap
+            new(SWSH) { Species = 823, Level = 39, Location = 152, Weather = All }, // Corviknight near the Giant’s Cap
+            new(SWSH) { Species = 573, Level = 46, Location = 152, Weather = Normal | Overcast | Heavy_Fog }, // Cinccino near the Giant’s Cap
+            new(SWSH) { Species = 826, Level = 41, Location = 152, Weather = All }, // Orbeetle near the Giant’s Cap
+            new(SWSH) { Species = 834, Level = 36, Location = 152, Weather = All }, // Drednaw near the Giant’s Cap
+            new(SWSH) { Species = 680, Level = 56, Location = 152, Weather = Normal | Overcast | Stormy | Intense_Sun | Icy | Sandstorm }, // Doublade near the Giant’s Cap
+            new(SWSH) { Species = 711, Level = 41, Location = 150, Weather = All }, // Gourgeist on the Hammerlocke Hills
+            new(SWSH) { Species = 600, Level = 46, Location = 150, Weather = Normal | Overcast | Raining | Snowing }, // Klang on the Hammerlocke Hills
+            new(SWSH) { Species = 045, Level = 41, Location = 148, Weather = Overcast | Stormy | Icy | Sandstorm }, // Vileplume around the Giant’s Mirror
+            new(SWSH) { Species = 823, Level = 38, Location = 150, Weather = All }, // Corviknight on the Hammerlocke Hills
+            new(SWSH) { Species = 853, Level = 56, Location = 154, Weather = All }, // Grapploct at the Lake of Outrage
+            new(SWSH) { Species = 282, Level = 60, Location = 154, Weather = Normal | Heavy_Fog }, // Gardevoir at the Lake of Outrage
+            new(SWSH) { Species = 470, Level = 56, Location = 154, Weather = Normal }, // Leafeon at the Lake of Outrage
             new(SWSH) { Species = 510, Level = 31, Location =  -1, }, // Liepard
-            new(SWSH) { Species = 832, Level = 65, Location = 122, }, // Dubwool in the Rolling Fields (in a Wild Area)
-            new(SWSH) { Species = 826, Level = 65, Location = 124, }, // Orbeetle in the Dappled Grove (in a Wild Area)
-            new(SWSH) { Species = 823, Level = 65, Location = 126, }, // Corviknight at Watchtower Ruins (in a Wild Area)
-            new(SWSH) { Species = 110, Level = 65, Location = 128, Form = 01, }, // Weezing at East Lake Axewell (in a Wild Area)
-            new(SWSH) { Species = 834, Level = 65, Location = 130, }, // Drednaw at West Lake Axewell (in a Wild Area)
-            new(SWSH) { Species = 845, Level = 65, Location = 132, }, // Cramorant on Axew’s Eye (in a Wild Area)
-            new(SWSH) { Species = 828, Level = 65, Location = 134, }, // Thievul at South Lake Miloch (in a Wild Area)
-            new(SWSH) { Species = 884, Level = 65, Location = 136, }, // Duraludon near the Giant’s Seat (in a Wild Area)
-            new(SWSH) { Species = 836, Level = 65, Location = 138, }, // Boltund at North Lake Miloch (in a Wild Area)
-            new(SWSH) { Species = 830, Level = 65, Location = 140, }, // Eldegoss at the Motostoke Riverbank (in a Wild Area)
-            new(SWSH) { Species = 862, Level = 65, Location = 142, }, // Obstagoon in Bridge Field (in a Wild Area)
-            new(SWSH) { Species = 861, Level = 65, Location = 144, Gender = 0, }, // Grimmsnarl in the Stony Wilderness (in a Wild Area)
-            new(SWSH) { Species = 844, Level = 65, Location = 146, }, // Sandaconda in Dusty Bowl (in a Wild Area)
-            new(SWSH) { Species = 863, Level = 65, Location = 148, }, // Perrserker around the Giant’s Mirror (in a Wild Area)
-            new(SWSH) { Species = 879, Level = 65, Location = 150, }, // Copperajah on the Hammerlocke Hills (in a Wild Area)
-            new(SWSH) { Species = 839, Level = 65, Location = 152, }, // Coalossal near the Giant’s Cap (in a Wild Area)
-            new(SWSH) { Species = 858, Level = 65, Location = 154, Gender = 1 }, // Hatterene at the Lake of Outrage (in a Wild Area)
-            new EncounterStatic8S(SWSH) { Species = 279, Level = 26, Locations = new[] {128, 130, 134, 138, 154 }, }, // Pelipper at North/South/East/West Lake Miloch/Axwell (in a Wild Area)
-            new(SWSH) { Species = 310, Level = 26, Location = 122, }, // Manectric in the Rolling Fields (in a Wild Area)
-            new(SWSH) { Species = 660, Level = 26, Location = 122, }, // Diggersby in the Rolling Fields (in a Wild Area)
-            new(SWSH) { Species = 281, Level = 26, Location = 122, }, // Kirlia in the Rolling Fields (in a Wild Area)
-            new(SWSH) { Species = 025, Level = 15, Location = 122, }, // Pikachu in the Rolling Fields (in a Wild Area)
-            new(SWSH) { Species = 439, Level = 15, Location = 122, }, // Mime Jr. in the Rolling Fields (in a Wild Area)
-            new(SWSH) { Species = 221, Level = 33, Location = 122, }, // Piloswine in the Rolling Fields (in a Wild Area)
-            new(SWSH) { Species = 558, Level = 34, Location = 122, }, // Crustle in the Rolling Fields (in a Wild Area)
-            new(SWSH) { Species = 282, Level = 32, Location = 122, }, // Gardevoir in the Rolling Fields (in a Wild Area)
-            new EncounterStatic8S(SWSH) { Species = 537, Level = 36, Locations = new[] {124, 138, 142}, }, // Seismitoad in the Dappled Grove, in Bridge Field, at North Lake Miloch (in a Wild Area)
-            new(SWSH) { Species = 583, Level = 36, Location = 124, }, // Vanillish in the Dappled Grove (in a Wild Area)
-            new(SWSH) { Species = 344, Level = 36, Location = 124, }, // Claydol in the Dappled Grove (in a Wild Area)
-            new(SWSH) { Species = 093, Level = 34, Location = 126, }, // Haunter at Watchtower Ruins (in a Wild Area)
-            new EncounterStatic8S(SWSH) { Species = 356, Level = 40, Locations = new[] {126, 130}, }, // Dusclops at Watchtower Ruins & at West Lake Axewell (in a Wild Area)
-            new EncounterStatic8S(SWSH) { Species = 362, Level = 40, Locations = new[] {126, 130}, }, // Glalie at Watchtower Ruins & at West Lake Axewell (in a Wild Area)
-            new EncounterStatic8S(SWSH) { Species = 279, Level = 28, Locations = new[] {138, 130}, }, // Pelipper at North Lake Miloch, West Lake Axewell (in a Wild Area)
-            new(SWSH) { Species = 536, Level = 28, Location = 130, }, // Palpitoad at West Lake Axewell (in a Wild Area)
-            new(SWSH) { Species = 660, Level = 28, Location = 130, }, // Diggersby at West Lake Axewell (in a Wild Area)
-            new(SWSH) { Species = 221, Level = 36, Location = 128, }, // Piloswine at East Lake Axewell (in a Wild Area)
-            new(SWSH) { Species = 750, Level = 36, Location = 128, }, // Mudsdale at East Lake Axewell (in a Wild Area)
-            new(SWSH) { Species = 437, Level = 36, Location = 128, }, // Bronzong at East Lake Axewell (in a Wild Area)
-            new(SWSH) { Species = 536, Level = 34, Location = 134, }, // Palpitoad at South Lake Miloch (in a Wild Area)
-            new(SWSH) { Species = 279, Level = 26, Location = 122, }, // Pelipper in the Rolling Fields (in a Wild Area)
-            new(SWSH) { Species = 093, Level = 31, Location = 122, }, // Haunter in the Rolling Fields (in a Wild Area)
-            new(SWSH) { Species = 221, Level = 33, Location = 128, }, // Piloswine at East Lake Axewell (in a Wild Area)
-            new(SWSH) { Species = 558, Level = 34, Location = 134, }, // Crustle at South Lake Miloch (in a Wild Area)
-            new(SWSH) { Species = 067, Level = 31, Location = 134, }, // Machoke at South Lake Miloch (in a Wild Area)
-            new(SWSH) { Species = 426, Level = 31, Location = 134, }, // Drifblim at South Lake Miloch (in a Wild Area)
-            new(SWSH) { Species = 435, Level = 36, Location = 138, }, // Skuntank at North Lake Miloch (in a Wild Area)
-            new(SWSH) { Species = 583, Level = 36, Location = 138, }, // Vanillish at North Lake Miloch (in a Wild Area)
-            new(SWSH) { Species = 426, Level = 36, Location = 138, }, // Drifblim at North Lake Miloch (in a Wild Area)
-            new(SWSH) { Species = 437, Level = 46, Location = 136, }, // Bronzong near the Giant’s Seat (in a Wild Area)
-            new(SWSH) { Species = 460, Level = 46, Location = 136, }, // Abomasnow near the Giant’s Seat (in a Wild Area)
-            new(SWSH) { Species = 750, Level = 46, Location = 136, }, // Mudsdale near the Giant’s Seat (in a Wild Area)
-            new(SWSH) { Species = 623, Level = 46, Location = 136, }, // Golurk near the Giant’s Seat (in a Wild Area)
-            new(SWSH) { Species = 356, Level = 46, Location = 136, }, // Dusclops near the Giant’s Seat (in a Wild Area)
-            new(SWSH) { Species = 518, Level = 46, Location = 136, }, // Musharna near the Giant’s Seat (in a Wild Area)
-            new(SWSH) { Species = 362, Level = 46, Location = 136, }, // Glalie near the Giant’s Seat (in a Wild Area)
-            new EncounterStatic8S(SWSH) { Species = 596, Level = 46, Locations = new[] {134, 136}, }, // Galvantula at South Lake Miloch and near the Giant’s Seat (in a Wild Area)
-            new EncounterStatic8S(SWSH) { Species = 584, Level = 47, Locations = new[] {128, 130, 134, 138, 142}, }, // Vanilluxe at North/East/South/West Lake Miloch/Axwell, Bridge Field (in a Wild Area)
-            new(SWSH) { Species = 537, Level = 60, Location = 132, }, // Seismitoad on Axew’s Eye (in a Wild Area)
-            new(SWSH) { Species = 460, Level = 60, Location = 132, }, // Abomasnow on Axew’s Eye (in a Wild Area)
-            new(SWSH) { Species = 036, Level = 36, Location = 140, }, // Clefable at the Motostoke Riverbank (in a Wild Area)
-            new(SWSH) { Species = 743, Level = 40, Location = 140, }, // Ribombee at the Motostoke Riverbank (in a Wild Area)
-            new(SWSH) { Species = 112, Level = 55, Location = 140, }, // Rhydon at the Motostoke Riverbank (in a Wild Area)
-            new(SWSH) { Species = 823, Level = 40, Location = 140, }, // Corviknight at the Motostoke Riverbank (in a Wild Area)
-            new EncounterStatic8S(SWSH) { Species = 760, Level = 40, Locations = new[] {140, 142}, }, // Bewear in Bridge Field, Motostoke Riverbank (in a Wild Area)
-            new(SWSH) { Species = 614, Level = 60, Location = 142, }, // Beartic in Bridge Field (in a Wild Area)
-            new(SWSH) { Species = 461, Level = 60, Location = 142, }, // Weavile in Bridge Field (in a Wild Area)
-            new(SWSH) { Species = 518, Level = 60, Location = 142, }, // Musharna in Bridge Field (in a Wild Area)
-            new EncounterStatic8S(SWSH) { Species = 437, Level = 42, Locations = new[] {142, 144}, }, // Bronzong in Bridge Field & Stony Wilderness (in a Wild Area)
-            new(SWSH) { Species = 344, Level = 42, Location = 142, }, // Claydol in Bridge Field (in a Wild Area)
-            new(SWSH) { Species = 452, Level = 50, Location = 142, }, // Drapion in Bridge Field (in a Wild Area)
-            new(SWSH) { Species = 164, Level = 50, Location = 142, }, // Noctowl in Bridge Field (in a Wild Area)
-            new(SWSH) { Species = 760, Level = 46, Location = 130, }, // Bewear at West Lake Axewell (in a Wild Area)
-            new(SWSH) { Species = 675, Level = 42, Location = 142, }, // Pangoro in Bridge Field (in a Wild Area)
-            new(SWSH) { Species = 584, Level = 50, Location = 142, }, // Vanilluxe in Bridge Field (in a Wild Area)
-            new(SWSH) { Species = 112, Level = 50, Location = 142, }, // Rhydon in Bridge Field (in a Wild Area)
-            new(SWSH) { Species = 778, Level = 50, Location = 142, }, // Mimikyu in Bridge Field (in a Wild Area)
-            new(SWSH) { Species = 521, Level = 40, Location = 144, }, // Unfezant in the Stony Wilderness (in a Wild Area)
-            new(SWSH) { Species = 752, Level = 34, Location = 144, }, // Araquanid in the Stony Wilderness (in a Wild Area)
-            new(SWSH) { Species = 537, Level = 41, Location = 146, }, // Seismitoad in Dusty Bowl (in a Wild Area)
-            new(SWSH) { Species = 435, Level = 41, Location = 146, }, // Skuntank in Dusty Bowl (in a Wild Area)
-            new(SWSH) { Species = 221, Level = 41, Location = 146, }, // Piloswine in Dusty Bowl (in a Wild Area)
-            new(SWSH) { Species = 356, Level = 41, Location = 146, }, // Dusclops in Dusty Bowl (in a Wild Area)
-            new(SWSH) { Species = 344, Level = 41, Location = 146, }, // Claydol in Dusty Bowl (in a Wild Area)
-            new(SWSH) { Species = 689, Level = 60, Location = 146, }, // Barbaracle in Dusty Bowl (in a Wild Area)
-            new(SWSH) { Species = 561, Level = 51, Location = 146, }, // Sigilyph in Dusty Bowl (in a Wild Area)
-            new(SWSH) { Species = 623, Level = 51, Location = 146, }, // Golurk in Dusty Bowl (in a Wild Area)
-            new(SWSH) { Species = 537, Level = 60, Location = 148, }, // Seismitoad around the Giant’s Mirror (in a Wild Area)
-            new(SWSH) { Species = 460, Level = 60, Location = 148, }, // Abomasnow around the Giant’s Mirror (in a Wild Area)
-            new(SWSH) { Species = 045, Level = 41, Location = 150, }, // Vileplume on the Hammerlocke Hills (in a Wild Area)
-            new(SWSH) { Species = 178, Level = 41, Location = 148, }, // Xatu around the Giant’s Mirror (in a Wild Area)
-            new(SWSH) { Species = 768, Level = 60, Location = 152, }, // Golisopod near the Giant’s Cap (in a Wild Area)
-            new(SWSH) { Species = 614, Level = 60, Location = 152, }, // Beartic near the Giant’s Cap (in a Wild Area)
-            new(SWSH) { Species = 530, Level = 46, Location = 152, }, // Excadrill near the Giant’s Cap (in a Wild Area)
-            new(SWSH) { Species = 362, Level = 46, Location = 152, }, // Glalie near the Giant’s Cap (in a Wild Area)
-            new(SWSH) { Species = 537, Level = 46, Location = 152, }, // Seismitoad near the Giant’s Cap (in a Wild Area)
-            new(SWSH) { Species = 681, Level = 58, Location = 152, }, // Aegislash near the Giant’s Cap (in a Wild Area)
-            new(SWSH) { Species = 601, Level = 49, Location = 150, }, // Klinklang on the Hammerlocke Hills (in a Wild Area)
-            new(SWSH) { Species = 407, Level = 41, Location = 150, }, // Roserade on the Hammerlocke Hills (in a Wild Area)
-            new(SWSH) { Species = 460, Level = 41, Location = 150, }, // Abomasnow on the Hammerlocke Hills (in a Wild Area)
-            new EncounterStatic8S(SWSH) { Species = 350, Level = 60, Locations = new[] {128, 130, 134, 138, 154 }, Gender = 0, Ability = 1, }, // Milotic at the Lake of Outrage, at North/South/East/West Lake Miloch/Axwell (in a Wild Area)
-            new(SWSH) { Species = 112, Level = 60, Location = 154, }, // Rhydon at the Lake of Outrage (in a Wild Area)
-            new(SWSH) { Species = 609, Level = 60, Location = 154, }, // Chandelure at the Lake of Outrage (in a Wild Area)
-            new(SWSH) { Species = 713, Level = 60, Location = 154, }, // Avalugg at the Lake of Outrage (in a Wild Area)
-            new(SWSH) { Species = 756, Level = 60, Location = 154, }, // Shiinotic at the Lake of Outrage (in a Wild Area)
-            new(SWSH) { Species = 134, Level = 56, Location = 154, }, // Vaporeon at the Lake of Outrage (in a Wild Area)
-            new(SWSH) { Species = 135, Level = 56, Location = 154, }, // Jolteon at the Lake of Outrage (in a Wild Area)
-            new(SWSH) { Species = 196, Level = 56, Location = 154, }, // Espeon at the Lake of Outrage (in a Wild Area)
-            new(SWSH) { Species = 471, Level = 56, Location = 154, }, // Glaceon at the Lake of Outrage (in a Wild Area)
-            new(SWSH) { Species = 136, Level = 56, Location = 154, }, // Flareon at the Lake of Outrage (in a Wild Area)
-            new(SWSH) { Species = 197, Level = 56, Location = 154, }, // Umbreon at the Lake of Outrage (in a Wild Area)
-            new(SWSH) { Species = 700, Level = 56, Location = 154, }, // Sylveon at the Lake of Outrage (in a Wild Area)
+            new(SWSH) { Species = 832, Level = 65, Location = 122, Weather = All }, // Dubwool in the Rolling Fields
+            new(SWSH) { Species = 826, Level = 65, Location = 124, Weather = All }, // Orbeetle in the Dappled Grove
+            new(SWSH) { Species = 823, Level = 65, Location = 126, Weather = All }, // Corviknight at Watchtower Ruins
+            new(SWSH) { Species = 110, Level = 65, Location = 128, Form = 01, Weather = All }, // Weezing at East Lake Axewell
+            new(SWSH) { Species = 834, Level = 65, Location = 130, Weather = All }, // Drednaw at West Lake Axewell
+            new(SWSH) { Species = 845, Level = 65, Location = 132, Weather = All }, // Cramorant on Axew’s Eye
+            new(SWSH) { Species = 828, Level = 65, Location = 134, Weather = All }, // Thievul at South Lake Miloch
+            new(SWSH) { Species = 884, Level = 65, Location = 136, Weather = All }, // Duraludon near the Giant’s Seat
+            new(SWSH) { Species = 836, Level = 65, Location = 138, Weather = All }, // Boltund at North Lake Miloch
+            new(SWSH) { Species = 830, Level = 65, Location = 140, Weather = All }, // Eldegoss at the Motostoke Riverbank
+            new(SWSH) { Species = 862, Level = 65, Location = 142, Weather = All }, // Obstagoon in Bridge Field
+            new(SWSH) { Species = 861, Level = 65, Location = 144, Gender = 0, Weather = All }, // Grimmsnarl in the Stony Wilderness
+            new(SWSH) { Species = 844, Level = 65, Location = 146, Weather = All }, // Sandaconda in Dusty Bowl
+            new(SWSH) { Species = 863, Level = 65, Location = 148, Weather = All }, // Perrserker around the Giant’s Mirror
+            new(SWSH) { Species = 879, Level = 65, Location = 150, Weather = All }, // Copperajah on the Hammerlocke Hills
+            new(SWSH) { Species = 839, Level = 65, Location = 152, Weather = All }, // Coalossal near the Giant’s Cap
+            new(SWSH) { Species = 858, Level = 65, Location = 154, Gender = 1, Weather = All }, // Hatterene at the Lake of Outrage
+            new EncounterStatic8S(SWSH) { Species = 279, Level = 26, Locations = new[] {122, 128, 138}, Weather = Stormy }, // Pelipper in the Rolling Fields, North Lake Miloch, East Lake Axewell
+            new(SWSH) { Species = 310, Level = 26, Location = 122, Weather = Thunderstorm }, // Manectric in the Rolling Fields
+            new(SWSH) { Species = 660, Level = 26, Location = 122, Weather = Overcast | Intense_Sun | Icy | Sandstorm}, // Diggersby in the Rolling Fields
+            new(SWSH) { Species = 281, Level = 26, Location = 122, Weather = Heavy_Fog }, // Kirlia in the Rolling Fields
+            new(SWSH) { Species = 025, Level = 15, Location = 122, Weather = Thunderstorm }, // Pikachu in the Rolling Fields
+            new(SWSH) { Species = 439, Level = 15, Location = 122, Weather = Snowstorm }, // Mime Jr. in the Rolling Fields
+            new(SWSH) { Species = 221, Level = 33, Location = 122, Weather = Icy }, // Piloswine in the Rolling Fields
+            new(SWSH) { Species = 558, Level = 34, Location = 122, Weather = Sandstorm }, // Crustle in the Rolling Fields
+            new(SWSH) { Species = 282, Level = 32, Location = 122, Weather = Heavy_Fog }, // Gardevoir in the Rolling Fields
+            new(SWSH) { Species = 537, Level = 36, Location = 124, Weather = Stormy }, // Seismitoad in the Dappled Grove
+            new(SWSH) { Species = 537, Level = 36, Location = 138, Weather = Overcast | Thunderstorm }, // Seismitoad at North Lake Miloch
+            new(SWSH) { Species = 537, Level = 36, Location = 142, Weather = Normal | Overcast | Stormy | Heavy_Fog }, // Seismitoad in Bridge Field
+            new(SWSH) { Species = 583, Level = 36, Location = 124, Weather = Icy }, // Vanillish in the Dappled Grove
+            new(SWSH) { Species = 344, Level = 36, Location = 124, Weather = Intense_Sun | Sandstorm }, // Claydol in the Dappled Grove
+            new(SWSH) { Species = 093, Level = 34, Location = 126, Weather = Overcast | Stormy | Snowstorm | Sandstorm | Heavy_Fog }, // Haunter at Watchtower Ruins
+            new EncounterStatic8S(SWSH) { Species = 356, Level = 40, Locations = new[] {126, 130}, Weather = Overcast | Stormy | Heavy_Fog }, // Dusclops at Watchtower Ruins, West Lake Axewell
+            new EncounterStatic8S(SWSH) { Species = 362, Level = 40, Locations = new[] {126, 130}, Weather = Icy }, // Glalie at Watchtower Ruins, West Lake Axewell
+            new(SWSH) { Species = 279, Level = 28, Location = 130, Weather = Stormy }, // Pelipper at West Lake Axewell
+            new(SWSH) { Species = 536, Level = 28, Location = 130, Weather = Overcast | Icy | Sandstorm | Heavy_Fog }, // Palpitoad at West Lake Axewell
+            new(SWSH) { Species = 660, Level = 28, Location = 130, Weather = Intense_Sun }, // Diggersby at West Lake Axewell
+            new(SWSH) { Species = 221, Level = 36, Location = 128, Weather = Icy }, // Piloswine at East Lake Axewell
+            new(SWSH) { Species = 750, Level = 36, Location = 128, Weather = Intense_Sun | Sandstorm }, // Mudsdale at East Lake Axewell
+            new(SWSH) { Species = 437, Level = 36, Location = 128, Weather = Heavy_Fog }, // Bronzong at East Lake Axewell
+            new(SWSH) { Species = 536, Level = 34, Location = 134, Weather = Stormy }, // Palpitoad at South Lake Miloch
+            new(SWSH) { Species = 093, Level = 31, Location = 122, Weather = Stormy }, // Haunter in the Rolling Fields
+            new(SWSH) { Species = 221, Level = 33, Location = 122, Weather = Icy }, // Piloswine in the Rolling Fields
+            new(SWSH) { Species = 558, Level = 34, Location = 134, Weather = Intense_Sun }, // Crustle at South Lake Miloch
+            new(SWSH) { Species = 067, Level = 31, Location = 134, Weather = Overcast | Intense_Sun | Icy | Sandstorm }, // Machoke at South Lake Miloch
+            new(SWSH) { Species = 426, Level = 31, Location = 134, Weather = Heavy_Fog }, // Drifblim at South Lake Miloch
+            new(SWSH) { Species = 435, Level = 36, Location = 138, Weather = Raining | Intense_Sun | Sandstorm }, // Skuntank at North Lake Miloch
+            new(SWSH) { Species = 583, Level = 36, Location = 138, Weather = Icy }, // Vanillish at North Lake Miloch
+            new(SWSH) { Species = 426, Level = 36, Location = 138, Weather = Heavy_Fog }, // Drifblim at North Lake Miloch
+            new(SWSH) { Species = 437, Level = 46, Location = 136, Weather = Overcast | Raining }, // Bronzong near the Giant’s Seat
+            new(SWSH) { Species = 460, Level = 46, Location = 136, Weather = Icy }, // Abomasnow near the Giant’s Seat
+            new(SWSH) { Species = 750, Level = 46, Location = 136, Weather = Intense_Sun }, // Mudsdale near the Giant’s Seat
+            new(SWSH) { Species = 623, Level = 46, Location = 136, Weather = Sandstorm }, // Golurk near the Giant’s Seat
+            new(SWSH) { Species = 356, Level = 46, Location = 136, Weather = Heavy_Fog }, // Dusclops near the Giant’s Seat
+            new(SWSH) { Species = 518, Level = 46, Location = 136, Weather = Heavy_Fog }, // Musharna near the Giant’s Seat
+            new(SWSH) { Species = 362, Level = 46, Location = 136, Weather = Icy }, // Glalie near the Giant’s Seat
+            new(SWSH) { Species = 596, Level = 46, Location = 136, Weather = Raining }, // Galvantula near the Giant’s Seat
+            new(SWSH) { Species = 596, Level = 46, Location = 134, Weather = All }, // Galvantula at South Lake Miloch
+            new EncounterStatic8S(SWSH) { Species = 584, Level = 47, Locations = new[] {128, 130, 134, 138, 142}, Weather = Icy }, // Vanilluxe at North/East/South/West Lake Miloch/Axewell, Bridge Field
+            new(SWSH) { Species = 537, Level = 60, Location = 132, Weather = Thunderstorm }, // Seismitoad on Axew’s Eye
+            new(SWSH) { Species = 460, Level = 60, Location = 132, Weather = Icy }, // Abomasnow on Axew’s Eye
+            new(SWSH) { Species = 036, Level = 36, Location = 140, Weather = Heavy_Fog }, // Clefable at the Motostoke Riverbank
+            new(SWSH) { Species = 743, Level = 40, Location = 140, Weather = Overcast | Icy | Heavy_Fog }, // Ribombee at the Motostoke Riverbank
+            new(SWSH) { Species = 112, Level = 55, Location = 140, Weather = Intense_Sun | Sandstorm }, // Rhydon at the Motostoke Riverbank
+            new(SWSH) { Species = 823, Level = 40, Location = 140, Weather = Stormy | Intense_Sun | Icy | Sandstorm }, // Corviknight at the Motostoke Riverbank
+            new EncounterStatic8S(SWSH) { Species = 760, Level = 40, Locations = new[] {140, 142}, Weather = Thunderstorm | Sandstorm }, // Bewear in Bridge Field, Motostoke Riverbank
+            new(SWSH) { Species = 614, Level = 60, Location = 142, Weather = Snowing }, // Beartic in Bridge Field
+            new(SWSH) { Species = 461, Level = 60, Location = 142, Weather = Snowstorm }, // Weavile in Bridge Field
+            new(SWSH) { Species = 518, Level = 60, Location = 142, Weather = Heavy_Fog }, // Musharna in Bridge Field
+            new(SWSH) { Species = 437, Level = 42, Location = 142, Weather = Stormy }, // Bronzong in Bridge Field
+            new(SWSH) { Species = 437, Level = 42, Location = 144, Weather = Stormy | Icy | Heavy_Fog }, // Bronzong in Stony Wilderness
+            new(SWSH) { Species = 344, Level = 42, Location = 142, Weather = Intense_Sun | Sandstorm }, // Claydol in Bridge Field
+            new(SWSH) { Species = 452, Level = 50, Location = 142, Weather = Overcast }, // Drapion in Bridge Field
+            new(SWSH) { Species = 164, Level = 50, Location = 142, Weather = Snowing }, // Noctowl in Bridge Field
+            new(SWSH) { Species = 760, Level = 46, Location = 142, Weather = Intense_Sun | Sandstorm }, // Bewear in Bridge Field
+            new(SWSH) { Species = 675, Level = 42, Location = 142, Weather = Overcast | Intense_Sun }, // Pangoro in Bridge Field
+            new(SWSH) { Species = 584, Level = 50, Location = 142, Weather = Icy }, // Vanilluxe in Bridge Field
+            new(SWSH) { Species = 112, Level = 50, Location = 142, Weather = Intense_Sun | Sandstorm }, // Rhydon in Bridge Field
+            new(SWSH) { Species = 778, Level = 50, Location = 142, Weather = Heavy_Fog }, // Mimikyu in Bridge Field
+            new(SWSH) { Species = 521, Level = 40, Location = 144, Weather = Overcast }, // Unfezant in the Stony Wilderness
+            new(SWSH) { Species = 752, Level = 34, Location = 144, Weather = Raining }, // Araquanid in the Stony Wilderness
+            new(SWSH) { Species = 537, Level = 41, Location = 146, Weather = Stormy }, // Seismitoad in Dusty Bowl
+            new(SWSH) { Species = 435, Level = 41, Location = 146, Weather = Overcast }, // Skuntank in Dusty Bowl
+            new(SWSH) { Species = 221, Level = 41, Location = 146, Weather = Icy }, // Piloswine in Dusty Bowl
+            new(SWSH) { Species = 356, Level = 41, Location = 146, Weather = Heavy_Fog }, // Dusclops in Dusty Bowl
+            new(SWSH) { Species = 344, Level = 41, Location = 146, Weather = Overcast | Intense_Sun | Sandstorm }, // Claydol in Dusty Bowl
+            new(SWSH) { Species = 689, Level = 60, Location = 146, Weather = Overcast | Stormy }, // Barbaracle in Dusty Bowl
+            new(SWSH) { Species = 561, Level = 51, Location = 146, Weather = Overcast | Stormy | Intense_Sun | Icy | Heavy_Fog }, // Sigilyph in Dusty Bowl
+            new(SWSH) { Species = 623, Level = 51, Location = 146, Weather = Overcast | Stormy | Icy | Sandstorm | Heavy_Fog }, // Golurk in Dusty Bowl
+            new(SWSH) { Species = 537, Level = 60, Location = 148, Weather = Raining }, // Seismitoad around the Giant’s Mirror
+            new(SWSH) { Species = 460, Level = 60, Location = 148, Weather = Snowing }, // Abomasnow around the Giant’s Mirror
+            new(SWSH) { Species = 045, Level = 41, Location = 150, Weather = Overcast | Stormy | Icy | Sandstorm }, // Vileplume on the Hammerlocke Hills
+            new(SWSH) { Species = 178, Level = 41, Location = 148, Weather = Raining | Icy | Sandstorm | Heavy_Fog }, // Xatu around the Giant’s Mirror
+            new(SWSH) { Species = 768, Level = 60, Location = 152, Weather = Raining }, // Golisopod near the Giant’s Cap
+            new(SWSH) { Species = 614, Level = 60, Location = 152, Weather = Snowing }, // Beartic near the Giant’s Cap
+            new(SWSH) { Species = 530, Level = 46, Location = 152, Weather = Intense_Sun | Sandstorm }, // Excadrill near the Giant’s Cap
+            new(SWSH) { Species = 362, Level = 46, Location = 152, Weather = Icy }, // Glalie near the Giant’s Cap
+            new(SWSH) { Species = 537, Level = 46, Location = 152, Weather = Raining }, // Seismitoad near the Giant’s Cap
+            new(SWSH) { Species = 681, Level = 58, Location = 152, Weather = Heavy_Fog }, // Aegislash near the Giant’s Cap
+            new(SWSH) { Species = 601, Level = 49, Location = 150, Weather = Thunderstorm | Intense_Sun | Snowstorm  | Sandstorm | Heavy_Fog }, // Klinklang on the Hammerlocke Hills
+            new(SWSH) { Species = 407, Level = 41, Location = 150, Weather = Overcast | Heavy_Fog }, // Roserade on the Hammerlocke Hills
+            new(SWSH) { Species = 460, Level = 41, Location = 150, Weather = Icy}, // Abomasnow on the Hammerlocke Hills
+            new EncounterStatic8S(SWSH) { Species = 350, Level = 60, Locations = new[] {134, 154}, Gender = 0, Ability = 1, Weather = Heavy_Fog }, // Milotic at South Lake Miloch, the Lake of Outrage
+            new EncounterStatic8S(SWSH) { Species = 130, Level = 60, Locations = new[] {134, 138, 154 }, Weather = Normal | Overcast | Stormy | Intense_Sun | Icy | Sandstorm }, // Gyarados at North/South Lake Miloch, the Lake of Outrage
+            new(SWSH) { Species = 112, Level = 60, Location = 154, Weather = Sandstorm }, // Rhydon at the Lake of Outrage
+            new(SWSH) { Species = 609, Level = 60, Location = 154, Weather = Intense_Sun }, // Chandelure at the Lake of Outrage
+            new(SWSH) { Species = 713, Level = 60, Location = 154, Weather = Icy }, // Avalugg at the Lake of Outrage
+            new(SWSH) { Species = 756, Level = 60, Location = 154, Weather = Overcast | Stormy }, // Shiinotic at the Lake of Outrage
+            new(SWSH) { Species = 134, Level = 56, Location = 154, Weather = Raining }, // Vaporeon at the Lake of Outrage
+            new(SWSH) { Species = 135, Level = 56, Location = 154, Weather = Thunderstorm }, // Jolteon at the Lake of Outrage
+            new(SWSH) { Species = 196, Level = 56, Location = 154, Weather = Overcast }, // Espeon at the Lake of Outrage
+            new(SWSH) { Species = 471, Level = 56, Location = 154, Weather = Icy }, // Glaceon at the Lake of Outrage
+            new(SWSH) { Species = 136, Level = 56, Location = 154, Weather = Intense_Sun }, // Flareon at the Lake of Outrage
+            new(SWSH) { Species = 197, Level = 56, Location = 154, Weather = Sandstorm }, // Umbreon at the Lake of Outrage
+            new(SWSH) { Species = 700, Level = 56, Location = 154, Weather = Heavy_Fog }, // Sylveon at the Lake of Outrage
             #endregion
 
             #region R1 Static Encounters
-            new(SWSH) { Species = 079, Level = 12, Location = 016, Form = 01, Shiny = Never }, // Slowpoke-1 at Wedgehurst Station
-            new(SWSH) { Species = 748, Level = 20, Location = 164 }, // Toxapex in the Fields of Honor (on the Isle of Armor)
-            new(SWSH) { Species = 099, Level = 20, Location = 164 }, // Kingler in the Fields of Honor (on the Isle of Armor)
-            new EncounterStatic8S(SWSH) { Species = 834, Level = 20, Locations = new[] {164, 166} }, // Drednaw in the Fields of Honor, in the Soothing Wetlands (on the Isle of Armor)
-            new EncounterStatic8S(SWSH) { Species = 687, Level = 26, Locations = new[] {164, 166} }, // Malamar in the Fields of Honor, in the Soothing Wetlands (on the Isle of Armor)
-            new EncounterStatic8S(SWSH) { Species = 764, Level = 15, Locations = new[] {164, 166} }, // Comfey in the Fields of Honor, in the Soothing Wetlands (on the Isle of Armor)
-            new EncounterStatic8S(SWSH) { Species = 404, Level = 20, Locations = new[] {164, 166} }, // Luxio in the Fields of Honor, in the Soothing Wetlands (on the Isle of Armor)
-            new EncounterStatic8S(SWSH) { Species = 744, Level = 15, Locations = new[] {164, 166} }, // Rockruff in the Fields of Honor, in the Soothing Wetlands (on the Isle of Armor)
-            new(SWSH) { Species = 195, Level = 20, Location = 166 }, // Quagsire in the Soothing Wetlands (on the Isle of Armor)
-            new EncounterStatic8S(SWSH) { Species = 570, Level = 15, Locations = new[] {164, 166} }, // Zorua in the Fields of Honor, in the Soothing Wetlands (on the Isle of Armor)
-            new EncounterStatic8S(SWSH) { Species = 040, Level = 27, Locations = new[] {164, 166} }, // Wigglytuff in the Fields of Honor, in the Soothing Wetlands (on the Isle of Armor)
-            new(SWSH) { Species = 626, Level = 20, Location = 166 }, // Bouffalant in the Soothing Wetlands (on the Isle of Armor)
-            new(SWSH) { Species = 242, Level = 22, Location = 166 }, // Blissey in the Soothing Wetlands (on the Isle of Armor)
-            new(SWSH) { Species = 452, Level = 22, Location = 166 }, // Drapion in the Soothing Wetlands (on the Isle of Armor)
-            new(SWSH) { Species = 463, Level = 27, Location = 166 }, // Lickilicky in the Soothing Wetlands (on the Isle of Armor)
+            new(SWSH) { Species = 079, Level = 12, Location = 016, ScriptedNoMarks = true, Form = 01, Shiny = Never }, // Slowpoke-1 at Wedgehurst Station
+            new(SWSH) { Species = 748, Level = 20, Location = 164, Weather = Normal | Heavy_Fog }, // Toxapex in the Fields of Honor
+            new(SWSH) { Species = 099, Level = 20, Location = 164, Weather = Normal | Overcast | Stormy | Intense_Sun | Sandstorm }, // Kingler in the Fields of Honor
+            new(SWSH) { Species = 834, Level = 20, Location = 164, Weather = Intense_Sun }, // Drednaw in the Fields of Honor
+            new(SWSH) { Species = 834, Level = 20, Location = 166, Weather = Normal | Overcast | Intense_Sun | Sandstorm }, // Drednaw in the Soothing Wetlands
+            new EncounterStatic8S(SWSH) { Species = 687, Level = 26, Locations = new[] {164, 166}, Weather = Overcast | Raining }, // Malamar in the Fields of Honor, Soothing Wetlands
+            new(SWSH) { Species = 764, Level = 15, Location = 164, Weather = Normal | Sandstorm }, // Comfey in the Fields of Honor
+            new(SWSH) { Species = 764, Level = 15, Location = 166, Weather = Normal | Intense_Sun | Heavy_Fog }, // Comfey in the Soothing Wetlands
+            new EncounterStatic8S(SWSH) { Species = 404, Level = 20, Locations = new[] {164, 166}, Weather = Thunderstorm }, // Luxio in the Fields of Honor, Soothing Wetlands
+            new(SWSH) { Species = 744, Level = 15, Location = 164, Weather = Normal | Intense_Sun }, // Rockruff in the Fields of Honor
+            new(SWSH) { Species = 744, Level = 15, Location = 166 }, // Rockruff in the Soothing Wetlands
+            new(SWSH) { Species = 195, Level = 20, Location = 166, Weather = Normal | Overcast | Raining | Intense_Sun | Sandstorm | Heavy_Fog }, // Quagsire in the Soothing Wetlands
+            new EncounterStatic8S(SWSH) { Species = 570, Level = 15, Locations = new[] {164, 166}, Weather = Overcast | Heavy_Fog }, // Zorua in the Fields of Honor, Soothing Wetlands
+            new EncounterStatic8S(SWSH) { Species = 040, Level = 27, Locations = new[] {164, 166}, Weather = Heavy_Fog }, // Wigglytuff in the Fields of Honor, Soothing Wetlands
+            new(SWSH) { Species = 626, Level = 20, Location = 166, Weather = Normal | Overcast | Stormy | Intense_Sun | Sandstorm }, // Bouffalant in the Soothing Wetlands
+            new(SWSH) { Species = 242, Level = 22, Location = 166, Weather = Heavy_Fog }, // Blissey in the Soothing Wetlands
+            new(SWSH) { Species = 452, Level = 22, Location = 166, Weather = Normal | Overcast | Raining | Sandstorm }, // Drapion in the Soothing Wetlands
+            new(SWSH) { Species = 463, Level = 27, Location = 166, Weather = Normal | Raining | Sandstorm }, // Lickilicky in the Soothing Wetlands
             new(SWSH) { Species = 834, Level = 21, Location = -01 }, // Drednaw
-            new(SWSH) { Species = 405, Level = 32, Location = 166 }, // Luxray in the Soothing Wetlands (on the Isle of Armor)
-            new(SWSH) { Species = 121, Level = 20, Location = 164 }, // Starmie in the Fields of Honor (on the Isle of Armor)
-            new EncounterStatic8S(SWSH) { Species = 428, Level = 22, Locations = new[] {164, 166} }, // Lopunny in the Fields of Honor, in the Soothing Wetlands (on the Isle of Armor)
-            new(SWSH) { Species = 453, Level = 20, Location = 166 }, // Croagunk in the Soothing Wetlands (on the Isle of Armor)
-            new(SWSH) { Species = 186, Level = 32, Location = 166 }, // Politoed in the Soothing Wetlands (on the Isle of Armor)
-            new(SWSH) { Species = 061, Level = 20, Location = 166 }, // Poliwhirl in the Soothing Wetlands (on the Isle of Armor)
-            new EncounterStatic8S(SWSH) { Species = 183, Level = 15, Locations = new[] {164, 166, 170} }, // Marill in the Fields of Honor, in the Soothing Wetlands, on Challenge Beach (on the Isle of Armor)
-            new EncounterStatic8S(SWSH) { Species = 662, Level = 20, Locations = new[] {164, 166} }, // Fletchinder in the Fields of Honor, in the Soothing Wetlands (on the Isle of Armor)
+            new(SWSH) { Species = 405, Level = 32, Location = 166, Weather = Thunderstorm }, // Luxray in the Soothing Wetlands
+            new(SWSH) { Species = 121, Level = 20, Location = 164, Weather = All_IoA }, // Starmie in the Fields of Honor
+            new(SWSH) { Species = 428, Level = 22, Location = 164, Weather = Normal | Intense_Sun | Sandstorm }, // Lopunny in the Fields of Honor
+            new(SWSH) { Species = 428, Level = 22, Location = 166, Weather = Normal | Sandstorm }, // Lopunny in the Soothing Wetlands
+            new(SWSH) { Species = 186, Level = 32, Location = 166, Weather = Stormy }, // Politoed in the Soothing Wetlands
+            new(SWSH) { Species = 061, Level = 20, Location = 166, Weather = Stormy | Heavy_Fog }, // Poliwhirl in the Soothing Wetlands
+            new EncounterStatic8S(SWSH) { Species = 183, Level = 15, Locations = new[] {164, 166}, Weather = Raining }, // Marill in the Fields of Honor, Soothing Wetlands
+            new(SWSH) { Species = 183, Level = 15, Location = 170, Weather = Normal | Sandstorm }, // Marill on Challenge Beach
+            new EncounterStatic8S(SWSH) { Species = 662, Level = 20, Locations = new[] {164, 166}, Weather = Intense_Sun }, // Fletchinder in the Fields of Honor, in the Soothing Wetlands
             new(SWSH) { Species = 768, Level = 26, Location = -01 }, // Golisopod
-            new(SWSH) { Species = 636, Level = 15, Location = 168 }, // Larvesta in the Forest of Focus (on the Isle of Armor)
-            new(SWSH) { Species = 549, Level = 22, Location = 166 }, // Lilligant in the Soothing Wetlands (on the Isle of Armor)
-            new(SWSH) { Species = 025, Level = 22, Location = 168 }, // Pikachu in the Forest of Focus (on the Isle of Armor)
-            new EncounterStatic8S(SWSH) { Species = 064, Level = 20, Locations = new[] {164, 166} }, // Kadabra in the Fields of Honor, in the Soothing Wetlands (on the Isle of Armor)
-            new EncounterStatic8S(SWSH) { Species = 026, Level = 26, Locations = new[] {166, 168} }, // Raichu in the Soothing Wetlands, in the Forest of Focus (on the Isle of Armor)
-            new EncounterStatic8S(SWSH) { Species = 025, Level = 15, Locations = new[] {164, 166} }, // Pikachu in the Fields of Honor, in the Soothing Wetlands (on the Isle of Armor)
-            new EncounterStatic8S(SWSH) { Species = 184, Level = 21, Locations = new[] {166, 168} }, // Azumarill in the Soothing Wetlands, in the Forest of Focus (on the Isle of Armor)
-            new(SW  ) { Species = 559, Level = 20, Location = 166 }, // Scraggy in the Soothing Wetlands (on the Isle of Armor)
-            new(SWSH) { Species = 663, Level = 32, Location = 166 }, // Talonflame in the Soothing Wetlands (on the Isle of Armor)
-            new(SW  ) { Species = 766, Level = 26, Location = 168 }, // Passimian in the Forest of Focus (on the Isle of Armor)
-            new(  SH) { Species = 765, Level = 26, Location = 168 }, // Oranguru in the Forest of Focus (on the Isle of Armor)
-            new(SWSH) { Species = 342, Level = 26, Location = 168 }, // Crawdaunt in the Forest of Focus (on the Isle of Armor)
-            new EncounterStatic8S(SWSH) { Species = 754, Level = 27, Locations = new[] {168, 170} }, // Lurantis in the Forest of Focus, on Challenge Beach (on the Isle of Armor)
-            new(SWSH) { Species = 040, Level = 26, Location = 168 }, // Wigglytuff in the Forest of Focus (on the Isle of Armor)
-            new(SWSH) { Species = 028, Level = 26, Location = 168 }, // Sandslash in the Forest of Focus (on the Isle of Armor)
-            new(SWSH) { Species = 545, Level = 32, Location = 168 }, // Scolipede in the Forest of Focus (on the Isle of Armor)
-            new(  SH) { Species = 214, Level = 26, Location = 168 }, // Heracross in the Forest of Focus (on the Isle of Armor)
-            new(  SH) { Species = 704, Level = 20, Location = 168 }, // Goomy in the Forest of Focus (on the Isle of Armor)
-            new(SWSH) { Species = 172, Level = 20, Location = 168 }, // Pichu in the Forest of Focus (on the Isle of Armor)
-            new(SWSH) { Species = 845, Level = 20, Location = 168 }, // Cramorant in the Forest of Focus (on the Isle of Armor)
-            new(SWSH) { Species = 465, Level = 36, Location = 168 }, // Tangrowth in the Forest of Focus (on the Isle of Armor)
-            new(SWSH) { Species = 589, Level = 32, Location = 168 }, // Escavalier in the Forest of Focus (on the Isle of Armor)
-            new(SWSH) { Species = 617, Level = 32, Location = 168 }, // Accelgor in the Forest of Focus (on the Isle of Armor)
-            new(SWSH) { Species = 591, Level = 26, Location = 168 }, // Amoonguss in the Forest of Focus (on the Isle of Armor)
-            new(SWSH) { Species = 764, Level = 22, Location = 168 }, // Comfey in the Forest of Focus (on the Isle of Armor)
-            new(SWSH) { Species = 570, Level = 22, Location = 168 }, // Zorua in the Forest of Focus (on the Isle of Armor)
-            new(SWSH) { Species = 104, Level = 20, Location = 168 }, // Cubone in the Forest of Focus (on the Isle of Armor)
-            new EncounterStatic8S(SWSH) { Species = 282, Level = 36, Locations = new[] {168, 180} }, // Gardevoir in the Forest of Focus (on the Isle of Armor)
-            new(SW  ) { Species = 127, Level = 26, Location = 168 }, // Pinsir in the Forest of Focus (on the Isle of Armor)
-            new(SWSH) { Species = 055, Level = 26, Location = 168 }, // Golduck in the Forest of Focus (on the Isle of Armor)
-            new(SWSH) { Species = 462, Level = 36, Location = 170 }, // Magnezone on Challenge Beach (on the Isle of Armor)
+            new(SWSH) { Species = 636, Level = 15, Location = 168, Weather = Intense_Sun }, // Larvesta in the Forest of Focus
+            new(SWSH) { Species = 549, Level = 22, Location = 166, Weather = Intense_Sun }, // Lilligant in the Soothing Wetlands
+            new(SWSH) { Species = 025, Level = 22, Location = 168, Weather = Normal | Overcast | Stormy }, // Pikachu in the Forest of Focus
+            new EncounterStatic8S(SWSH) { Species = 064, Level = 20, Locations = new[] {164, 166}, Weather = Heavy_Fog }, // Kadabra in the Fields of Honor, in the Soothing Wetlands
+            new EncounterStatic8S(SWSH) { Species = 026, Level = 26, Locations = new[] {166, 168}, Weather = Thunderstorm }, // Raichu in the Soothing Wetlands, in the Forest of Focus
+            new EncounterStatic8S(SWSH) { Species = 025, Level = 15, Locations = new[] {164, 166}, Weather = Thunderstorm }, // Pikachu in the Fields of Honor, in the Soothing Wetlands
+            new EncounterStatic8S(SWSH) { Species = 184, Level = 21, Locations = new[] {166, 168}, Weather = Heavy_Fog }, // Azumarill in the Soothing Wetlands, in the Forest of Focus
+            new(  SH) { Species = 453, Level = 20, Location = 166, Weather = Overcast }, // Croagunk in the Soothing Wetlands
+            new(SW  ) { Species = 559, Level = 20, Location = 166, Weather = Overcast }, // Scraggy in the Soothing Wetlands
+            new(SWSH) { Species = 663, Level = 32, Location = 166, Weather = Intense_Sun }, // Talonflame in the Soothing Wetlands
+            new(SW  ) { Species = 766, Level = 26, Location = 168 }, // Passimian in the Forest of Focus
+            new(  SH) { Species = 765, Level = 26, Location = 168 }, // Oranguru in the Forest of Focus
+            new(SWSH) { Species = 342, Level = 26, Location = 168, Weather = Overcast | Stormy }, // Crawdaunt in the Forest of Focus
+            new EncounterStatic8S(SWSH) { Species = 754, Level = 27, Locations = new[] {168, 170}, Weather = Intense_Sun }, // Lurantis in the Forest of Focus, on Challenge Beach
+            new(SWSH) { Species = 040, Level = 26, Location = 168, Weather = Heavy_Fog }, // Wigglytuff in the Forest of Focus
+            new(SWSH) { Species = 028, Level = 26, Location = 168, Weather = Sandstorm }, // Sandslash in the Forest of Focus
+            new(SWSH) { Species = 545, Level = 32, Location = 168, Weather = Overcast }, // Scolipede in the Forest of Focus
+            new(SW  ) { Species = 127, Level = 26, Location = 168, Weather = Intense_Sun }, // Pinsir in the Forest of Focus
+            new(  SH) { Species = 214, Level = 26, Location = 168, Weather = Intense_Sun }, // Heracross in the Forest of Focus
+            new(SW  ) { Species = 616, Level = 20, Location = 168, Weather = Stormy }, // Shelmet in the Forest of Focus
+            new(  SH) { Species = 704, Level = 20, Location = 168, Weather = Stormy }, // Goomy in the Forest of Focus
+            new(SWSH) { Species = 172, Level = 20, Location = 168, Weather = Thunderstorm }, // Pichu in the Forest of Focus
+            new(SWSH) { Species = 845, Level = 20, Location = 168, Weather = Normal | Raining | Intense_Sun | Heavy_Fog }, // Cramorant in the Forest of Focus
+            new(SWSH) { Species = 465, Level = 36, Location = 168, Weather = Intense_Sun }, // Tangrowth in the Forest of Focus
+            new(SWSH) { Species = 589, Level = 32, Location = 168, Weather = Sandstorm }, // Escavalier in the Forest of Focus
+            new(SWSH) { Species = 617, Level = 32, Location = 168, Weather = Raining }, // Accelgor in the Forest of Focus
+            new(SWSH) { Species = 591, Level = 26, Location = 168, Weather = Normal | Overcast | Raining | Intense_Sun }, // Amoonguss in the Forest of Focus
+            new(SWSH) { Species = 764, Level = 22, Location = 168, Weather = Intense_Sun | Heavy_Fog }, // Comfey in the Forest of Focus
+            new(SWSH) { Species = 570, Level = 22, Location = 168, Weather = Heavy_Fog }, // Zorua in the Forest of Focus
+            new(SWSH) { Species = 104, Level = 20, Location = 168, Weather = Sandstorm }, // Cubone in the Forest of Focus
+            new EncounterStatic8S(SWSH) { Species = 282, Level = 36, Locations = new[] {168, 180}, Weather = Heavy_Fog }, // Gardevoir in the Forest of Focus, Training Lowlands
+            new(SWSH) { Species = 055, Level = 26, Location = 168, Weather = Raining }, // Golduck in the Forest of Focus
+            new(SWSH) { Species = 039, Level = 20, Location = 168, Weather = Heavy_Fog }, // Jigglypuff in the Forest of Focus
+            new(SWSH) { Species = 462, Level = 36, Location = 170, Weather = Thunderstorm }, // Magnezone on Challenge Beach
             new(SWSH) { Species = 475, Level = 20, Location = -01 }, // Gallade
             new(SWSH) { Species = 625, Level = 20, Location = -01 }, // Bisharp
             new(SWSH) { Species = 082, Level = 27, Location = -01 }, // Magneton
-            new(SW  ) { Species = 616, Level = 20, Location = 168 }, // Shelmet in the Forest of Focus (on the Isle of Armor)
             new(SWSH) { Species = 105, Level = 20, Location = -01 }, // Marowak
-            new(SWSH) { Species = 637, Level = 42, Location = 170 }, // Volcarona on Challenge Beach (on the Isle of Armor)
-            new(SWSH) { Species = 687, Level = 29, Location = 170 }, // Malamar on Challenge Beach (on the Isle of Armor)
-            new(SWSH) { Species = 428, Level = 27, Location = 170 }, // Lopunny on Challenge Beach (on the Isle of Armor)
-            new(SWSH) { Species = 452, Level = 27, Location = 170 }, // Drapion on Challenge Beach (on the Isle of Armor)
-            new(SWSH) { Species = 026, Level = 29, Location = 170 }, // Raichu on Challenge Beach (on the Isle of Armor)
+            new(SWSH) { Species = 637, Level = 42, Location = 170, Weather = Intense_Sun }, // Volcarona on Challenge Beach
+            new(SWSH) { Species = 687, Level = 29, Location = 170, Weather = Overcast | Raining }, // Malamar on Challenge Beach
+            new(SWSH) { Species = 428, Level = 27, Location = 170, Weather = Normal | Sandstorm | Heavy_Fog }, // Lopunny on Challenge Beach
+            new(SWSH) { Species = 452, Level = 27, Location = 170, Weather = Overcast | Raining }, // Drapion on Challenge Beach
+            new(SWSH) { Species = 026, Level = 29, Location = 170, Weather = Thunderstorm }, // Raichu on Challenge Beach
             new(SWSH) { Species = 558, Level = 20, Location = -01 }, // Crustle
-            new(SWSH) { Species = 764, Level = 25, Location = 170 }, // Comfey on Challenge Beach (on the Isle of Armor)
-            new(SWSH) { Species = 877, Level = 25, Location = 170 }, // Morpeko on Challenge Beach (on the Isle of Armor)
-            new(SWSH) { Species = 834, Level = 26, Location = 170 }, // Drednaw on Challenge Beach (on the Isle of Armor)
-            new(SWSH) { Species = 040, Level = 29, Location = 170 }, // Wigglytuff on Challenge Beach (on the Isle of Armor)
-            new(SWSH) { Species = 528, Level = 27, Location = 170 }, // Swoobat on Challenge Beach (on the Isle of Armor)
-            new(SWSH) { Species = 279, Level = 26, Location = 170 }, // Pelipper on Challenge Beach (on the Isle of Armor)
-            new(SWSH) { Species = 082, Level = 26, Location = 170 }, // Magneton on Challenge Beach (on the Isle of Armor)
-            new EncounterStatic8S(SW) { Species = 782, Level = 22, Locations = new[] {172, 174, 180} }, // Jangmo-o on Challenge Road, in the Training Lowlands (on the Isle of Armor) and in Brawlers' Cave
-            new(SWSH) { Species = 426, Level = 26, Location = 170 }, // Drifblim on Challenge Beach (on the Isle of Armor)
-            new(SWSH) { Species = 768, Level = 36, Location = 170 }, // Golisopod on Challenge Beach (on the Isle of Armor)
-            new(SWSH) { Species = 662, Level = 26, Location = 170 }, // Fletchinder on Challenge Beach (on the Isle of Armor)
-            new(SWSH) { Species = 342, Level = 27, Location = 170 }, // Crawdaunt on Challenge Beach (on the Isle of Armor)
-            new(SWSH) { Species = 184, Level = 27, Location = 170 }, // Azumarill on Challenge Beach (on the Isle of Armor)
-            new(SWSH) { Species = 549, Level = 26, Location = 170 }, // Lilligant on Challenge Beach (on the Isle of Armor)
-            new(SWSH) { Species = 845, Level = 24, Location = 170 }, // Cramorant on Challenge Beach (on the Isle of Armor)
-            new(SWSH) { Species = 055, Level = 27, Location = 170, Ability = 2 }, // Golduck on Challenge Beach (on the Isle of Armor)
-            new(SWSH) { Species = 702, Level = 25, Location = 170 }, // Dedenne on Challenge Beach (on the Isle of Armor)
+            new(SWSH) { Species = 764, Level = 25, Location = 170, Weather = Normal | Intense_Sun | Heavy_Fog }, // Comfey on Challenge Beach
+            new(SWSH) { Species = 877, Level = 25, Location = 170, Weather = Normal | Overcast | Stormy }, // Morpeko on Challenge Beach
+            new(SWSH) { Species = 834, Level = 26, Location = 170, Weather = Normal | Overcast | Thunderstorm | Intense_Sun | Sandstorm }, // Drednaw on Challenge Beach
+            new(SWSH) { Species = 040, Level = 29, Location = 170, Weather = Heavy_Fog }, // Wigglytuff on Challenge Beach
+            new(SWSH) { Species = 528, Level = 27, Location = 170, Weather = Overcast }, // Swoobat on Challenge Beach
+            new(SWSH) { Species = 279, Level = 26, Location = 170, Weather = All_IoA }, // Pelipper on Challenge Beach
+            new(SWSH) { Species = 082, Level = 26, Location = 170, Weather = Thunderstorm }, // Magneton on Challenge Beach
+            new(SW  ) { Species = 782, Level = 22, Location = 174, Weather = Intense_Sun | Sandstorm | Heavy_Fog }, // Jangmo-o on Challenge Road
+            new(SW  ) { Species = 782, Level = 22, Location = 180, Weather = Sandstorm }, // Jangmo-o in Training Lowlands
+            new(SWSH) { Species = 426, Level = 26, Location = 170, Weather = Overcast | Heavy_Fog }, // Drifblim on Challenge Beach
+            new(SWSH) { Species = 768, Level = 36, Location = 170, Weather = Raining }, // Golisopod on Challenge Beach
+            new(SWSH) { Species = 662, Level = 26, Location = 170, Weather = Intense_Sun }, // Fletchinder on Challenge Beach
+            new(SWSH) { Species = 342, Level = 27, Location = 170, Weather = Overcast | Raining }, // Crawdaunt on Challenge Beach
+            new(SWSH) { Species = 184, Level = 27, Location = 170, Weather = Heavy_Fog }, // Azumarill on Challenge Beach
+            new(SWSH) { Species = 549, Level = 26, Location = 170, Weather = Intense_Sun }, // Lilligant on Challenge Beach
+            new(SWSH) { Species = 845, Level = 24, Location = 170, Weather = Normal | Overcast | Raining | Intense_Sun | Sandstorm | Heavy_Fog }, // Cramorant on Challenge Beach
+            new(SWSH) { Species = 055, Level = 27, Location = 170, Ability = 2, Weather = Thunderstorm | Intense_Sun }, // Golduck on Challenge Beach
+            new(SWSH) { Species = 702, Level = 25, Location = 170, Weather = Normal | Stormy | Sandstorm }, // Dedenne on Challenge Beach
             new(SWSH) { Species = 113, Level = 27, Location = -01 }, // Chansey
-            new(SWSH) { Species = 405, Level = 36, Location = 170 }, // Luxray on Challenge Beach (on the Isle of Armor)
-            new(SWSH) { Species = 099, Level = 26, Location = 170 }, // Kingler on Challenge Beach (on the Isle of Armor)
-            new(SWSH) { Species = 121, Level = 26, Location = 170 }, // Starmie on Challenge Beach (on the Isle of Armor)
-            new(SWSH) { Species = 748, Level = 26, Location = 170 }, // Toxapex on Challenge Beach (on the Isle of Armor)
-            new(SWSH) { Species = 062, Level = 36, Location = 172 }, // Poliwrath in Brawlers’ Cave (on the Isle of Armor)
-            new(SWSH) { Species = 294, Level = 26, Location = 172 }, // Loudred in Brawlers’ Cave (on the Isle of Armor)
-            new(SWSH) { Species = 528, Level = 26, Location = 172 }, // Swoobat in Brawlers’ Cave (on the Isle of Armor)
-            new(SWSH) { Species = 621, Level = 36, Location = 172 }, // Druddigon in Brawlers’ Cave (on the Isle of Armor)
-            new(SWSH) { Species = 055, Level = 26, Location = 172 }, // Golduck in Brawlers’ Cave (on the Isle of Armor)
-            new(SWSH) { Species = 526, Level = 42, Location = 172 }, // Gigalith in Brawlers’ Cave (on the Isle of Armor)
-            new(SWSH) { Species = 620, Level = 28, Location = 174 }, // Mienshao on Challenge Road (on the Isle of Armor)
-            new(SWSH) { Species = 625, Level = 36, Location = 174 }, // Bisharp on Challenge Road (on the Isle of Armor)
-            new EncounterStatic8S(SH) { Species = 454, Level = 26, Locations = new[] {172, 174, 180} }, // Toxicroak on Challenge Road (on the Isle of Armor) and in Brawlers’ Cave
-            new EncounterStatic8S(SW) { Species = 560, Level = 26, Locations = new[] {172, 174, 180} }, // Scrafty on Challenge Road, in the Training Lowlands (on the Isle of Armor) and in Brawlers’ Cave
-            new(SWSH) { Species = 758, Level = 28, Location = 174, Gender = 1 }, // Salazzle on Challenge Road (on the Isle of Armor)
-            new EncounterStatic8S(SWSH) { Species = 558, Level = 26, Locations = new[] {172, 174, 180} }, // Crustle on Challenge Road, in the Training Lowlands (on the Isle of Armor) and in Brawlers’ Cave
-            new(SWSH) { Species = 475, Level = 32, Location = 174 }, // Gallade on Challenge Road (on the Isle of Armor)
-            new(SWSH) { Species = 745, Level = 32, Location = 174 }, // Lycanroc on Challenge Road (on the Isle of Armor)
-            new(SWSH) { Species = 745, Level = 32, Location = 174, Form = 01 }, // Lycanroc-1 on Challenge Road (on the Isle of Armor)
-            new(SWSH) { Species = 212, Level = 40, Location = 174 }, // Scizor on Challenge Road (on the Isle of Armor)
-            new(  SH) { Species = 214, Level = 26, Location = 174 }, // Heracross on Challenge Road (on the Isle of Armor)
-            new EncounterStatic8S(SWSH) { Species = 744, Level = 22, Locations = new[] {172,  174} }, // Rockruff on Challenge Road (on the Isle of Armor) and in Brawlers' Cave
-            new(SW  ) { Species = 127, Level = 26, Location = 174 }, // Pinsir on Challenge Road (on the Isle of Armor)
-            new EncounterStatic8S(SWSH) { Species = 227, Level = 26, Locations = new[] {174, 180} }, // Skarmory on Challenge Road (on the Isle of Armor), in the Training Lowlands (on the Isle of Armor)
-            new(SWSH) { Species = 426, Level = 26, Location = 174 }, // Drifblim on Challenge Road (on the Isle of Armor)
-            new(  SH) { Species = 630, Level = 26, Location = 174 }, // Mandibuzz on Challenge Road (on the Isle of Armor)
-            new(SW  ) { Species = 628, Level = 26, Location = 174 }, // Braviary on Challenge Road (on the Isle of Armor)
-            new(SWSH) { Species = 082, Level = 26, Location = 174 }, // Magneton on Challenge Road (on the Isle of Armor)
-            new(SWSH) { Species = 558, Level = 28, Location = 176 }, // Crustle in Courageous Cavern (on the Isle of Armor)
+            new(SWSH) { Species = 405, Level = 36, Location = 170, Weather = Thunderstorm }, // Luxray on Challenge Beach
+            new(SWSH) { Species = 099, Level = 26, Location = 170, Weather = Normal | Raining | Intense_Sun | Sandstorm }, // Kingler on Challenge Beach
+            new(SWSH) { Species = 121, Level = 26, Location = 170, Weather = All_IoA }, // Starmie on Challenge Beach
+            new(SWSH) { Species = 748, Level = 26, Location = 170, Weather = Overcast | Stormy | Heavy_Fog }, // Toxapex on Challenge Beach
+            new(SWSH) { Species = 224, Level = 45, Location = 170, Weather = Normal | Intense_Sun | Sandstorm }, // Octillery on Challenge Beach
+            new(SWSH) { Species = 171, Level = 42, Location = 170, Weather = Thunderstorm | Heavy_Fog }, // Lanturn on Challenge Beach
+            new EncounterStatic8S(SWSH) { Species = 342, Level = 42, Locations = new[] {170, 180}, Weather = Overcast }, // Crawdaunt on Challenge Beach, Training Lowlands
+            new(SWSH) { Species = 593, Level = 42, Location = 170, Weather = Overcast | Raining | Heavy_Fog }, // Jellicent on Challenge Beach
+            new(SWSH) { Species = 593, Level = 42, Location = 178, Weather = Overcast | Heavy_Fog }, // Jellicent in Loop Lagoon
+            new(SWSH) { Species = 091, Level = 42, Location = 170, Weather = Raining | Heavy_Fog }, // Cloyster on Challenge Beach
+            new(SWSH) { Species = 130, Level = 50, Location = 170, Weather = Normal | Raining | Intense_Sun | Sandstorm }, // Gyarados on Challenge Beach
+            new(SWSH) { Species = 062, Level = 36, Location = 172, Weather = All_IoA }, // Poliwrath in Brawlers’ Cave
+            new(SWSH) { Species = 294, Level = 26, Location = 172, Weather = All_IoA }, // Loudred in Brawlers’ Cave
+            new(SWSH) { Species = 528, Level = 26, Location = 172, Weather = All_IoA }, // Swoobat in Brawlers’ Cave
+            new(SWSH) { Species = 621, Level = 36, Location = 172, Weather = All_IoA }, // Druddigon in Brawlers’ Cave
+            new(SWSH) { Species = 055, Level = 26, Location = 172, Weather = All_IoA }, // Golduck in Brawlers’ Cave
+            new(SWSH) { Species = 526, Level = 42, Location = 172, Weather = All_IoA }, // Gigalith in Brawlers’ Cave
+            new(SWSH) { Species = 620, Level = 28, Location = 174, Weather = Normal }, // Mienshao on Challenge Road
+            new(SWSH) { Species = 625, Level = 36, Location = 174, Weather = Overcast }, // Bisharp on Challenge Road
+            new EncounterStatic8S(SH) { Species = 454, Level = 26, Locations = new[] {172, 174, 180}, Weather = Stormy }, // Toxicroak on Challenge Road, Brawlers’ Cave, Training Lowlands
+            new EncounterStatic8S(SW) { Species = 560, Level = 26, Locations = new[] {172, 174, 180}, Weather = Stormy }, // Scrafty on Challenge Road, Brawlers’ Cave, Training Lowlands
+            new(SWSH) { Species = 758, Level = 28, Location = 174, Gender = 1, Weather = Intense_Sun }, // Salazzle on Challenge Road
+            new EncounterStatic8S(SWSH) { Species = 558, Level = 26, Locations = new[] {172, 174, 180}, Weather = Sandstorm }, // Crustle on Challenge Road, Brawlers’ Cave, Training Lowlands
+            new(SWSH) { Species = 475, Level = 32, Location = 174, Weather = Heavy_Fog }, // Gallade on Challenge Road
+            new(SWSH) { Species = 745, Level = 32, Location = 174, Weather = Normal }, // Lycanroc on Challenge Road
+            new(SWSH) { Species = 745, Level = 32, Location = 174, Form = 01, Weather = Overcast }, // Lycanroc-1 on Challenge Road
+            new(SWSH) { Species = 212, Level = 40, Location = 174, Weather = Sandstorm }, // Scizor on Challenge Road
+            new(  SH) { Species = 214, Level = 26, Location = 174, Weather = Intense_Sun }, // Heracross on Challenge Road
+            new EncounterStatic8S(SW) { Species = 744, Level = 22, Locations = new[] {172,  174}, Weather = Normal | Overcast }, // Rockruff on Challenge Road, Brawlers' Cave
+            new EncounterStatic8S(SH) { Species = 744, Level = 22, Locations = new[] {172,  174}, Weather = Normal | Overcast | Intense_Sun | Heavy_Fog }, // Rockruff on Challenge Road, Brawlers' Cave
+            new(SW  ) { Species = 127, Level = 26, Location = 174, Weather = Intense_Sun }, // Pinsir on Challenge Road
+            new(SWSH) { Species = 227, Level = 26, Location = 174, Weather = Normal | Raining | Intense_Sun | Sandstorm }, // Skarmory on Challenge Road
+            new(SWSH) { Species = 227, Level = 26, Location = 180, Weather = Sandstorm }, // Skarmory in the Training Lowlands
+            new(SWSH) { Species = 426, Level = 26, Location = 174, Weather = Heavy_Fog }, // Drifblim on Challenge Road
+            new(  SH) { Species = 630, Level = 26, Location = 174, Weather = Overcast }, // Mandibuzz on Challenge Road
+            new(SW  ) { Species = 628, Level = 26, Location = 174, Weather = Overcast }, // Braviary on Challenge Road
+            new(SWSH) { Species = 082, Level = 26, Location = 174, Weather = Thunderstorm }, // Magneton on Challenge Road
+            new(SWSH) { Species = 558, Level = 28, Location = 176, Weather = All_IoA }, // Crustle in Courageous Cavern
             new(SWSH) { Species = 526, Level = 42, Location = -01 }, // Gigalith
-            new(SWSH) { Species = 768, Level = 32, Location = 176 }, // Golisopod in Courageous Cavern (on the Isle of Armor)
-            new(SWSH) { Species = 528, Level = 28, Location = 176 }, // Swoobat in Courageous Cavern (on the Isle of Armor)
-            new(SWSH) { Species = 834, Level = 28, Location = 176 }, // Drednaw in Courageous Cavern (on the Isle of Armor)
+            new(SWSH) { Species = 768, Level = 32, Location = 176, Weather = All_IoA }, // Golisopod in Courageous Cavern
+            new(SWSH) { Species = 528, Level = 28, Location = 176, Weather = All_IoA }, // Swoobat in Courageous Cavern
+            new(SWSH) { Species = 834, Level = 28, Location = 176, Weather = All_IoA }, // Drednaw in Courageous Cavern
+            new(SWSH) { Species = 621, Level = 42, Location = 176, Weather = All_IoA }, // Druddigon in Courageous Cavern
             new(SWSH) { Species = 113, Level = 30, Location = -01 }, // Chansey
-            new(SWSH) { Species = 687, Level = 32, Location = 178 }, // Malamar in Loop Lagoon (on the Isle of Armor)
-            new(SWSH) { Species = 040, Level = 32, Location = 178 }, // Wigglytuff in Loop Lagoon (on the Isle of Armor)
+            new(SWSH) { Species = 687, Level = 32, Location = 178, Weather = Overcast | Raining }, // Malamar in Loop Lagoon
+            new(SWSH) { Species = 040, Level = 32, Location = 178, Weather = Heavy_Fog }, // Wigglytuff in Loop Lagoon
             new(SWSH) { Species = 768, Level = 32, Location = -01 }, // Golisopod
-            new(SWSH) { Species = 404, Level = 30, Location = 178 }, // Luxio in Loop Lagoon (on the Isle of Armor)
-            new(SWSH) { Species = 834, Level = 30, Location = 178 }, // Drednaw in Loop Lagoon (on the Isle of Armor)
+            new(SWSH) { Species = 404, Level = 30, Location = 178, Weather = Thunderstorm }, // Luxio in Loop Lagoon
+            new(SWSH) { Species = 834, Level = 30, Location = 178, Weather = Normal | Intense_Sun | Sandstorm }, // Drednaw in Loop Lagoon
             new(SWSH) { Species = 558, Level = 30, Location = -01 }, // Crustle
-            new(SWSH) { Species = 871, Level = 22, Location = 178 }, // Pincurchin in Loop Lagoon (on the Isle of Armor)
-            new(SWSH) { Species = 748, Level = 26, Location = 178 }, // Toxapex in Loop Lagoon (on the Isle of Armor)
-            new(SWSH) { Species = 853, Level = 32, Location = 178 }, // Grapploct in Loop Lagoon (on the Isle of Armor)
-            new(SWSH) { Species = 770, Level = 32, Location = 178 }, // Palossand in Loop Lagoon (on the Isle of Armor)
-            new EncounterStatic8S(SWSH)  { Species = 065, Level = 50, Locations = new[] { 178, 190 } }, // Alakazam in Loop Lagoon (on the Isle of Armor) and in the Insular Sea (on the Isle of Armor)
-            new(SWSH) { Species = 571, Level = 50, Location = 178 }, // Zoroark in Loop Lagoon (on the Isle of Armor)
-            new(SWSH) { Species = 462, Level = 50, Location = 178 }, // Magnezone in Loop Lagoon (on the Isle of Armor)
-            new(SWSH) { Species = 744, Level = 40, Location = 178 }, // Rockruff in Loop Lagoon (on the Isle of Armor)
-            new(SWSH) { Species = 636, Level = 40, Location = 178 }, // Larvesta in Loop Lagoon (on the Isle of Armor)
-            new(SWSH) { Species = 279, Level = 42, Location = 178 }, // Pelipper in Loop Lagoon (on the Isle of Armor)
-            new(SWSH) { Species = 405, Level = 50, Location = 178 }, // Luxray in Loop Lagoon (on the Isle of Armor)
-            new(SWSH) { Species = 663, Level = 50, Location = 178 }, // Talonflame in Loop Lagoon (on the Isle of Armor)
-            new(SWSH) { Species = 508, Level = 42, Location = 180 }, // Stoutland in the Training Lowlands (on the Isle of Armor)
-            new(SWSH) { Species = 625, Level = 36, Location = 180 }, // Bisharp in the Training Lowlands (on the Isle of Armor)
-            new(SWSH) { Species = 405, Level = 36, Location = 180 }, // Luxray in the Training Lowlands (on the Isle of Armor)
-            new(SWSH) { Species = 663, Level = 36, Location = 180 }, // Talonflame in the Training Lowlands (on the Isle of Armor)
-            new(SWSH) { Species = 040, Level = 30, Location = 180 }, // Wigglytuff in the Training Lowlands (on the Isle of Armor)
-            new(SWSH) { Species = 099, Level = 28, Location = 180 }, // Kingler in the Training Lowlands (on the Isle of Armor)
-            new(SWSH) { Species = 115, Level = 32, Location = 180 }, // Kangaskhan in the Training Lowlands (on the Isle of Armor)
-            new(SWSH) { Species = 123, Level = 28, Location = 180 }, // Scyther in the Training Lowlands (on the Isle of Armor)
-            new(SWSH) { Species = 404, Level = 28, Location = 180 }, // Luxio in the Training Lowlands (on the Isle of Armor)
-            new(SWSH) { Species = 764, Level = 28, Location = 180 }, // Comfey in the Training Lowlands (on the Isle of Armor)
-            new(SWSH) { Species = 452, Level = 28, Location = 180 }, // Drapion in the Training Lowlands (on the Isle of Armor)
-            new(SWSH) { Species = 279, Level = 28, Location = 180 }, // Pelipper in the Training Lowlands (on the Isle of Armor)
-            new(SWSH) { Species = 127, Level = 28, Location = 180 }, // Pinsir in the Training Lowlands (on the Isle of Armor)
-            new(SWSH) { Species = 528, Level = 28, Location = 180 }, // Swoobat in the Training Lowlands (on the Isle of Armor)
-            new(SWSH) { Species = 241, Level = 28, Location = 180 }, // Miltank in the Training Lowlands (on the Isle of Armor)
-            new(SWSH) { Species = 082, Level = 28, Location = 180 }, // Magneton in the Training Lowlands (on the Isle of Armor)
-            new(SWSH) { Species = 662, Level = 28, Location = 180 }, // Fletchinder in the Training Lowlands (on the Isle of Armor)
-            new(SWSH) { Species = 128, Level = 28, Location = 180 }, // Tauros in the Training Lowlands (on the Isle of Armor)
-            new(SWSH) { Species = 687, Level = 28, Location = 180 }, // Malamar in the Training Lowlands (on the Isle of Armor)
-            new(SWSH) { Species = 214, Level = 28, Location = 180 }, // Heracross in the Training Lowlands (on the Isle of Armor)
-            new EncounterStatic8S(SWSH) { Species = 507, Level = 28, Locations = new[] {174, 180} }, // Herdier on Challenge Road and in the Training Lowlands (on the Isle of Armor)
-            new(SWSH) { Species = 549, Level = 28, Location = 180 }, // Lilligant in the Training Lowlands (on the Isle of Armor)
-            new(SWSH) { Species = 426, Level = 28, Location = 180 }, // Drifblim in the Training Lowlands (on the Isle of Armor
-            new(SWSH) { Species = 055, Level = 26, Location = 180 }, // Golduck in the Training Lowlands (on the Isle of Armor)
-            new(SWSH) { Species = 184, Level = 26, Location = 180 }, // Azumarill in the Training Lowlands (on the Isle of Armor
-            new(SWSH) { Species = 617, Level = 36, Location = 180 }, // Accelgor in the Training Lowlands (on the Isle of Armor
-            new(SWSH) { Species = 212, Level = 42, Location = 180 }, // Scizor in the Training Lowlands (on the Isle of Armor)
-            new(SWSH) { Species = 589, Level = 36, Location = 180 }, // Escavalier in the Training Lowlands (on the Isle of Armor)
-            new(SWSH) { Species = 616, Level = 26, Location = 180 }, // Shelmet in the Training Lowlands (on the Isle of Armor)
-            new(SWSH) { Species = 588, Level = 26, Location = 180 }, // Karrablast in the Training Lowlands (on the Isle of Armor)
-            new(SWSH) { Species = 553, Level = 50, Location = 184 }, // Krookodile in the Potbottom Desert (on the Isle of Armor)
-            new(SWSH) { Species = 464, Level = 50, Location = 184 }, // Rhyperior in the Potbottom Desert (on the Isle of Armor)
-            new(SWSH) { Species = 105, Level = 42, Location = 184 }, // Marowak in the Potbottom Desert (on the Isle of Armor)
-            new(SWSH) { Species = 552, Level = 42, Location = 184 }, // Krokorok in the Potbottom Desert (on the Isle of Armor)
-            new(SWSH) { Species = 112, Level = 42, Location = 184 }, // Rhydon in the Potbottom Desert (on the Isle of Armor)
-            new(SWSH) { Species = 324, Level = 42, Location = 184 }, // Torkoal in the Potbottom Desert (on the Isle of Armor)
-            new(SWSH) { Species = 844, Level = 42, Location = 184 }, // Sandaconda in the Potbottom Desert (on the Isle of Armor)
-            new(SWSH) { Species = 637, Level = 50, Location = 184 }, // Volcarona in the Potbottom Desert (on the Isle of Armor)
-            new(SW  ) { Species = 628, Level = 42, Location = 184 }, // Braviary in the Potbottom Desert (on the Isle of Armor)
-            new(  SH) { Species = 630, Level = 42, Location = 184 }, // Mandibuzz in the Potbottom Desert (on the Isle of Armor)
-            new(SWSH) { Species = 103, Level = 50, Location = 190 }, // Exeggutor in the Insular Sea (on the Isle of Armor)
-         // new(SWSH) { Species = 132, Level = 50, Location = 186, FlawlessIVCount = 3 }, // Ditto in the Workout Sea (on the Isle of Armor) -- collision with wild Ditto in the same area
+            new(SWSH) { Species = 871, Level = 22, Location = 178, Weather = Normal | Stormy | Heavy_Fog }, // Pincurchin in Loop Lagoon
+            new(SWSH) { Species = 748, Level = 26, Location = 178, Weather = Overcast | Raining | Heavy_Fog }, // Toxapex in Loop Lagoon
+            new(SWSH) { Species = 853, Level = 32, Location = 178, Weather = Normal | Overcast | Intense_Sun | Sandstorm | Heavy_Fog }, // Grapploct in Loop Lagoon
+            new(SWSH) { Species = 770, Level = 32, Location = 178, Weather = Overcast | Sandstorm | Heavy_Fog }, // Palossand in Loop Lagoon
+            new(SWSH) { Species = 065, Level = 50, Location = 178, Weather = Normal | Raining | Sandstorm }, // Alakazam in Loop Lagoon
+            new(SWSH) { Species = 065, Level = 50, Location = 190, Weather = Heavy_Fog }, // Alakazam in the Insular Sea
+            new(SWSH) { Species = 571, Level = 50, Location = 178, Weather = Overcast | Heavy_Fog }, // Zoroark in Loop Lagoon
+            new(SWSH) { Species = 462, Level = 50, Location = 178, Weather = Thunderstorm }, // Magnezone in Loop Lagoon
+            new(SWSH) { Species = 744, Level = 40, Location = 178 }, // Rockruff in Loop Lagoon
+            new(SWSH) { Species = 636, Level = 40, Location = 178, Weather = Intense_Sun | Sandstorm }, // Larvesta in Loop Lagoon
+            new(SWSH) { Species = 279, Level = 42, Location = 178, Weather = Raining }, // Pelipper in Loop Lagoon
+            new(SWSH) { Species = 405, Level = 50, Location = 178, Weather = Thunderstorm }, // Luxray in Loop Lagoon
+            new(SWSH) { Species = 663, Level = 50, Location = 178, Weather = Intense_Sun }, // Talonflame in Loop Lagoon
+            new(SWSH) { Species = 508, Level = 42, Location = 180 }, // Stoutland in the Training Lowlands
+            new(SWSH) { Species = 625, Level = 36, Location = 180, Weather = Overcast }, // Bisharp in the Training Lowlands
+            new(SWSH) { Species = 405, Level = 36, Location = 180, Weather = Thunderstorm }, // Luxray in the Training Lowlands
+            new(SWSH) { Species = 663, Level = 36, Location = 180, Weather = Intense_Sun }, // Talonflame in the Training Lowlands
+            new(SWSH) { Species = 040, Level = 30, Location = 180, Weather = Heavy_Fog }, // Wigglytuff in the Training Lowlands
+            new(SWSH) { Species = 099, Level = 28, Location = 180, Weather = Normal | Overcast | Stormy | Intense_Sun | Sandstorm }, // Kingler in the Training Lowlands
+            new(SWSH) { Species = 115, Level = 32, Location = 180, Weather = Normal | Overcast }, // Kangaskhan in the Training Lowlands
+            new(SWSH) { Species = 123, Level = 28, Location = 180, Weather = Normal | Intense_Sun }, // Scyther in the Training Lowlands
+            new(SWSH) { Species = 404, Level = 28, Location = 180, Weather = Thunderstorm }, // Luxio in the Training Lowlands
+            new(SWSH) { Species = 764, Level = 28, Location = 180, Weather = Heavy_Fog }, // Comfey in the Training Lowlands
+            new(SWSH) { Species = 452, Level = 28, Location = 180, Weather = Overcast | Intense_Sun }, // Drapion in the Training Lowlands
+            new(SWSH) { Species = 279, Level = 28, Location = 180, Weather = Raining }, // Pelipper in the Training Lowlands
+            new(SW  ) { Species = 127, Level = 28, Location = 180, Weather = Normal | Intense_Sun }, // Pinsir in the Training Lowlands
+            new(  SH) { Species = 214, Level = 28, Location = 180, Weather = Normal | Intense_Sun }, // Heracross in the Training Lowlands
+            new(SWSH) { Species = 528, Level = 28, Location = 180, Weather = Overcast }, // Swoobat in the Training Lowlands
+            new(SWSH) { Species = 241, Level = 28, Location = 180, Weather = Normal | Overcast | Intense_Sun }, // Miltank in the Training Lowlands
+            new(SWSH) { Species = 082, Level = 28, Location = 180, Weather = Thunderstorm }, // Magneton in the Training Lowlands
+            new(SWSH) { Species = 662, Level = 28, Location = 180, Weather = Intense_Sun }, // Fletchinder in the Training Lowlands
+            new(SWSH) { Species = 128, Level = 28, Location = 180, Weather = All_IoA }, // Tauros in the Training Lowlands
+            new(SWSH) { Species = 687, Level = 28, Location = 180, Weather = Overcast | Raining }, // Malamar in the Training Lowlands
+            new EncounterStatic8S(SWSH) { Species = 507, Level = 28, Locations = new[] {174, 180}, Weather = Normal | Heavy_Fog }, // Herdier on Challenge Road and in the Training Lowlands
+            new(SWSH) { Species = 549, Level = 28, Location = 180, Weather = Intense_Sun }, // Lilligant in the Training Lowlands
+            new(SWSH) { Species = 426, Level = 28, Location = 180, Weather = Heavy_Fog }, // Drifblim in the Training Lowlands
+            new(SWSH) { Species = 055, Level = 26, Location = 180, Weather = Normal | Overcast | Stormy | Intense_Sun }, // Golduck in the Training Lowlands
+            new(SWSH) { Species = 184, Level = 26, Location = 180, Weather = Heavy_Fog }, // Azumarill in the Training Lowlands
+            new(SWSH) { Species = 617, Level = 36, Location = 180, Weather = Thunderstorm }, // Accelgor in the Training Lowlands
+            new(SWSH) { Species = 212, Level = 42, Location = 180, Weather = Sandstorm }, // Scizor in the Training Lowlands
+            new(SWSH) { Species = 589, Level = 36, Location = 180, Weather = Sandstorm }, // Escavalier in the Training Lowlands
+            new(SWSH) { Species = 616, Level = 26, Location = 180, Weather = Raining }, // Shelmet in the Training Lowlands
+            new(SWSH) { Species = 588, Level = 26, Location = 180, Weather = Overcast }, // Karrablast in the Training Lowlands
+            new(SWSH) { Species = 553, Level = 50, Location = 184, Weather = Overcast | Stormy }, // Krookodile in the Potbottom Desert
+            new(SWSH) { Species = 464, Level = 50, Location = 184, Weather = Normal | Intense_Sun | Sandstorm | Heavy_Fog }, // Rhyperior in the Potbottom Desert
+            new(SWSH) { Species = 105, Level = 42, Location = 184, Weather = Normal | Intense_Sun | Heavy_Fog }, // Marowak in the Potbottom Desert
+            new(SWSH) { Species = 552, Level = 42, Location = 184, Weather = Overcast | Stormy }, // Krokorok in the Potbottom Desert
+            new(SWSH) { Species = 112, Level = 42, Location = 184, Weather = Normal | Intense_Sun | Sandstorm }, // Rhydon in the Potbottom Desert
+            new(SWSH) { Species = 324, Level = 42, Location = 184, Weather = Intense_Sun | Heavy_Fog }, // Torkoal in the Potbottom Desert
+            new(SWSH) { Species = 844, Level = 42, Location = 184, Weather = Normal | Intense_Sun | Heavy_Fog }, // Sandaconda in the Potbottom Desert
+            new(SWSH) { Species = 637, Level = 50, Location = 184, Weather = Intense_Sun }, // Volcarona in the Potbottom Desert
+            new(SWSH) { Species = 028, Level = 42, Location = 184, Weather = Sandstorm }, // Sandslash in the Potbottom Desert
+            new(SW  ) { Species = 628, Level = 42, Location = 184, Weather = All_IoA }, // Braviary in the Potbottom Desert
+            new(  SH) { Species = 630, Level = 42, Location = 184, Weather = All_IoA }, // Mandibuzz in the Potbottom Desert
+            new(SWSH) { Species = 103, Level = 50, Location = 190, Weather = Normal | Raining | Intense_Sun | Sandstorm }, // Exeggutor in the Insular Sea
+          //new(SWSH) { Species = 132, Level = 50, Location = 186, FlawlessIVCount = 3 }, // Ditto in the Workout Sea -- collision with wild Ditto in the same area
             new(SWSH) { Species = 242, Level = 50, Location = -01 }, // Blissey
-            new(SWSH) { Species = 571, Level = 50, Location = 190 }, // Zoroark in the Insular Sea (on the Isle of Armor)
-            new(SWSH) { Species = 462, Level = 50, Location = 190 }, // Magnezone in the Insular Sea (on the Isle of Armor)
-            new(SWSH) { Species = 637, Level = 50, Location = 190 }, // Volcarona in the Insular Sea (on the Isle of Armor)
-            new(SWSH) { Species = 279, Level = 45, Location = 190 }, // Pelipper in the Insular Sea (on the Isle of Armor)
-            new(SWSH) { Species = 549, Level = 45, Location = 194 }, // Lilligant on Honeycalm Island (on the Isle of Armor)
-            new(SWSH) { Species = 415, Level = 40, Location = 194 }, // Combee on Honeycalm Island (on the Isle of Armor)
-            new(SWSH) { Species = 028, Level = 42, Location = 184 }, // Sandslash in the Potbottom Desert (on the Isle of Armor)
-            new EncounterStatic8S(SWSH) { Species = 587, Level = 20, Locations = new[] {166, 168} }, // Emolga in the Soothing Wetlands and in the Forest of Focus (on the Isle of Armor)
-            new EncounterStatic8S(SWSH) { Species = 847, Level = 42, Locations = new[] {166, 170, 176, 180} }, // Barraskewda in the Soothing Wetlands, on Challenge Beach, in Courageous Cavern, and Training Lowlands (on the Isle of Armor)
-            new(SWSH) { Species = 224, Level = 45, Location = 170 }, // Octillery on Challenge Beach (on the Isle of Armor)
-            new(SWSH) { Species = 171, Level = 42, Location = 170 }, // Lanturn on Challenge Beach (on the Isle of Armor)
-            new EncounterStatic8S(SWSH) { Species = 593, Level = 42, Locations = new[] {170, 178} }, // Jellicent on Challenge Beach and in Loop Lagoon (on the Isle of Armor)
-            new(SWSH) { Species = 091, Level = 42, Location = 170 }, // Cloyster on Challenge Beach (on the Isle of Armor)
-            new(SWSH) { Species = 130, Level = 50, Location = 170 }, // Gyarados on Challenge Beach (on the Isle of Armor)
-            new(SWSH) { Species = 073, Level = 42, Location = 176 }, // Tentacruel in Courageous Cavern (on the Isle of Armor)
-            new EncounterStatic8S(SWSH) { Species = 340, Level = 42, Locations = new[] {168, 172, 176} }, // Whiscash in the Forest of Focus, in Brawlers’ Cave, in Courageous Cavern (on the Isle of Armor)
-            new(SWSH) { Species = 342, Level = 42, Location = 180 }, // Crawdaunt in the Training Lowlands (on the Isle of Armor)
-            // new(SWSH) { Species = 479, Level = 50, Location = 186, FlawlessIVCount = 3 }, // Rotom in the Workout Sea (on the Isle of Armor) -- collision with subsequent static Rotom
-            new(SWSH) { Species = 479, Level = 50, Location = 186, Moves = new[] {435,506,268}, Form = 01 }, // Rotom-1 in the Workout Sea (on the Isle of Armor)
-            new(SWSH) { Species = 479, Level = 50, Location = 186, Moves = new[] {435,506,268}, Form = 02 }, // Rotom-2 in the Workout Sea (on the Isle of Armor)
-            new(SWSH) { Species = 479, Level = 50, Location = 186, Moves = new[] {435,506,268}, Form = 03 }, // Rotom-3 in the Workout Sea (on the Isle of Armor)
-            new(SWSH) { Species = 479, Level = 50, Location = 186, Moves = new[] {435,506,268}, Form = 04 }, // Rotom-4 in the Workout Sea (on the Isle of Armor)
-            new(SWSH) { Species = 479, Level = 50, Location = 186, Moves = new[] {435,506,268}, Form = 05 }, // Rotom-5 in the Workout Sea (on the Isle of Armor)
-            new(SWSH) { Species = 230, Level = 60, Location = 192 }, // Kingdra in the Honeycalm Sea (on the Isle of Armor)
-            new(SWSH) { Species = 117, Level = 45, Location = 192 }, // Seadra in the Honeycalm Sea (on the Isle of Armor)
-            new(SWSH) { Species = 321, Level = 80, Location = 186 }, // Wailord in the Workout Sea (on the Isle of Armor)
-            new(SWSH) { Species = 039, Level = 20, Location = 168 }, // Jigglypuff in the Forest of Focus (on the Isle of Armor)
-            new EncounterStatic8S(SWSH) { Species = 764, Level = 50, Locations = new[] {190, 194} }, // Comfey in the Insular Sea and in the Honeycalm Sea (on the Isle of Armor)
-            new(SWSH) { Species = 621, Level = 42, Location = 176 }, // Druddigon in Courageous Cavern (on the Isle of Armor)
+            new(SWSH) { Species = 571, Level = 50, Location = 190, Weather = Overcast }, // Zoroark in the Insular Sea
+            new(SWSH) { Species = 462, Level = 50, Location = 190, Weather = Thunderstorm }, // Magnezone in the Insular Sea
+            new(SWSH) { Species = 637, Level = 50, Location = 190, Weather = Intense_Sun }, // Volcarona in the Insular Sea
+            new(SWSH) { Species = 279, Level = 45, Location = 190, Weather = Overcast | Stormy }, // Pelipper in the Insular Sea
+            new EncounterStatic8S(SWSH) { Species = 764, Level = 50, Locations = new[] {190, 194}, Weather = Heavy_Fog }, // Comfey in the Insular Sea, Honeycalm Sea
+            new(SWSH) { Species = 549, Level = 45, Location = 194, Weather = Normal | Intense_Sun | Sandstorm }, // Lilligant on Honeycalm Island
+            new(SWSH) { Species = 415, Level = 40, Location = 194, Weather = Overcast | Stormy }, // Combee on Honeycalm Island
+            new EncounterStatic8S(SWSH) { Species = 587, Level = 20, Locations = new[] {166, 168}, Weather = All_IoA }, // Emolga in the Soothing Wetlands, Forest of Focus
+            new EncounterStatic8S(SWSH) { Species = 847, Level = 42, Locations = new[] {166, 170, 176, 180}, Weather = Normal | Stormy | Intense_Sun | Sandstorm | Heavy_Fog }, // Barraskewda in the Soothing Wetlands, Challenge Beach, Courageous Cavern, Training Lowlands
+            new(SWSH) { Species = 073, Level = 42, Location = 176, Weather = All_IoA }, // Tentacruel in Courageous Cavern
+            new EncounterStatic8S(SWSH) { Species = 340, Level = 42, Locations = new[] {172, 176}, Weather = All_IoA}, // Whiscash in Courageous Cavern, Brawlers' Cave
+            new(SWSH) { Species = 340, Level = 42, Location = 168, Weather = Normal | Overcast | Intense_Sun | Sandstorm }, // Whiscash in the Forest of Focus
+          //new(SWSH) { Species = 479, Level = 50, Location = 186, FlawlessIVCount = 3 }, // Rotom in the Workout Sea -- collision with subsequent static Rotom
+            new(SWSH) { Species = 479, Level = 50, Location = 186, Moves = new[] {435,506,268}, Form = 01, Weather = Normal | Stormy | Intense_Sun | Sandstorm | Heavy_Fog }, // Rotom-1 in the Workout Sea
+            new(SWSH) { Species = 479, Level = 50, Location = 186, Moves = new[] {435,506,268}, Form = 02, Weather = Normal | Stormy | Intense_Sun | Sandstorm | Heavy_Fog }, // Rotom-2 in the Workout Sea
+            new(SWSH) { Species = 479, Level = 50, Location = 186, Moves = new[] {435,506,268}, Form = 03, Weather = Normal | Stormy | Intense_Sun | Sandstorm | Heavy_Fog }, // Rotom-3 in the Workout Sea
+            new(SWSH) { Species = 479, Level = 50, Location = 186, Moves = new[] {435,506,268}, Form = 04, Weather = Normal | Stormy | Intense_Sun | Sandstorm | Heavy_Fog }, // Rotom-4 in the Workout Sea
+            new(SWSH) { Species = 479, Level = 50, Location = 186, Moves = new[] {435,506,268}, Form = 05, Weather = Normal | Stormy | Intense_Sun | Sandstorm | Heavy_Fog }, // Rotom-5 in the Workout Sea
+            new(SWSH) { Species = 230, Level = 60, Location = 192, Weather = Thunderstorm }, // Kingdra in the Honeycalm Sea
+            new(SWSH) { Species = 117, Level = 45, Location = 192, Weather = Normal | Overcast | Raining | Intense_Sun | Sandstorm | Heavy_Fog }, // Seadra in the Honeycalm Sea
+            new(SWSH) { Species = 321, Level = 80, Location = 186, Weather = All_IoA }, // Wailord in the Workout Sea
             #endregion
 
             #region R2 Static Encounters
-            new EncounterStatic8S(SWSH) { Species = 144, Level = 70, Locations = new[] {208, 210, 212, 214}, Moves = new[] {821,542,427,375}, FlawlessIVCount = 3, Shiny = Never, Ability = 1, Form = 01 }, // Articuno-1 in the Crown Tundra
-            new EncounterStatic8S(SWSH) { Species = 145, Level = 70, Locations = new[] {122, 124, 126, 128, 130}, Moves = new[] {823,065,179,116}, FlawlessIVCount = 3, Shiny = Never, Ability = 1, Form = 01 }, // Zapdos-1 in a Wild Area
-            new EncounterStatic8S(SWSH) { Species = 146, Level = 70, Locations = new[] {164, 166, 170, 178, 186, 188, 190}, Moves = new[] {822,542,389,417}, FlawlessIVCount = 3, Shiny = Never, Ability = 1, Form = 01 }, // Moltres-1 on the Isle of Armor
-            new(SWSH) { Species = 377, Level = 70, Location = 236, Moves = new[] {276,444,359,174}, FlawlessIVCount = 3, Ability = 1 }, // Regirock
-            new(SWSH) { Species = 378, Level = 70, Location = 238, Moves = new[] {058,192,133,196}, FlawlessIVCount = 3, Ability = 1 }, // Regice
-            new(SWSH) { Species = 379, Level = 70, Location = 240, Moves = new[] {484,430,334,451}, FlawlessIVCount = 3, Ability = 1 }, // Registeel
-            new(SWSH) { Species = 894, Level = 70, Location = 242, Moves = new[] {819,527,245,393}, FlawlessIVCount = 3, Ability = 1 }, // Regieleki
-            new(SWSH) { Species = 895, Level = 70, Location = 242, Moves = new[] {820,337,359,673}, FlawlessIVCount = 3, Ability = 1 }, // Regidrago
-            new(SWSH) { Species = 486, Level =100, Location = 210, Moves = new[] {416,428,359,462}, FlawlessIVCount = 3, Ability = 1, DynamaxLevel = 10, ScriptedNoMarks = true }, // Regigigas in the Giant’s Bed (in the Crown Tundra)
-            new(SWSH) { Species = 638, Level = 70, Location = 226, FlawlessIVCount = 3, Ability = 1 }, // Cobalion
-            new(SWSH) { Species = 639, Level = 70, Location = 232, FlawlessIVCount = 3, Ability = 1 }, // Terrakion
-            new(SWSH) { Species = 640, Level = 70, Location = 210, FlawlessIVCount = 3, Ability = 1 }, // Virizion
-            new(SWSH) { Species = 647, Level = 65, Location = 230, Moves = new[] {548,533,014,056}, FlawlessIVCount = 3, Shiny = Never, Ability = 1, Form = 01, Fateful = true }, // Keldeo-1 at Ballimere Lake (in the Crown Tundra)
+            new EncounterStatic8S(SWSH) { Species = 144, Level = 70, Locations = new[] {208, 210, 212, 214}, Moves = new[] {821,542,427,375}, FlawlessIVCount = 3, Shiny = Never, Ability = 1, Form = 01, Weather = All_CT }, // Articuno-1 in the Crown Tundra
+            new EncounterStatic8S(SWSH) { Species = 145, Level = 70, Locations = new[] {122, 124, 126, 128, 130}, Moves = new[] {823,065,179,116}, FlawlessIVCount = 3, Shiny = Never, Ability = 1, Form = 01, Weather = All }, // Zapdos-1 in a Wild Area
+            new EncounterStatic8S(SWSH) { Species = 146, Level = 70, Locations = new[] {164, 166, 170, 178, 186, 188, 190}, Moves = new[] {822,542,389,417}, FlawlessIVCount = 3, Shiny = Never, Ability = 1, Form = 01, Weather = All_IoA }, // Moltres-1 on the Isle of Armor
+            new(SWSH) { Species = 377, Level = 70, Location = 236, ScriptedNoMarks = true, Moves = new[] {276,444,359,174}, FlawlessIVCount = 3, Ability = 1 }, // Regirock
+            new(SWSH) { Species = 378, Level = 70, Location = 238, ScriptedNoMarks = true, Moves = new[] {058,192,133,196}, FlawlessIVCount = 3, Ability = 1 }, // Regice
+            new(SWSH) { Species = 379, Level = 70, Location = 240, ScriptedNoMarks = true, Moves = new[] {484,430,334,451}, FlawlessIVCount = 3, Ability = 1 }, // Registeel
+            new(SWSH) { Species = 894, Level = 70, Location = 242, ScriptedNoMarks = true, Moves = new[] {819,527,245,393}, FlawlessIVCount = 3, Ability = 1 }, // Regieleki
+            new(SWSH) { Species = 895, Level = 70, Location = 242, ScriptedNoMarks = true, Moves = new[] {820,337,359,673}, FlawlessIVCount = 3, Ability = 1 }, // Regidrago
+            new(SWSH) { Species = 486, Level =100, Location = 210, ScriptedNoMarks = true, Moves = new[] {416,428,359,462}, FlawlessIVCount = 3, Ability = 1, DynamaxLevel = 10 }, // Regigigas in the Giant’s Bed
+            new(SWSH) { Species = 638, Level = 70, Location = 226, FlawlessIVCount = 3, Ability = 1, Weather = All_CT }, // Cobalion at the Frigid Sea
+            new(SWSH) { Species = 639, Level = 70, Location = 232, FlawlessIVCount = 3, Ability = 1, Weather = Overcast }, // Terrakion in Lakeside Cavern
+            new(SWSH) { Species = 640, Level = 70, Location = 210, FlawlessIVCount = 3, Ability = 1, Weather = All_CT }, // Virizion at Giant's Bed
+            new(SWSH) { Species = 647, Level = 65, Location = 230, Moves = new[] {548,533,014,056}, FlawlessIVCount = 3, Shiny = Never, Ability = 1, Form = 01, Fateful = true, Weather = All_CT }, // Keldeo-1 at Ballimere Lake
             // new(SWSH) { Species = 896, Level = 75, Location = -01, Moves = new[] {556,037,419,023}, FlawlessIVCount = 3, Shiny = Never, Ability = 1 }, // Glastrier
             // new(SWSH) { Species = 897, Level = 75, Location = -01, Moves = new[] {247,037,506,024}, FlawlessIVCount = 3, Shiny = Never, Ability = 1 }, // Spectrier
             new(SWSH) { Species = 898, Level = 80, Location = 220, Moves = new[] {202,094,473,505}, FlawlessIVCount = 3, Shiny = Never, Ability = 1, ScriptedNoMarks = true }, // Calyrex
@@ -580,157 +608,176 @@ namespace PKHeX.Core
             // new(SWSH) { Species = 789, Level = 60, Location = -01, FlawlessIVCount = 3, Shiny = Never, Ability = 1 }, // Cosmog
             // new(SWSH) { Species = 494, Level = 70, Location = -01, FlawlessIVCount = 3, Shiny = Never, Ability = 1 }, // Victini
 
-            new(SWSH) { Species = 473, Level = 65, Location = 204 }, // Mamoswine on Slippery Slope (in the Crown Tundra)
-            new EncounterStatic8S(SWSH) { Species = 698, Level = 60, Locations = new[] {204, 208}, }, // Amaura on Slippery Slope, in Frostpoint Field (in the Crown Tundra)
-            new EncounterStatic8S(SWSH) { Species = 858, Level = 65, Locations = new[] {208, 210}, }, // Hatterene in Frostpoint Field, in the Giant’s Bed (in the Crown Tundra)
-            new(SWSH) { Species = 461, Level = 63, Location = 208 }, // Weavile in Frostpoint Field (in the Crown Tundra)
-            new EncounterStatic8S(SWSH) { Species = 832, Level = 63, Locations = new[] {204, 208, 210}, }, // Dubwool on Slippery Slope, in Frostpoint Field, in the Giant’s Bed (in the Crown Tundra)
-            new EncounterStatic8S(SWSH) { Species = 333, Level = 60, Locations = new[] {204, 208, 210}, }, // Swablu on Slippery Slope, in Frostpoint Field, in the Giant’s Bed (in the Crown Tundra)
-            new EncounterStatic8S(SWSH) { Species = 124, Level = 62, Locations = new[] {204, 208}, }, // Jynx on Slippery Slope, in Frostpoint Field (in the Crown Tundra)
-            new EncounterStatic8S(SWSH) { Species = 615, Level = 62, Locations = new[] {204, 208, 210}, }, // Cryogonal on Slippery Slope, in Frostpoint Field, in the Giant’s Bed (in the Crown Tundra)
-            new EncounterStatic8S(SWSH) { Species = 778, Level = 62, Locations = new[] {204, 208, 210, 212}, }, // Mimikyu on Slippery Slope, in Frostpoint Field, in the Giant’s Bed, in the Old Cemetery (in the Crown Tundra)
-            new EncounterStatic8S(SWSH) { Species = 460, Level = 65, Locations = new[] {204, 208}, }, // Abomasnow on Slippery Slope, in Frostpoint Field (in the Crown Tundra)
-            new(SWSH) { Species = 872, Level = 60, Location = 204 }, // Snom on Slippery Slope (in the Crown Tundra)
-            new EncounterStatic8S(SW  ) { Species = 576, Level = 65, Locations = new[] {204, 208}, }, // Gothitelle on Slippery Slope, in Frostpoint Field (in the Crown Tundra)
-            new EncounterStatic8S(SWSH) { Species = 133, Level = 60, Locations = new[] {208, 210}, }, // Eevee in Frostpoint Field, in the Giant’s Bed (in the Crown Tundra)
-            new EncounterStatic8S(  SH) { Species = 579, Level = 65, Locations = new[] {204, 208}, }, // Reuniclus on Slippery Slope, in Frostpoint Field (in the Crown Tundra)
-            new(SWSH) { Species = 857, Level = 62, Location = 204 }, // Hattrem on Slippery Slope (in the Crown Tundra)
-            new EncounterStatic8S(SWSH) { Species = 584, Level = 65, Locations = new[] {208, 210}, }, // Vanilluxe in Frostpoint Field, in the Giant’s Bed (in the Crown Tundra)
-            new EncounterStatic8S(SWSH) { Species = 126, Level = 62, Locations = new[] {204, 210}, }, // Magmar on Slippery Slope, in the Giant’s Bed (in the Crown Tundra)
-            new EncounterStatic8S(SWSH) { Species = 143, Level = 65, Locations = new[] {204, 208}, }, // Snorlax on Slippery Slope, in Frostpoint Field (in the Crown Tundra)
-            new EncounterStatic8S(SWSH) { Species = 861, Level = 65, Locations = new[] {204, 210}, }, // Grimmsnarl on Slippery Slope, in the Giant’s Bed (in the Crown Tundra)
-            new(SWSH) { Species = 709, Level = 63, Location = 212 }, // Trevenant in the Old Cemetery (in the Crown Tundra)
-            new EncounterStatic8S(SWSH) { Species = 437, Level = 63, Locations = new[] {210, 214} }, // Bronzong in the Giant’s Bed, on Snowslide Slope (in the Crown Tundra)
-            new(SWSH) { Species = 470, Level = 63, Location = 210 }, // Leafeon in the Giant’s Bed (in the Crown Tundra)
-            new EncounterStatic8S(SWSH) { Species = 034, Level = 65, Locations = new[] {208, 210}, }, // Nidoking in Frostpoint Field, in the Giant’s Bed (in the Crown Tundra)
-            new EncounterStatic8S(SWSH) { Species = 030, Level = 63, Locations = new[] {208, 210}, }, // Nidorina in Frostpoint Field, in the Giant’s Bed (in the Crown Tundra)
-            new(SWSH) { Species = 033, Level = 63, Location = 210 }, // Nidorino in the Giant’s Bed (in the Crown Tundra)
-            new(SWSH) { Species = 534, Level = 65, Location = 210 }, // Conkeldurr in the Giant’s Bed (in the Crown Tundra)
-            new(SWSH) { Species = 874, Level = 63, Location = 210 }, // Stonjourner in the Giant’s Bed (in the Crown Tundra)
-            new(SWSH) { Species = 820, Level = 65, Location = 210 }, // Greedent in the Giant’s Bed (in the Crown Tundra)
-            new(SWSH) { Species = 031, Level = 65, Location = 210 }, // Nidoqueen in the Giant’s Bed (in the Crown Tundra)
-            new(SWSH) { Species = 862, Level = 65, Location = 210 }, // Obstagoon in the Giant’s Bed (in the Crown Tundra)
-            new(SWSH) { Species = 609, Level = 65, Location = 210 }, // Chandelure in the Giant’s Bed (in the Crown Tundra)
-            new(SWSH) { Species = 752, Level = 65, Location = 210 }, // Araquanid in the Giant’s Bed (in the Crown Tundra)
-            new EncounterStatic8S(SWSH) { Species = 334, Level = 65, Locations = new[] {210, 222, 226, 230}, }, // Altaria in the Giant’s Bed, at the Giant’s Foot, at the Frigid Sea, at Ballimere Lake (in the Crown Tundra)
-            new(SWSH) { Species = 134, Level = 63, Location = 210 }, // Vaporeon in the Giant’s Bed (in the Crown Tundra)
-            new(SWSH) { Species = 596, Level = 63, Location = 210 }, // Galvantula in the Giant’s Bed (in the Crown Tundra)
-            new(SWSH) { Species = 466, Level = 65, Location = 210 }, // Electivire in the Giant’s Bed (in the Crown Tundra)
-            new(SWSH) { Species = 135, Level = 63, Location = 210 }, // Jolteon in the Giant’s Bed (in the Crown Tundra)
-            new(SWSH) { Species = 125, Level = 63, Location = 210 }, // Electabuzz in the Giant’s Bed (in the Crown Tundra)
-            new(SWSH) { Species = 467, Level = 63, Location = 210 }, // Magmortar in the Giant’s Bed (in the Crown Tundra)
-            new(SWSH) { Species = 631, Level = 63, Location = 210 }, // Heatmor in the Giant’s Bed (in the Crown Tundra)
-            new(SWSH) { Species = 632, Level = 63, Location = 210 }, // Durant in the Giant’s Bed (in the Crown Tundra)
-            new(SWSH) { Species = 136, Level = 63, Location = 210 }, // Flareon in the Giant’s Bed (in the Crown Tundra)
-            new(SWSH) { Species = 197, Level = 63, Location = 210 }, // Umbreon in the Giant’s Bed (in the Crown Tundra)
-            new(SWSH) { Species = 196, Level = 63, Location = 210 }, // Espeon in the Giant’s Bed (in the Crown Tundra)
-            new EncounterStatic8S(SWSH) { Species = 478, Level = 65, Locations = new[] {210, 212, 216}, }, // Froslass in the Giant’s Bed, in the Old Cemetery, in the Tunnel to the Top (in the Crown Tundra)
-            new EncounterStatic8S(SWSH) { Species = 362, Level = 65, Locations = new[] {210, 214}, }, // Glalie in the Giant’s Bed (in the Crown Tundra), on Snowslide Slope (in the Crown Tundra)
-            new(SWSH) { Species = 359, Level = 65, Location = 210 }, // Absol in the Giant’s Bed (in the Crown Tundra)
-            new(SWSH) { Species = 471, Level = 63, Location = 210 }, // Glaceon in the Giant’s Bed (in the Crown Tundra)
-            new(SWSH) { Species = 700, Level = 63, Location = 210 }, // Sylveon in the Giant’s Bed (in the Crown Tundra)
-            new(SWSH) { Species = 036, Level = 63, Location = 210 }, // Clefable in the Giant’s Bed (in the Crown Tundra)
-            new EncounterStatic8S(SWSH) { Species = 855, Level = 63, Locations = new[] {210, 212}, }, // Polteageist in the Giant’s Bed, in the Old Cemetery (in the Crown Tundra)
-            new EncounterStatic8S(SWSH) { Species = 887, Level = 65, Locations = new[] {210, 212 }, }, // Dragapult in the Giant’s Bed (in the Crown Tundra), in the Old Cemetery (in the Crown Tundra)
-            new(SWSH) { Species = 872, Level = 62, Location = 214 }, // Snom on Snowslide Slope (in the Crown Tundra)
-            new(SWSH) { Species = 698, Level = 62, Location = 214 }, // Amaura on Snowslide Slope (in the Crown Tundra)
-            new EncounterStatic8S(SWSH) { Species = 621, Level = 65, Locations = new[] {214, 216, 218}, }, // Druddigon on Snowslide Slope, in the Tunnel to the Top, on the Path to the Peak (in the Crown Tundra)
-            new(SWSH) { Species = 832, Level = 65, Location = 214 }, // Dubwool on Snowslide Slope (in the Crown Tundra)
-            new EncounterStatic8S(SWSH) { Species = 375, Level = 63, Locations = new[] {214, 216 } }, // Metang on Snowslide Slope, in the Tunnel to the Top (in the Crown Tundra)
-            new(SWSH) { Species = 699, Level = 65, Location = 214 }, // Aurorus on Snowslide Slope (in the Crown Tundra)
-            new(SWSH) { Species = 376, Level = 68, Location = 214 }, // Metagross on Snowslide Slope (in the Crown Tundra)
-            new(SWSH) { Species = 461, Level = 65, Location = 214 }, // Weavile on Snowslide Slope (in the Crown Tundra)
-            new(SWSH) { Species = 709, Level = 65, Location = 214 }, // Trevenant on Snowslide Slope (in the Crown Tundra)
-            new EncounterStatic8S(SWSH) { Species = 126, Level = 65, Locations = new[] {214, 230}, }, // Magmar on Snowslide Slope, at Ballimere Lake (in the Crown Tundra)
-            new(SWSH) { Species = 467, Level = 67, Location = 214 }, // Magmortar on Snowslide Slope (in the Crown Tundra)
-            new(SWSH) { Species = 362, Level = 67, Location = 214 }, // Glalie on Snowslide Slope (in the Crown Tundra)
-            new EncounterStatic8S(SWSH) { Species = 615, Level = 65, Locations = new[] {214, 222, 230}, }, // Cryogonal on Snowslide Slope, at the Giant’s Foot, at Ballimere Lake (in the Crown Tundra)
-            new EncounterStatic8S(SWSH) { Species = 614, Level = 67, Locations = new[] {214, 226, 228}, }, // Beartic on Snowslide Slope, at the Frigid Sea, in Three-Point Pass (in the Crown Tundra)
-            new EncounterStatic8S(SWSH) { Species = 584, Level = 67, Locations = new[] {214, 230}, }, // Vanilluxe on Snowslide Slope, at Ballimere Lake (in the Crown Tundra)
-            new EncounterStatic8S(SWSH) { Species = 478, Level = 65, Locations = new[] {214, 216}, }, // Froslass on Snowslide Slope, in the Tunnel to the Top (in the Crown Tundra)
-            new EncounterStatic8S(SWSH) { Species = 359, Level = 67, Locations = new[] {214, 218, 222}, }, // Absol on Snowslide Slope, on the Path to the Peak, at the Giant’s Foot (in the Crown Tundra)
-            new(SW  ) { Species = 555, Level = 67, Location = 214, Form = 02 }, // Darmanitan-2 on Snowslide Slope (in the Crown Tundra)
-            new(SWSH) { Species = 861, Level = 67, Location = 214 }, // Grimmsnarl on Snowslide Slope (in the Crown Tundra)
-            new EncounterStatic8S(SWSH) { Species = 778, Level = 65, Locations = new[] {214, 222, 230}, }, // Mimikyu on Snowslide Slope, at the Giant’s Foot, at Ballimere Lake (in the Crown Tundra)
-            new EncounterStatic8S(SWSH) { Species = 036, Level = 65, Locations = new[] {214, 216}, }, // Clefable on Snowslide Slope, in the Tunnel to the Top (in the Crown Tundra)
-            new EncounterStatic8S(SWSH) { Species = 041, Level = 63, Locations = new[] {216, 224}, }, // Zubat in the Tunnel to the Top, in Roaring-Sea Caves (in the Crown Tundra)
-            new EncounterStatic8S(SWSH) { Species = 042, Level = 65, Locations = new[] {216, 224}, }, // Golbat in the Tunnel to the Top, in Roaring-Sea Caves (in the Crown Tundra)
-            new(SW  ) { Species = 371, Level = 65, Location = 216 }, // Bagon in the Tunnel to the Top (in the Crown Tundra)
-            new(  SH) { Species = 443, Level = 65, Location = 216 }, // Gible in the Tunnel to the Top (in the Crown Tundra)
-            new EncounterStatic8S(SW  ) { Species = 373, Level = 68, Locations = new[] {216, 218} }, // Salamence in the Tunnel to the Top, on the Path to the Peak (in the Crown Tundra)
-            new EncounterStatic8S(  SH) { Species = 445, Level = 68, Locations = new[] {216, 218} }, // Garchomp in the Tunnel to the Top, on the Path to the Peak (in the Crown Tundra)
-            new(SWSH) { Species = 703, Level = 65, Location = 216 }, // Carbink in the Tunnel to the Top (in the Crown Tundra)
-            new(SWSH) { Species = 873, Level = 65, Location = 218 }, // Frosmoth on the Path to the Peak (in the Crown Tundra)
-            new EncounterStatic8S(SWSH) { Species = 334, Level = 65, Locations = new[] {218, 222}, }, // Altaria on the Path to the Peak, at the Giant’s Foot (in the Crown Tundra)
-            new(SWSH) { Species = 851, Level = 67, Location = 222 }, // Centiskorch at the Giant’s Foot (in the Crown Tundra)
-            new(SWSH) { Species = 879, Level = 67, Location = 222 }, // Copperajah at the Giant’s Foot (in the Crown Tundra)
-            new(SWSH) { Species = 534, Level = 67, Location = 222 }, // Conkeldurr at the Giant’s Foot (in the Crown Tundra)
-            new(SWSH) { Species = 566, Level = 63, Location = 222 }, // Archen at the Giant’s Foot (in the Crown Tundra)
-            new EncounterStatic8S(SWSH) { Species = 344, Level = 65, Locations = new[] {210, 222 } }, // Claydol in the Giant’s Bed, at the Giant’s Foot (in the Crown Tundra)
-            new EncounterStatic8S(SWSH) { Species = 437, Level = 65, Locations = new[] {208, 222 } }, // Bronzong at the Giant’s Foot, in Frostpoint Field (in the Crown Tundra)
-            new EncounterStatic8S(SWSH) { Species = 752, Level = 67, Locations = new[] {222, 230}, }, // Araquanid at Ballimere Lake, at the Giant’s Foot (in the Crown Tundra)
-            new EncounterStatic8S(SWSH) { Species = 125, Level = 65, Locations = new[] {222, 230}, }, // Electabuzz at the Giant’s Foot, at Ballimere Lake (in the Crown Tundra)
-            new EncounterStatic8S(SWSH) { Species = 466, Level = 68, Locations = new[] {226, 228, 230}, }, // Electivire at the Frigid Sea, in Three-Point Pass, at Ballimere Lake (in the Crown Tundra)
-            new(SWSH) { Species = 126, Level = 65, Location = 222 }, // Magmar at the Giant’s Foot (in the Crown Tundra)
-            new EncounterStatic8S(SWSH) { Species = 467, Level = 68, Locations = new[] {226, 230}, }, // Magmortar at the Frigid Sea, at Ballimere Lake (in the Crown Tundra)
+            new(SWSH) { Species = 473, Level = 65, Location = 204, Weather = Normal | Overcast | Intense_Sun | Icy }, // Mamoswine on Slippery Slope
+            new(SWSH) { Species = 698, Level = 60, Location = 204, Weather = Normal | Overcast | Icy }, // Amaura on Slippery Slope
+            new(SWSH) { Species = 698, Level = 60, Location = 208, Weather = Normal | Icy }, // Amaura in Frostpoint Field
+            new EncounterStatic8S(SWSH) { Species = 832, Level = 63, Locations = new[] {204, 208}, Weather = Normal | Intense_Sun }, // Dubwool on Slippery Slope, Frostpoint Field
+            new(SWSH) { Species = 832, Level = 63, Location = 210 }, // Dubwool in the Giant’s Bed
+            new(SWSH) { Species = 333, Level = 60, Location = 204, Weather = Overcast | Snowing }, // Swablu on Slippery Slope
+            new EncounterStatic8S(SWSH) { Species = 333, Level = 60, Locations = new[] {208, 210}, Weather = Overcast }, // Swablu in Frostpoint Field, Giant’s Bed
+            new(SWSH) { Species = 124, Level = 62, Location = 204, Weather = Icy | Heavy_Fog }, // Jynx on Slippery Slope
+            new(SWSH) { Species = 124, Level = 62, Location = 208, Weather = Snowing | Heavy_Fog }, // Jynx in Frostpoint Field
+            new EncounterStatic8S(SWSH) { Species = 615, Level = 62, Locations = new[] {204, 208, 210}, Weather = Icy }, // Cryogonal on Slippery Slope, Frostpoint Field, Giant’s Bed
+            new EncounterStatic8S(SWSH) { Species = 778, Level = 62, Locations = new[] {204, 208, 210, 212}, Weather = Heavy_Fog }, // Mimikyu on Slippery Slope, Frostpoint Field, Giant’s Bed, Old Cemetery
+            new(SWSH) { Species = 460, Level = 65, Location = 204, Weather = Snowing }, // Abomasnow on Slippery Slope
+            new(SWSH) { Species = 460, Level = 65, Location = 208, Weather = Normal | Overcast | Intense_Sun | Snowing }, // Abomasnow in Frostpoint Field
+            new EncounterStatic8S(SWSH) { Species = 584, Level = 65, Locations = new[] {208, 210}, Weather = Icy }, // Vanilluxe in Frostpoint Field, Giant’s Bed
+            new(SWSH) { Species = 872, Level = 60, Location = 204, Weather = Normal | Heavy_Fog }, // Snom on Slippery Slope
+            new EncounterStatic8S(SW  ) { Species = 576, Level = 65, Locations = new[] {204, 208}, Weather = Heavy_Fog }, // Gothitelle on Slippery Slope, Frostpoint Field
+            new(SWSH) { Species = 133, Level = 60, Location = 208, Weather = Snowstorm }, // Eevee in Frostpoint Field
+            new(SWSH) { Species = 029, Level = 60, Location = 208, Weather = Normal | Overcast | Intense_Sun | Icy }, // Nidoran♀ in Frostpoint Field
+            new(SWSH) { Species = 029, Level = 60, Location = 210, Weather = Normal | Stormy | Intense_Sun }, // Nidoran♀ in the Giant’s Bed
+            new(SWSH) { Species = 032, Level = 60, Location = 208, Weather = Normal | Overcast | Intense_Sun | Icy }, // Nidoran♂ in Frostpoint Field
+            new EncounterStatic8S(SWSH) { Species = 531, Level = 62, Locations = new[] {204, 208}, Weather = Normal | Overcast | Intense_Sun | Icy | Heavy_Fog }, // Audino on Slippery Slope, Frostpoint Field
+            new EncounterStatic8S(SWSH) { Species = 531, Level = 62, Locations = new[] {210, 222, 230}, Weather = All_CT }, // Audino in the Giant’s Bed, Giant’s Foot
+            new(SWSH) { Species = 531, Level = 62, Location = 230, Weather = Normal | Overcast | Stormy | Intense_Sun | Snowing }, // Audino at Ballimere Lake
+            new(SWSH) { Species = 359, Level = 62, Location = 208, Weather = Snowstorm }, // Absol in Frostpoint Field
+            new EncounterStatic8S(SWSH) { Species = 858, Level = 65, Locations = new[] {208, 210}, Weather = Heavy_Fog }, // Hatterene in Frostpoint Field, Giant’s Bed
+            new(SWSH) { Species = 461, Level = 63, Location = 208, Weather = Overcast }, // Weavile in Frostpoint Field
+            new EncounterStatic8S(  SH) { Species = 579, Level = 65, Locations = new[] {204, 208}, Weather = Heavy_Fog }, // Reuniclus on Slippery Slope, Frostpoint Field
+            new(SWSH) { Species = 857, Level = 62, Location = 204, Weather = Heavy_Fog }, // Hattrem on Slippery Slope
+            new(SWSH) { Species = 478, Level = 63, Location = 204, Weather = Snowstorm }, // Froslass on Slippery Slope
+            new(SWSH) { Species = 362, Level = 63, Location = 204, Weather = Snowstorm }, // Glalie on Slippery Slope
+            new(SWSH) { Species = 467, Level = 65, Location = 204, Weather = Intense_Sun }, // Magmortar on Slippery Slope
+            new EncounterStatic8S(SWSH) { Species = 126, Level = 62, Locations = new[] {204, 210}, Weather = Intense_Sun }, // Magmar on Slippery Slope, Giant’s Bed
+            new(SWSH) { Species = 143, Level = 65, Location = 204, Weather = Normal | Intense_Sun }, // Snorlax on Slippery Slope
+            new(SWSH) { Species = 143, Level = 65, Location = 208, Weather = Normal | Intense_Sun | Overcast }, // Snorlax in Frostpoint Field
+            new(  SH) { Species = 143, Level = 65, Location = 210, Weather = All_CT }, // Snorlax in the Giant’s Bed
+            new EncounterStatic8S(SWSH) { Species = 861, Level = 65, Locations = new[] {204, 210}, Weather = Heavy_Fog }, // Grimmsnarl on Slippery Slope, Giant’s Bed
+            new(SWSH) { Species = 709, Level = 63, Location = 212, Weather = Overcast }, // Trevenant in the Old Cemetery
+            new(  SH) { Species = 078, Level = 67, Location = 212, Form = 01, Weather = Heavy_Fog }, // Rapidash-1 in the Old Cemetery
+            new(SWSH) { Species = 142, Level = 65, Location = 210, Weather = All_CT }, // Aerodactyl in the Giant’s Bed
+            new(SWSH) { Species = 133, Level = 60, Location = 210 }, // Eevee in the Giant’s Bed
+            new EncounterStatic8S(SWSH) { Species = 437, Level = 63, Locations = new[] {210, 214}, Weather = All_CT }, // Bronzong in the Giant’s Bed, Snowslide Slope
+            new(SWSH) { Species = 470, Level = 63, Location = 210 }, // Leafeon in the Giant’s Bed
+            new EncounterStatic8S(SWSH) { Species = 034, Level = 65, Locations = new[] {208, 210}, Weather = No_Sun_Sand }, // Nidoking in Frostpoint Field, Giant’s Bed
+            new EncounterStatic8S(SWSH) { Species = 030, Level = 63, Locations = new[] {208, 210}, Weather = All_CT }, // Nidorina in Frostpoint Field, in the Giant’s Bed
+            new(SWSH) { Species = 033, Level = 63, Location = 210, Weather = All_CT }, // Nidorino in the Giant’s Bed
+            new(SWSH) { Species = 534, Level = 65, Location = 210 }, // Conkeldurr in the Giant’s Bed
+            new(SW  ) { Species = 874, Level = 63, Location = 210, Weather = All_CT }, // Stonjourner in the Giant’s Bed
+            new(SWSH) { Species = 820, Level = 65, Location = 210, Weather = No_Sun_Sand }, // Greedent in the Giant’s Bed
+            new(SWSH) { Species = 031, Level = 65, Location = 210, Weather = Normal | Overcast | Raining | Intense_Sun | Icy | Heavy_Fog }, // Nidoqueen in the Giant’s Bed
+            new(SWSH) { Species = 862, Level = 65, Location = 210, Weather = Overcast | Raining }, // Obstagoon in the Giant’s Bed
+            new(SWSH) { Species = 609, Level = 65, Location = 210, Weather = Overcast | Heavy_Fog }, // Chandelure in the Giant’s Bed
+            new(SWSH) { Species = 752, Level = 65, Location = 210, Weather = Stormy }, // Araquanid in the Giant’s Bed
+            new EncounterStatic8S(SWSH) { Species = 334, Level = 65, Locations = new[] {210, 218, 222, 226, 230}, Weather = Overcast }, // Altaria in the Giant’s Bed, Path to the Peak, Giant’s Foot, Frigid Sea, Ballimere Lake
+            new(SWSH) { Species = 134, Level = 63, Location = 210, Weather = Raining }, // Vaporeon in the Giant’s Bed
+            new(SWSH) { Species = 596, Level = 63, Location = 210, Weather = Thunderstorm }, // Galvantula in the Giant’s Bed
+            new(SWSH) { Species = 466, Level = 65, Location = 210, Weather = Thunderstorm }, // Electivire in the Giant’s Bed
+            new(SWSH) { Species = 135, Level = 63, Location = 210, Weather = Thunderstorm }, // Jolteon in the Giant’s Bed
+            new(SWSH) { Species = 125, Level = 63, Location = 210, Weather = Thunderstorm }, // Electabuzz in the Giant’s Bed
+            new(SWSH) { Species = 467, Level = 63, Location = 210, Weather = Intense_Sun }, // Magmortar in the Giant’s Bed
+            new(SWSH) { Species = 631, Level = 63, Location = 210, Weather = Intense_Sun }, // Heatmor in the Giant’s Bed
+            new(SWSH) { Species = 632, Level = 63, Location = 210, Weather = Intense_Sun }, // Durant in the Giant’s Bed
+            new(SWSH) { Species = 136, Level = 63, Location = 210, Weather = Intense_Sun }, // Flareon in the Giant’s Bed
+            new(SWSH) { Species = 197, Level = 63, Location = 210, Weather = Overcast }, // Umbreon in the Giant’s Bed
+            new(SWSH) { Species = 196, Level = 63, Location = 210, Weather = Snowing }, // Espeon in the Giant’s Bed
+            new EncounterStatic8S(SWSH) { Species = 478, Level = 65, Locations = new[] {210, 212, 214}, Weather = Icy }, // Froslass in the Giant’s Bed, Old Cemetery, Snowslide Slope
+            new(SWSH) { Species = 478, Level = 65, Location = 216, Weather = Overcast }, // Froslass in the Tunnel to the Top
+            new EncounterStatic8S(SWSH) { Species = 362, Level = 65, Locations = new[] {210, 214}, Weather = Icy }, // Glalie in the Giant’s Bed, Snowslide Slope
+            new(SWSH) { Species = 359, Level = 65, Location = 210, Weather = Snowstorm }, // Absol in the Giant’s Bed
+            new(SWSH) { Species = 471, Level = 63, Location = 210, Weather = Snowstorm }, // Glaceon in the Giant’s Bed
+            new(SWSH) { Species = 700, Level = 63, Location = 210, Weather = Heavy_Fog }, // Sylveon in the Giant’s Bed
+            new(SWSH) { Species = 036, Level = 63, Location = 210, Weather = Heavy_Fog }, // Clefable in the Giant’s Bed
+            new(SWSH) { Species = 340, Level = 65, Location = 210, Weather = All_CT }, // Whiscash in the Giant’s Bed
+            new(SWSH) { Species = 130, Level = 67, Location = 210, Weather = Normal | Overcast | Stormy | Intense_Sun | Icy }, // Gyarados in the Giant’s Bed
+            new(SWSH) { Species = 350, Level = 67, Location = 210, Weather = Heavy_Fog }, // Milotic in the Giant’s Bed
+            new EncounterStatic8S(SWSH) { Species = 855, Level = 63, Locations = new[] {210, 212}, Weather = Normal | Stormy | Intense_Sun | Snowstorm  | Heavy_Fog }, // Polteageist in the Giant’s Bed, Old Cemetery
+            new EncounterStatic8S(SWSH) { Species = 887, Level = 65, Locations = new[] {210, 212}, Weather = Normal | Overcast | Stormy | Intense_Sun | Snowing }, // Dragapult in the Giant’s Bed, Old Cemetery
+            new(SWSH) { Species = 872, Level = 62, Location = 214, Weather = Normal | Overcast }, // Snom on Snowslide Slope
+            new(SWSH) { Species = 698, Level = 62, Location = 214, Weather = Normal | Overcast | Heavy_Fog }, // Amaura on Snowslide Slope
+            new(SWSH) { Species = 621, Level = 65, Location = 214, Weather = Normal | Intense_Sun }, // Druddigon on Snowslide Slope
+            new(SWSH) { Species = 621, Level = 65, Location = 218 }, // Druddigon on the Path to the Peak
+            new(SWSH) { Species = 621, Level = 65, Location = 216, Weather = Overcast }, // Druddigon in the Tunnel to the Top
+            new(SWSH) { Species = 832, Level = 65, Location = 214, Weather = Normal | Intense_Sun }, // Dubwool on Snowslide Slope
+            new EncounterStatic8S(SWSH) { Species = 375, Level = 63, Locations = new[] {214, 216 }, Weather = Normal | Overcast | Intense_Sun | Icy | Heavy_Fog }, // Metang on Snowslide Slope, Tunnel to the Top
+            new(SWSH) { Species = 699, Level = 65, Location = 214, Weather = Normal | Overcast | Icy | Heavy_Fog }, // Aurorus on Snowslide Slope
+            new(SWSH) { Species = 376, Level = 68, Location = 214, Weather = Normal | Overcast | Intense_Sun | Icy | Heavy_Fog }, // Metagross on Snowslide Slope
+            new(SWSH) { Species = 461, Level = 65, Location = 214, Weather = Overcast }, // Weavile on Snowslide Slope
+            new(SWSH) { Species = 709, Level = 65, Location = 214, Weather = Overcast }, // Trevenant on Snowslide Slope
+            new EncounterStatic8S(SWSH) { Species = 126, Level = 65, Locations = new[] {214, 230}, Weather = Intense_Sun }, // Magmar on Snowslide Slope, Ballimere Lake
+            new(SWSH) { Species = 467, Level = 67, Location = 214, Weather = Intense_Sun }, // Magmortar on Snowslide Slope
+            new(SWSH) { Species = 362, Level = 67, Location = 214, Weather = Icy }, // Glalie on Snowslide Slope
+            new EncounterStatic8S(SWSH) { Species = 615, Level = 65, Locations = new[] {214, 222, 230}, Weather = Icy }, // Cryogonal on Snowslide Slope, Giant’s Foot, Ballimere Lake
+            new EncounterStatic8S(SWSH) { Species = 614, Level = 67, Locations = new[] {214, 226, 228}, Weather = Icy }, // Beartic on Snowslide Slope, Frigid Sea, Three-Point Pass
+            new(SWSH) { Species = 584, Level = 67, Location = 214, Weather = Icy }, // Vanilluxe on Snowslide Slope
+            new(SWSH) { Species = 584, Level = 67, Location = 230, Weather = Snowing }, // Vanilluxe at Ballimere Lake
+            new EncounterStatic8S(SWSH) { Species = 359, Level = 67, Locations = new[] {214, 218, 222}, Weather = Snowstorm }, // Absol on Snowslide Slope, Path to the Peak, Giant’s Foot
+            new(SW  ) { Species = 555, Level = 67, Location = 214, Form = 02, Weather = Snowstorm }, // Darmanitan-2 on Snowslide Slope
+            new(SWSH) { Species = 861, Level = 67, Location = 214, Weather = Heavy_Fog }, // Grimmsnarl on Snowslide Slope
+            new EncounterStatic8S(SWSH) { Species = 778, Level = 65, Locations = new[] {214, 222, 230}, Weather = Heavy_Fog }, // Mimikyu on Snowslide Slope, Giant’s Foot, Ballimere Lake
+            new(SWSH) { Species = 036, Level = 65, Location = 214, Weather = Heavy_Fog }, // Clefable on Snowslide Slope
+            new(SWSH) { Species = 036, Level = 65, Location = 216, Weather = Overcast }, // Clefable in the Tunnel to the Top
+            new EncounterStatic8S(SWSH) { Species = 041, Level = 63, Locations = new[] {216, 224}, Weather = Overcast }, // Zubat in the Tunnel to the Top, Roaring-Sea Caves
+            new EncounterStatic8S(SWSH) { Species = 042, Level = 65, Locations = new[] {216, 224}, Weather = Overcast }, // Golbat in the Tunnel to the Top, Roaring-Sea Caves
+            new(SW  ) { Species = 371, Level = 65, Location = 216, Weather = Overcast }, // Bagon in the Tunnel to the Top
+            new(  SH) { Species = 443, Level = 65, Location = 216, Weather = Overcast }, // Gible in the Tunnel to the Top
+            new(SW  ) { Species = 373, Level = 68, Location = 216, Weather = Overcast }, // Salamence in the Tunnel to the Top
+            new(SW  ) { Species = 373, Level = 68, Location = 218, Weather = Intense_Sun }, // Salamence on the Path to the Peak
+            new(  SH) { Species = 445, Level = 68, Location = 216, Weather = Overcast }, // Garchomp in the Tunnel to the Top
+            new(  SH) { Species = 445, Level = 68, Location = 218, Weather = Intense_Sun }, // Garchomp on the Path to the Peak
+            new(SWSH) { Species = 703, Level = 65, Location = 216, Weather = Overcast }, // Carbink in the Tunnel to the Top
+            new(SWSH) { Species = 873, Level = 65, Location = 218, Weather = Normal | Overcast | Intense_Sun | Icy | Heavy_Fog }, // Frosmoth on the Path to the Peak
+            new(SWSH) { Species = 851, Level = 67, Location = 222, Weather = Normal | Intense_Sun }, // Centiskorch at the Giant’s Foot
+            new(SWSH) { Species = 879, Level = 67, Location = 222, Weather = Overcast | Stormy | Icy | Heavy_Fog }, // Copperajah at the Giant’s Foot
+            new(SWSH) { Species = 534, Level = 67, Location = 222 }, // Conkeldurr at the Giant’s Foot
+            new(  SH) { Species = 140, Level = 63, Location = 222, Weather = All_CT }, // Kabuto at the Giant’s Foot
+            new(SW  ) { Species = 138, Level = 63, Location = 222, Weather = All_CT }, // Omanyte at the Giant’s Foot
+            new(SWSH) { Species = 566, Level = 63, Location = 222, Weather = All_CT }, // Archen at the Giant’s Foot
+            new EncounterStatic8S(SWSH) { Species = 344, Level = 65, Locations = new[] {210, 222}, Weather = Overcast | Stormy | Intense_Sun | Icy | Heavy_Fog }, // Claydol in the Giant’s Bed, Giant’s Foot
+            new EncounterStatic8S(SWSH) { Species = 437, Level = 65, Locations = new[] {208, 222}, Weather = Normal | Overcast }, // Bronzong at the Giant’s Foot, Frostpoint Field
+            new EncounterStatic8S(SWSH) { Species = 752, Level = 67, Locations = new[] {222, 230}, Weather = Raining }, // Araquanid at Ballimere Lake, Giant’s Foot
+            new EncounterStatic8S(SWSH) { Species = 125, Level = 65, Locations = new[] {222, 230}, Weather = Thunderstorm }, // Electabuzz at the Giant’s Foot, Ballimere Lake
+            new EncounterStatic8S(SWSH) { Species = 466, Level = 68, Locations = new[] {226, 228, 230}, Weather = Thunderstorm }, // Electivire at the Frigid Sea, Three-Point Pass, Ballimere Lake
+            new(SWSH) { Species = 126, Level = 65, Location = 222, Weather = Intense_Sun }, // Magmar at the Giant’s Foot
+            new EncounterStatic8S(SWSH) { Species = 467, Level = 68, Locations = new[] {226, 230}, Weather = Intense_Sun }, // Magmortar at the Frigid Sea, Ballimere Lake
             new(SWSH) { Species = 567, Level = 67, Location = -01 }, // Archeops
-            new(SW  ) { Species = 635, Level = 68, Location = 224 }, // Hydreigon in Roaring-Sea Caves (in the Crown Tundra)
-            new(  SH) { Species = 248, Level = 68, Location = 224 }, // Tyranitar in Roaring-Sea Caves (in the Crown Tundra)
-            new(SWSH) { Species = 448, Level = 67, Location = 224 }, // Lucario in Roaring-Sea Caves (in the Crown Tundra)
-            new(SWSH) { Species = 363, Level = 63, Location = 226 }, // Spheal at the Frigid Sea (in the Crown Tundra)
-            new(SWSH) { Species = 364, Level = 65, Location = 226 }, // Sealeo at the Frigid Sea (in the Crown Tundra)
-            new(SWSH) { Species = 564, Level = 63, Location = 226 }, // Tirtouga at the Frigid Sea (in the Crown Tundra)
-            new(SWSH) { Species = 713, Level = 65, Location = 226 }, // Avalugg at the Frigid Sea (in the Crown Tundra)
-            new EncounterStatic8S(SWSH) { Species = 858, Level = 67, Locations = new[] {226, 230}, }, // Hatterene at the Frigid Sea, at Ballimere Lake (in the Crown Tundra)
-            new(SWSH) { Species = 365, Level = 68, Location = 226 }, // Walrein at the Frigid Sea (in the Crown Tundra)
-            new(SWSH) { Species = 565, Level = 67, Location = 226 }, // Carracosta at the Frigid Sea (in the Crown Tundra)
-            new(SWSH) { Species = 871, Level = 65, Location = 226 }, // Pincurchin at the Frigid Sea (in the Crown Tundra)
-            new(  SH) { Species = 875, Level = 65, Location = 226 }, // Eiscue at the Frigid Sea (in the Crown Tundra)
-            new EncounterStatic8S(SWSH) { Species = 623, Level = 65, Locations = new[] {226, 228} }, // Golurk at the Frigid Sea, in Three-Point Pass (in the Crown Tundra)
-            new(SWSH) { Species = 887, Level = 68, Location = 228 }, // Dragapult in Three-Point Pass (in the Crown Tundra)
-            new(  SH) { Species = 141, Level = 68, Location = 224 }, // Kabutops in Roaring-Sea Caves (in the Crown Tundra)
-            new(SW  ) { Species = 139, Level = 68, Location = 224 }, // Omastar in Roaring-Sea Caves (in the Crown Tundra)
-            new(SWSH) { Species = 823, Level = 68, Location = 230 }, // Corviknight at Ballimere Lake (in the Crown Tundra)
-            new(SWSH) { Species = 862, Level = 68, Location = 230 }, // Obstagoon at Ballimere Lake (in the Crown Tundra)
-            new EncounterStatic8S(SWSH) { Species = 715, Level = 67, Locations = new[] {230, 232}, }, // Noivern at Ballimere Lake, in Lakeside Cave (in the Crown Tundra)
-            new(SWSH) { Species = 547, Level = 65, Location = 230 }, // Whimsicott at Ballimere Lake (in the Crown Tundra)
-            new(SWSH) { Species = 836, Level = 67, Location = 230 }, // Boltund at Ballimere Lake (in the Crown Tundra)
-            new(SWSH) { Species = 830, Level = 65, Location = 230 }, // Eldegoss at Ballimere Lake (in the Crown Tundra)
-            new(SW  ) { Species = 876, Level = 65, Location = 230 }, // Indeedee at Ballimere Lake (in the Crown Tundra)
-            new(  SH) { Species = 876, Level = 65, Location = 230, Form = 01 }, // Indeedee-1 at Ballimere Lake (in the Crown Tundra)
-            new(SWSH) { Species = 696, Level = 63, Location = 230 }, // Tyrunt at Ballimere Lake (in the Crown Tundra)
-            new(SWSH) { Species = 213, Level = 65, Location = 230 }, // Shuckle at Ballimere Lake (in the Crown Tundra)
-            new EncounterStatic8S(SWSH) { Species = 820, Level = 68, Locations = new[] {230, 234}, }, // Greedent at Ballimere Lake, at Dyna Tree Hill (in the Crown Tundra)
-            new(SWSH) { Species = 877, Level = 65, Location = 230 }, // Morpeko at Ballimere Lake (in the Crown Tundra)
-            new(SWSH) { Species = 596, Level = 67, Location = 230 }, // Galvantula at Ballimere Lake (in the Crown Tundra)
-            new EncounterStatic8S(SWSH) { Species = 839, Level = 68, Locations = new[] {230, 232}, }, // Coalossal at Ballimere Lake, in Lakeside Cave (in the Crown Tundra)
-            new(SWSH) { Species = 697, Level = 69, Location = 230 }, // Tyrantrum at Ballimere Lake (in the Crown Tundra)
-            new(SWSH) { Species = 531, Level = 65, Location = 230 }, // Audino at Ballimere Lake (in the Crown Tundra)
-            new(SWSH) { Species = 304, Level = 63, Location = 230 }, // Aron at Ballimere Lake (in the Crown Tundra)
-            new(SWSH) { Species = 149, Level = 70, Location = 230 }, // Dragonite at Ballimere Lake (in the Crown Tundra)
-            new(SWSH) { Species = 306, Level = 68, Location = 232 }, // Aggron in Lakeside Cave (in the Crown Tundra)
-            new(SWSH) { Species = 598, Level = 67, Location = 232 }, // Ferrothorn in Lakeside Cave (in the Crown Tundra)
-            new(SWSH) { Species = 305, Level = 63, Location = 232 }, // Lairon in Lakeside Cave (in the Crown Tundra)
-            new(SWSH) { Species = 348, Level = 67, Location = 230 }, // Armaldo at Ballimere Lake (in the Crown Tundra)
-            new(SWSH) { Species = 340, Level = 65, Location = 210 }, // Whiscash in the Giant’s Bed (in the Crown Tundra)
-            new EncounterStatic8S(SWSH) { Species = 130, Level = 67, Locations = new[] {210, 230 } }, // Gyarados in the Giant’s Bed, at Ballimere Lake (in the Crown Tundra)
-            new(SWSH) { Species = 350, Level = 67, Location = 210 }, // Milotic in the Giant’s Bed (in the Crown Tundra)
-            new(  SH) { Species = 140, Level = 63, Location = 222 }, // Kabuto at the Giant’s Foot (in the Crown Tundra)
-            new(SW  ) { Species = 138, Level = 63, Location = 222 }, // Omanyte at the Giant’s Foot (in the Crown Tundra)
-            new(SWSH) { Species = 347, Level = 63, Location = 230 }, // Anorith at Ballimere Lake (in the Crown Tundra)
-            new(SWSH) { Species = 369, Level = 65, Location = 230 }, // Relicanth at Ballimere Lake (in the Crown Tundra)
-            new(SWSH) { Species = 147, Level = 63, Location = 230 }, // Dratini at Ballimere Lake (in the Crown Tundra)
-            new(SWSH) { Species = 148, Level = 65, Location = 230 }, // Dragonair at Ballimere Lake (in the Crown Tundra)
-            new(  SH) { Species = 078, Level = 67, Location = 212, Form = 01 }, // Rapidash-1 in the Old Cemetery (in the Crown Tundra)
-            new(SWSH) { Species = 478, Level = 63, Location = 204 }, // Froslass on Slippery Slope (in the Crown Tundra)
-            new(SWSH) { Species = 362, Level = 63, Location = 204 }, // Glalie on Slippery Slope (in the Crown Tundra)
-            new(SWSH) { Species = 467, Level = 65, Location = 204 }, // Magmortar on Slippery Slope (in the Crown Tundra)
-            new EncounterStatic8S(SWSH) { Species = 029, Level = 60, Locations = new[] {208, 210}, }, // Nidoran♀ in Frostpoint Field, in the Giant’s Bed (in the Crown Tundra)
-            new(SWSH) { Species = 032, Level = 60, Location = 208 }, // Nidoran♂ in Frostpoint Field (in the Crown Tundra)
-            new EncounterStatic8S(SWSH) { Species = 531, Level = 62, Locations = new[] {204, 208, 210, 222, 230}, }, // Audino on Slippery Slope, in Frostpoint Field, in the Giant’s Bed at the Giant’s Foot, at Ballimere Lake (in the Crown Tundra)
-            new(SWSH) { Species = 359, Level = 62, Location = 208 }, // Absol in Frostpoint Field (in the Crown Tundra)
-            new(SWSH) { Species = 142, Level = 65, Location = 210 }, // Aerodactyl in the Giant’s Bed (in the Crown Tundra)
-            new(SWSH) { Species = 442, Level = 72, Location = 230, FlawlessIVCount = 3, Ability = 4 }, // Spiritomb at Ballimere Lake (in the Crown Tundra)
+            new(SW  ) { Species = 635, Level = 68, Location = 224, Weather = Overcast }, // Hydreigon in Roaring-Sea Caves
+            new(  SH) { Species = 248, Level = 68, Location = 224, Weather = Overcast }, // Tyranitar in Roaring-Sea Caves
+            new(SWSH) { Species = 448, Level = 67, Location = 224, Weather = Overcast }, // Lucario in Roaring-Sea Caves
+            new(SWSH) { Species = 363, Level = 63, Location = 226, Weather = No_Sun_Sand }, // Spheal at the Frigid Sea
+            new(SWSH) { Species = 364, Level = 65, Location = 226, Weather = No_Sun_Sand }, // Sealeo at the Frigid Sea
+            new(SWSH) { Species = 564, Level = 63, Location = 226, Weather = Normal | Overcast | Stormy | Heavy_Fog }, // Tirtouga at the Frigid Sea
+            new(SWSH) { Species = 713, Level = 65, Location = 226, Weather = No_Sun_Sand }, // Avalugg at the Frigid Sea
+            new EncounterStatic8S(SWSH) { Species = 858, Level = 67, Locations = new[] {226, 230}, Weather = Heavy_Fog }, // Hatterene at the Frigid Sea, Ballimere Lake
+            new(SWSH) { Species = 365, Level = 68, Location = 226, Weather = Normal | Overcast | Icy | Heavy_Fog }, // Walrein at the Frigid Sea
+            new(SWSH) { Species = 565, Level = 67, Location = 226, Weather = Normal | Stormy }, // Carracosta at the Frigid Sea
+            new(SWSH) { Species = 871, Level = 65, Location = 226, Weather = Thunderstorm }, // Pincurchin at the Frigid Sea
+            new(  SH) { Species = 875, Level = 65, Location = 226, Weather = No_Sun_Sand }, // Eiscue at the Frigid Sea
+            new EncounterStatic8S(SWSH) { Species = 623, Level = 65, Locations = new[] {226, 228}, Weather = All_CT }, // Golurk at the Frigid Sea, Three-Point Pass
+            new(SWSH) { Species = 887, Level = 68, Location = 228, Weather = Normal | Overcast | Raining | Intense_Sun | Icy | Heavy_Fog }, // Dragapult in Three-Point Pass
+            new(  SH) { Species = 141, Level = 68, Location = 224, Weather = Overcast }, // Kabutops in Roaring-Sea Caves
+            new(SW  ) { Species = 139, Level = 68, Location = 224, Weather = Overcast }, // Omastar in Roaring-Sea Caves
+            new(SWSH) { Species = 823, Level = 68, Location = 230, Weather = Normal | Snowing }, // Corviknight at Ballimere Lake
+            new(SWSH) { Species = 862, Level = 68, Location = 230, Weather = Overcast }, // Obstagoon at Ballimere Lake
+            new(SWSH) { Species = 715, Level = 67, Location = 230, Weather = Overcast | Raining }, // Noivern at Ballimere Lake
+            new(SWSH) { Species = 715, Level = 67, Location = 232, Weather = Overcast }, // Noivern in Lakeside Cave
+            new(SWSH) { Species = 547, Level = 65, Location = 230, Weather = Normal | Raining }, // Whimsicott at Ballimere Lake
+            new(SWSH) { Species = 836, Level = 67, Location = 230, Weather = Normal | Stormy | Snowing | Heavy_Fog }, // Boltund at Ballimere Lake
+            new(SWSH) { Species = 830, Level = 65, Location = 230, Weather = Raining | Intense_Sun }, // Eldegoss at Ballimere Lake
+            new(SW  ) { Species = 876, Level = 65, Location = 230, Weather = Normal | Heavy_Fog }, // Indeedee at Ballimere Lake
+            new(  SH) { Species = 876, Level = 65, Location = 230, Form = 01, Weather = Normal | Heavy_Fog }, // Indeedee-1 at Ballimere Lake
+            new(SWSH) { Species = 696, Level = 63, Location = 230, Weather = All_Ballimere }, // Tyrunt at Ballimere Lake
+            new(SWSH) { Species = 213, Level = 65, Location = 230, Weather = Normal | Intense_Sun }, // Shuckle at Ballimere Lake
+            new(SWSH) { Species = 820, Level = 68, Location = 230, Weather = All_Ballimere }, // Greedent at Ballimere Lake
+            new(SWSH) { Species = 820, Level = 68, Location = 234, Weather = Normal | Overcast | Stormy | Intense_Sun | Icy | Heavy_Fog }, // Greedent at Dyna Tree Hill
+            new(SWSH) { Species = 877, Level = 65, Location = 230, Weather = Overcast | Thunderstorm }, // Morpeko at Ballimere Lake
+            new(SWSH) { Species = 596, Level = 67, Location = 230, Weather = Thunderstorm }, // Galvantula at Ballimere Lake
+            new(SWSH) { Species = 839, Level = 68, Location = 230, Weather = Normal | Thunderstorm | Intense_Sun | Snowing | Heavy_Fog }, // Coalossal at Ballimere Lake
+            new(SWSH) { Species = 839, Level = 68, Location = 232, Weather = Overcast }, // Coalossal in Lakeside Cave
+            new(SWSH) { Species = 697, Level = 69, Location = 230, Weather = All_Ballimere }, // Tyrantrum at Ballimere Lake
+            new(SWSH) { Species = 531, Level = 65, Location = 230, Weather = Heavy_Fog }, // Audino at Ballimere Lake
+            new(SWSH) { Species = 304, Level = 63, Location = 230, Weather = All_Ballimere }, // Aron at Ballimere Lake
+            new(SWSH) { Species = 149, Level = 70, Location = 230, Weather = Raining | Thunderstorm }, // Dragonite at Ballimere Lake
+            new(SWSH) { Species = 306, Level = 68, Location = 232, Weather = Overcast }, // Aggron in Lakeside Cave
+            new(SWSH) { Species = 598, Level = 67, Location = 232, Weather = Overcast }, // Ferrothorn in Lakeside Cave
+            new(SWSH) { Species = 305, Level = 63, Location = 232, Weather = Overcast }, // Lairon in Lakeside Cave
+            new(SWSH) { Species = 348, Level = 67, Location = 230, Weather = Raining | Thunderstorm }, // Armaldo at Ballimere Lake
+            new(SWSH) { Species = 347, Level = 63, Location = 230, Weather = All_Ballimere }, // Anorith at Ballimere Lake
+            new(SWSH) { Species = 369, Level = 65, Location = 230, Weather = Normal | Overcast | Stormy | Intense_Sun | Snowing }, // Relicanth at Ballimere Lake
+            new(SWSH) { Species = 147, Level = 63, Location = 230, Weather = Raining | Heavy_Fog }, // Dratini at Ballimere Lake
+            new(SWSH) { Species = 148, Level = 65, Location = 230, Weather = Thunderstorm | Heavy_Fog }, // Dragonair at Ballimere Lake
+            new(SWSH) { Species = 442, Level = 72, Location = 230, FlawlessIVCount = 3, Ability = 4, Weather = All_CT }, // Spiritomb at Ballimere Lake
             #endregion
         };
 

--- a/PKHeX.Core/Legality/Encounters/EncounterStatic/EncounterStatic8.cs
+++ b/PKHeX.Core/Legality/Encounters/EncounterStatic/EncounterStatic8.cs
@@ -15,6 +15,8 @@ namespace PKHeX.Core
         public byte DynamaxLevel { get; set; }
         public IReadOnlyList<int> Relearn { get; init; } = Array.Empty<int>();
 
+        public AreaWeather8 Weather {get; init; } = AreaWeather8.Normal;
+
         public EncounterStatic8(GameVersion game) : base(game) { }
 
         protected override bool IsMatchLevel(PKM pkm, DexLevel evo)


### PR DESCRIPTION
This only matches the weather table with the Pokemon and does not fully
account for whether a location can spawn a particular weather.

Additional minor changes:
- Adds ScriptedNoMarks to Regis and Glimwood Tangle static encounters
- Corrects a few version-specific Pokemon such as Ludicolo/Shiftry
- Removes erroneous encounters such as Milotic in East/West Lake Axewell
- Removes an unused Motostoke Stadium encounter