### PR TITLE
Emulate Height & Weight float calculations matching the game

### DIFF
--- a/PKHeX.Core/Legality/Verifiers/MiscVerifier.cs
+++ b/PKHeX.Core/Legality/Verifiers/MiscVerifier.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using static PKHeX.Core.LegalityCheckStrings;
 using static PKHeX.Core.CheckIdentifier;
-using static System.Buffers.Binary.BinaryPrimitives;
 
 namespace PKHeX.Core
 {
@@ -480,17 +479,6 @@ namespace PKHeX.Core
             // ReSharper disable once CompareOfFloatsByEqualityOperator -- THESE MUST MATCH EXACTLY
             if (obj.WeightAbsolute != obj.CalcWeightAbsolute)
                 data.AddLine(GetInvalid(LStatIncorrectWeight, Encounter));
-        }
-
-        private static bool IsCloseEnough(float a, float b)
-        {
-            // since we don't have access to SingleToInt32Bits on net46, just do a temp write-read.
-            Span<byte> ta = stackalloc byte[4];
-            WriteSingleLittleEndian(ta, a);
-            var ia = ReadInt32LittleEndian(ta);
-            WriteSingleLittleEndian(ta, b);
-            var ib = ReadInt32LittleEndian(ta);
-            return Math.Abs(ia - ib) <= 7;
         }
 
         private static bool IsStarterLGPE(ISpeciesForm pk) => pk.Species switch

--- a/PKHeX.Core/Legality/Verifiers/MiscVerifier.cs
+++ b/PKHeX.Core/Legality/Verifiers/MiscVerifier.cs
@@ -475,10 +475,10 @@ namespace PKHeX.Core
         private static void VerifyAbsoluteSizes(LegalityAnalysis data, IScaledSizeValue obj)
         {
             // ReSharper disable once CompareOfFloatsByEqualityOperator -- THESE MUST MATCH EXACTLY
-            if (!IsCloseEnough(obj.HeightAbsolute, obj.CalcHeightAbsolute))
+            if (obj.HeightAbsolute != obj.CalcHeightAbsolute)
                 data.AddLine(GetInvalid(LStatIncorrectHeight, Encounter));
             // ReSharper disable once CompareOfFloatsByEqualityOperator -- THESE MUST MATCH EXACTLY
-            if (!IsCloseEnough(obj.WeightAbsolute, obj.CalcWeightAbsolute))
+            if (obj.WeightAbsolute != obj.CalcWeightAbsolute)
                 data.AddLine(GetInvalid(LStatIncorrectWeight, Encounter));
         }
 

--- a/PKHeX.Core/PKM/PA8.cs
+++ b/PKHeX.Core/PKM/PA8.cs
@@ -785,9 +785,9 @@ public sealed class PA8 : PKM, ISanityChecksum,
     private static float GetHeightRatio(int heightScalar)
     {
         // +/- 20% (down from +/- 40% in LGP/E)
-        float result = (byte)heightScalar / 255f;
-        result *= 0.4f;
-        result += 0.8f;
+        float result = heightScalar / 255f; // 0x437F0000
+        result *= 0.40000004f; // 0x3ECCCCCE
+        result += 0.8f; // 0x3F4CCCCD
         return result;
     }
 
@@ -795,9 +795,9 @@ public sealed class PA8 : PKM, ISanityChecksum,
     private static float GetWeightRatio(int weightScalar)
     {
         // +/- 20%
-        float result = (byte)weightScalar / 255f;
-        result *= 0.4f;
-        result += 0.8f;
+        float result = weightScalar / 255f; // 0x437F0000
+        result *= 0.40000004f; // 0x3ECCCCCE
+        result += 0.8f; // 0x3F4CCCCD
         return result;
     }
 
@@ -814,8 +814,8 @@ public sealed class PA8 : PKM, ISanityChecksum,
         float HeightRatio = GetHeightRatio(heightScalar);
         float WeightRatio = GetWeightRatio(weightScalar);
 
-        float weight = WeightRatio * p.Weight;
-        return HeightRatio * weight;
+        float ratio = (WeightRatio * HeightRatio);
+        return ratio * p.Weight;
     }
 
     [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
@@ -823,7 +823,7 @@ public sealed class PA8 : PKM, ISanityChecksum,
     {
         // height is already *100
         float biasH = avgHeight * -0.8f;
-        float biasL = avgHeight * 0.4f;
+        float biasL = avgHeight * 0.40000004f;
         float numerator = biasH + height;
         float result = numerator / biasL;
         result *= 255f;
@@ -841,7 +841,7 @@ public sealed class PA8 : PKM, ISanityChecksum,
         float weightComponent = heightRatio * weight;
         float top = avgWeight * -0.8f;
         top += weightComponent;
-        float bot = avgWeight * 0.4f;
+        float bot = avgWeight * 0.40000004f;
         float result = top / bot;
         result *= 255f;
         int value = (int)result;

--- a/PKHeX.Core/PKM/PB7.cs
+++ b/PKHeX.Core/PKM/PB7.cs
@@ -544,10 +544,10 @@ namespace PKHeX.Core
         [MethodImpl(MethodImplOptions.NoOptimization | MethodImplOptions.NoInlining)]
         private static float GetHeightRatio(int heightScalar)
         {
-            // +/- 40%
-            float result = (byte)heightScalar / 255f;
-            result *= 0.8f;
-            result += 0.6f;
+            // + 40%, -20
+            float result = heightScalar / 255f; // 0x437F0000
+            result *= 0.79999995f; // 0x3F4CCCCC
+            result += 0.6f; // 0x3F19999A
             return result;
         }
 
@@ -555,9 +555,9 @@ namespace PKHeX.Core
         private static float GetWeightRatio(int weightScalar)
         {
             // +/- 20%
-            float result = (byte)weightScalar / 255f;
-            result *= 0.4f;
-            result += 0.8f;
+            float result = weightScalar / 255f; // 0x437F0000
+            result *= 0.40000004f; // 0x3ECCCCCE
+            result += 0.8f; // 0x3F4CCCCD
             return result;
         }
 
@@ -583,7 +583,7 @@ namespace PKHeX.Core
         {
             // height is already *100
             float biasH = avgHeight * -0.6f;
-            float biasL = avgHeight * 0.8f;
+            float biasL = avgHeight * 0.79999995f;
             float numerator = biasH + height;
             float result = numerator / biasL;
             result *= 255f;
@@ -601,7 +601,7 @@ namespace PKHeX.Core
             float weightComponent = heightRatio * weight;
             float top = avgWeight * -0.8f;
             top += weightComponent;
-            float bot = avgWeight * 0.4f;
+            float bot = avgWeight * 0.40000004f;
             float result = top / bot;
             result *= 255f;
             int value = (int)result;

--- a/PKHeX.WinForms/Controls/PKM Editor/SizeCP.cs
+++ b/PKHeX.WinForms/Controls/PKM Editor/SizeCP.cs
@@ -48,6 +48,8 @@ namespace PKHeX.WinForms.Controls
             pkm?.ResetCP();
         }
 
+        private static string GetString(float value) => value.ToString("F6", CultureInfo.InvariantCulture);
+
         private void LoadStoredValues()
         {
             Loading = true;
@@ -60,8 +62,8 @@ namespace PKHeX.WinForms.Controls
             }
             if (sv != null)
             {
-                TB_HeightAbs.Text = sv.HeightAbsolute.ToString(CultureInfo.InvariantCulture);
-                TB_WeightAbs.Text = sv.WeightAbsolute.ToString(CultureInfo.InvariantCulture);
+                TB_HeightAbs.Text = GetString(sv.HeightAbsolute);
+                TB_WeightAbs.Text = GetString(sv.WeightAbsolute);
             }
             if (pkm != null)
             {
@@ -98,8 +100,8 @@ namespace PKHeX.WinForms.Controls
                 return;
             sv.ResetHeight();
             sv.ResetWeight();
-            TB_HeightAbs.Text = sv.HeightAbsolute.ToString(CultureInfo.InvariantCulture);
-            TB_WeightAbs.Text = sv.WeightAbsolute.ToString(CultureInfo.InvariantCulture);
+            TB_HeightAbs.Text = GetString(sv.HeightAbsolute);
+            TB_WeightAbs.Text = GetString(sv.WeightAbsolute);
             if (sv is PA8 a)
                 a.HeightScalarCopy = a.HeightScalar;
         }
@@ -116,12 +118,12 @@ namespace PKHeX.WinForms.Controls
             if (!CHK_Auto.Checked || Loading || sv == null)
                 return;
             sv.ResetWeight();
-            TB_WeightAbs.Text = sv.WeightAbsolute.ToString(CultureInfo.InvariantCulture);
+            TB_WeightAbs.Text = GetString(sv.WeightAbsolute);
         }
 
         private void TB_HeightAbs_TextChanged(object sender, EventArgs e)
         {
-            if (sv == null)
+            if (sv == null || Loading)
                 return;
             if (CHK_Auto.Checked)
                 sv.ResetHeight();
@@ -131,7 +133,7 @@ namespace PKHeX.WinForms.Controls
 
         private void TB_WeightAbs_TextChanged(object sender, EventArgs e)
         {
-            if (sv == null)
+            if (sv == null || Loading)
                 return;
             if (CHK_Auto.Checked)
                 sv.ResetWeight();


### PR DESCRIPTION
Order of operations and specific mult/add constants, yay.

Reverse engineered, and PB7/PA8 are slightly different in their implementations:
* PA8 combines the Height & Weight ratios prior to multiplying `pi.Weight`
* PB7 multiplies the height ratio after the `Weight Ratio * pi.Weight`
* PB7 uses 0x3F4CCCCC (0.79999995f) for height ratio mult
* PB7 uses 0x3F4CCCCD (0.8f) for weight ratio mult
* Both use 0x3ECCCCCE (0.40000004f) in place of 0.4f

Removes the lowest-3-bit epsilon comparison legality check, as we can now check for strict equality.

Prevents updating the HeightAbsolute & WeightAbsolute when loading data into the `SizeCP` control, resolving the behavior issue in #3416.