### PR TITLE
create a command line interface to support bots create pokemon from showdown files

### DIFF
--- a/PKHeX.CLI/App.config
+++ b/PKHeX.CLI/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" />
+    </startup>
+</configuration>

--- a/PKHeX.CLI/CLI.cs
+++ b/PKHeX.CLI/CLI.cs
@@ -1,0 +1,242 @@
+﻿using PKHeX.Core;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace PKHeX.CLI
+{
+    internal class CLI
+    {
+        private SaveFile SAV;
+        private GameVersion game;
+        private readonly List<ShowdownSet> showdownSets = new List<ShowdownSet>();
+        private readonly List<PKM> ENTITIES = new List<PKM>();
+        private readonly List<bool> IsValid = new List<bool>();
+        /// <summary>
+        /// Loading a <see cref="SaveFile"/>.
+        /// </summary>
+        /// <param name="path">Path to the savefile.</param>
+        public void LoadSavefile(string path)
+        {
+            try
+            {
+                FileInfo fileInfo = new FileInfo(path);
+                if (fileInfo.Exists)
+                {
+                    string ext = fileInfo.Extension;
+                    byte[] input = File.ReadAllBytes(path);
+                    object obj = FileUtil.GetSupportedFile(input, ext);
+                    if (obj == null)
+                    {
+                        throw new Exception(path + " was not found or isn't a supported file.");
+                    }
+                    SAV = (SaveFile)obj;
+                    game = (GameVersion)SAV.Game;
+                    Console.WriteLine("Savefile \"" + path + "\" successfully loaded.");
+                }
+            }
+            catch
+            {
+                ShowError(path + " was not found or isn't a supported file.");
+            }
+        }
+        /// <summary>
+        /// Loading a file and creates <see cref="ShowdownSet"/>s form them.
+        /// </summary>
+        /// <param name="path">Path to the file containing showdown data.</param>
+        public void LoadShowdown(string path)
+        {
+            try
+            {
+                string[] sets = File.ReadAllText(path).Split(new string[] { "\n\n", "\r\n\r\n" }, StringSplitOptions.None);
+                if (string.IsNullOrWhiteSpace(sets[0]))
+                {
+                    throw new Exception("Showdown file was invalid! Aborting loading showdown sets");
+                }
+                for (int i = 0; i < sets.Length; i++)
+                {
+                    showdownSets.Add(new ShowdownSet(sets[i]));
+                    if (showdownSets[i].InvalidLines.Count() == 0)
+                    {
+                        Console.WriteLine("Loading showdown set for " + SpeciesName.GetSpeciesName(showdownSets[i].Species, 2));
+                    }
+                    else
+                    {
+                        showdownSets.Clear();
+                        throw new Exception("Showdown file was invalid! Aborting loading showdown sets");
+                    }
+                }
+                Console.WriteLine("Showdown file was successfully loaded.");
+            }
+            catch (Exception ex)
+            {
+                ShowError(ex.Message);
+            }
+        }
+        /// <summary>
+        /// Creates <see cref="PKM"/> from the showdownsets and checks compatibility with the savefile.
+        /// </summary>
+        /// <remarks>REMEMBER: Many moves was removed in the 8th gen, so some showdownsets will eventually be incompatible with your savefile.</remarks>
+        public void CreatePkM()
+        {
+            if (SAV == null)
+            {
+                Console.WriteLine("No savefile loaded yet.");
+                return;
+            }
+            if (showdownSets.Count == 0)
+            {
+                Console.WriteLine("No showdown set loaded.");
+                return;
+            }
+            foreach (ShowdownSet set in showdownSets)
+            {
+                PKM pkm = SAV.BlankPKM;
+                string speciesname = SpeciesName.GetSpeciesName(set.Species, 2);
+                Console.WriteLine("Creating " + speciesname);
+
+                if (Breeding.CanHatchAsEgg(set.Species))
+                {
+                    EncounterEgg egg = new EncounterEgg(set.Species, set.Form, set.Level, SAV.Generation, game);
+                    pkm = egg.ConvertToPKM(SAV);
+                }
+                else
+                {
+                    pkm.Species = set.Species;
+                    pkm.Form = set.Form;
+                    pkm.SetGender(pkm.GetSaneGender());
+                    IEncounterable[] encs = EncounterMovesetGenerator.GenerateEncounter(pkm, SAV.Generation).ToArray();
+                    if (encs.Length == 0)
+                    {
+                        // use debut generation for Pokemon that available but not catchable in current generation e.g. Meltan
+                        encs = EncounterMovesetGenerator.GenerateEncounter(pkm, pkm.DebutGeneration).ToArray();
+                    }
+                    foreach (IEncounterable enc in encs)
+                    {
+                        PKM pk = enc.ConvertToPKM(SAV);
+                        // not all Pokemon in database are legal in all games
+                        if (new LegalityAnalysis(pk, SAV.Personal).Valid)
+                        {
+                            pkm = PKMConverter.ConvertToType(pk, SAV.PKMType, out _);
+                            if ((pk.Generation != SAV.Generation || pk.GO || pk.GO_HOME || pk.LGPE) && pkm is IBattleVersion b)
+                            {
+                                b.BattleVersion = (int)game;
+                            }
+                            break;
+                        }
+                    }
+                }
+                pkm.Language = SAV.Language;
+                pkm.ApplySetDetails(set);
+                LegalityAnalysis la = new LegalityAnalysis(pkm, SAV.Personal);
+                string report = la.Report();
+                if (report == "Legal!")
+                {
+                    ENTITIES.Add(pkm);
+                    IsValid.Add(true);
+                }
+                else
+                {
+                    // setting blank pkm if invalid for better indexing
+                    ENTITIES.Add(SAV.BlankPKM);
+                    IsValid.Add(false);
+                    Console.WriteLine("Warning: " + speciesname + " is invalid!");
+                    Console.WriteLine(report);
+                    Console.WriteLine("Ignoring " + speciesname);
+                }
+            }
+        }
+        /// <summary>
+        /// Set a chosen <see cref="PKM"/> to a box.
+        /// </summary>
+        /// <param name="showdownSetIndex">Index of the showdown set. index of ignored sets a invalid</param>
+        /// <param name="box">Box to set the <see cref="PKM"/>.</param>
+        /// <param name="slot">Slot of the chosen box to set the <see cref="PKM"/>.</param>
+        /// <remarks>You can get the <paramref name="showdownSetIndex"/> by calling getshowdownsets.</remarks>
+        public void SetPkm(int showdownSetIndex, int box, int slot)
+        {
+            string paramName = string.Empty;
+            if (showdownSets[showdownSetIndex] == null || !IsValid[showdownSetIndex])
+            {
+                paramName = nameof(showdownSetIndex);
+            }
+            if (box < 0 || box > 31)
+            {
+                paramName = nameof(box);
+            }
+            if (slot < 0 || slot > 29)
+            {
+                paramName = nameof(slot);
+            }
+            try
+            {
+                if (paramName != string.Empty)
+                {
+                    throw new Exception(paramName + " is invalid");
+                }
+                PKM pkm = ENTITIES[showdownSetIndex];
+                BoxEdit boxEdit = new BoxEdit(SAV);
+                boxEdit.LoadBox(box);
+                boxEdit[slot] = pkm;
+                Console.WriteLine(SpeciesName.GetSpeciesName(pkm.Species, 2) + " was set to box " + box + " slot " + slot);
+            }
+            catch (Exception ex)
+            {
+                ShowError(ex.Message);
+            }
+        }
+        /// <summary>
+        /// Shows the loaded showdownsets and if they ignored.
+        /// </summary>
+        /// <remarks>Showdownsets with correct syntax but illegal Pokemon (e.g. Blastoise with Solar Beam) are ignored. Showdown files with syntax errors are completely discarded.</remarks>
+        public void GetShowdownSets()
+        {
+            if (showdownSets.Count == 0)
+            {
+                Console.WriteLine("No showdown set loaded.");
+                return;
+            }
+            for (int i = 0; i < showdownSets.Count; i++)
+            {
+                string ignored = string.Empty;
+                if (IsValid.Count > 0 && !IsValid[i])
+                {
+                    ignored = " [ignored]";
+                }
+                if (i == 0)
+                {
+                    Console.WriteLine();
+                }
+                Console.WriteLine("Showdown Set " + i + ignored);
+                Console.WriteLine("--------------------");
+                Console.WriteLine(showdownSets[i].Text);
+                Console.WriteLine();
+            }
+        }
+        /// <summary>
+        /// Write the modified data to the savefile.
+        /// </summary>
+        /// <param name="path">Path where to save the savefile.</param>
+        public void Save(string path)
+        {
+            string ext = Path.GetExtension(path).ToLower();
+            ExportFlags flags = SAV.Metadata.GetSuggestedFlags(ext);
+            try
+            {
+                File.WriteAllBytes(path, SAV.Write(flags));
+                SAV.Metadata.SetExtraInfo(path);
+                Console.WriteLine("Savefile was successfully written to " + path);
+            }
+            catch (Exception ex)
+            {
+                ShowError(ex.Message);
+            }
+        }
+
+        private void ShowError(string msg)
+        {
+            Console.WriteLine("ERROR: " + msg);
+        }
+    }
+}

--- a/PKHeX.CLI/PKHeX.CLI.csproj
+++ b/PKHeX.CLI/PKHeX.CLI.csproj
@@ -1,0 +1,60 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{A4C9224E-9375-4A1D-AB01-EE1634FA1CBE}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>PKHeX.CLI</RootNamespace>
+    <AssemblyName>PKHeX.CLI</AssemblyName>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="CLI.cs" />
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\PKHeX.Core\PKHeX.Core.csproj">
+      <Project>{279e59f2-50ea-475d-8ba4-fa69f0578c0d}</Project>
+      <Name>PKHeX.Core</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/PKHeX.CLI/Program.cs
+++ b/PKHeX.CLI/Program.cs
@@ -1,0 +1,64 @@
+﻿using System;
+
+namespace PKHeX.CLI
+{
+    internal class Program
+    {
+        private static void Main(string[] args)
+        {
+            CLI cli = new CLI();
+            foreach (string arg in args)
+            {
+                if (arg.Contains("-savefile:"))
+                {
+                    cli.LoadSavefile(arg.Substring(10));
+                }
+                else if (arg.Contains("-showdown:"))
+                {
+                    cli.LoadShowdown(arg.Substring(10));
+                }
+            }
+            do
+            {
+                string consoleInput = Console.ReadLine();
+                string[] cmd = consoleInput.Split(' ');
+                if (consoleInput == "exit")
+                {
+                    break;
+                }
+                try
+                {
+                    switch (cmd[0])
+                    {
+                        case "loadsavefile":
+                            cli.LoadSavefile(cmd[1]);
+                            break;
+                        case "loadshowdown":
+                            cli.LoadShowdown(cmd[1]);
+                            break;
+                        case "createpkm":
+                            cli.CreatePkM();
+                            break;
+                        case "setpkm":
+                            cli.SetPkm(int.Parse(cmd[1]), int.Parse(cmd[1]), int.Parse(cmd[2]));
+                            break;
+                        case "getshowdownsets":
+                            cli.GetShowdownSets();
+                            break;
+                        case "save":
+                            cli.Save(cmd[1]);
+                            break;
+                        default:
+                            Console.WriteLine("unknown command");
+                            break;
+                    }
+                }
+                catch
+                {
+                    Console.WriteLine(cmd[0] + " has missing arguments");
+                }
+            }
+            while (true);
+        }
+    }
+}

--- a/PKHeX.CLI/Properties/AssemblyInfo.cs
+++ b/PKHeX.CLI/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// Allgemeine Informationen über eine Assembly werden über die folgenden
+// Attribute gesteuert. Ändern Sie diese Attributwerte, um die Informationen zu ändern,
+// die einer Assembly zugeordnet sind.
+[assembly: AssemblyTitle("PKHeX.CLI")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("PKHeX.CLI")]
+[assembly: AssemblyCopyright("Copyright ©  2021")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Durch Festlegen von ComVisible auf FALSE werden die Typen in dieser Assembly
+// für COM-Komponenten unsichtbar.  Wenn Sie auf einen Typ in dieser Assembly von
+// COM aus zugreifen müssen, sollten Sie das ComVisible-Attribut für diesen Typ auf "True" festlegen.
+[assembly: ComVisible(false)]
+
+// Die folgende GUID bestimmt die ID der Typbibliothek, wenn dieses Projekt für COM verfügbar gemacht wird
+[assembly: Guid("a4c9224e-9375-4a1d-ab01-ee1634fa1cbe")]
+
+// Versionsinformationen für eine Assembly bestehen aus den folgenden vier Werten:
+//
+//      Hauptversion
+//      Nebenversion
+//      Buildnummer
+//      Revision
+//
+// Sie können alle Werte angeben oder Standardwerte für die Build- und Revisionsnummern verwenden,
+// indem Sie "*" wie unten gezeigt eingeben:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/PKHeX.sln
+++ b/PKHeX.sln
@@ -19,6 +19,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PKHeX.Core.Tests", "Tests\P
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PKHeX.Drawing", "PKHeX.Drawing\PKHeX.Drawing.csproj", "{87976C6C-3E91-42DE-B098-1E97E42C9588}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PKHeX.CLI", "PKHeX.CLI\PKHeX.CLI.csproj", "{A4C9224E-9375-4A1D-AB01-EE1634FA1CBE}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -59,6 +61,14 @@ Global
 		{87976C6C-3E91-42DE-B098-1E97E42C9588}.Release|Any CPU.Build.0 = Release|Any CPU
 		{87976C6C-3E91-42DE-B098-1E97E42C9588}.Release|x86.ActiveCfg = Release|Any CPU
 		{87976C6C-3E91-42DE-B098-1E97E42C9588}.Release|x86.Build.0 = Release|Any CPU
+		{A4C9224E-9375-4A1D-AB01-EE1634FA1CBE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A4C9224E-9375-4A1D-AB01-EE1634FA1CBE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A4C9224E-9375-4A1D-AB01-EE1634FA1CBE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A4C9224E-9375-4A1D-AB01-EE1634FA1CBE}.Debug|x86.Build.0 = Debug|Any CPU
+		{A4C9224E-9375-4A1D-AB01-EE1634FA1CBE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A4C9224E-9375-4A1D-AB01-EE1634FA1CBE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A4C9224E-9375-4A1D-AB01-EE1634FA1CBE}.Release|x86.ActiveCfg = Release|Any CPU
+		{A4C9224E-9375-4A1D-AB01-EE1634FA1CBE}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
create a command line interface to support bots create pokemon from showdown files
commands:

- **loadsavefile "path/to/savefile"** // loads the savefile
- **loadshowdown "path/to/showdown"** // loads a file that containing showdown sets
- **createpkm** // creates PKM-objects from the showdown sets
- **setpkm showdownindex box slot** // sets a pokemon of the chosen showdown index to a specific box an slot
- **getshowdownsets** // lists the loaded showdownsets and shows the index
- **save "path/where/to/save"** // saves the savefile to the given path
- **exit** // closes the cli