### PR TITLE
Add load plugin method setting

### DIFF
--- a/PKHeX.WinForms/MainWindow/Main.cs
+++ b/PKHeX.WinForms/MainWindow/Main.cs
@@ -40,7 +40,7 @@ namespace PKHeX.WinForms
             FormLoadInitialFiles(args);
             FormLoadCheckForUpdates();
 
-            if (Settings.Startup.LoadPlugins)
+            if (Settings.Startup.PluginLoadMethod != PluginLoadSetting.DontLoad)
                 FormLoadPlugins();
 
             if (HaX)

--- a/PKHeX.WinForms/MainWindow/PluginLoader.cs
+++ b/PKHeX.WinForms/MainWindow/PluginLoader.cs
@@ -42,13 +42,20 @@ namespace PKHeX.WinForms
             #if UNSAFEDLL
             var assemblies = dllFileNames.Select(Assembly.UnsafeLoadFrom);
             #else
-            var assemblies = dllFileNames.Select(Assembly.LoadFrom);
+            var assemblies = dllFileNames.Select(GetPluginLoadMethod(Main.Settings.Startup.PluginLoadMethod));
             #endif
             #if MERGED
             assemblies = assemblies.Concat(new[] { Assembly.GetExecutingAssembly() }); // load merged too
             #endif
             return assemblies;
         }
+
+        private static Func<string, Assembly> GetPluginLoadMethod(PluginLoadSetting pls) => pls switch
+        {
+            PluginLoadSetting.LoadFrom => Assembly.LoadFrom,
+            PluginLoadSetting.LoadFile => Assembly.LoadFile,
+            _ => throw new NotImplementedException($"PluginLoadSetting: {pls} method not defined."),
+        };
 
         private static IEnumerable<Type> GetPluginsOfType<T>(IEnumerable<Assembly> assemblies)
         {

--- a/PKHeX.WinForms/Properties/PKHeXSettings.cs
+++ b/PKHeX.WinForms/Properties/PKHeXSettings.cs
@@ -126,8 +126,8 @@ namespace PKHeX.WinForms
         [LocalizedDescription("Show the changelog when a new version of the program is run for the first time.")]
         public bool ShowChangelogOnUpdate { get; set; } = true;
 
-        [LocalizedDescription("Loads plugins from the plugins folder, assuming the folder exists.")]
-        public bool LoadPlugins { get; set; } = true;
+        [LocalizedDescription("Loads plugins from the plugins folder, assuming the folder exists. Try LoadFile to mitigate intermittent load failures.")]
+        public PluginLoadSetting PluginLoadMethod { get; set; } = PluginLoadSetting.LoadFrom;
 
         public List<string> RecentlyLoaded = new(MaxRecentCount);
 
@@ -169,6 +169,13 @@ namespace PKHeX.WinForms
                 recent.RemoveAt(recent.Count - 1);
             recent.Insert(0, path);
         }
+    }
+
+    public enum PluginLoadSetting
+    {
+        DontLoad,
+        LoadFrom,
+        LoadFile
     }
 
     public enum AutoLoadSetting


### PR DESCRIPTION
Following from my ramblings in the server, I think you were hesitant to change the method for loading plugins suddenly and potentially cause breaking changes with other/future plugins so I've turned it into a setting with the current method (`LoadFrom`) being the default.

If users observe the race condition/cast error multiple times in a row then asking them to change their plugin load setting to `LoadFile` should fix the issue, at the very least for the most popular plugins (ALM/RaidSeed)