### PR TITLE
Rework EncounterCriteria to be ability indexed rather than direct ability

### DIFF
--- a/PKHeX.Core/Legality/Encounters/EncounterSlot/EncounterSlot.cs
+++ b/PKHeX.Core/Legality/Encounters/EncounterSlot/EncounterSlot.cs
@@ -132,7 +132,7 @@ namespace PKHeX.Core
             var pi = pk.PersonalInfo;
             int gender = criteria.GetGender(-1, pi);
             int nature = (int)criteria.GetNature(Nature.Random);
-            var ability = criteria.GetAbilityFromNumber(Ability, pi);
+            var ability = criteria.GetAbilityFromNumber(Ability);
 
             if (Generation == 3 && Species == (int)Unown)
             {

--- a/PKHeX.Core/Legality/Encounters/EncounterSlot/EncounterSlot3PokeSpot.cs
+++ b/PKHeX.Core/Legality/Encounters/EncounterSlot/EncounterSlot3PokeSpot.cs
@@ -23,7 +23,7 @@ namespace PKHeX.Core
             var pi = pk.PersonalInfo;
             int gender = criteria.GetGender(-1, pi);
             int nature = (int)criteria.GetNature(Nature.Random);
-            int ability = criteria.GetAbilityFromNumber(0, pi);
+            int ability = criteria.GetAbilityFromNumber(0);
             PIDGenerator.SetRandomPokeSpotPID(pk, nature, gender, ability, SlotNumber);
             pk.Gender = gender;
             pk.StatNature = nature;

--- a/PKHeX.Core/Legality/Encounters/EncounterSlot/EncounterSlot7.cs
+++ b/PKHeX.Core/Legality/Encounters/EncounterSlot/EncounterSlot7.cs
@@ -23,7 +23,7 @@ namespace PKHeX.Core
             int num = Ability;
             if (Area.Type == SlotType.SOS && pk.FlawlessIVCount < 2)
                 num = 0; // let's fake it as an insufficient chain, no HA possible.
-            var ability = criteria.GetAbilityFromNumber(num, pi);
+            var ability = criteria.GetAbilityFromNumber(num);
             pk.RefreshAbility(ability);
             pk.SetRandomEC();
         }

--- a/PKHeX.Core/Legality/Encounters/EncounterStatic/EncounterStatic.cs
+++ b/PKHeX.Core/Legality/Encounters/EncounterStatic/EncounterStatic.cs
@@ -109,7 +109,7 @@ namespace PKHeX.Core
             var pi = pk.PersonalInfo;
             int gender = criteria.GetGender(Gender, pi);
             int nature = (int)criteria.GetNature(Nature);
-            int ability = criteria.GetAbilityFromNumber(Ability, pi);
+            int ability = criteria.GetAbilityFromNumber(Ability);
 
             var pidtype = GetPIDType();
             PIDGenerator.SetRandomWildPID(pk, pk.Format, nature, ability, gender, pidtype);

--- a/PKHeX.Core/Legality/Encounters/EncounterStatic/EncounterStaticShadow.cs
+++ b/PKHeX.Core/Legality/Encounters/EncounterStatic/EncounterStaticShadow.cs
@@ -81,7 +81,7 @@ namespace PKHeX.Core
             var pi = pk.PersonalInfo;
             int gender = criteria.GetGender(-1, pi);
             int nature = (int)criteria.GetNature(Nature.Random);
-            int ability = criteria.GetAbilityFromNumber(0, pi);
+            int ability = criteria.GetAbilityFromNumber(0);
 
             // Ensure that any generated specimen has valid Shadow Locks
             // This can be kinda slow, depending on how many locks / how strict they are.

--- a/PKHeX.Core/Legality/Encounters/EncounterTrade/EncounterTrade.cs
+++ b/PKHeX.Core/Legality/Encounters/EncounterTrade/EncounterTrade.cs
@@ -146,7 +146,7 @@ namespace PKHeX.Core
             var pi = pk.PersonalInfo;
             int gender = criteria.GetGender(Gender, pi);
             int nature = (int)criteria.GetNature(Nature);
-            int ability = criteria.GetAbilityFromNumber(Ability, pi);
+            int ability = criteria.GetAbilityFromNumber(Ability);
 
             PIDGenerator.SetRandomWildPID(pk, Generation, nature, ability, gender);
             pk.Nature = pk.StatNature = nature;

--- a/PKHeX.Core/Legality/Encounters/EncounterTrade/EncounterTrade3.cs
+++ b/PKHeX.Core/Legality/Encounters/EncounterTrade/EncounterTrade3.cs
@@ -70,7 +70,7 @@ namespace PKHeX.Core
             var pi = pk.PersonalInfo;
             int gender = criteria.GetGender(PKX.GetGenderFromPID(Species, PID), pi);
             int nature = (int)criteria.GetNature(Nature);
-            int ability = criteria.GetAbilityFromNumber(Ability, pi);
+            int ability = criteria.GetAbilityFromNumber(Ability);
 
             pk.PID = PID;
             pk.Nature = nature;

--- a/PKHeX.Core/Legality/Encounters/EncounterTrade/EncounterTrade5.cs
+++ b/PKHeX.Core/Legality/Encounters/EncounterTrade/EncounterTrade5.cs
@@ -38,7 +38,7 @@
             var pi = pk.PersonalInfo;
             int gender = criteria.GetGender(PKX.GetGenderFromPID(Species, PID), pi);
             int nature = (int)criteria.GetNature(Nature);
-            int ability = criteria.GetAbilityFromNumber(Ability, pi);
+            int ability = criteria.GetAbilityFromNumber(Ability);
 
             pk.PID = PID;
             pk.Nature = nature;

--- a/PKHeX.Core/Legality/Encounters/Generator/EncounterCriteria.cs
+++ b/PKHeX.Core/Legality/Encounters/Generator/EncounterCriteria.cs
@@ -158,9 +158,10 @@ namespace PKHeX.Core
 
         private int GetAbilityIndexPreference(bool canBeHidden = false) => AbilityNumber switch
         {
+            1 => 0,
+            2 => 1,
             -1 or 4 when canBeHidden => 2, // hidden allowed
-            0 or 1 => 0,
-            _ => 1
+            _ => Util.Rand.Next(2),
         };
 
         /// <summary>

--- a/PKHeX.Core/Legality/Formatting/BaseLegalityFormatter.cs
+++ b/PKHeX.Core/Legality/Formatting/BaseLegalityFormatter.cs
@@ -5,6 +5,9 @@ using static PKHeX.Core.LegalityCheckStrings;
 
 namespace PKHeX.Core
 {
+    /// <summary>
+    /// Default formatter for Legality Result displays.
+    /// </summary>
     public class BaseLegalityFormatter : ILegalityFormatter
     {
         public string GetReport(LegalityAnalysis l)

--- a/PKHeX.Core/Legality/Formatting/ILegalityFormatter.cs
+++ b/PKHeX.Core/Legality/Formatting/ILegalityFormatter.cs
@@ -1,8 +1,18 @@
 ﻿namespace PKHeX.Core
 {
+    /// <summary>
+    /// Formats legality results into a <see cref="T:System.String"/> for display.
+    /// </summary>
     public interface ILegalityFormatter
     {
+        /// <summary>
+        /// Gets a small summary of the legality analysis.
+        /// </summary>
         string GetReport(LegalityAnalysis l);
+
+        /// <summary>
+        /// Gets a verbose summary of the legality analysis.
+        /// </summary>
         string GetReportVerbose(LegalityAnalysis l);
     }
 }

--- a/PKHeX.Core/Legality/Formatting/LegalityFormatting.cs
+++ b/PKHeX.Core/Legality/Formatting/LegalityFormatting.cs
@@ -4,6 +4,9 @@ using static PKHeX.Core.LegalityCheckStrings;
 
 namespace PKHeX.Core
 {
+    /// <summary>
+    /// Formatting logic for <see cref="LegalityAnalysis"/> to create a human readable <see cref="T:System.String"/>.
+    /// </summary>
     public static class LegalityFormatting
     {
         /// <summary>

--- a/PKHeX.Core/MysteryGifts/PGF.cs
+++ b/PKHeX.Core/MysteryGifts/PGF.cs
@@ -284,7 +284,7 @@ namespace PKHeX.Core
         private int GetAbilityIndex(EncounterCriteria criteria, PersonalInfo pi) => AbilityType switch
         {
             00 or 01 or 02 => AbilityType, // Fixed 0/1/2
-            03 or 04 => criteria.GetAbilityFromType(AbilityType, pi), // 0/1 or 0/1/H
+            03 or 04 => criteria.GetAbilityFromType(AbilityType), // 0/1 or 0/1/H
             _ => throw new ArgumentException(nameof(AbilityType)),
         };
 

--- a/PKHeX.Core/MysteryGifts/WB7.cs
+++ b/PKHeX.Core/MysteryGifts/WB7.cs
@@ -416,7 +416,7 @@ namespace PKHeX.Core
         private int GetAbilityIndex(EncounterCriteria criteria, PersonalInfo pi) => AbilityType switch
         {
             00 or 01 or 02 => AbilityType, // Fixed 0/1/2
-            03 or 04 => criteria.GetAbilityFromType(AbilityType, pi), // 0/1 or 0/1/H
+            03 or 04 => criteria.GetAbilityFromType(AbilityType), // 0/1 or 0/1/H
             _ => throw new ArgumentException(nameof(AbilityType)),
         };
 

--- a/PKHeX.Core/MysteryGifts/WC6.cs
+++ b/PKHeX.Core/MysteryGifts/WC6.cs
@@ -410,7 +410,7 @@ namespace PKHeX.Core
         private int GetAbilityIndex(EncounterCriteria criteria, PersonalInfo pi) => AbilityType switch
         {
             00 or 01 or 02 => AbilityType, // Fixed 0/1/2
-            03 or 04 => criteria.GetAbilityFromType(AbilityType, pi), // 0/1 or 0/1/H
+            03 or 04 => criteria.GetAbilityFromType(AbilityType), // 0/1 or 0/1/H
             _ => throw new ArgumentException(nameof(AbilityType)),
         };
 

--- a/PKHeX.Core/MysteryGifts/WC7.cs
+++ b/PKHeX.Core/MysteryGifts/WC7.cs
@@ -441,7 +441,7 @@ namespace PKHeX.Core
         private int GetAbilityIndex(EncounterCriteria criteria, PersonalInfo pi) => AbilityType switch
         {
             00 or 01 or 02 => AbilityType, // Fixed 0/1/2
-            03 or 04 => criteria.GetAbilityFromType(AbilityType, pi), // 0/1 or 0/1/H
+            03 or 04 => criteria.GetAbilityFromType(AbilityType), // 0/1 or 0/1/H
             _ => throw new ArgumentException(nameof(AbilityType)),
         };
 

--- a/PKHeX.Core/MysteryGifts/WC7.cs
+++ b/PKHeX.Core/MysteryGifts/WC7.cs
@@ -316,6 +316,9 @@ namespace PKHeX.Core
 
             int currentLevel = Level > 0 ? Level : rnd.Next(1, 101);
             int metLevel = MetLevel > 0 ? MetLevel : currentLevel;
+            var version = OriginGame != 0 ? OriginGame : (int)this.GetCompatibleVersion((GameVersion)sav.Game);
+            var language = Language != 0 ? Language : (int)Core.Language.GetSafeLanguage(Generation, (LanguageID)sav.Language, (GameVersion)version);
+
             var pi = PersonalTable.USUM.GetFormEntry(Species, Form);
             PK7 pk = new()
             {
@@ -326,8 +329,8 @@ namespace PKHeX.Core
                 Met_Level = metLevel,
                 Form = Form,
                 EncryptionConstant = EncryptionConstant != 0 ? EncryptionConstant : Util.Rand32(),
-                Version = OriginGame != 0 ? OriginGame : sav.Game,
-                Language = Language != 0 ? Language : sav.Language,
+                Version = version,
+                Language = language,
                 Ball = Ball,
                 Move1 = Move1, Move2 = Move2, Move3 = Move3, Move4 = Move4,
                 RelearnMove1 = RelearnMove1, RelearnMove2 = RelearnMove2,
@@ -546,6 +549,12 @@ namespace PKHeX.Core
                 return pkm.SM; // not USUM
 
             return PIDType != 0 || pkm.PID == PID;
+        }
+
+        public override GameVersion Version
+        {
+            get => CardID == 2046 ? GameVersion.SM : GameVersion.Gen7;
+            set { }
         }
 
         protected override bool IsMatchDeferred(PKM pkm) => Species != pkm.Species;

--- a/PKHeX.Core/MysteryGifts/WC8.cs
+++ b/PKHeX.Core/MysteryGifts/WC8.cs
@@ -497,7 +497,7 @@ namespace PKHeX.Core
         private int GetAbilityIndex(EncounterCriteria criteria, PersonalInfo pi) => AbilityType switch
         {
             00 or 01 or 02 => AbilityType, // Fixed 0/1/2
-            03 or 04 => criteria.GetAbilityFromType(AbilityType, pi), // 0/1 or 0/1/H
+            03 or 04 => criteria.GetAbilityFromType(AbilityType), // 0/1 or 0/1/H
             _ => throw new ArgumentException(nameof(AbilityType)),
         };
 

--- a/PKHeX.Core/PKM/Shared/IRegionOrigin.cs
+++ b/PKHeX.Core/PKM/Shared/IRegionOrigin.cs
@@ -2,8 +2,12 @@
 {
     public interface IRegionOrigin
     {
+        /// <summary> Console hardware region. </summary>
+        /// <see cref="RegionID"/>
         int ConsoleRegion { get; set; }
+        /// <summary> Console's configured Country via System Settings. </summary>
         int Country { get; set; }
+        /// <summary> Console's configured Region within <see cref="Country"/> via System Settings. </summary>
         int Region { get; set; }
     }
 

--- a/PKHeX.Core/PKM/Shared/ISpeciesForm.cs
+++ b/PKHeX.Core/PKM/Shared/ISpeciesForm.cs
@@ -1,8 +1,14 @@
 ﻿namespace PKHeX.Core
 {
+    /// <summary>
+    /// Simple identification values for an Pokémon Entity.
+    /// </summary>
     public interface ISpeciesForm
     {
+        /// <summary> Species ID of the entity (National Dex). </summary>
         int Species { get; }
+
+        /// <summary> Form ID of the entity. </summary>
         int Form { get; }
     }
 }

--- a/PKHeX.Core/PersonalInfo/PersonalInfo.cs
+++ b/PKHeX.Core/PersonalInfo/PersonalInfo.cs
@@ -299,7 +299,7 @@ namespace PKHeX.Core
         /// <summary>
         /// Indicates that the entry has two genders.
         /// </summary>
-        public bool IsDualGender => (uint)(Gender - 1) >= 253;
+        public bool IsDualGender => (uint)(Gender - 1) < 253;
 
         /// <summary>
         /// Indicates that the entry is exclusively Genderless.

--- a/PKHeX.Core/PersonalInfo/PersonalInfo.cs
+++ b/PKHeX.Core/PersonalInfo/PersonalInfo.cs
@@ -279,8 +279,6 @@ namespace PKHeX.Core
             return fix >= 0 ? fix : Util.Rand.Next(2);
         }
 
-        public bool IsDualGender => FixedGender < 0;
-
         public int FixedGender
         {
             get
@@ -294,6 +292,11 @@ namespace PKHeX.Core
                 return -1;
             }
         }
+
+        /// <summary>
+        /// Indicates that the entry has two genders.
+        /// </summary>
+        public bool IsDualGender => (uint)(Gender - 1) >= 253;
 
         /// <summary>
         /// Indicates that the entry is exclusively Genderless.

--- a/PKHeX.Core/PersonalInfo/PersonalInfo.cs
+++ b/PKHeX.Core/PersonalInfo/PersonalInfo.cs
@@ -279,6 +279,9 @@ namespace PKHeX.Core
             return fix >= 0 ? fix : Util.Rand.Next(2);
         }
 
+        /// <summary>
+        /// Gets a gender value. Returns -1 if the entry <see cref="IsDualGender"/>.
+        /// </summary>
         public int FixedGender
         {
             get
@@ -327,7 +330,6 @@ namespace PKHeX.Core
         /// Checks to see if the <see cref="PKM.Form"/> is valid within the <see cref="FormCount"/>
         /// </summary>
         /// <param name="form"></param>
-        /// <returns></returns>
         public bool IsFormWithinRange(int form)
         {
             if (form == 0)
@@ -338,7 +340,7 @@ namespace PKHeX.Core
         /// <summary>
         /// Checks to see if the provided Types match the entry's types.
         /// </summary>
-        /// <remarks>Input order matters! If input order does not matter, use <see cref="o:IsType(type1, type2)"/>.</remarks>
+        /// <remarks>Input order matters! If input order does not matter, use <see cref="IsType(int, int)"/> instead.</remarks>
         /// <param name="type1">First type</param>
         /// <param name="type2">Second type</param>
         /// <returns>Typing is an exact match</returns>

--- a/PKHeX.Core/PersonalInfo/PersonalTable.cs
+++ b/PKHeX.Core/PersonalInfo/PersonalTable.cs
@@ -262,7 +262,7 @@ namespace PKHeX.Core
         }
 
         /// <summary>
-        /// Count of entries in the table, which includes default species entries and their separate <see cref="PKM.Form"/> entreis.
+        /// Count of entries in the table, which includes default species entries and their separate <see cref="PKM.Form"/> entries.
         /// </summary>
         public int TableLength => Table.Length;
 

--- a/PKHeX.Core/Saves/Substructures/Gen7/GP1.cs
+++ b/PKHeX.Core/Saves/Substructures/Gen7/GP1.cs
@@ -172,7 +172,7 @@ namespace PKHeX.Core
             const int av = 3;
             pk.Gender = criteria.GetGender(Gender, pi);
             pk.Nature = (int)criteria.GetNature(Nature.Random);
-            pk.RefreshAbility(criteria.GetAbilityFromType(av, pi));
+            pk.RefreshAbility(criteria.GetAbilityFromType(av));
 
             bool isShiny = pk.IsShiny;
             if (IsShiny && !isShiny) // Force Square

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen6/SAV_HallOfFame.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen6/SAV_HallOfFame.cs
@@ -355,16 +355,15 @@ namespace PKHeX.WinForms
             // Get Gender Threshold
             int species = WinFormsUtil.GetIndex(CB_Species);
             var pi = SAV.Personal[species];
-
-            var fg = pi.FixedGender;
-            if (fg == -1) // dual gender
+            if (pi.IsDualGender)
             {
-                fg = PKX.GetGenderFromString(Label_Gender.Text);
+                var fg = PKX.GetGenderFromString(Label_Gender.Text);
                 fg = (fg ^ 1) & 1;
                 Label_Gender.Text = Main.GenderSymbols[fg];
             }
             else
             {
+                var fg = pi.FixedGender;
                 Label_Gender.Text = Main.GenderSymbols[fg];
                 return;
             }


### PR DESCRIPTION
Some miscellaneous xmldoc + minor tweaks elsewhere as I noticed them, but this change is `EncounterCriteria` changing the GetAbility (index) call sites.

Contains a tweak for WC7 to change the `Version` if it's the SMDEMO greninja card. Would be better if the Restrict values were used instead, but oh well.