### PR TITLE
Add PKHeX icon to generic/simple/whatever editor

### DIFF
--- a/PKHeX.WinForms/Controls/SAV Editor/SAVEditor.cs
+++ b/PKHeX.WinForms/Controls/SAV Editor/SAVEditor.cs
@@ -606,6 +606,7 @@ namespace PKHeX.WinForms.Controls
                 MinimumSize = new Size(350, 380),
                 MinimizeBox = false,
                 MaximizeBox = false,
+                Icon = Properties.Resources.Icon,
             };
             var pg = new PropertyGrid {SelectedObject = sav, Dock = DockStyle.Fill};
             form.Controls.Add(pg);


### PR DESCRIPTION
Replaces the generic winforms icon with PKHeX's icon.

The only known instance that I know of, changes the "Block Data" for BDSP saves.