### PR TITLE
fix overworld encounter validation

### DIFF
--- a/PKHeX.Core/Legality/Encounters/EncounterSlot/EncounterSlot8.cs
+++ b/PKHeX.Core/Legality/Encounters/EncounterSlot/EncounterSlot8.cs
@@ -52,7 +52,7 @@ namespace PKHeX.Core
 
         public bool IsOverworldCorrelationCorrect(PKM pk)
         {
-            return Overworld8RNG.ValidateOverworldEncounter(pk);
+            return Overworld8RNG.ValidateOverworldEncounter(pk, flawless:0) || Overworld8RNG.ValidateOverworldEncounter(pk, flawless:2) || Overworld8RNG.ValidateOverworldEncounter(pk, flawless:3);
         }
 
         public override EncounterMatchRating GetMatchRating(PKM pkm)

--- a/PKHeX.Core/Legality/Encounters/EncounterSlot/EncounterSlot8.cs
+++ b/PKHeX.Core/Legality/Encounters/EncounterSlot/EncounterSlot8.cs
@@ -52,6 +52,8 @@ namespace PKHeX.Core
 
         public bool IsOverworldCorrelationCorrect(PKM pk)
         {
+            if (!((EncounterArea8)Area).PermitCrossover)
+                return Overworld8RNG.ValidateOverworldEncounter(pk, flawless: 0); // Hidden table encounters cannot have brilliant aura.
             return Overworld8RNG.ValidateOverworldEncounter(pk, flawless:0) || Overworld8RNG.ValidateOverworldEncounter(pk, flawless:2) || Overworld8RNG.ValidateOverworldEncounter(pk, flawless:3);
         }
 

--- a/PKHeX.Core/Legality/RNG/Overworld8RNG.cs
+++ b/PKHeX.Core/Legality/RNG/Overworld8RNG.cs
@@ -135,6 +135,7 @@
 
         private const int NoMatchIVs = -1;
         private const int UNSET = -1;
+        private const int MAX = 31;
 
         private static int GetIsMatchEnd(PKM pk, Xoroshiro128Plus xoro, int start = 0, int end = 3)
         {
@@ -146,7 +147,6 @@
 
                 var copy = xoro;
                 int[] ivs = { UNSET, UNSET, UNSET, UNSET, UNSET, UNSET };
-                const int MAX = 31;
                 for (int i = 0; i < iv_count; i++)
                 {
                     int index;
@@ -175,9 +175,10 @@
         {
             for (int i = 0; i < 6; i++)
             {
+                int expect;
                 if (template[i] != UNSET)
-                    continue;
-                var expect = (int) rng.NextInt(32);
+                    expect = MAX;
+                else expect = (int) rng.NextInt(32);
                 var actual = i switch
                 {
                     0 => pk.IV_HP,

--- a/PKHeX.Core/Legality/RNG/Overworld8RNG.cs
+++ b/PKHeX.Core/Legality/RNG/Overworld8RNG.cs
@@ -103,7 +103,7 @@
             if (!IsPIDValid(pk, pid, shiny))
                 return false;
 
-            var actualCount = flawless == -1 ? GetIsMatchEnd(pk, xoro) : GetIsMatchEnd(pk, xoro, flawless, flawless);
+            var actualCount = flawless == -1 ? GetIsMatchEnd(pk, xoro, 0, 0) : GetIsMatchEnd(pk, xoro, flawless, flawless);
             return actualCount != NoMatchIVs;
         }
 


### PR DESCRIPTION
EncounterSlot8 should only allow 0 IV by default and 2/3 IV for brilliant aura
EncounterStatic with unspecified flawless IVs shouldnt validate for 0-3 IVs, instead only validate with 0 IVs (Empirically tested by @Lusamine )