### PR TITLE
More memory legality checks

### DIFF
--- a/PKHeX.Core/Legality/Restrictions/Memories/MemoryContext.cs
+++ b/PKHeX.Core/Legality/Restrictions/Memories/MemoryContext.cs
@@ -11,7 +11,7 @@ namespace PKHeX.Core
         public abstract bool IsUsedKeyItemUnspecific(int item);
         public abstract bool IsUsedKeyItemSpecific(int item, int species);
         public abstract bool CanBuyItem(int item, GameVersion version);
-        public virtual bool CanWinRotoLoto(int item) => false;
+        public abstract bool CanWinLottoID(int item);
         public virtual bool CanPlantBerry(int item) => false;
         public abstract bool CanHoldItem(int item);
 

--- a/PKHeX.Core/Legality/Restrictions/Memories/MemoryContext.cs
+++ b/PKHeX.Core/Legality/Restrictions/Memories/MemoryContext.cs
@@ -11,7 +11,7 @@ namespace PKHeX.Core
         public abstract bool IsUsedKeyItemUnspecific(int item);
         public abstract bool IsUsedKeyItemSpecific(int item, int species);
         public abstract bool CanBuyItem(int item, GameVersion version);
-        public abstract bool CanWinLottoID(int item);
+        public abstract bool CanWinLotoID(int item);
         public virtual bool CanPlantBerry(int item) => false;
         public abstract bool CanHoldItem(int item);
 

--- a/PKHeX.Core/Legality/Restrictions/Memories/MemoryContext6.cs
+++ b/PKHeX.Core/Legality/Restrictions/Memories/MemoryContext6.cs
@@ -70,7 +70,7 @@ namespace PKHeX.Core
         private static bool CanObtainMemoryXY(int memory) => memory <= MAX_MEMORY_ID_XY && !Memory_NotXY.Contains(memory);
         public override bool CanObtainMemoryHT(GameVersion pkmVersion, int memory) => CanObtainMemory(memory);
 
-        public override bool CanWinLotoID(int item) => LottoPrizeXYAO.Contains((ushort)item);
+        public override bool CanWinLotoID(int item) => LotoPrizeXYAO.Contains((ushort)item);
 
         public override bool CanBuyItem(int item, GameVersion version)
         {

--- a/PKHeX.Core/Legality/Restrictions/Memories/MemoryContext6.cs
+++ b/PKHeX.Core/Legality/Restrictions/Memories/MemoryContext6.cs
@@ -70,6 +70,8 @@ namespace PKHeX.Core
         private static bool CanObtainMemoryXY(int memory) => memory <= MAX_MEMORY_ID_XY && !Memory_NotXY.Contains(memory);
         public override bool CanObtainMemoryHT(GameVersion pkmVersion, int memory) => CanObtainMemory(memory);
 
+        public override bool CanWinLottoID(int item) => LottoPrizeXYAO.Contains((ushort)item);
+
         public override bool CanBuyItem(int item, GameVersion version)
         {
             if (version is GameVersion.Any)

--- a/PKHeX.Core/Legality/Restrictions/Memories/MemoryContext6.cs
+++ b/PKHeX.Core/Legality/Restrictions/Memories/MemoryContext6.cs
@@ -70,7 +70,7 @@ namespace PKHeX.Core
         private static bool CanObtainMemoryXY(int memory) => memory <= MAX_MEMORY_ID_XY && !Memory_NotXY.Contains(memory);
         public override bool CanObtainMemoryHT(GameVersion pkmVersion, int memory) => CanObtainMemory(memory);
 
-        public override bool CanWinLottoID(int item) => LottoPrizeXYAO.Contains((ushort)item);
+        public override bool CanWinLotoID(int item) => LottoPrizeXYAO.Contains((ushort)item);
 
         public override bool CanBuyItem(int item, GameVersion version)
         {

--- a/PKHeX.Core/Legality/Restrictions/Memories/MemoryContext6Data.cs
+++ b/PKHeX.Core/Legality/Restrictions/Memories/MemoryContext6Data.cs
@@ -159,5 +159,10 @@ namespace PKHeX.Core
             379, 384, 395, 398, 400, 403, 405, 409, 577, 692,
             694,
         };
+
+        private static readonly ushort[] LottoPrizeXYAO =
+        {
+            0001, 0033, 0050, 0051, 0053,
+        };
     }
 }

--- a/PKHeX.Core/Legality/Restrictions/Memories/MemoryContext6Data.cs
+++ b/PKHeX.Core/Legality/Restrictions/Memories/MemoryContext6Data.cs
@@ -160,7 +160,7 @@ namespace PKHeX.Core
             694,
         };
 
-        private static readonly ushort[] LottoPrizeXYAO =
+        private static readonly ushort[] LotoPrizeXYAO =
         {
             0001, 0033, 0050, 0051, 0053,
         };

--- a/PKHeX.Core/Legality/Restrictions/Memories/MemoryContext8.cs
+++ b/PKHeX.Core/Legality/Restrictions/Memories/MemoryContext8.cs
@@ -53,7 +53,7 @@ namespace PKHeX.Core
 
         private static bool CanObtainMemorySWSH(int memory) => memory <= MAX_MEMORY_ID_SWSH && !Memory_NotSWSH.Contains(memory);
 
-        public override bool CanWinLottoID(int item) => LottoPrizeSWSH.Contains((ushort)item);
+        public override bool CanWinLotoID(int item) => LottoPrizeSWSH.Contains((ushort)item);
 
         public override bool CanBuyItem(int item, GameVersion version)
         {

--- a/PKHeX.Core/Legality/Restrictions/Memories/MemoryContext8.cs
+++ b/PKHeX.Core/Legality/Restrictions/Memories/MemoryContext8.cs
@@ -53,7 +53,7 @@ namespace PKHeX.Core
 
         private static bool CanObtainMemorySWSH(int memory) => memory <= MAX_MEMORY_ID_SWSH && !Memory_NotSWSH.Contains(memory);
 
-        public override bool CanWinLotoID(int item) => LottoPrizeSWSH.Contains((ushort)item);
+        public override bool CanWinLotoID(int item) => LotoPrizeSWSH.Contains((ushort)item);
 
         public override bool CanBuyItem(int item, GameVersion version)
         {

--- a/PKHeX.Core/Legality/Restrictions/Memories/MemoryContext8.cs
+++ b/PKHeX.Core/Legality/Restrictions/Memories/MemoryContext8.cs
@@ -45,15 +45,15 @@ namespace PKHeX.Core
         {
             return memory switch
             {
-                // {0} was excited when {1} won prizes like {2} through Loto-ID.
-                51 when variable is not (1 or 33 or 50 or 51 or 53) => true, // item IDs
+                // {0} encountered {2} when it was with {1}. {4} that {3}.
+                29 when variable is not (888 or 889 or 898) => true, // Zacian, Zamazenta, Calyrex
                 _ => false,
             };
         }
 
         private static bool CanObtainMemorySWSH(int memory) => memory <= MAX_MEMORY_ID_SWSH && !Memory_NotSWSH.Contains(memory);
 
-        public override bool CanWinRotoLoto(int item) => true;
+        public override bool CanWinLottoID(int item) => LottoPrizeSWSH.Contains((ushort)item);
 
         public override bool CanBuyItem(int item, GameVersion version)
         {
@@ -125,14 +125,20 @@ namespace PKHeX.Core
             var arg = (byte)variable;
             return memory switch
             {
+                // {0} became {1}’s friend when it came through Link Trade {2}. {4} that {3}.
+                4 when !PossibleGeneralLocations8.Contains(arg) || arg is 79 => true, // dangerous place - all locations are Y-Comm locked
+
+                // {0} rode a bike with {1} {2}. {4} that {3}.
+                32 when arg is not (1 or 8 or 12 or 22 or 33 or 35 or 37 or 40 or 41 or 44 or 47 or 48 or 49 or 50 or 51 or 53 or 65 or 71 or 72 or 75 or 76 or 77 or 78) => true,
+
                 // {0} saw {1} secretly picking up something {2}. {4} that {3}.
-                39 when variable is not (4 or 8 or 12 or 22 or 33 or 35 or 37 or 40 or 41 or 44 or 47 or 48 or 49 or 50 or 51 or 53 or 65 or 71 or 72 or 75 or 76 or 77) => true,
+                39 when arg is not (8 or 12 or 22 or 33 or 35 or 37 or 40 or 41 or 44 or 47 or 48 or 49 or 50 or 51 or 53 or 65 or 71 or 72 or 75 or 76 or 77) => true,
 
                 // {0} checked the sign with {1} {2}. {4} that {3}.
-                42 when variable is not (1 or 12 or 22 or 33 or 35 or 37 or 44 or 47 or 53 or 71 or 72 or 76 or 77) => true,
+                42 when arg is not (1 or 12 or 22 or 33 or 35 or 37 or 44 or 47 or 53 or 71 or 72 or 76 or 77) => true,
 
                 // {0} sat with {1} on a bench {2}. {4} that {3}.
-                70 when variable is not (12 or 22 or 28 or 33 or 35 or 37 or 38 or 44 or 53 or 77) => true,
+                70 when arg is not (12 or 22 or 28 or 33 or 35 or 37 or 38 or 44 or 53 or 77) => true,
 
                 _ => !PossibleGeneralLocations8.Contains(arg),
             };

--- a/PKHeX.Core/Legality/Restrictions/Memories/MemoryContext8Data.cs
+++ b/PKHeX.Core/Legality/Restrictions/Memories/MemoryContext8Data.cs
@@ -70,6 +70,11 @@ namespace PKHeX.Core
             1260, 1261, 1262, 1263,
         };
 
+        private static readonly ushort[] LottoPrizeSWSH =
+        {
+            0001, 0033, 0050, 0051, 0053,
+        };
+
         // {met, values allowed}
         private static readonly Dictionary<byte, byte[]> MultiGenLocAreas = new()
         {

--- a/PKHeX.Core/Legality/Restrictions/Memories/MemoryContext8Data.cs
+++ b/PKHeX.Core/Legality/Restrictions/Memories/MemoryContext8Data.cs
@@ -137,6 +137,10 @@ namespace PKHeX.Core
             // town of Freezington
             // someone’s house, snowcapped town
             {206, new byte[] {04, 37}},
+
+            // at the Crown Shrine
+            // on a snow-swept road, in a mystical place
+            {220, new byte[] {53, 65}},
         };
 
         // {met, value allowed}
@@ -223,7 +227,6 @@ namespace PKHeX.Core
             {214, 53}, // Snowslide Slope, snow-swept road
             {216, 40}, // Tunnel to the Top, cave
             {218, 53}, // the Path to the Peak, snow-swept road
-            {220, 65}, // Crown Shrine, mystical place
             {222, 44}, // Giant’s Foot, tranquil road
             {224, 40}, // Roaring-Sea Caves, cave
             {226, 49}, // Frigid Sea, seaside road

--- a/PKHeX.Core/Legality/Restrictions/Memories/MemoryContext8Data.cs
+++ b/PKHeX.Core/Legality/Restrictions/Memories/MemoryContext8Data.cs
@@ -70,7 +70,7 @@ namespace PKHeX.Core
             1260, 1261, 1262, 1263,
         };
 
-        private static readonly ushort[] LottoPrizeSWSH =
+        private static readonly ushort[] LotoPrizeSWSH =
         {
             0001, 0033, 0050, 0051, 0053,
         };

--- a/PKHeX.Core/Legality/Restrictions/Memories/MemoryPermissions.cs
+++ b/PKHeX.Core/Legality/Restrictions/Memories/MemoryPermissions.cs
@@ -15,10 +15,10 @@ namespace PKHeX.Core
     {
         public static bool IsMemoryOfKnownMove(int memory) => memory is 48 or 80 or 81;
 
-        public static bool CanWinRotoLoto(int generation, int item)
+        public static bool CanWinLottoID(int generation, int item)
         {
             var context = Memories.GetContext(generation);
-            return context.CanWinRotoLoto(item);
+            return context.CanWinLottoID(item);
         }
 
         public static bool CanHoldItem(int generation, int item)
@@ -265,6 +265,97 @@ namespace PKHeX.Core
             (int)Copperajah,
             (int)Duraludon,
             (int)Urshifu,
+        };
+
+        public static bool GetCanFishSpecies(int species, int gen, GameVersion version) => gen switch
+        {
+            6 => version switch
+            {
+                GameVersion.Any => FishingSpecies_XY.Contains(species) || FishingSpecies_AO.Contains(species)
+                                || IsFishingSpeciesX(species) || IsFishingSpeciesY(species),
+
+                GameVersion.X => FishingSpecies_XY.Contains(species) || IsFishingSpeciesX(species),
+                GameVersion.Y => FishingSpecies_XY.Contains(species) || IsFishingSpeciesY(species),
+
+                GameVersion.OR or GameVersion.AS => FishingSpecies_AO.Contains(species),
+                _ => false,
+            },
+            8 => version switch
+            {
+                GameVersion.Any or GameVersion.SW or GameVersion.SH => FishingSpecies_SWSH.Contains(species),
+                _ => false,
+            },
+            _ => false,
+        };
+
+        private static readonly HashSet<int> FishingSpecies_SWSH = new()
+        {
+            (int)Shellder, (int)Cloyster,
+            (int)Krabby,
+            (int)Goldeen,
+            (int)Magikarp, (int)Gyarados,
+            (int)Lapras,
+            (int)Dratini,
+            (int)Chinchou, (int)Lanturn,
+            (int)Qwilfish,
+            (int)Remoraid, (int)Octillery,
+            (int)Carvanha, (int)Sharpedo,
+            (int)Wailmer, (int)Wailord,
+            (int)Barboach, (int)Whiscash,
+            (int)Corphish,
+            (int)Lileep,
+            (int)Feebas,
+            (int)Mantyke, (int)Mantine,
+            (int)Basculin,
+            (int)Wishiwashi,
+            (int)Mareanie,
+            (int)Pyukumuku,
+            (int)Dhelmise,
+            (int)Chewtle, (int)Drednaw,
+            (int)Arrokuda, (int)Barraskewda,
+        };
+
+        private static readonly HashSet<int> FishingSpecies_AO = new()
+        {
+            (int)Tentacool,
+            (int)Horsea, (int)Seadra,
+            (int)Goldeen, (int)Seaking,
+            (int)Staryu,
+            (int)Magikarp, (int)Gyarados,
+            (int)Corsola,
+            (int)Remoraid, (int)Octillery,
+            (int)Carvanha, (int)Sharpedo,
+            (int)Wailmer,
+            (int)Barboach, (int)Whiscash,
+            (int)Corphish, (int)Crawdaunt,
+            (int)Feebas,
+            (int)Luvdisc,
+        };
+
+        // exclusive to version
+        private static bool IsFishingSpeciesX(int species) => species is (int)Staryu or (int)Starmie or (int)Huntail or (int)Clauncher or (int)Clawitzer;
+        private static bool IsFishingSpeciesY(int species) => species is (int)Shellder or (int)Cloyster or (int)Gorebyss or (int)Skrelp or (int)Dragalge;
+
+        // common to X & Y
+        private static readonly HashSet<int> FishingSpecies_XY = new()
+        {
+            (int)Poliwag, (int)Poliwhirl, (int)Poliwrath, (int)Politoed,
+            (int)Horsea, (int)Seadra,
+            (int)Goldeen, (int)Seaking,
+            (int)Magikarp, (int)Gyarados,
+            (int)Dratini, (int)Dragonair,
+            (int)Chinchou, (int)Lanturn,
+            (int)Qwilfish,
+            (int)Corsola,
+            (int)Remoraid, (int)Octillery,
+            (int)Carvanha, (int)Sharpedo,
+            (int)Barboach, (int)Whiscash,
+            (int)Corphish, (int)Crawdaunt,
+            (int)Clamperl,
+            (int)Relicanth,
+            (int)Luvdisc,
+            (int)Basculin,
+            (int)Alomomola,
         };
     }
 }

--- a/PKHeX.Core/Legality/Restrictions/Memories/MemoryPermissions.cs
+++ b/PKHeX.Core/Legality/Restrictions/Memories/MemoryPermissions.cs
@@ -15,10 +15,10 @@ namespace PKHeX.Core
     {
         public static bool IsMemoryOfKnownMove(int memory) => memory is 48 or 80 or 81;
 
-        public static bool CanWinLottoID(int generation, int item)
+        public static bool CanWinLotoID(int generation, int item)
         {
             var context = Memories.GetContext(generation);
-            return context.CanWinLottoID(item);
+            return context.CanWinLotoID(item);
         }
 
         public static bool CanHoldItem(int generation, int item)

--- a/PKHeX.Core/Legality/Verifiers/MemoryVerifier.cs
+++ b/PKHeX.Core/Legality/Verifiers/MemoryVerifier.cs
@@ -106,7 +106,7 @@ namespace PKHeX.Core
                 // {1} had {0} hold items like {2} to help it along. {4} that {3}.
                 case 40 when !CanHoldItem(gen, memory.Variable):
                 // {0} was excited when {1} won prizes like {2} through Loto-ID. {4} that {3}.
-                case 51 when !CanWinLottoID(gen, memory.Variable):
+                case 51 when !CanWinLotoID(gen, memory.Variable):
                 // {0} was worried if {1} was looking for the {2} that it was holding in a Box. {4} that {3}.
                 // When {0} was in a Box, it thought about the reason why {1} had it hold the {2}. {4} that {3}.
                 case 84 or 88 when !Legal.HeldItems_SWSH.Contains((ushort)memory.Variable) || pkm.IsEgg:

--- a/PKHeX.Core/Legality/Verifiers/MemoryVerifier.cs
+++ b/PKHeX.Core/Legality/Verifiers/MemoryVerifier.cs
@@ -74,14 +74,20 @@ namespace PKHeX.Core
                     return Get(string.Format(LMemoryArgBadMove, memory.Handler), Severity.Invalid);
 
                 // Species
+                // With {1}, {0} went fishing, and they caught {2}. {4} that {3}.
+                case 7 when !GetCanFishSpecies(memory.Variable, gen, handler == 0 ? (GameVersion)pkm.Version : GameVersion.Any):
+                    return GetInvalid(string.Format(LMemoryArgBadSpecies, memory.Handler));
+
+                // {0} saw {1} paying attention to {2}. {4} that {3}.
+                // {0} fought hard until it had to use Struggle when it battled at {1}’s side against {2}. {4} that {3}.
+                // {0} was taken to a Pokémon Nursery by {1} and left with {2}. {4} that {3}.
+                case 9 or 60 or 75 when gen == 8 && !((PersonalInfoSWSH)PersonalTable.SWSH[memory.Variable]).IsPresentInGame:
+                    return GetInvalid(string.Format(LMemoryArgBadSpecies, memory.Handler));
+
                 // {0} had a great chat about {1} with the {2} that it was in a Box with. {4} that {3}.
                 // {0} became good friends with the {2} in a Box, practiced moves with it, and talked about the day that {0} would be praised by {1}. {4} that {3}.
                 // {0} got in a fight with the {2} that it was in a Box with about {1}. {4} that {3}.
                 case 82 or 83 or 87 when !((PersonalInfoSWSH)PersonalTable.SWSH[memory.Variable]).IsPresentInGame:
-                    return GetInvalid(string.Format(LMemoryArgBadSpecies, memory.Handler));
-
-                // {0} fought hard until it had to use Struggle when it battled at {1}’s side against {2}. {4} that {3}.
-                case 60 when gen == 8 && !((PersonalInfoSWSH)PersonalTable.SWSH[memory.Variable]).IsPresentInGame:
                     return GetInvalid(string.Format(LMemoryArgBadSpecies, memory.Handler));
 
                 // {0} had a very hard training session with {1}. {4} that {3}.
@@ -100,7 +106,7 @@ namespace PKHeX.Core
                 // {1} had {0} hold items like {2} to help it along. {4} that {3}.
                 case 40 when !CanHoldItem(gen, memory.Variable):
                 // {0} was excited when {1} won prizes like {2} through Loto-ID. {4} that {3}.
-                case 51 when !CanWinRotoLoto(gen, memory.Variable):
+                case 51 when !CanWinLottoID(gen, memory.Variable):
                 // {0} was worried if {1} was looking for the {2} that it was holding in a Box. {4} that {3}.
                 // When {0} was in a Box, it thought about the reason why {1} had it hold the {2}. {4} that {3}.
                 case 84 or 88 when !Legal.HeldItems_SWSH.Contains((ushort)memory.Variable) || pkm.IsEgg:


### PR DESCRIPTION
Includes the following new memory checks for gen 8 unless otherwise specified:
- 4: met in link-trade, allows all possible genlocs except dangerous place
- 7: successful fishing, allows fishable species in gen 6 and 8
- 9: paying attention to another mon, allows only available species for gen 8
- 29: encountering legendary Pokémon, only seen on Zacian, Zamazenta, Calyrex so far
- 32: riding a bike, only in genlocs where biking is possible
- 75: taken to Nursery and placed with a mon, allows only available species for gen 8

Unstubs lotto check for memory 51 and applies it to gen 6.

With this, only memories 12, 13, 18, and 25 have no checks at all for gen 8.