### PR TITLE
Correct HOME Shiny Zeraora date

### DIFF
--- a/PKHeX.Core/Legality/Encounters/Data/EncountersHOME.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/EncountersHOME.cs
@@ -21,7 +21,7 @@ namespace PKHeX.Core
             {(int) Pichu,      new DateTime(2020, 02, 12)},
             {(int) Rotom,      new DateTime(2020, 02, 12)},
             {(int) Magearna,   new DateTime(2020, 02, 15)},
-            {(int) Zeraora,    new DateTime(2020, 06, 30)},
+            {(int) Zeraora,    new DateTime(2020, 06, 29)},
             {(int) Melmetal,   new DateTime(2020, 11, 10)},
             {(int) Grookey,    new DateTime(2020, 06, 02)},
             {(int) Scorbunny,  new DateTime(2020, 06, 02)},


### PR DESCRIPTION
https://bulbapedia.bulbagarden.net/wiki/List_of_game-based_Pok%C3%A9mon_distributions_in_Generation_VIII#1_Million_Victories_Shiny_Zeraora