### PR TITLE
[Enhancement#2916] Difference smalls items by null pixels

### DIFF
--- a/PKHeX.Drawing/Sprites/SpriteBuilder.cs
+++ b/PKHeX.Drawing/Sprites/SpriteBuilder.cs
@@ -131,12 +131,37 @@ namespace PKHeX.Drawing
                 _ => (Image?)Resources.ResourceManager.GetObject(GetItemResourceName(item)) ?? UnknownItem,
             };
 
-            // Redraw item in bottom right corner; since images are cropped, try to not have them at the edge
-            int x = ItemShiftX + ((ItemMaxSize - itemimg.Width) / 2);
-            if (x + itemimg.Width > baseImage.Width)
-                x = baseImage.Width - itemimg.Width;
-            int y = ItemShiftY + (ItemMaxSize - itemimg.Height);
+            // Calculate number of null/blank pixels in item's sprite. If is 800 or more, it's a small item.
+            int pixels = CountNullPixels((Bitmap)itemimg);
+            int x, y;
+
+            if (pixels >= 800)
+            {
+                x = 39;
+                y = 29;
+            }
+            else
+            {
+                // Redraw item in bottom right corner; since images are cropped, try to not have them at the edge
+                x = ItemShiftX + ((ItemMaxSize - itemimg.Width) / 2);
+                if (x + itemimg.Width > baseImage.Width)
+                    x = baseImage.Width - itemimg.Width;
+                y = ItemShiftY + (ItemMaxSize - itemimg.Height);
+            }
             return ImageUtil.LayerImage(baseImage, itemimg, x, y);
+        }
+
+        private int CountNullPixels(Bitmap bm)
+        {
+            int matches = 0;
+            for (int y = 0; y < bm.Height; y++)
+            {
+                for (int x = 0; x < bm.Width; x++)
+                {
+                    if (bm.GetPixel(x, y).Name == "0") matches++;
+                }
+            }
+            return matches;
         }
 
         private static Image LayerOverImageShiny(Image baseImage, bool isBoxBGRed, bool altShiny)


### PR DESCRIPTION
Hello, this is my collaboration to PKHeX:
I've been working on the following issue: https://github.com/kwsch/PKHeX/issues/2916 . I suggested a feature that differences the small items's  sprites of the bigger ones by counting the blanks/nulls pixels. If a sprite has 800 or more nulls pixels it's a small one.
I've used the next source of topic-related information: http://csharphelper.com/blog/2016/10/count-pixels-of-different-colors-in-c/

Before:
![Before](https://user-images.githubusercontent.com/54759100/121256893-6d99d080-c883-11eb-947a-0318967bfc47.JPG)

After:
![After](https://user-images.githubusercontent.com/54759100/121256901-7094c100-c883-11eb-9c51-6c26ce6079e8.JPG)


**IMPORTANT**: The bigger sprites doesn't change their coordinates. The first column in the provided images is an example of small sprites and the second of biggers ones. 
You can modify the coordinates in the lines 140 and 141 of SpriteBuilder.cs
