### PR TITLE
Fix swarm seed location for pokemon platinum

### DIFF
--- a/PKHeX.Core/Saves/SAV4Pt.cs
+++ b/PKHeX.Core/Saves/SAV4Pt.cs
@@ -123,8 +123,8 @@ namespace PKHeX.Core
         public override int Y2 { get => ReadUInt16LittleEndian(General.AsSpan(0x2882)); set => WriteUInt16LittleEndian(General.AsSpan(0x2882), (ushort)value); }
         public override int Z { get => ReadUInt16LittleEndian(General.AsSpan(0x2886)); set => WriteUInt16LittleEndian(General.AsSpan(0x2886), (ushort)value); }
 
-        public override uint SafariSeed { get => ReadUInt32LittleEndian(General.AsSpan(0x72D4)); set => WriteUInt32LittleEndian(General.AsSpan(0x72D4), value); }
-        public override uint SwarmSeed { get => ReadUInt32LittleEndian(General.AsSpan(0x72D8)); set => WriteUInt32LittleEndian(General.AsSpan(0x72D8), value); }
+        public override uint SafariSeed { get => ReadUInt32LittleEndian(General.AsSpan(0x5660)); set => WriteUInt32LittleEndian(General.AsSpan(0x5660), value); }
+        public override uint SwarmSeed { get => ReadUInt32LittleEndian(General.AsSpan(0x5664)); set => WriteUInt32LittleEndian(General.AsSpan(0x5664), value); }
         public override uint SwarmMaxCountModulo => 22;
     }
 }


### PR DESCRIPTION
The seed was being read/written to the wrong location of the save. I've tested this on my pokemon platinum savefile, diamond/pearl locations might be wrong as well, but I haven't checked those.