### PR TITLE
Only use the TreatWarningsAsErrors for debug build

### DIFF
--- a/PKHeX.Core/PKHeX.Core.csproj
+++ b/PKHeX.Core/PKHeX.Core.csproj
@@ -14,6 +14,10 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="IndexRange" Version="1.0.0" />
     <PackageReference Include="System.Memory" Version="4.5.4" />

--- a/PKHeX.Core/PKHeX.Core.csproj
+++ b/PKHeX.Core/PKHeX.Core.csproj
@@ -12,7 +12,6 @@
     <RepositoryUrl>https://github.com/kwsch/PKHeX</RepositoryUrl>
     <LangVersion>9</LangVersion>
     <Nullable>enable</Nullable>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Azure Pipelines emits a warning during `dotnet pack` which causes the build to fail.

```
##[warning].NET 5 has some compatibility issues with older Nuget versions(<=5.7), so if you are using an older Nuget version(and not dotnet cli) to restore, then the dotnet cli commands (e.g. dotnet build) which rely on such restored packages might fail. To mitigate such error, you can either: (1) - Use dotnet cli to restore, (2) - Use Nuget version 5.8 to restore, (3) - Use global.json using an older sdk version(<=3) to build
##[error]Error: The process 'C:\Program Files\dotnet\dotnet.exe' failed with exit code 1
##[error]An error occurred while trying to pack the files.
```

![image](https://user-images.githubusercontent.com/6393368/128137704-e3f64409-19c9-4829-8327-8a48f381989a.png)

Probably will work fine when NET 6 comes out and the pipeline agents are updated.