### PR TITLE
check moves that are already set as relearn for dexnav encs

### DIFF
--- a/PKHeX.Core/Editing/Applicators/MoveSetApplicator.cs
+++ b/PKHeX.Core/Editing/Applicators/MoveSetApplicator.cs
@@ -82,7 +82,7 @@ namespace PKHeX.Core
                 var moves = legal.Info.Moves;
                 for (int i = 0; i < moves.Length; i++)
                 {
-                    if (moves[i].Valid)
+                    if (moves[i].Valid && !moves[i].IsRelearn)
                         continue;
 
                     var move = legal.pkm.GetMove(i);


### PR DESCRIPTION
prevents a bug where a move is overlooked because it is considered "valid" because it is a relearn move that is already set