### PR TITLE
Track a PKM's Box,Slot,StorageFlags,Identifier metadata separately

### DIFF
--- a/PKHeX.Core/Editing/Bulk/BatchEditor.cs
+++ b/PKHeX.Core/Editing/Bulk/BatchEditor.cs
@@ -26,10 +26,10 @@ namespace PKHeX.Core
         {
             if (pkm.Species <= 0)
                 return false;
-            if (!pkm.Valid || pkm.Locked)
+            if (!pkm.Valid)
             {
                 Iterated++;
-                var reason = pkm.Locked ? "Locked." : "Not Valid.";
+                const string reason = "Not Valid.";
                 Debug.WriteLine($"{MsgBEModifyFailBlocked} {reason}");
                 return false;
             }
@@ -76,6 +76,11 @@ namespace PKHeX.Core
             }
 
             return editor;
+        }
+
+        public void AddSkipped()
+        {
+            ++Iterated;
         }
     }
 }

--- a/PKHeX.Core/Editing/Bulk/BatchFilters.cs
+++ b/PKHeX.Core/Editing/Bulk/BatchFilters.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections.Generic;
+using static PKHeX.Core.BatchEditing;
+
+namespace PKHeX.Core
+{
+    public static class BatchFilters
+    {
+        public static readonly List<IComplexFilter> FilterMods = new()
+        {
+            new ComplexFilter(PROP_LEGAL,
+                (pkm, cmd) => new LegalityAnalysis(pkm).Valid == cmd.Evaluator,
+                (info, cmd) => info.Legality.Valid == cmd.Evaluator),
+
+            new ComplexFilter(PROP_TYPENAME,
+                (pkm, cmd) => (pkm.GetType().Name == cmd.PropertyValue) == cmd.Evaluator,
+                (info, cmd) => (info.Entity.GetType().Name == cmd.PropertyValue) == cmd.Evaluator),
+        };
+
+        public static readonly List<IComplexFilterMeta> FilterMeta = new()
+        {
+            new MetaFilter(IdentifierContains,
+                (obj, cmd) => obj is SlotCache s && s.Identify().Contains(cmd.PropertyValue) == cmd.Evaluator),
+
+            new MetaFilter(nameof(SlotInfoBox.Box),
+                (obj, cmd) => obj is SlotCache { Source: SlotInfoBox b } && (b.Box.ToString() == cmd.PropertyValue) == cmd.Evaluator),
+
+            new MetaFilter(nameof(ISlotInfo.Slot),
+                (obj, cmd) => obj is SlotCache s && (s.Source.Slot.ToString() == cmd.PropertyValue) == cmd.Evaluator),
+        };
+    }
+}

--- a/PKHeX.Core/Editing/Bulk/BatchMods.cs
+++ b/PKHeX.Core/Editing/Bulk/BatchMods.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using static PKHeX.Core.BatchEditing;
+
+namespace PKHeX.Core
+{
+    public static class BatchMods
+    {
+        public static readonly List<ISuggestModification> SuggestionMods = new()
+        {
+            // PB7 Specific
+            new TypeSuggestion<PB7>(nameof(PB7.Stat_CP), p => p.ResetCP()),
+            new TypeSuggestion<PB7>(nameof(PB7.HeightAbsolute), p => p.HeightAbsolute = p.CalcHeightAbsolute),
+            new TypeSuggestion<PB7>(nameof(PB7.WeightAbsolute), p => p.WeightAbsolute = p.CalcWeightAbsolute),
+
+            // Date Copy
+            new TypeSuggestion<PKM>(nameof(PKM.EggMetDate), p => p.EggMetDate = p.MetDate),
+            new TypeSuggestion<PKM>(nameof(PKM.MetDate), p => p.MetDate = p.EggMetDate),
+
+            new TypeSuggestion<PKM>(nameof(PKM.Nature), p => p.Format >= 8, p => p.Nature = p.StatNature),
+            new TypeSuggestion<PKM>(nameof(PKM.StatNature), p => p.Format >= 8, p => p.StatNature = p.Nature),
+            new TypeSuggestion<PKM>(nameof(PKM.Stats), p => p.ResetPartyStats()),
+            new TypeSuggestion<PKM>(nameof(PKM.Ball), p => BallApplicator.ApplyBallLegalByColor(p)),
+            new TypeSuggestion<PKM>(nameof(PKM.Heal), p => p.Heal()),
+            new TypeSuggestion<PKM>(nameof(PKM.HealPP), p => p.HealPP()),
+            new TypeSuggestion<PKM>(nameof(IHyperTrain.HyperTrainFlags), p => p.SetSuggestedHyperTrainingData()),
+
+            new TypeSuggestion<PKM>(nameof(PKM.Move1_PP), p => p.SetSuggestedMovePP(0)),
+            new TypeSuggestion<PKM>(nameof(PKM.Move2_PP), p => p.SetSuggestedMovePP(1)),
+            new TypeSuggestion<PKM>(nameof(PKM.Move3_PP), p => p.SetSuggestedMovePP(2)),
+            new TypeSuggestion<PKM>(nameof(PKM.Move4_PP), p => p.SetSuggestedMovePP(3)),
+
+            new ComplexSuggestion(nameof(PKM.Moves), (_, _, info) => BatchModifications.SetMoves(info.Entity, info.Legality.GetMoveSet())),
+            new ComplexSuggestion(nameof(PKM.RelearnMoves), (_, value, info) => BatchModifications.SetSuggestedRelearnData(info, value)),
+            new ComplexSuggestion(PROP_RIBBONS, (_, value, info) => BatchModifications.SetSuggestedRibbons(info, value)),
+            new ComplexSuggestion(nameof(PKM.Met_Location), (_, _, info) => BatchModifications.SetSuggestedMetData(info)),
+        };
+
+        private static DateTime ParseDate(string val) => DateTime.ParseExact(val, "yyyyMMdd", CultureInfo.InvariantCulture, DateTimeStyles.None);
+
+        public static readonly List<IComplexSet> ComplexMods = new()
+        {
+            // Date
+            new ComplexSet(nameof(PKM.MetDate), (pk, cmd) => pk.MetDate = ParseDate(cmd.PropertyValue)),
+            new ComplexSet(nameof(PKM.EggMetDate), (pk, cmd) => pk.EggMetDate = ParseDate(cmd.PropertyValue)),
+
+            // Value Swap
+            new ComplexSet(nameof(PKM.EncryptionConstant), value => value == nameof(PKM.PID), (pk, _) => pk.EncryptionConstant = pk.PID),
+            new ComplexSet(nameof(PKM.PID), value => value == nameof(PKM.EncryptionConstant), (pk, _) => pk.PID = pk.EncryptionConstant),
+
+            // Realign to Derived Value
+            new ComplexSet(nameof(PKM.Ability), value => value.StartsWith("$"), (pk, cmd) => pk.RefreshAbility(Convert.ToInt16(cmd.PropertyValue[1]) - 0x30)),
+            new ComplexSet(nameof(PKM.AbilityNumber), value => value.StartsWith("$"), (pk, cmd) => pk.RefreshAbility(Convert.ToInt16(cmd.PropertyValue[1]) - 0x30)),
+
+            // Random
+            new ComplexSet(nameof(PKM.EncryptionConstant), value => value == CONST_RAND, (pk, _) => pk.EncryptionConstant = Util.Rand32()),
+            new ComplexSet(nameof(PKM.PID), value => value == CONST_RAND, (pk, _) => pk.PID = Util.Rand32()),
+            new ComplexSet(nameof(PKM.Gender), value => value == CONST_RAND, (pk, _) => pk.SetPIDGender(pk.Gender)),
+
+            // Shiny
+            new ComplexSet(nameof(PKM.PID),
+                value => value.StartsWith(CONST_SHINY, true, CultureInfo.CurrentCulture),
+                (pk, cmd) => CommonEdits.SetShiny(pk, GetRequestedShinyState(cmd.PropertyValue))),
+
+            new ComplexSet(nameof(PKM.Species), value => value == "0", (pk, _) => Array.Clear(pk.Data, 0, pk.Data.Length)),
+            new ComplexSet(nameof(PKM.IsNicknamed), value => string.Equals(value, "false", StringComparison.OrdinalIgnoreCase), (pk, _) => pk.SetDefaultNickname()),
+        };
+
+        private static Shiny GetRequestedShinyState(string text)
+        {
+            if (text.EndsWith("0"))
+                return Shiny.AlwaysSquare;
+            if (text.EndsWith("1"))
+                return Shiny.AlwaysStar;
+            return Shiny.Random;
+        }
+    }
+}

--- a/PKHeX.Core/Editing/Bulk/ComplexSet/IComplexFilterMeta.cs
+++ b/PKHeX.Core/Editing/Bulk/ComplexSet/IComplexFilterMeta.cs
@@ -1,0 +1,11 @@
+﻿namespace PKHeX.Core
+{
+    /// <summary>
+    /// Complex filter of data based on a string value.
+    /// </summary>
+    public interface IComplexFilterMeta
+    {
+        bool IsMatch(string prop);
+        bool IsFiltered(object cache, StringInstruction value);
+    }
+}

--- a/PKHeX.Core/Editing/Bulk/ComplexSet/MetaFilter.cs
+++ b/PKHeX.Core/Editing/Bulk/ComplexSet/MetaFilter.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace PKHeX.Core
+{
+    /// <inheritdoc cref="IComplexFilter"/>
+    public class MetaFilter : IComplexFilterMeta
+    {
+        private readonly string Property;
+        private readonly Func<object, StringInstruction, bool> FilterPKM;
+
+        public MetaFilter(
+            string property,
+            Func<object, StringInstruction, bool> filterPkm)
+        {
+            Property = property;
+            FilterPKM = filterPkm;
+        }
+
+        public bool IsMatch(string prop) => prop == Property;
+        public bool IsFiltered(object pkm, StringInstruction cmd) => FilterPKM(pkm, cmd);
+    }
+}

--- a/PKHeX.Core/Editing/PKM/EntitySummary.cs
+++ b/PKHeX.Core/Editing/PKM/EntitySummary.cs
@@ -14,7 +14,7 @@ namespace PKHeX.Core
         private readonly ushort[] Stats;
         protected readonly PKM pkm; // protected for children generating extra properties
 
-        public string? Position => pkm.Identifier;
+        public virtual string Position => "???";
         public string Nickname => pkm.Nickname;
         public string Species => Get(Strings.specieslist, pkm.Species);
         public string Nature => Get(Strings.natures, pkm.StatNature);

--- a/PKHeX.Core/Editing/Saves/BoxManipBase.cs
+++ b/PKHeX.Core/Editing/Saves/BoxManipBase.cs
@@ -29,7 +29,7 @@ namespace PKHeX.Core
             new BoxManipSort(BoxManipType.SortDate, PKMSorting.OrderByDateObtained, s => s.Generation >= 4),
             new BoxManipSort(BoxManipType.SortName, list => list.OrderBySpeciesName(GameInfo.Strings.Species)),
             new BoxManipSort(BoxManipType.SortFavorite, list => list.OrderByCustom(pk => pk is PB7 {Favorite: true}), s => s is SAV7b),
-            new BoxManipSortComplex(BoxManipType.SortParty, (list, sav) => list.OrderByCustom(pk => ((SAV7b)sav).Blocks.Storage.GetPartyIndex(pk.Box - 1, pk.Slot - 1)), s => s is SAV7b),
+            new BoxManipSortComplex(BoxManipType.SortParty, (list, sav, start) => list.BubbleUp(sav, i => ((SAV7b)sav).Blocks.Storage.IsParty(i), start), s => s is SAV7b),
             new BoxManipSort(BoxManipType.SortShiny, list => list.OrderByCustom(pk => !pk.IsShiny)),
             new BoxManipSort(BoxManipType.SortRandom, list => list.OrderByCustom(_ => Util.Rand32())),
         };

--- a/PKHeX.Core/Editing/Saves/BoxManipSort.cs
+++ b/PKHeX.Core/Editing/Saves/BoxManipSort.cs
@@ -15,7 +15,7 @@ namespace PKHeX.Core
 
         public override int Execute(SaveFile sav, BoxManipParam param)
         {
-            IEnumerable<PKM> Method(IEnumerable<PKM> p) => Sorter(p);
+            IEnumerable<PKM> Method(IEnumerable<PKM> p, int index) => Sorter(p);
             return sav.SortBoxes(param.Start, param.Stop, Method, param.Reverse);
         }
     }

--- a/PKHeX.Core/Editing/Saves/BoxManipSortComplex.cs
+++ b/PKHeX.Core/Editing/Saves/BoxManipSortComplex.cs
@@ -5,9 +5,12 @@ namespace PKHeX.Core
 {
     public sealed class BoxManipSortComplex : BoxManipBase
     {
-        private readonly Func<IEnumerable<PKM>, SaveFile, IEnumerable<PKM>> Sorter;
+        private readonly Func<IEnumerable<PKM>, SaveFile, int, IEnumerable<PKM>> Sorter;
         public BoxManipSortComplex(BoxManipType type, Func<IEnumerable<PKM>, SaveFile, IEnumerable<PKM>> sorter) : this(type, sorter, _ => true) { }
-        public BoxManipSortComplex(BoxManipType type, Func<IEnumerable<PKM>, SaveFile, IEnumerable<PKM>> sorter, Func<SaveFile, bool> usable) : base(type, usable) => Sorter = sorter;
+        public BoxManipSortComplex(BoxManipType type, Func<IEnumerable<PKM>, SaveFile, IEnumerable<PKM>> sorter, Func<SaveFile, bool> usable) : base(type, usable) => Sorter = (pkms, file, _) => sorter(pkms, file);
+
+        public BoxManipSortComplex(BoxManipType type, Func<IEnumerable<PKM>, SaveFile, int, IEnumerable<PKM>> sorter) : this(type, sorter, _ => true) { }
+        public BoxManipSortComplex(BoxManipType type, Func<IEnumerable<PKM>, SaveFile, int, IEnumerable<PKM>> sorter, Func<SaveFile, bool> usable) : base(type, usable) => Sorter = sorter;
 
         public override string GetPrompt(bool all) => all ? MessageStrings.MsgSaveBoxSortAll : MessageStrings.MsgSaveBoxSortCurrent;
         public override string GetFail(bool all) => all ? MessageStrings.MsgSaveBoxSortAllFailBattle : MessageStrings.MsgSaveBoxSortCurrentFailBattle;
@@ -15,7 +18,7 @@ namespace PKHeX.Core
 
         public override int Execute(SaveFile sav, BoxManipParam param)
         {
-            IEnumerable<PKM> Method(IEnumerable<PKM> p) => Sorter(p, sav);
+            IEnumerable<PKM> Method(IEnumerable<PKM> p, int index) => Sorter(p, sav, index);
             return sav.SortBoxes(param.Start, param.Stop, Method, param.Reverse);
         }
     }

--- a/PKHeX.Core/Editing/Saves/Slots/Info/ISlotInfo.cs
+++ b/PKHeX.Core/Editing/Saves/Slots/Info/ISlotInfo.cs
@@ -7,9 +7,38 @@ namespace PKHeX.Core
     /// </summary>
     public interface ISlotInfo : IEquatable<ISlotInfo>
     {
+        /// <summary>
+        /// Indicates the type of format the slot originates. Useful for legality purposes.
+        /// </summary>
+        SlotOrigin Origin { get; }
+
+        /// <summary>
+        /// Differentiating slot number from other infos of the same type.
+        /// </summary>
         int Slot { get; }
+
+        /// <summary>
+        /// Indicates if this slot can write to the requested <see cref="sav"/>.
+        /// </summary>
+        /// <param name="sav">Save file to try writing to.</param>
+        /// <returns>True if can write to</returns>
         bool CanWriteTo(SaveFile sav);
+
+        /// <summary>
+        /// Checks if the <see cref="pkm"/> can be written to the <see cref="sav"/> for this slot.
+        /// </summary>
+        /// <param name="sav">Save file to try writing to.</param>
+        /// <param name="pkm">Entity data to try writing.</param>
+        /// <returns>True if can write to</returns>
         WriteBlockedMessage CanWriteTo(SaveFile sav, PKM pkm);
+
+        /// <summary>
+        /// Tries writing the <see cref="pkm"/> to the <see cref="sav"/>.
+        /// </summary>
+        /// <param name="sav">Save file to try writing to.</param>
+        /// <param name="pkm">Entity data to try writing.</param>
+        /// <param name="setting">Setting to use when importing the <see cref="pkm"/> data</param>
+        /// <returns>Returns false if it did not succeed.</returns>
         bool WriteTo(SaveFile sav, PKM pkm, PKMImportSetting setting = PKMImportSetting.UseDefault);
         PKM Read(SaveFile sav);
     }

--- a/PKHeX.Core/Editing/Saves/Slots/Info/SlotCache.cs
+++ b/PKHeX.Core/Editing/Saves/Slots/Info/SlotCache.cs
@@ -1,0 +1,64 @@
+using System;
+
+namespace PKHeX.Core
+{
+    /// <summary>
+    /// Contains slot data and metadata indicating where the <see cref="PKM"/> originated from.
+    /// </summary>
+    public class SlotCache
+    {
+        /// <summary>
+        /// Information regarding how the <see cref="Entity"/> was obtained.
+        /// </summary>
+        public readonly ISlotInfo Source;
+
+        /// <summary>
+        /// Save File reference that obtained the <see cref="Entity"/>.
+        /// </summary>
+        public readonly SaveFile SAV;
+
+        /// <summary>
+        /// Data that was loaded.
+        /// </summary>
+        public readonly PKM Entity;
+
+        private static readonly FakeSaveFile NoSaveFile = new();
+
+        public SlotCache(SlotInfoFile source, PKM entity)
+        {
+            Source = source;
+            Entity = entity;
+            SAV = NoSaveFile;
+        }
+
+        public SlotCache(ISlotInfo source, PKM entity, SaveFile sav)
+        {
+            Source = source;
+            Entity = entity;
+            SAV = sav;
+        }
+
+        public string Identify() => GetFileName() + Source switch
+        {
+            SlotInfoBox box => $"[{box.Box + 1:00}] ({SAV.GetBoxName(box.Box)})-{box.Slot + 1:00}: {Entity.FileName}",
+            SlotInfoFile file => $"File: {file.Path}",
+            SlotInfoMisc misc => $"{misc.Type}-{misc.Slot}: {Entity.FileName}",
+            SlotInfoParty party => $"Party: {party.Slot}: {Entity.FileName}",
+            _ => throw new ArgumentOutOfRangeException(nameof(Source))
+        };
+
+        private string GetFileName()
+        {
+            var fn = SAV.Metadata.FileName;
+            if (fn is null)
+                return string.Empty;
+            return $"{fn} @ ";
+        }
+
+        public bool IsDataValid()
+        {
+            var e = Entity;
+            return e.Species != 0 && e.ChecksumValid && (e.Sanity == 0 || e is BK4);
+        }
+    }
+}

--- a/PKHeX.Core/Editing/Saves/Slots/Info/SlotInfoBox.cs
+++ b/PKHeX.Core/Editing/Saves/Slots/Info/SlotInfoBox.cs
@@ -3,10 +3,11 @@ namespace PKHeX.Core
     /// <summary>
     /// Box Data <see cref="ISlotInfo"/>
     /// </summary>
-    public sealed class SlotInfoBox : ISlotInfo
+    public class SlotInfoBox : ISlotInfo
     {
         public int Box { get; }
         public int Slot { get; }
+        public SlotOrigin Origin => SlotOrigin.Box;
         public bool CanWriteTo(SaveFile sav) => sav.HasBox && !sav.IsSlotLocked(Box, Slot);
         public WriteBlockedMessage CanWriteTo(SaveFile sav, PKM pkm) => WriteBlockedMessage.None;
 

--- a/PKHeX.Core/Editing/Saves/Slots/Info/SlotInfoFile.cs
+++ b/PKHeX.Core/Editing/Saves/Slots/Info/SlotInfoFile.cs
@@ -1,0 +1,17 @@
+namespace PKHeX.Core
+{
+    public sealed class SlotInfoFile : ISlotInfo
+    {
+        public readonly string Path;
+        public SlotOrigin Origin => SlotOrigin.Party;
+        public int Slot => 0;
+
+        public SlotInfoFile(string path) => Path = path;
+        public bool Equals(ISlotInfo other) => other is SlotInfoFile f && f.Path == Path;
+
+        public bool CanWriteTo(SaveFile sav) => false;
+        public WriteBlockedMessage CanWriteTo(SaveFile sav, PKM pkm) => WriteBlockedMessage.InvalidDestination;
+        public bool WriteTo(SaveFile sav, PKM pkm, PKMImportSetting setting = PKMImportSetting.UseDefault) => false;
+        public PKM Read(SaveFile sav) => sav.BlankPKM;
+    }
+}

--- a/PKHeX.Core/Editing/Saves/Slots/Info/SlotInfoLoader.cs
+++ b/PKHeX.Core/Editing/Saves/Slots/Info/SlotInfoLoader.cs
@@ -1,0 +1,163 @@
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+
+namespace PKHeX.Core
+{
+    public static class SlotInfoLoader
+    {
+        // The "Add" method isn't shared for any interface... so we'll just do this twice.
+
+        #region ConcurrentBag Implementation
+        public static void AddFromSaveFile(SaveFile sav, ConcurrentBag<SlotCache> db)
+        {
+            if (sav.HasBox)
+                AddBoxData(sav, db);
+
+            if (sav.HasParty)
+                AddPartyData(sav, db);
+
+            AddExtraData(sav, db);
+        }
+
+        public static void AddFromLocalFile(string file, ConcurrentBag<SlotCache> db, ITrainerInfo dest, ICollection<string> validExtensions)
+        {
+            var fi = new FileInfo(file);
+            if (!validExtensions.Contains(fi.Extension) || !PKX.IsPKM(fi.Length))
+                return;
+
+            var data = File.ReadAllBytes(file);
+            var prefer = PKX.GetPKMFormatFromExtension(fi.Extension, dest.Generation);
+            var pk = PKMConverter.GetPKMfromBytes(data, prefer);
+            if (pk?.Species is not > 0)
+                return;
+
+            var info = new SlotInfoFile(file);
+            var entry = new SlotCache(info, pk);
+            db.Add(entry);
+        }
+
+        private static void AddBoxData(SaveFile sav, ConcurrentBag<SlotCache> db)
+        {
+            var bd = sav.BoxData;
+            var bc = sav.BoxCount;
+            var sc = sav.BoxSlotCount;
+            int ctr = 0;
+            for (int box = 0; box < bc; box++)
+            {
+                for (int slot = 0; slot < sc; slot++, ctr++)
+                {
+                    var ident = new SlotInfoBox(box, slot);
+                    var result = new SlotCache(ident, bd[ctr], sav);
+                    db.Add(result);
+                }
+            }
+        }
+
+        private static void AddPartyData(SaveFile sav, ConcurrentBag<SlotCache> db)
+        {
+            var pd = sav.PartyData;
+            for (var index = 0; index < pd.Count; index++)
+            {
+                var pk = pd[index];
+                if (pk.Species == 0)
+                    continue;
+
+                var ident = new SlotInfoParty(index);
+                var result = new SlotCache(ident, pk, sav);
+                db.Add(result);
+            }
+        }
+
+        private static void AddExtraData(SaveFile sav, ConcurrentBag<SlotCache> db)
+        {
+            var extra = sav.GetExtraSlots(true);
+            foreach (var x in extra)
+            {
+                var pk = x.Read(sav);
+                if (pk.Species == 0)
+                    continue;
+
+                var result = new SlotCache(x, pk, sav);
+                db.Add(result);
+            }
+        }
+        #endregion
+
+        #region ICollection Implementation
+        public static void AddFromSaveFile(SaveFile sav, ICollection<SlotCache> db)
+        {
+            if (sav.HasBox)
+                AddBoxData(sav, db);
+
+            if (sav.HasParty)
+                AddPartyData(sav, db);
+
+            AddExtraData(sav, db);
+        }
+
+        public static void AddFromLocalFile(string file, ICollection<SlotCache> db, ITrainerInfo dest, ICollection<string> validExtensions)
+        {
+            var fi = new FileInfo(file);
+            if (!validExtensions.Contains(fi.Extension) || !PKX.IsPKM(fi.Length))
+                return;
+
+            var data = File.ReadAllBytes(file);
+            var prefer = PKX.GetPKMFormatFromExtension(fi.Extension, dest.Generation);
+            var pk = PKMConverter.GetPKMfromBytes(data, prefer);
+            if (pk?.Species is not > 0)
+                return;
+
+            var info = new SlotInfoFile(file);
+            var entry = new SlotCache(info, pk);
+            db.Add(entry);
+        }
+
+        public static void AddBoxData(SaveFile sav, ICollection<SlotCache> db)
+        {
+            var bd = sav.BoxData;
+            var bc = sav.BoxCount;
+            var sc = sav.BoxSlotCount;
+            int ctr = 0;
+            for (int box = 0; box < bc; box++)
+            {
+                for (int slot = 0; slot < sc; slot++, ctr++)
+                {
+                    var ident = new SlotInfoBox(box, slot);
+                    var result = new SlotCache(ident, bd[ctr], sav);
+                    db.Add(result);
+                }
+            }
+        }
+
+        public static void AddPartyData(SaveFile sav, ICollection<SlotCache> db)
+        {
+            var pd = sav.PartyData;
+            for (var index = 0; index < pd.Count; index++)
+            {
+                var pk = pd[index];
+                if (pk.Species == 0)
+                    continue;
+
+                var ident = new SlotInfoParty(index);
+                var result = new SlotCache(ident, pk, sav);
+                db.Add(result);
+            }
+        }
+
+        private static void AddExtraData(SaveFile sav, ICollection<SlotCache> db)
+        {
+            var extra = sav.GetExtraSlots(true);
+            foreach (var x in extra)
+            {
+                var pk = x.Read(sav);
+                if (pk.Species == 0)
+                    continue;
+
+                var result = new SlotCache(x, pk, sav);
+                db.Add(result);
+            }
+        }
+        #endregion
+    }
+}

--- a/PKHeX.Core/Editing/Saves/Slots/Info/SlotInfoMisc.cs
+++ b/PKHeX.Core/Editing/Saves/Slots/Info/SlotInfoMisc.cs
@@ -8,6 +8,7 @@ namespace PKHeX.Core
         public int Slot { get; }
         public bool PartyFormat { get; }
         public int Offset { get; }
+        public SlotOrigin Origin => PartyFormat ? SlotOrigin.Party : SlotOrigin.Box;
         public bool CanWriteTo(SaveFile sav) => false;
         public WriteBlockedMessage CanWriteTo(SaveFile sav, PKM pkm) => WriteBlockedMessage.InvalidDestination;
         public StorageSlotType Type { get; init; }

--- a/PKHeX.Core/Editing/Saves/Slots/Info/SlotInfoParty.cs
+++ b/PKHeX.Core/Editing/Saves/Slots/Info/SlotInfoParty.cs
@@ -8,6 +8,7 @@ namespace PKHeX.Core
     public sealed class SlotInfoParty : ISlotInfo
     {
         public int Slot { get; private set; }
+        public SlotOrigin Origin => SlotOrigin.Party;
         public bool CanWriteTo(SaveFile sav) => sav.HasParty;
 
         public WriteBlockedMessage CanWriteTo(SaveFile sav, PKM pkm) => pkm.IsEgg && sav.IsPartyAllEggs(Slot)

--- a/PKHeX.Core/Editing/Saves/Slots/Info/SlotOrigin.cs
+++ b/PKHeX.Core/Editing/Saves/Slots/Info/SlotOrigin.cs
@@ -1,0 +1,8 @@
+﻿namespace PKHeX.Core
+{
+    public enum SlotOrigin
+    {
+        Party = 0,
+        Box = 1,
+    }
+}

--- a/PKHeX.Core/Legality/Encounters/Generator/ByGeneration/EncounterGenerator4.cs
+++ b/PKHeX.Core/Legality/Encounters/Generator/ByGeneration/EncounterGenerator4.cs
@@ -60,9 +60,7 @@ namespace PKHeX.Core
             IEncounterable? deferred = null;
             IEncounterable? partial = null;
 
-            bool sport = pkm.Ball == (int)Ball.Sport; // never static encounters (conflict with non bcc / bcc)
-            bool safari = pkm.Ball == (int)Ball.Safari; // never static encounters
-            bool safariSport = safari || sport;
+            bool safariSport = pkm.Ball is (int)Ball.Sport or (int)Ball.Safari; // never static encounters
             if (!safariSport)
             {
                 foreach (var z in GetValidStaticEncounter(pkm, chain))

--- a/PKHeX.Core/Legality/Encounters/Generator/ByGeneration/EncounterGenerator4.cs
+++ b/PKHeX.Core/Legality/Encounters/Generator/ByGeneration/EncounterGenerator4.cs
@@ -49,7 +49,7 @@ namespace PKHeX.Core
                 { yield return z; ++ctr; }
                 if (ctr != 0) yield break;
             }
-            if (pkm.WasBredEgg)
+            if (Locations.IsEggLocationBred4(pkm.Egg_Location, (GameVersion)pkm.Version))
             {
                 foreach (var z in GenerateEggs(pkm, 4))
                     yield return z;

--- a/PKHeX.Core/Legality/Encounters/Generator/ByGeneration/EncounterGenerator5.cs
+++ b/PKHeX.Core/Legality/Encounters/Generator/ByGeneration/EncounterGenerator5.cs
@@ -23,7 +23,7 @@ namespace PKHeX.Core
                 if (ctr != 0) yield break;
             }
 
-            if (pkm.WasBredEgg)
+            if (Locations.IsEggLocationBred5(pkm.Egg_Location))
             {
                 foreach (var z in GenerateEggs(pkm, 5))
                 { yield return z; ++ctr; }

--- a/PKHeX.Core/Legality/Encounters/Generator/ByGeneration/EncounterGenerator5.cs
+++ b/PKHeX.Core/Legality/Encounters/Generator/ByGeneration/EncounterGenerator5.cs
@@ -16,7 +16,7 @@ namespace PKHeX.Core
             int ctr = 0;
 
             var chain = EncounterOrigin.GetOriginChain(pkm);
-            if (pkm.WasEvent || pkm.WasEventEgg)
+            if (pkm.FatefulEncounter)
             {
                 foreach (var z in GetValidGifts(pkm, chain))
                 { yield return z; ++ctr; }

--- a/PKHeX.Core/Legality/Encounters/Generator/ByGeneration/EncounterGenerator6.cs
+++ b/PKHeX.Core/Legality/Encounters/Generator/ByGeneration/EncounterGenerator6.cs
@@ -46,7 +46,7 @@ namespace PKHeX.Core
                 }
             }
 
-            if (pkm.WasBredEgg)
+            if (Locations.IsEggLocationBred6(pkm.Egg_Location))
             {
                 foreach (var z in GenerateEggs(pkm, 6))
                 { yield return z; ++ctr; }

--- a/PKHeX.Core/Legality/Encounters/Generator/ByGeneration/EncounterGenerator6.cs
+++ b/PKHeX.Core/Legality/Encounters/Generator/ByGeneration/EncounterGenerator6.cs
@@ -20,7 +20,7 @@ namespace PKHeX.Core
             IEncounterable? deferred = null;
             IEncounterable? partial = null;
 
-            if (pkm.WasEvent || pkm.WasEventEgg || pkm.Met_Location == Locations.LinkGift6)
+            if (pkm.FatefulEncounter || pkm.Met_Location == Locations.LinkGift6)
             {
                 foreach (var z in GetValidGifts(pkm, chain))
                 {

--- a/PKHeX.Core/Legality/Encounters/Generator/ByGeneration/EncounterGenerator6.cs
+++ b/PKHeX.Core/Legality/Encounters/Generator/ByGeneration/EncounterGenerator6.cs
@@ -20,7 +20,7 @@ namespace PKHeX.Core
             IEncounterable? deferred = null;
             IEncounterable? partial = null;
 
-            if (pkm.WasEvent || pkm.WasEventEgg || pkm.WasLink)
+            if (pkm.WasEvent || pkm.WasEventEgg || pkm.Met_Location == Locations.LinkGift6)
             {
                 foreach (var z in GetValidGifts(pkm, chain))
                 {

--- a/PKHeX.Core/Legality/Encounters/Generator/ByGeneration/EncounterGenerator7.cs
+++ b/PKHeX.Core/Legality/Encounters/Generator/ByGeneration/EncounterGenerator7.cs
@@ -112,7 +112,7 @@ namespace PKHeX.Core
                 if (ctr != 0) yield break;
             }
 
-            if (pkm.WasBredEgg)
+            if (Locations.IsEggLocationBred6(pkm.Egg_Location))
             {
                 foreach (var z in GenerateEggs(pkm, 7))
                 { yield return z; ++ctr; }

--- a/PKHeX.Core/Legality/Encounters/Generator/ByGeneration/EncounterGenerator7.cs
+++ b/PKHeX.Core/Legality/Encounters/Generator/ByGeneration/EncounterGenerator7.cs
@@ -50,7 +50,7 @@ namespace PKHeX.Core
         private static IEnumerable<IEncounterable> GetEncountersGG(PKM pkm, IReadOnlyList<EvoCriteria> chain)
         {
             int ctr = 0;
-            if (pkm.WasEvent)
+            if (pkm.FatefulEncounter)
             {
                 foreach (var z in GetValidGifts(pkm, chain))
                 { yield return z; ++ctr; }
@@ -105,7 +105,7 @@ namespace PKHeX.Core
         private static IEnumerable<IEncounterable> GetEncountersMainline(PKM pkm, IReadOnlyList<EvoCriteria> chain)
         {
             int ctr = 0;
-            if (pkm.WasEvent || pkm.WasEventEgg)
+            if (pkm.FatefulEncounter)
             {
                 foreach (var z in GetValidGifts(pkm, chain))
                 { yield return z; ++ctr; }

--- a/PKHeX.Core/Legality/Encounters/Generator/ByGeneration/EncounterGenerator8.cs
+++ b/PKHeX.Core/Legality/Encounters/Generator/ByGeneration/EncounterGenerator8.cs
@@ -31,7 +31,7 @@ namespace PKHeX.Core
                 if (ctr != 0) yield break;
             }
 
-            if (pkm.WasBredEgg)
+            if (Locations.IsEggLocationBred6(pkm.Egg_Location))
             {
                 foreach (var z in GenerateEggs(pkm, 8))
                 { yield return z; ++ctr; }

--- a/PKHeX.Core/Legality/Encounters/Generator/ByGeneration/EncounterGenerator8.cs
+++ b/PKHeX.Core/Legality/Encounters/Generator/ByGeneration/EncounterGenerator8.cs
@@ -24,7 +24,7 @@ namespace PKHeX.Core
         private static IEnumerable<IEncounterable> GetEncountersMainline(PKM pkm, IReadOnlyList<EvoCriteria> chain)
         {
             int ctr = 0;
-            if (pkm.WasEvent || pkm.WasEventEgg)
+            if (pkm.FatefulEncounter)
             {
                 foreach (var z in GetValidGifts(pkm, chain))
                 { yield return z; ++ctr; }

--- a/PKHeX.Core/Legality/Encounters/Verifiers/VerifyCurrentMoves.cs
+++ b/PKHeX.Core/Legality/Encounters/Verifiers/VerifyCurrentMoves.cs
@@ -510,12 +510,13 @@ namespace PKHeX.Core
             else if (enc is not EncounterEgg)
             {
                 // Event eggs cannot inherit moves from parents; they are not bred.
+                var gift = enc is EncounterStatic {Gift: true}; // otherwise, EncounterInvalid
                 foreach (int m in RegularEggMovesLearned)
                 {
                     if (learnInfo.EggMovesLearned.Contains(m))
-                        res[m] = new CheckMoveResult(res[m], Invalid, pkm.WasGiftEgg ? LMoveEggMoveGift : LMoveEggInvalidEvent, CurrentMove);
+                        res[m] = new CheckMoveResult(res[m], Invalid, gift ? LMoveEggMoveGift : LMoveEggInvalidEvent, CurrentMove);
                     else if (learnInfo.LevelUpEggMoves.Contains(m))
-                        res[m] = new CheckMoveResult(res[m], Invalid, pkm.WasGiftEgg ? LMoveEggInvalidEventLevelUpGift : LMoveEggInvalidEventLevelUp, CurrentMove);
+                        res[m] = new CheckMoveResult(res[m], Invalid, gift ? LMoveEggInvalidEventLevelUpGift : LMoveEggInvalidEventLevelUp, CurrentMove);
                 }
             }
         }

--- a/PKHeX.Core/Legality/LegalityAnalysis.cs
+++ b/PKHeX.Core/Legality/LegalityAnalysis.cs
@@ -46,6 +46,8 @@ namespace PKHeX.Core
         /// </remarks>
         public IEncounterable EncounterOriginal => Info.EncounterOriginal;
 
+        public readonly SlotOrigin SlotOrigin;
+
         /// <summary>
         /// Indicates if all checks ran to completion.
         /// </summary>
@@ -67,23 +69,27 @@ namespace PKHeX.Core
         /// </summary>
         /// <param name="pk">Input data to check</param>
         /// <param name="table"><see cref="SaveFile"/> specific personal data</param>
-        public LegalityAnalysis(PKM pk, PersonalTable table) : this(pk, table.GetFormEntry(pk.Species, pk.Form)) { }
+        /// <param name="source">Details about where the <see cref="pk"/> originated from.</param>
+        public LegalityAnalysis(PKM pk, PersonalTable table, SlotOrigin source = SlotOrigin.Party) : this(pk, table.GetFormEntry(pk.Species, pk.Form), source) { }
 
         /// <summary>
         /// Checks the input <see cref="PKM"/> data for legality.
         /// </summary>
         /// <param name="pk">Input data to check</param>
-        public LegalityAnalysis(PKM pk) : this(pk, pk.PersonalInfo) { }
+        /// <param name="source">Details about where the <see cref="pk"/> originated from.</param>
+        public LegalityAnalysis(PKM pk, SlotOrigin source = SlotOrigin.Party) : this(pk, pk.PersonalInfo, source) { }
 
         /// <summary>
         /// Checks the input <see cref="PKM"/> data for legality.
         /// </summary>
         /// <param name="pk">Input data to check</param>
         /// <param name="pi">Personal info to parse with</param>
-        public LegalityAnalysis(PKM pk, PersonalInfo pi)
+        /// <param name="source">Details about where the <see cref="pk"/> originated from.</param>
+        public LegalityAnalysis(PKM pk, PersonalInfo pi, SlotOrigin source = SlotOrigin.Party)
         {
             pkm = pk;
             PersonalInfo = pi;
+            SlotOrigin = source;
 
             if (pkm.Format <= 2) // prior to storing GameVersion
                 pkm.TradebackStatus = GBRestrictions.GetTradebackStatusInitial(pkm);

--- a/PKHeX.Core/Legality/LegalityAnalysis.cs
+++ b/PKHeX.Core/Legality/LegalityAnalysis.cs
@@ -127,14 +127,16 @@ namespace PKHeX.Core
                 System.Diagnostics.Debug.WriteLine(e.Message);
                 Valid = false;
 
+                var moves = Info.Moves;
                 // Moves and Relearn arrays can potentially be empty on error.
                 // ReSharper disable once ConstantNullCoalescingCondition
-                for (int i = 0; i < Info.Moves.Length; i++)
-                    Info.Moves[i] ??= new CheckMoveResult(MoveSource.None, pkm.Format, Severity.Indeterminate, L_AError, CheckIdentifier.CurrentMove);
+                for (int i = 0; i < moves.Length; i++)
+                    moves[i] ??= new CheckMoveResult(MoveSource.None, pkm.Format, Severity.Indeterminate, L_AError, CheckIdentifier.CurrentMove);
 
+                var relearn = Info.Relearn;
                 // ReSharper disable once ConstantNullCoalescingCondition
-                for (int i = 0; i < Info.Relearn.Length; i++)
-                    Info.Relearn[i] ??= new CheckResult(Severity.Indeterminate, L_AError, CheckIdentifier.CurrentMove);
+                for (int i = 0; i < relearn.Length; i++)
+                    relearn[i] ??= new CheckResult(Severity.Indeterminate, L_AError, CheckIdentifier.RelearnMove);
 
                 AddLine(Severity.Invalid, L_AError, CheckIdentifier.Misc);
             }

--- a/PKHeX.Core/Legality/Tables/Locations.cs
+++ b/PKHeX.Core/Legality/Tables/Locations.cs
@@ -18,6 +18,9 @@
         public const int LinkTrade5NPC = 30002;
         public const int LinkTrade6NPC = 30001;
 
+        public const int Breeder5 = 60003;
+        public const int Breeder6 = 60004;
+
         public const int PokeWalker4 = 233;
         public const int Ranger4 = 3001;
         public const int Faraway4 = 3002;
@@ -109,6 +112,7 @@
 
         public static bool IsPtHGSSLocation(int location) => location is > 111 and < 2000;
         public static bool IsPtHGSSLocationEgg(int location) => location is > 2010 and < 3000;
+        public static bool IsEventLocation4(int location) => location is >= 3000 and <= 3076;
         public static bool IsEventLocation5(int location) => location is > 40000 and < 50000;
 
         private const int SafariLocation_RSE = 57;
@@ -117,5 +121,15 @@
         private const int MarshLocation_DPPt = 52;
         public static bool IsSafariZoneLocation3(int loc) => loc is SafariLocation_RSE or SafariLocation_FRLG;
         public static bool IsSafariZoneLocation4(int loc) => loc is MarshLocation_DPPt or SafariLocation_HGSS;
+
+        public static bool IsEggLocationBred4(int loc, GameVersion ver)
+        {
+            if (loc is Daycare4 or LinkTrade4)
+                return true;
+            return loc == Faraway4 && ver is GameVersion.Pt or GameVersion.HG or GameVersion.SS;
+        }
+
+        public static bool IsEggLocationBred5(int loc) => loc is Daycare5 or LinkTrade5;
+        public static bool IsEggLocationBred6(int loc) => loc is Daycare5 or LinkTrade6;
     }
 }

--- a/PKHeX.Core/Legality/Tables/Tables4.cs
+++ b/PKHeX.Core/Legality/Tables/Tables4.cs
@@ -274,29 +274,5 @@ namespace PKHeX.Core
                 _ => Locations.Transfer4
             };
         }
-
-        internal static int[] RemoveMovesHM45(int[] moves)
-        {
-            var banned = GetFavorableHMBanlist(moves);
-
-            for (int i = 0; i < 4; i++)
-            {
-                if (banned.Contains(moves[i]))
-                    moves[i] = 0;
-            }
-
-            return moves;
-        }
-
-        /// <summary>
-        /// Transfer via advantageous game
-        /// </summary>
-        /// <param name="moves">Current moves</param>
-        /// <returns>Preferred move ban list</returns>
-        private static ICollection<int> GetFavorableHMBanlist(int[] moves)
-        {
-            // if has defog, return ban list with whirlpool
-            return moves.Contains((int)Move.Defog) ? HM_HGSS : HM_DPPt;
-        }
     }
 }

--- a/PKHeX.Core/Legality/Verifiers/FormVerifier.cs
+++ b/PKHeX.Core/Legality/Verifiers/FormVerifier.cs
@@ -154,7 +154,7 @@ namespace PKHeX.Core
                 case Shaymin:
                 case Furfrou:
                 case Hoopa:
-                    if (form != 0 && pkm.Box > -1 && pkm.Format <= 6) // has form but stored in box
+                    if (form != 0 && data.SlotOrigin is not SlotOrigin.Party && pkm.Format <= 6) // has form but stored in box
                         return GetInvalid(LFormParty);
                     break;
             }

--- a/PKHeX.Core/Legality/Verifiers/MemoryVerifier.cs
+++ b/PKHeX.Core/Legality/Verifiers/MemoryVerifier.cs
@@ -314,7 +314,7 @@ namespace PKHeX.Core
             data.AddLine(commonResult);
         }
 
-        private static bool WasTradedSWSHEgg(PKM pkm) => pkm.Gen8 && pkm.WasBredEgg;
+        private static bool WasTradedSWSHEgg(PKM pkm) => pkm.SWSH && pkm.Egg_Location is Locations.LinkTrade6;
 
         private void VerifyHTMemoryTransferTo7(LegalityAnalysis data, PKM pkm, LegalInfo Info)
         {

--- a/PKHeX.Core/Legality/Verifiers/MiscVerifier.cs
+++ b/PKHeX.Core/Legality/Verifiers/MiscVerifier.cs
@@ -273,10 +273,18 @@ namespace PKHeX.Core
                     data.AddLine(GetInvalid(LPIDTypeMismatch, PID));
             }
 
-            var result = pkm.FatefulEncounter != pkm.WasLink
+            bool shouldHave = GetFatefulState(g);
+            var result = pkm.FatefulEncounter == shouldHave
                 ? GetValid(LFatefulMystery, Fateful)
                 : GetInvalid(LFatefulMysteryMissing, Fateful);
             data.AddLine(result);
+        }
+
+        private static bool GetFatefulState(MysteryGift g)
+        {
+            if (g is WC6 {IsLinkGift: true})
+                return false; // Pokémon Link fake-gifts do not have Fateful
+            return true;
         }
 
         private static void VerifyReceivability(LegalityAnalysis data, MysteryGift g)

--- a/PKHeX.Core/MysteryGifts/WC6.cs
+++ b/PKHeX.Core/MysteryGifts/WC6.cs
@@ -264,6 +264,8 @@ namespace PKHeX.Core
             }
         }
 
+        public bool IsLinkGift => MetLocation == Locations.LinkGift6;
+
         public override PKM ConvertToPKM(ITrainerInfo sav, EncounterCriteria criteria)
         {
             if (!IsPokémon)
@@ -329,7 +331,7 @@ namespace PKHeX.Core
                 OT_Memory = OT_Memory,
                 OT_TextVar = OT_TextVar,
                 OT_Feeling = OT_Feeling,
-                FatefulEncounter = MetLocation != 30011, // Link gifts do not set fateful encounter
+                FatefulEncounter = !IsLinkGift, // Link gifts do not set fateful encounter
 
                 EVs = EVs,
             };

--- a/PKHeX.Core/PKM/BK4.cs
+++ b/PKHeX.Core/PKM/BK4.cs
@@ -44,7 +44,7 @@ namespace PKHeX.Core
 
         public BK4() : this(new byte[PokeCrypto.SIZE_4STORED]) { }
 
-        public override PKM Clone() => new BK4((byte[])Data.Clone()){Identifier = Identifier};
+        public override PKM Clone() => new BK4((byte[])Data.Clone());
 
         public string GetString(int Offset, int Count) => StringConverter4.GetBEString4(Data, Offset, Count);
         private static byte[] SetString(string value, int maxLength) => StringConverter4.SetBEString4(value, maxLength);

--- a/PKHeX.Core/PKM/CK3.cs
+++ b/PKHeX.Core/PKM/CK3.cs
@@ -23,7 +23,7 @@ namespace PKHeX.Core
         public override PersonalInfo PersonalInfo => PersonalTable.RS[Species];
         public CK3(byte[] data) : base(data) { }
         public CK3() : this(new byte[PokeCrypto.SIZE_3CSTORED]) { }
-        public override PKM Clone() => new CK3((byte[])Data.Clone()) {Identifier = Identifier};
+        public override PKM Clone() => new CK3((byte[])Data.Clone());
 
         private string GetString(int Offset, int Count) => StringConverter3.GetBEString3(Data, Offset, Count);
         private static byte[] SetString(string value, int maxLength) => StringConverter3.SetBEString3(value, maxLength);

--- a/PKHeX.Core/PKM/PB7.cs
+++ b/PKHeX.Core/PKM/PB7.cs
@@ -39,7 +39,7 @@ namespace PKHeX.Core
             return data;
         }
 
-        public override PKM Clone() => new PB7((byte[])Data.Clone()){Identifier = Identifier};
+        public override PKM Clone() => new PB7((byte[])Data.Clone());
 
         private string GetString(int Offset, int Count) => StringConverter.GetString7b(Data, Offset, Count);
         private static byte[] SetString(string value, int maxLength) => StringConverter.SetString7b(value, maxLength);

--- a/PKHeX.Core/PKM/PK1.cs
+++ b/PKHeX.Core/PKM/PK1.cs
@@ -28,7 +28,6 @@ namespace PKHeX.Core
 
         public override PKM Clone() => new PK1((byte[])Data.Clone(), Japanese)
         {
-            Identifier = Identifier,
             OT_Trash = RawOT,
             Nickname_Trash = RawNickname,
         };

--- a/PKHeX.Core/PKM/PK2.cs
+++ b/PKHeX.Core/PKM/PK2.cs
@@ -28,7 +28,6 @@ namespace PKHeX.Core
 
         public override PKM Clone() => new PK2((byte[])Data.Clone(), Japanese)
         {
-            Identifier = Identifier,
             OT_Trash = RawOT,
             Nickname_Trash = RawNickname,
             IsEgg = IsEgg,

--- a/PKHeX.Core/PKM/PK3.cs
+++ b/PKHeX.Core/PKM/PK3.cs
@@ -32,7 +32,7 @@ namespace PKHeX.Core
         {
             // Don't use the byte[] constructor, the DecryptIfEncrypted call is based on checksum.
             // An invalid checksum will shuffle the data; we already know it's un-shuffled. Set up manually.
-            var pk = new PK3 {Identifier = Identifier};
+            var pk = new PK3();
             Data.CopyTo(pk.Data, 0);
             return pk;
         }

--- a/PKHeX.Core/PKM/PK4.cs
+++ b/PKHeX.Core/PKM/PK4.cs
@@ -416,7 +416,13 @@ namespace PKHeX.Core
             pk5.Met_Level = pk5.CurrentLevel;
 
             // Remove HM moves; Defog should be kept if both are learned.
-            pk5.Moves = Legal.RemoveMovesHM45(pk5.Moves);
+            // if has defog, remove whirlpool.
+            bool hasDefog = HasMove((int) Move.Defog);
+            var banned = hasDefog ? Legal.HM_HGSS : Legal.HM_DPPt;
+            if (banned.Contains(Move1)) Move1 = 0;
+            if (banned.Contains(Move2)) Move2 = 0;
+            if (banned.Contains(Move3)) Move3 = 0;
+            if (banned.Contains(Move4)) Move4 = 0;
             pk5.FixMoves();
 
             pk5.RefreshChecksum();

--- a/PKHeX.Core/PKM/PK4.cs
+++ b/PKHeX.Core/PKM/PK4.cs
@@ -29,7 +29,7 @@ namespace PKHeX.Core
             return data;
         }
 
-        public override PKM Clone() => new PK4((byte[])Data.Clone()){Identifier = Identifier};
+        public override PKM Clone() => new PK4((byte[])Data.Clone());
 
         private string GetString(int Offset, int Count) => StringConverter4.GetString4(Data, Offset, Count);
         private static byte[] SetString(string value, int maxLength) => StringConverter4.SetString4(value, maxLength);

--- a/PKHeX.Core/PKM/PK5.cs
+++ b/PKHeX.Core/PKM/PK5.cs
@@ -33,7 +33,7 @@ namespace PKHeX.Core
             return data;
         }
 
-        public override PKM Clone() => new PK5((byte[])Data.Clone()){Identifier = Identifier};
+        public override PKM Clone() => new PK5((byte[])Data.Clone());
 
         private string GetString(int Offset, int Count) => StringConverter.GetString5(Data, Offset, Count);
         private static byte[] SetString(string value, int maxLength) => StringConverter.SetString5(value, maxLength);

--- a/PKHeX.Core/PKM/PK6.cs
+++ b/PKHeX.Core/PKM/PK6.cs
@@ -27,7 +27,7 @@ namespace PKHeX.Core
             return data;
         }
 
-        public override PKM Clone() => new PK6((byte[])Data.Clone()){Identifier = Identifier};
+        public override PKM Clone() => new PK6((byte[])Data.Clone());
 
         private string GetString(int Offset, int Count) => StringConverter.GetString6(Data, Offset, Count);
         private static byte[] SetString(string value, int maxLength) => StringConverter.SetString6(value, maxLength);

--- a/PKHeX.Core/PKM/PK7.cs
+++ b/PKHeX.Core/PKM/PK7.cs
@@ -28,7 +28,7 @@ namespace PKHeX.Core
             return data;
         }
 
-        public override PKM Clone() => new PK7((byte[])Data.Clone()){Identifier = Identifier};
+        public override PKM Clone() => new PK7((byte[])Data.Clone());
 
         private string GetString(int Offset, int Count) => StringConverter.GetString7(Data, Offset, Count);
         private byte[] SetString(string value, int maxLength, bool chinese = false) => StringConverter.SetString7(value, maxLength, Language, chinese: chinese);

--- a/PKHeX.Core/PKM/PK8.cs
+++ b/PKHeX.Core/PKM/PK8.cs
@@ -57,7 +57,7 @@ namespace PKHeX.Core
             set { if (CurrentHandler == 0) OT_Friendship = value; else HT_Friendship = value; }
         }
 
-        public override PKM Clone() => new PK8((byte[])Data.Clone()) { Identifier = Identifier };
+        public override PKM Clone() => new PK8((byte[])Data.Clone());
 
         private string GetString(int Offset, int Count) => StringConverter.GetString7b(Data, Offset, Count);
         private static byte[] SetString(string value, int maxLength) => StringConverter.SetString7b(value, maxLength);

--- a/PKHeX.Core/PKM/PK8.cs
+++ b/PKHeX.Core/PKM/PK8.cs
@@ -69,9 +69,7 @@ namespace PKHeX.Core
         public override byte[] Nickname_Trash { get => GetData(0x58, 24); set { if (value.Length == 24) value.CopyTo(Data, 0x58); } }
         public override byte[] HT_Trash { get => GetData(0xA8, 24); set { if (value.Length == 24) value.CopyTo(Data, 0xA8); } }
         public override byte[] OT_Trash { get => GetData(0xF8, 24); set { if (value.Length == 24) value.CopyTo(Data, 0xF8); } }
-        public override bool WasEvent => Locations.IsEventLocation5(Met_Location) || FatefulEncounter;
-        public override bool WasEventEgg => Generation < 5 ? base.WasEventEgg : (Locations.IsEventLocation5(Egg_Location) || (FatefulEncounter && Egg_Location == Locations.LinkTrade6)) && Met_Level == 1;
-
+        
         // Maximums
         public override int MaxIV => 31;
         public override int MaxEV => 252;

--- a/PKHeX.Core/PKM/PK8.cs
+++ b/PKHeX.Core/PKM/PK8.cs
@@ -69,7 +69,6 @@ namespace PKHeX.Core
         public override byte[] Nickname_Trash { get => GetData(0x58, 24); set { if (value.Length == 24) value.CopyTo(Data, 0x58); } }
         public override byte[] HT_Trash { get => GetData(0xA8, 24); set { if (value.Length == 24) value.CopyTo(Data, 0xA8); } }
         public override byte[] OT_Trash { get => GetData(0xF8, 24); set { if (value.Length == 24) value.CopyTo(Data, 0xF8); } }
-        public override bool WasLink => Met_Location == Locations.LinkGift6 && Gen6;
         public override bool WasEvent => Locations.IsEventLocation5(Met_Location) || FatefulEncounter;
         public override bool WasEventEgg => Generation < 5 ? base.WasEventEgg : (Locations.IsEventLocation5(Egg_Location) || (FatefulEncounter && Egg_Location == Locations.LinkTrade6)) && Met_Level == 1;
 

--- a/PKHeX.Core/PKM/PKM.cs
+++ b/PKHeX.Core/PKM/PKM.cs
@@ -293,7 +293,7 @@ namespace PKHeX.Core
         public bool LGPE => Version is (int)GP or (int)GE;
         public bool SWSH => Version is (int)SW or (int)SH;
 
-        protected bool PtHGSS => Pt || HGSS;
+        protected internal bool PtHGSS => Pt || HGSS;
         public bool GO_LGPE => GO && Met_Location == Locations.GO7;
         public bool GO_HOME => GO && Met_Location == Locations.GO8;
         public bool VC => VC1 || VC2;
@@ -502,64 +502,15 @@ namespace PKHeX.Core
         public bool Gen1_NotTradeback => TradebackStatus == TradebackType.Gen1_NotTradeback;
         public bool Gen2_NotTradeback => TradebackStatus == TradebackType.Gen2_NotTradeback;
 
-        public bool WasEgg
-        {
-            get
-            {
-                int loc = Egg_Location;
-                return Generation switch
-                {
-                    4 => (Legal.EggLocations4.Contains(loc) || (Species == (int) Core.Species.Manaphy && loc == Locations.Ranger4) || (loc == Locations.Faraway4 && PtHGSS)), // faraway
-                    5 => Legal.EggLocations5.Contains(loc),
-                    6 => Legal.EggLocations6.Contains(loc),
-                    7 => Legal.EggLocations7.Contains(loc),
-                    8 => Legal.EggLocations8.Contains(loc),
-                    // Gen 1/2 and pal park Gen 3
-                    _ => false
-                };
-            }
-        }
-
-        public virtual bool WasGiftEgg
-        {
-            get
-            {
-                if (!WasEgg)
-                    return false;
-                int loc = Egg_Location;
-                return Generation switch
-                {
-                    4 => Legal.GiftEggLocation4.Contains(loc) || (loc == Locations.Faraway4 && HGSS),
-                    5 => loc == Locations.Breeder5,
-                    6 or 7 or 8 => loc == Locations.Breeder6,
-                    _ => false,
-                };
-            }
-        }
-
-        public virtual bool WasEvent => Locations.IsEventLocation5(Met_Location) || FatefulEncounter;
-
-        public virtual bool WasEventEgg
-        {
-            get
-            {
-                if (Gen4)
-                    return WasEgg && Species == (int) Core.Species.Manaphy;
-                // Gen5+
-                if (Met_Level != 1)
-                    return false;
-                int loc = Egg_Location;
-                return Locations.IsEventLocation5(loc) || (FatefulEncounter && loc != 0);
-            }
-        }
-
+        // Misc Egg Facts
+        public bool WasEgg => IsEgg || Egg_Location != 0;
         public bool WasTradedEgg => Egg_Location == GetTradedEggLocation();
         public bool IsTradedEgg => Met_Location == GetTradedEggLocation();
         private int GetTradedEggLocation() => Locations.TradedEggLocation(Generation);
 
         public virtual bool IsUntraded => false;
         public bool IsNative => Generation == Format;
-        public bool IsOriginValid => Species <= Legal.GetMaxSpeciesOrigin(Format);
+        public bool IsOriginValid => Species <= MaxSpeciesID;
 
         /// <summary>
         /// Checks if the <see cref="PKM"/> could inhabit a set of games.

--- a/PKHeX.Core/PKM/PKM.cs
+++ b/PKHeX.Core/PKM/PKM.cs
@@ -501,7 +501,6 @@ namespace PKHeX.Core
         public TradebackType TradebackStatus { get; set; } = TradebackType.Any;
         public bool Gen1_NotTradeback => TradebackStatus == TradebackType.Gen1_NotTradeback;
         public bool Gen2_NotTradeback => TradebackStatus == TradebackType.Gen2_NotTradeback;
-        public virtual bool WasLink => false;
 
         public bool WasEgg
         {

--- a/PKHeX.Core/PKM/PKM.cs
+++ b/PKHeX.Core/PKM/PKM.cs
@@ -520,21 +520,6 @@ namespace PKHeX.Core
             }
         }
 
-        public bool WasBredEgg
-        {
-            get
-            {
-                int loc = Egg_Location;
-                return Generation switch
-                {
-                    4 => loc is Locations.Daycare4 or Locations.LinkTrade4 || (loc == Locations.Faraway4 && PtHGSS),
-                    5 => loc is Locations.Daycare5 or Locations.LinkTrade5,
-                    6 or 7 or 8 => loc is Locations.Daycare5 or Locations.LinkTrade6,
-                    _ => false,// Gen 1/2 and pal park Gen 3
-                };
-            }
-        }
-
         public virtual bool WasGiftEgg
         {
             get
@@ -545,8 +530,8 @@ namespace PKHeX.Core
                 return Generation switch
                 {
                     4 => Legal.GiftEggLocation4.Contains(loc) || (loc == Locations.Faraway4 && HGSS),
-                    5 => loc == 60003,
-                    6 or 7 or 8 => loc == 60004,
+                    5 => loc == Locations.Breeder5,
+                    6 or 7 or 8 => loc == Locations.Breeder6,
                     _ => false,
                 };
             }

--- a/PKHeX.Core/PKM/PKM.cs
+++ b/PKHeX.Core/PKM/PKM.cs
@@ -19,9 +19,6 @@ namespace PKHeX.Core
 
         // Internal Attributes set on creation
         public readonly byte[] Data; // Raw Storage
-        public string? Identifier; // User or Form Custom Attribute
-        public int Box { get; set; } = -1; // Batch Editor
-        public int Slot { get; set; } = -1; // Batch Editor
 
         protected PKM(byte[] data) => Data = data;
         protected PKM(int size) => Data = new byte[size];
@@ -248,8 +245,6 @@ namespace PKHeX.Core
         public int SpecForm { get => Species + (Form << 11); set { Species = value & 0x7FF; Form = value >> 11; } }
         public virtual int SpriteItem => HeldItem;
         public virtual bool IsShiny => TSV == PSV;
-        public StorageSlotFlag StorageFlags { get; internal set; }
-        public bool Locked => StorageFlags.HasFlagFast(StorageSlotFlag.Locked);
         public int TrainerID7 { get => (int)((uint)(TID | (SID << 16)) % 1000000); set => SetID7(TrainerSID7, value); }
         public int TrainerSID7 { get => (int)((uint)(TID | (SID << 16)) / 1000000); set => SetID7(value, TrainerID7); }
 

--- a/PKHeX.Core/PKM/SK2.cs
+++ b/PKHeX.Core/PKM/SK2.cs
@@ -26,7 +26,6 @@ namespace PKHeX.Core
 
         public override PKM Clone() => new SK2((byte[])Data.Clone(), Japanese)
         {
-            Identifier = Identifier,
             IsEgg = IsEgg,
         };
 

--- a/PKHeX.Core/PKM/Shared/G3PKM.cs
+++ b/PKHeX.Core/PKM/Shared/G3PKM.cs
@@ -24,9 +24,6 @@
         public sealed override int PSV => (int)((PID >> 16 ^ (PID & 0xFFFF)) >> 3);
         public sealed override int TSV => (TID ^ SID) >> 3;
         public sealed override bool Japanese => Language == (int)LanguageID.Japanese;
-        public sealed override bool WasEvent => Met_Location == 255; // Fateful
-        public sealed override bool WasGiftEgg => IsEgg && Met_Location == 253; // Gift Egg, indistinguible from normal eggs after hatch
-        public sealed override bool WasEventEgg => IsEgg && Met_Location == 255; // Event Egg, indistinguible from normal eggs after hatch
 
         public sealed override int Ability { get => ((PersonalInfoG3)PersonalInfo).GetAbility(AbilityBit); set { } }
         public sealed override uint EncryptionConstant { get => PID; set { } }

--- a/PKHeX.Core/PKM/Shared/G4PKM.cs
+++ b/PKHeX.Core/PKM/Shared/G4PKM.cs
@@ -49,7 +49,7 @@
         public sealed override int AbilityNumber { get => 1 << PIDAbility; set { } }
 
         // Legality Extensions
-        public sealed override bool WasEvent => (Met_Location is >= 3000 and <= 3076) || FatefulEncounter;
+        public sealed override bool WasEvent => Locations.IsEventLocation4(Met_Location) || FatefulEncounter;
         public sealed override bool WasEventEgg => WasEgg && Species == (int)Core.Species.Manaphy; // Manaphy was the only generation 4 released event egg
 
         public abstract int ShinyLeaf { get; set; }

--- a/PKHeX.Core/PKM/Shared/G4PKM.cs
+++ b/PKHeX.Core/PKM/Shared/G4PKM.cs
@@ -48,10 +48,6 @@
         public sealed override int CurrentHandler { get => 0; set { } }
         public sealed override int AbilityNumber { get => 1 << PIDAbility; set { } }
 
-        // Legality Extensions
-        public sealed override bool WasEvent => Locations.IsEventLocation4(Met_Location) || FatefulEncounter;
-        public sealed override bool WasEventEgg => WasEgg && Species == (int)Core.Species.Manaphy; // Manaphy was the only generation 4 released event egg
-
         public abstract int ShinyLeaf { get; set; }
 
         #region Ribbons

--- a/PKHeX.Core/PKM/Shared/G6PKM.cs
+++ b/PKHeX.Core/PKM/Shared/G6PKM.cs
@@ -112,7 +112,6 @@ namespace PKHeX.Core
         protected abstract void TradeHT(ITrainerInfo tr);
 
         // Legality Properties
-        public sealed override bool WasLink => Met_Location == Locations.LinkGift6 && Gen6;
         public sealed override bool WasEvent => Locations.IsEventLocation5(Met_Location) || FatefulEncounter;
         public sealed override bool WasEventEgg => Generation < 5 ? base.WasEventEgg : (Locations.IsEventLocation5(Egg_Location) || (FatefulEncounter && Egg_Location == Locations.LinkTrade6)) && Met_Level == 1;
 

--- a/PKHeX.Core/PKM/Shared/G6PKM.cs
+++ b/PKHeX.Core/PKM/Shared/G6PKM.cs
@@ -110,11 +110,7 @@ namespace PKHeX.Core
 
         protected abstract bool TradeOT(ITrainerInfo tr);
         protected abstract void TradeHT(ITrainerInfo tr);
-
-        // Legality Properties
-        public sealed override bool WasEvent => Locations.IsEventLocation5(Met_Location) || FatefulEncounter;
-        public sealed override bool WasEventEgg => Generation < 5 ? base.WasEventEgg : (Locations.IsEventLocation5(Egg_Location) || (FatefulEncounter && Egg_Location == Locations.LinkTrade6)) && Met_Level == 1;
-
+        
         // Maximums
         public sealed override int MaxIV => 31;
         public sealed override int MaxEV => 252;

--- a/PKHeX.Core/PKM/Util/PKMSorting.cs
+++ b/PKHeX.Core/PKM/Util/PKMSorting.cs
@@ -122,6 +122,33 @@ namespace PKHeX.Core
         /// Sorts an <see cref="Enumerable"/> list of <see cref="PKM"/> objects based on the provided filter operations.
         /// </summary>
         /// <param name="list">Source list to sort</param>
+        /// <param name="sav">Save file destination</param>
+        /// <param name="check">Position check</param>
+        /// <param name="start">Starting position</param>
+        /// <returns>Enumerable list that is sorted</returns>
+        public static IEnumerable<PKM> BubbleUp(this IEnumerable<PKM> list, SaveFile sav, Func<int, bool> check, int start)
+        {
+            var matches = new List<PKM>();
+            var failures = new List<PKM>();
+            var ctr = start;
+            foreach (var x in list)
+            {
+                while (sav.IsSlotOverwriteProtected(ctr))
+                    ctr++;
+                bool isMatch = check(ctr);
+                var arr = isMatch ? matches : failures;
+                arr.Add(x);
+                ctr++;
+            }
+
+            var result = matches.Concat(failures);
+            return result.InitialSortBy();
+        }
+
+        /// <summary>
+        /// Sorts an <see cref="Enumerable"/> list of <see cref="PKM"/> objects based on the provided filter operations.
+        /// </summary>
+        /// <param name="list">Source list to sort</param>
         /// <param name="filters">Filter operations to sort with (sorted with ThenBy after the initial sort).</param>
         /// <returns>Enumerable list that is sorted</returns>
         public static IEnumerable<PKM> OrderByCustom(this IEnumerable<PKM> list, params Func<PKM, IComparable>[] filters)

--- a/PKHeX.Core/PKM/XK3.cs
+++ b/PKHeX.Core/PKM/XK3.cs
@@ -22,7 +22,7 @@ namespace PKHeX.Core
         public override PersonalInfo PersonalInfo => PersonalTable.RS[Species];
         public XK3(byte[] data) : base(data) { }
         public XK3() : base(PokeCrypto.SIZE_3XSTORED) { }
-        public override PKM Clone() => new XK3((byte[])Data.Clone()){Identifier = Identifier, Purification = Purification};
+        public override PKM Clone() => new XK3((byte[])Data.Clone()){Purification = Purification};
 
         private string GetString(int Offset, int Count) => StringConverter3.GetBEString3(Data, Offset, Count);
         private static byte[] SetString(string value, int maxLength) => StringConverter3.SetBEString3(value, maxLength);

--- a/PKHeX.Core/Saves/Storage/SlotPointerUtil.cs
+++ b/PKHeX.Core/Saves/Storage/SlotPointerUtil.cs
@@ -47,7 +47,7 @@ namespace PKHeX.Core
                     if (newIndex < 0)
                         continue;
 
-                    Debug.WriteLine($"Repointing {pk.Nickname} from ({pk.Box}|{pk.Slot}) to {newIndex}");
+                    Debug.WriteLine($"Re-pointing {pk.Nickname} from {index} to {newIndex}");
                     Debug.WriteLine($"{result[newIndex]}");
                     p[i] = start + newIndex;
                 }

--- a/PKHeX.Core/Saves/Substructures/Battle Videos/BV3.cs
+++ b/PKHeX.Core/Saves/Substructures/Battle Videos/BV3.cs
@@ -31,30 +31,35 @@ namespace PKHeX.Core
         {
             get => new[]
             {
-                GetTeam(0, 0),
-                GetTeam(0, 6 * PokeCrypto.SIZE_3PARTY),
+                GetTeam(0),
+                GetTeam(1),
             };
             set
             {
                 SetTeam(value[0], 0);
-                SetTeam(value[1], 6 * PokeCrypto.SIZE_3PARTY);
+                SetTeam(value[1], 1);
             }
         }
 
-        public PK3[] GetTeam(int teamIndex, int ofs)
+        public PK3[] GetTeam(int teamIndex)
         {
+            if ((uint)teamIndex > 2)
+                throw new ArgumentOutOfRangeException(nameof(teamIndex));
+
+            var ofs = (6 * PokeCrypto.SIZE_3PARTY) * teamIndex;
             var team = new PK3[6];
             for (int p = 0; p < 6; p++)
             {
                 int offset = ofs + (PokeCrypto.SIZE_3PARTY * p);
-                team[p] = new PK3(Data.Slice(offset, PokeCrypto.SIZE_3PARTY)) { Identifier = $"Team {teamIndex}, Slot {p}" };
+                team[p] = new PK3(Data.Slice(offset, PokeCrypto.SIZE_3PARTY));
             }
 
             return team;
         }
 
-        public void SetTeam(IReadOnlyList<PK3> team, int ofs)
+        public void SetTeam(IReadOnlyList<PK3> team, int teamIndex)
         {
+            var ofs = (6 * PokeCrypto.SIZE_3PARTY) * teamIndex;
             for (int p = 0; p < 6; p++)
             {
                 int offset = ofs + (PokeCrypto.SIZE_3PARTY * p);

--- a/PKHeX.Core/Saves/Substructures/Battle Videos/BV6.cs
+++ b/PKHeX.Core/Saves/Substructures/Battle Videos/BV6.cs
@@ -96,7 +96,7 @@ namespace PKHeX.Core
             {
                 int offset = start + (PokeCrypto.SIZE_6PARTY * ((t * 6) + p));
                 offset += 8 * (((t * 6) + p) / 6); // 8 bytes padding between teams
-                team[p] = new PK6(Data.Slice(offset, PokeCrypto.SIZE_6PARTY)) { Identifier = $"Team {t}, Slot {p}" };
+                team[p] = new PK6(Data.Slice(offset, PokeCrypto.SIZE_6PARTY));
             }
 
             return team;

--- a/PKHeX.Core/Saves/Substructures/Battle Videos/BV7.cs
+++ b/PKHeX.Core/Saves/Substructures/Battle Videos/BV7.cs
@@ -43,7 +43,7 @@ namespace PKHeX.Core
             for (int p = 0; p < 6; p++)
             {
                 int offset = ofs + (PokeCrypto.SIZE_6PARTY * p);
-                team[p] = new PK7(Data.Slice(offset, PokeCrypto.SIZE_6STORED)) { Identifier = $"Team {teamIndex}, Slot {p}" };
+                team[p] = new PK7(Data.Slice(offset, PokeCrypto.SIZE_6STORED));
             }
 
             return team;

--- a/PKHeX.Core/Saves/Substructures/Gen7/PokeListHeader.cs
+++ b/PKHeX.Core/Saves/Substructures/Gen7/PokeListHeader.cs
@@ -123,14 +123,15 @@ namespace PKHeX.Core
             return SAV.GetBoxSlotOffset(position);
         }
 
-        public int GetPartyIndex(int box, int slot)
+        private int GetPartyIndex(int slotIndex)
         {
-            int slotIndex = slot + (SAV.BoxSlotCount * box);
-            if ((uint)slotIndex >= MAX_SLOTS)
+            if ((uint) slotIndex >= MAX_SLOTS)
                 return MAX_SLOTS;
             var index = Array.IndexOf(PokeListInfo, slotIndex);
             return index >= 0 ? index : MAX_SLOTS;
         }
+
+        public bool IsParty(int slotIndex) => GetPartyIndex(slotIndex) != MAX_SLOTS;
 
         public bool CompressStorage()
         {

--- a/PKHeX.Core/Saves/Substructures/Gen7/ResortSave7.cs
+++ b/PKHeX.Core/Saves/Substructures/Gen7/ResortSave7.cs
@@ -18,7 +18,7 @@ namespace PKHeX.Core
                 for (int i = 0; i < data.Length; i++)
                 {
                     var bytes = SAV.GetData(GetResortSlotOffset(i), PokeCrypto.SIZE_6STORED);
-                    data[i] = new PK7(bytes) { Identifier = $"Resort Slot {i}" };
+                    data[i] = new PK7(bytes);
                 }
                 return data;
             }

--- a/PKHeX.Core/Saves/Util/BoxUtil.cs
+++ b/PKHeX.Core/Saves/Util/BoxUtil.cs
@@ -24,16 +24,19 @@ namespace PKHeX.Core
                 return -1;
 
             var boxData = sav.BoxData;
+            int boxSlotCount = sav.BoxSlotCount;
             var ctr = 0;
-            foreach (var pk in boxData)
+            for (var slot = 0; slot < boxData.Count; slot++)
             {
+                var pk = boxData[slot];
+                var box = slot / boxSlotCount;
                 if (pk.Species == 0 || !pk.Valid)
                     continue;
 
                 var boxFolder = path;
                 if (boxFolders)
                 {
-                    var boxName = Util.CleanFileName(sav.GetBoxName(pk.Box - 1));
+                    var boxName = Util.CleanFileName(sav.GetBoxName(box));
                     boxFolder = Path.Combine(path, boxName);
                     Directory.CreateDirectory(boxFolder);
                 }
@@ -62,10 +65,13 @@ namespace PKHeX.Core
                 return -1;
 
             var boxData = sav.BoxData;
+            int boxSlotCount = sav.BoxSlotCount;
             var ctr = 0;
-            foreach (var pk in boxData)
+            for (var slot = 0; slot < boxData.Count; slot++)
             {
-                if (pk.Species == 0 || !pk.Valid || pk.Box - 1 != currentBox)
+                var pk = boxData[slot];
+                var box = slot / boxSlotCount;
+                if (pk.Species == 0 || !pk.Valid || box != currentBox)
                     continue;
 
                 var fileName = Path.Combine(path, Util.CleanFileName(pk.FileName));

--- a/PKHeX.Core/Util/ArrayUtil.cs
+++ b/PKHeX.Core/Util/ArrayUtil.cs
@@ -84,7 +84,7 @@ namespace PKHeX.Core
         /// <param name="skip">Criteria for skipping a slot</param>
         /// <param name="start">Starting point to copy to</param>
         /// <returns>Count of <see cref="T"/> copied.</returns>
-        public static int CopyTo<T>(this IEnumerable<T> list, IList<T> dest, Func<T, bool> skip, int start = 0)
+        public static int CopyTo<T>(this IEnumerable<T> list, IList<T> dest, Func<int, bool> skip, int start = 0)
         {
             int ctr = start;
             int skipped = 0;
@@ -101,14 +101,14 @@ namespace PKHeX.Core
             return ctr - start - skipped;
         }
 
-        public static int FindNextValidIndex<T>(IList<T> dest, Func<T, bool> skip, int ctr)
+        public static int FindNextValidIndex<T>(IList<T> dest, Func<int, bool> skip, int ctr)
         {
             while (true)
             {
                 if ((uint)ctr >= dest.Count)
                     return -1;
                 var exist = dest[ctr];
-                if (exist == null || !skip(exist))
+                if (exist == null || !skip(ctr))
                     return ctr;
                 ctr++;
             }

--- a/PKHeX.Drawing/Sprites/SpriteUtil.cs
+++ b/PKHeX.Drawing/Sprites/SpriteUtil.cs
@@ -135,9 +135,7 @@ namespace PKHeX.Drawing
 
             if (!empty && flagIllegal)
             {
-                if (box >= 0)
-                    pk.Box = box;
-                var la = new LegalityAnalysis(pk, sav.Personal);
+                var la = new LegalityAnalysis(pk, sav.Personal, box != -1 ? SlotOrigin.Box : SlotOrigin.Party);
                 if (!la.Valid)
                     sprite = ImageUtil.LayerImage(sprite, Resources.warn, 0, FlagIllegalShiftY);
                 else if (pk.Format >= 8 && pk.Moves.Any(Legal.DummiedMoves_SWSH.Contains))

--- a/PKHeX.WinForms/Controls/SAV Editor/ContextMenuSAV.cs
+++ b/PKHeX.WinForms/Controls/SAV Editor/ContextMenuSAV.cs
@@ -14,8 +14,8 @@ namespace PKHeX.WinForms.Controls
         public SaveDataEditor<PictureBox> Editor { private get; set; } = null!;
         public SlotChangeManager Manager { get; set; } = null!;
 
-        public event LegalityRequest? RequestEditorLegality;
-        public delegate void LegalityRequest(object sender, EventArgs e, PKM pkm);
+        public Action<LegalityAnalysis>? RequestEditorLegality;
+        public delegate void LegalityRequest(object sender, EventArgs e, LegalityAnalysis la);
 
         public void OmniClick(object sender, EventArgs e, Keys z)
         {
@@ -108,7 +108,9 @@ namespace PKHeX.WinForms.Controls
             var info = GetSenderInfo(ref sender);
             var sav = info.View.SAV;
             var pk = info.Slot.Read(sav);
-            RequestEditorLegality?.Invoke(sender, e, pk);
+            var type = info.Slot is SlotInfoBox ? SlotOrigin.Box : SlotOrigin.Party;
+            var la = new LegalityAnalysis(pk, sav.Personal, type);
+            RequestEditorLegality?.Invoke(la);
         }
 
         private void MenuOpening(object sender, CancelEventArgs e)

--- a/PKHeX.WinForms/MainWindow/Main.cs
+++ b/PKHeX.WinForms/MainWindow/Main.cs
@@ -147,7 +147,7 @@ namespace PKHeX.WinForms
             mnu.RequestEditorQR += (o, args) => ClickQR(mnu, args);
             mnu.RequestEditorSaveAs += (o, args) => MainMenuSave(mnu, args);
             dragout.ContextMenuStrip = mnu.mnuL;
-            C_SAV.menu.RequestEditorLegality += ShowLegality;
+            C_SAV.menu.RequestEditorLegality = DisplayLegalityReport;
         }
 
         private void FormLoadInitialFiles(string[] args)
@@ -353,7 +353,9 @@ namespace PKHeX.WinForms
 
             var report = new ReportGrid();
             report.Show();
-            report.PopulateData(C_SAV.SAV.BoxData);
+            var list = new List<SlotCache>();
+            SlotInfoLoader.AddFromSaveFile(C_SAV.SAV, list);
+            report.PopulateData(list);
         }
 
         private void MainMenuDatabase(object sender, EventArgs e)
@@ -1024,14 +1026,13 @@ namespace PKHeX.WinForms
             if (pk.Species == 0 || !pk.ChecksumValid)
             { SystemSounds.Hand.Play(); return; }
 
-            ShowLegality(sender, e, pk);
+            var la = new LegalityAnalysis(pk, C_SAV.SAV.Personal);
+            PKME_Tabs.UpdateLegality(la);
+            DisplayLegalityReport(la);
         }
 
-        private void ShowLegality(object sender, EventArgs e, PKM pk)
+        private static void DisplayLegalityReport(LegalityAnalysis la)
         {
-            var la = new LegalityAnalysis(pk, C_SAV.SAV.Personal);
-            if (pk.Slot < 0)
-                PKME_Tabs.UpdateLegality(la);
             bool verbose = ModifierKeys == Keys.Control;
             var report = la.Report(verbose);
             if (verbose)

--- a/PKHeX.WinForms/Subforms/Misc/EntitySummaryImage.cs
+++ b/PKHeX.WinForms/Subforms/Misc/EntitySummaryImage.cs
@@ -10,9 +10,11 @@ namespace PKHeX.WinForms
     public sealed class EntitySummaryImage : EntitySummary
     {
         public Image Sprite => pkm.Sprite();
+        public override string Position { get; }
 
-        public EntitySummaryImage(PKM p, GameStrings strings) : base(p, strings)
+        public EntitySummaryImage(PKM p, GameStrings strings, string position) : base(p, strings)
         {
+            Position = position;
         }
     }
 }

--- a/PKHeX.WinForms/Subforms/ReportGrid.cs
+++ b/PKHeX.WinForms/Subforms/ReportGrid.cs
@@ -51,16 +51,17 @@ namespace PKHeX.WinForms
 
         private sealed class PokemonList<T> : SortableBindingList<T> where T : class { }
 
-        public void PopulateData(IList<PKM> Data)
+        public void PopulateData(IList<SlotCache> Data)
         {
             SuspendLayout();
             BoxBar.Step = 1;
             var PL = new PokemonList<EntitySummaryImage>();
             var strings = GameInfo.Strings;
-            foreach (PKM pkm in Data.Where(pkm => pkm.ChecksumValid && pkm.Species != 0))
+            foreach (var entry in Data)
             {
-                pkm.Stat_Level = Experience.GetLevel(pkm.EXP, pkm.PersonalInfo.EXPGrowth); // recalc Level
-                PL.Add(new EntitySummaryImage(pkm, strings));
+                var pkm = entry.Entity;
+                pkm.Stat_Level = pkm.CurrentLevel; // recalc Level
+                PL.Add(new EntitySummaryImage(pkm, strings, entry.Identify()));
                 BoxBar.PerformStep();
             }
 

--- a/PKHeX.WinForms/Subforms/SAV_Database.Designer.cs
+++ b/PKHeX.WinForms/Subforms/SAV_Database.Designer.cs
@@ -36,6 +36,7 @@
             this.Menu_Tools = new System.Windows.Forms.ToolStripMenuItem();
             this.Menu_SearchSettings = new System.Windows.Forms.ToolStripMenuItem();
             this.Menu_SearchBoxes = new System.Windows.Forms.ToolStripMenuItem();
+            this.Menu_SearchBackups = new System.Windows.Forms.ToolStripMenuItem();
             this.Menu_SearchDatabase = new System.Windows.Forms.ToolStripMenuItem();
             this.Menu_SearchLegal = new System.Windows.Forms.ToolStripMenuItem();
             this.Menu_SearchIllegal = new System.Windows.Forms.ToolStripMenuItem();
@@ -170,6 +171,7 @@
             this.Menu_SearchSettings.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             this.Menu_SearchBoxes,
             this.Menu_SearchDatabase,
+            this.Menu_SearchBackups,
             this.Menu_SearchLegal,
             this.Menu_SearchIllegal,
             this.Menu_SearchClones});
@@ -186,6 +188,15 @@
             this.Menu_SearchBoxes.Name = "Menu_SearchBoxes";
             this.Menu_SearchBoxes.Size = new System.Drawing.Size(198, 22);
             this.Menu_SearchBoxes.Text = "Search Within Boxes";
+            // 
+            // Menu_SearchBackups
+            // 
+            this.Menu_SearchBackups.Checked = true;
+            this.Menu_SearchBackups.CheckOnClick = true;
+            this.Menu_SearchBackups.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.Menu_SearchBackups.Name = "Menu_SearchBackups";
+            this.Menu_SearchBackups.Size = new System.Drawing.Size(198, 22);
+            this.Menu_SearchBackups.Text = "Search Within Backups";
             // 
             // Menu_SearchDatabase
             // 
@@ -1094,5 +1105,6 @@
         private System.Windows.Forms.TabPage Tab_General;
         private System.Windows.Forms.TabPage Tab_Advanced;
         private System.Windows.Forms.RichTextBox RTB_Instructions;
+        private System.Windows.Forms.ToolStripMenuItem Menu_SearchBackups;
     }
 }

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen6/SAV_SuperTrain.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen6/SAV_SuperTrain.cs
@@ -102,7 +102,7 @@ namespace PKHeX.WinForms
                 comboBox.DroppedDown = true;
             }
 #pragma warning disable CA1031 // Do not catch general exception types
-            catch { Console.WriteLine("Failed to modify item."); }
+            catch { System.Diagnostics.Debug.WriteLine("Failed to modify item."); }
 #pragma warning restore CA1031 // Do not catch general exception types
         }
 

--- a/PKHeX.WinForms/Util/WinFormsTranslator.cs
+++ b/PKHeX.WinForms/Util/WinFormsTranslator.cs
@@ -172,7 +172,7 @@ namespace PKHeX.WinForms
             {
                 var constructors = t.GetConstructors();
                 if (constructors.Length == 0)
-                { System.Console.WriteLine($"No constructors: {t.Name}"); continue; }
+                { Debug.WriteLine($"No constructors: {t.Name}"); continue; }
                 var argCount = constructors[0].GetParameters().Length;
                 try
                 {


### PR DESCRIPTION
Don't store within the object, track the slot origin data separately.

Batch editing now pre-filters if using Box/Slot/Identifier logic; split up mods/filters as they're starting to get pretty hefty.

- Requesting a Box Data report now shows all slots in the save file (party, misc)
- Can now exclude backup saves from database search via toggle (separate from settings preventing load entirely)
- Replace some linq usages with direct code