### PR TITLE
Add/Enable BDSP Battle Tower Points (BP).

### DIFF
--- a/PKHeX.Core/Saves/SAV8BS.cs
+++ b/PKHeX.Core/Saves/SAV8BS.cs
@@ -259,6 +259,12 @@ namespace PKHeX.Core
             set => BitConverter.GetBytes(value).CopyTo(Data, 0x5638);
         }
 
+        public uint BP
+        {
+            get => BitConverter.ToUInt32(Data, 0x95C00);
+            set => BitConverter.GetBytes(value).CopyTo(Data, 0x95C00);
+        }
+
         protected override void SetPKM(PKM pkm, bool isParty = false)
         {
             var pk = (PB8)pkm;

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen8/SAV_Trainer8b.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen8/SAV_Trainer8b.cs
@@ -49,7 +49,7 @@ namespace PKHeX.WinForms
             CB_Game.SelectedIndex = Math.Max(0, Math.Min(1, SAV.Game - (int)GameVersion.BD));
             CB_Gender.SelectedIndex = SAV.Gender;
 
-            L_BP.Visible = NUD_BP.Visible = false;
+            NUD_BP.Value = SAV.BP;
 
             // Display Data
             TB_OTName.Text = SAV.OT;
@@ -104,6 +104,7 @@ namespace PKHeX.WinForms
             SAV.Language = WinFormsUtil.GetIndex(CB_Language);
             SAV.OT = TB_OTName.Text;
             SAV.Rival = TB_Rival.Text;
+            SAV.BP = (uint) NUD_BP.Value;
 
             // Copy Position
             if (GB_Map.Enabled && MapUpdated)


### PR DESCRIPTION
I saw it existed but was not populated/disabled, so I found the offset and added it in.
It works in my tests though I'm not sure what the max is (assuming 9999 from previous gens?) and I hope the saves are the same size and there's no offset issues. (I say other hard-coded offsets so I'm assuming this to be true as well.)

So this just unhides the existing NUD in trainer info and binds the data to the SAV.