### PR TITLE
Minimize BAK file allocations

### DIFF
--- a/PKHeX.Core/Saves/SAV3.cs
+++ b/PKHeX.Core/Saves/SAV3.cs
@@ -148,6 +148,19 @@ namespace PKHeX.Core
         public sealed override int MaxBallID => Legal.MaxBallID_3;
         public sealed override int MaxGameID => Legal.MaxGameID_3;
 
+        /// <summary>
+        /// Force loads a new <see cref="SAV3"/> object to the requested <see cref="version"/>.
+        /// </summary>
+        /// <param name="version"> Version to retrieve for</param>
+        /// <returns>New <see cref="SaveFile"/> object.</returns>
+        public SAV3 ForceLoad(GameVersion version) => version switch
+        {
+            GameVersion.R or GameVersion.S or GameVersion.RS     => new SAV3RS(Data),
+            GameVersion.E                                        => new SAV3E(Data),
+            GameVersion.FR or GameVersion.LG or GameVersion.FRLG => new SAV3FRLG(Data),
+            _ => throw new ArgumentOutOfRangeException(nameof(version)),
+        };
+
         public sealed override IReadOnlyList<ushort> HeldItems => Legal.HeldItems_RS;
 
         public sealed override int BoxCount => 14;
@@ -182,7 +195,7 @@ namespace PKHeX.Core
                 WriteUInt16LittleEndian(sector[0xFF6..], chk);
             }
 
-            if (State.BAK.Length < SaveUtil.SIZE_G3RAW) // don't update HoF for half-sizes
+            if (Data.Length < SaveUtil.SIZE_G3RAW) // don't update HoF for half-sizes
                 return;
 
             // Hall of Fame Checksums
@@ -208,7 +221,7 @@ namespace PKHeX.Core
                         return false;
                 }
 
-                if (State.BAK.Length < SaveUtil.SIZE_G3RAW) // don't check HoF for half-sizes
+                if (Data.Length < SaveUtil.SIZE_G3RAW) // don't check HoF for half-sizes
                     return true;
 
                 if (!IsSectorValidExtra(0x1C000))
@@ -246,7 +259,7 @@ namespace PKHeX.Core
                         list.Add($"Sector {i} @ {i*SIZE_SECTOR:X5} invalid.");
                 }
 
-                if (State.BAK.Length > SaveUtil.SIZE_G3RAW) // don't check HoF for half-sizes
+                if (Data.Length > SaveUtil.SIZE_G3RAW) // don't check HoF for half-sizes
                 {
                     if (!IsSectorValidExtra(0x1C000))
                         list.Add("HoF first sector invalid.");

--- a/PKHeX.Core/Saves/SAV3RSBox.cs
+++ b/PKHeX.Core/Saves/SAV3RSBox.cs
@@ -14,11 +14,10 @@ namespace PKHeX.Core
         public override string Extension => this.GCExtension();
         public override PersonalTable Personal => PersonalTable.RS;
         public override IReadOnlyList<ushort> HeldItems => Legal.HeldItems_RS;
-        public SAV3GCMemoryCard? MemoryCard { get; }
+        public SAV3GCMemoryCard? MemoryCard { get; init; }
         public readonly bool Japanese = false; // todo?
 
-        public SAV3RSBox(byte[] data, SAV3GCMemoryCard memCard) : this(data, memCard.Data) => MemoryCard = memCard;
-        public SAV3RSBox(byte[] data) : this(data, (byte[])data.Clone()) { }
+        public SAV3RSBox(byte[] data, SAV3GCMemoryCard memCard) : this(data) => MemoryCard = memCard;
 
         public SAV3RSBox() : base(SaveUtil.SIZE_G3BOX)
         {
@@ -27,7 +26,7 @@ namespace PKHeX.Core
             ClearBoxes();
         }
 
-        private SAV3RSBox(byte[] data, byte[] bak) : base(data, bak)
+        public SAV3RSBox(byte[] data) : base(data)
         {
             Blocks = ReadBlocks(data);
             InitializeData();

--- a/PKHeX.Core/Saves/SAV8LA.cs
+++ b/PKHeX.Core/Saves/SAV8LA.cs
@@ -19,9 +19,8 @@ public sealed class SAV8LA : SaveFile, ISaveBlock8LA, ISCBlockArray
         Initialize();
     }
 
-    private SAV8LA(byte[] data, IReadOnlyList<SCBlock> blocks) : base(data)
+    private SAV8LA(IReadOnlyList<SCBlock> blocks) : base(Array.Empty<byte>())
     {
-        Data = Array.Empty<byte>();
         AllBlocks = blocks;
         Blocks = new SaveBlockAccessor8LA(this);
         Initialize();
@@ -112,7 +111,7 @@ public sealed class SAV8LA : SaveFile, ISaveBlock8LA, ISCBlockArray
         var blockCopy = new SCBlock[AllBlocks.Count];
         for (int i = 0; i < AllBlocks.Count; i++)
             blockCopy[i] = AllBlocks[i].Clone();
-        return new SAV8LA(State.BAK, blockCopy);
+        return new SAV8LA(blockCopy);
     }
 
     public override int MaxMoveID => Legal.MaxMoveID_8a;

--- a/PKHeX.Core/Saves/SAV8SWSH.cs
+++ b/PKHeX.Core/Saves/SAV8SWSH.cs
@@ -17,7 +17,7 @@ namespace PKHeX.Core
             Initialize();
         }
 
-        private SAV8SWSH(byte[] data, IReadOnlyList<SCBlock> blocks) : base(data)
+        private SAV8SWSH(IReadOnlyList<SCBlock> blocks) : base(Array.Empty<byte>())
         {
             Data = Array.Empty<byte>();
             AllBlocks = blocks;
@@ -109,7 +109,7 @@ namespace PKHeX.Core
             var blockCopy = new SCBlock[AllBlocks.Count];
             for (int i = 0; i < AllBlocks.Count; i++)
                 blockCopy[i] = AllBlocks[i].Clone();
-            return new SAV8SWSH(State.BAK, blockCopy);
+            return new SAV8SWSH(blockCopy);
         }
 
         private int m_spec, m_item, m_move, m_abil;

--- a/PKHeX.Core/Saves/SaveFile.cs
+++ b/PKHeX.Core/Saves/SaveFile.cs
@@ -16,21 +16,17 @@ namespace PKHeX.Core
         public SaveFileState State { get; }
         public SaveFileMetadata Metadata { get; private set; }
 
-        protected SaveFile(byte[] data, byte[] bak, bool exportable = true)
+        protected SaveFile(byte[] data, bool exportable = true)
         {
             Data = data;
-            State = new SaveFileState(bak, exportable);
+            State = new SaveFileState(exportable);
             Metadata = new SaveFileMetadata(this);
-        }
-
-        protected SaveFile(byte[] data, bool exportable = true) : this(data, (byte[])data.Clone(), exportable)
-        {
         }
 
         protected SaveFile(int size = 0)
         {
             Data = size == 0 ? Array.Empty<byte>() : new byte[size];
-            State = new SaveFileState(Array.Empty<byte>(), false);
+            State = new SaveFileState(false);
             Metadata = new SaveFileMetadata(this);
         }
 

--- a/PKHeX.Core/Saves/SaveFileState.cs
+++ b/PKHeX.Core/Saves/SaveFileState.cs
@@ -18,14 +18,8 @@
         /// </remarks>
         public readonly bool Exportable;
 
-        /// <summary>
-        /// Original Binary Data the save file was loaded with.
-        /// </summary>
-        public readonly byte[] BAK;
-
-        public SaveFileState(byte[] bak, bool exportable = true)
+        public SaveFileState(bool exportable = true)
         {
-            BAK = bak;
             Exportable = exportable;
         }
     }

--- a/PKHeX.Core/Saves/Util/SaveUtil.cs
+++ b/PKHeX.Core/Saves/Util/SaveUtil.cs
@@ -650,9 +650,9 @@ namespace PKHeX.Core
             switch (memCard.SelectedGameVersion)
             {
                 // Side Games
-                case COLO: sav = new SAV3Colosseum(data, memCard); break;
-                case XD: sav = new SAV3XD(data, memCard); break;
-                case RSBOX: sav = new SAV3RSBox(data, memCard); break;
+                case COLO: sav = new SAV3Colosseum(data) { MemoryCard = memCard }; break;
+                case XD: sav = new SAV3XD(data) { MemoryCard = memCard }; break;
+                case RSBOX: sav = new SAV3RSBox(data, memCard) { MemoryCard = memCard }; break;
 
                 // No pattern matched
                 default: return null;
@@ -821,19 +821,5 @@ namespace PKHeX.Core
         /// <param name="size">Size in bytes of the save data</param>
         /// <returns>A boolean indicating whether or not the save data size is valid.</returns>
         public static bool IsSizeValid(int size) => Sizes.Contains(size) || Handlers.Any(z => z.IsRecognized(size));
-
-        /// <summary>
-        /// Force loads the provided <see cref="sav"/> to the requested <see cref="version"/>.
-        /// </summary>
-        /// <param name="sav">SaveFile data to force</param>
-        /// <param name="version"> Version to retrieve for</param>
-        /// <returns>New <see cref="SaveFile"/> object.</returns>
-        public static SAV3 GetG3SaveOverride(SaveFile sav, GameVersion version) => version switch // Reset save file info
-        {
-            R or S or RS => new SAV3RS(sav.State.BAK),
-            E => new SAV3E(sav.State.BAK),
-            FR or LG or FRLG => new SAV3FRLG(sav.State.BAK),
-            _ => throw new ArgumentOutOfRangeException(nameof(version)),
-        };
     }
 }

--- a/PKHeX.WinForms/Controls/SAV Editor/SAVEditor.cs
+++ b/PKHeX.WinForms/Controls/SAV Editor/SAVEditor.cs
@@ -1110,7 +1110,8 @@ namespace PKHeX.WinForms.Controls
         {
             // Generational Interface
             ToggleSecrets(sav, HideSecretDetails);
-            B_VerifyCHK.Visible = Menu_ExportBAK.Visible = SAV.State.Exportable;
+            B_VerifyCHK.Visible = SAV.State.Exportable;
+            Menu_ExportBAK.Visible = SAV.State.Exportable && SAV.Metadata.FilePath is not null;
 
             if (sav is SAV4BR br)
             {

--- a/PKHeX.WinForms/Controls/SAV Editor/SAVEditor.cs
+++ b/PKHeX.WinForms/Controls/SAV Editor/SAVEditor.cs
@@ -778,14 +778,14 @@ namespace PKHeX.WinForms.Controls
 
         public bool ExportBackup()
         {
-            if (!SAV.State.Exportable)
+            if (!SAV.State.Exportable || SAV.Metadata.FilePath is not { } file)
                 return false;
             using var sfd = new SaveFileDialog {FileName = Util.CleanFileName(SAV.Metadata.BAKName)};
             if (sfd.ShowDialog() != DialogResult.OK)
                 return false;
 
             string path = sfd.FileName;
-            File.WriteAllBytes(path, SAV.State.BAK);
+            File.Copy(file, path);
             WinFormsUtil.Alert(MsgSaveBackup, path);
 
             return true;


### PR DESCRIPTION
Stop allocating an entire shadow copy of the save file whenever we create a new savefile object from file.

Prior commits added the clear SaveFileMetadata class to cleanly track the file path. Backups are copied from the original path.