### PR TITLE
Add logic for PLA wild RNG correlation

### DIFF
--- a/PKHeX.Core/Legality/Encounters/EncounterStatic/EncounterStatic8a.cs
+++ b/PKHeX.Core/Legality/Encounters/EncounterStatic/EncounterStatic8a.cs
@@ -32,18 +32,6 @@ public sealed record EncounterStatic8a(GameVersion Version) : EncounterStatic(Ve
     protected override void ApplyDetails(ITrainerInfo sav, EncounterCriteria criteria, PKM pk)
     {
         base.ApplyDetails(sav, criteria, pk);
-        if (pk is IScaledSize s)
-        {
-            if (HasFixedHeight)
-                s.HeightScalar = HeightScalar;
-            if (HasFixedWeight)
-                s.WeightScalar = WeightScalar;
-        }
-        if (pk is IScaledSizeValue v)
-        {
-            v.ResetHeight();
-            v.ResetWeight();
-        }
 
         if (IsAlpha && pk is IAlpha a)
             a.IsAlpha = true;
@@ -59,20 +47,12 @@ public sealed record EncounterStatic8a(GameVersion Version) : EncounterStatic(Ve
                 pk.PushMove(extra);
             }
         }
-
-        pk.SetRandomEC();
     }
 
     protected override void SetPINGA(PKM pk, EncounterCriteria criteria)
     {
-        var pi = pk.PersonalInfo;
-        int gender = criteria.GetGender(Gender, pi);
-        int nature = (int)criteria.GetNature(Nature);
-        int ability = criteria.GetAbilityFromNumber(Ability);
-        PIDGenerator.SetRandomWildPID(pk, pk.Format, nature, ability, gender);
-        pk.PID = Overworld8aRNG.AdaptPID(pk, Shiny, pk.PID);
-        SetIVs(pk);
-        pk.StatNature = pk.Nature;
+        var para = GetParams();
+        Overworld8aRNG.ApplyDetails(pk, criteria, para);
     }
 
     protected override void ApplyDetailsBall(PKM pk) => pk.Ball = Gift ? Ball : (int)Core.Ball.LAPoke;
@@ -150,5 +130,20 @@ public sealed record EncounterStatic8a(GameVersion Version) : EncounterStatic(Ve
         }
 
         return true;
+    }
+
+    private OverworldParam8a GetParams()
+    {
+        var pt = PersonalTable.LA;
+        var entry = pt.GetFormEntry(Species, Form);
+        var gender = (byte)entry.Gender;
+        return new OverworldParam8a
+        {
+            IsAlpha = IsAlpha,
+            FlawlessIVs = (byte)FlawlessIVCount,
+            Shiny = Shiny,
+            RollCount = 1, // Everything is shiny locked anyways
+            GenderRatio = gender,
+        };
     }
 }

--- a/PKHeX.Core/Legality/RNG/Algorithms/Xoroshiro128Plus.cs
+++ b/PKHeX.Core/Legality/RNG/Algorithms/Xoroshiro128Plus.cs
@@ -1,104 +1,104 @@
 ﻿using System.Runtime.CompilerServices;
 
-namespace PKHeX.Core
+namespace PKHeX.Core;
+
+/// <summary>
+/// Self-modifying RNG structure that implements xoroshiro128+
+/// </summary>
+/// <remarks>https://en.wikipedia.org/wiki/Xoroshiro128%2B</remarks>
+public ref struct Xoroshiro128Plus
 {
+    public const ulong XOROSHIRO_CONST0= 0x0F4B17A579F18960;
+    public const ulong XOROSHIRO_CONST = 0x82A2B175229D6A5B;
+
+    private ulong s0, s1;
+
+    public Xoroshiro128Plus(ulong s0 = XOROSHIRO_CONST0, ulong s1 = XOROSHIRO_CONST) => (this.s0, this.s1) = (s0, s1);
+
+    public (ulong s0, ulong s1) GetState() => (s0, s1);
+    public string FullState => $"{s1:X16}{s0:X16}";
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static ulong RotateLeft(ulong x, int k) => (x << k) | (x >> -k);
+
     /// <summary>
-    /// Self-modifying RNG structure that implements xoroshiro128+
+    /// Gets the next random <see cref="ulong"/>.
     /// </summary>
-    /// <remarks>https://en.wikipedia.org/wiki/Xoroshiro128%2B</remarks>
-    public ref struct Xoroshiro128Plus
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public ulong Next()
     {
-        public const ulong XOROSHIRO_CONST = 0x82A2B175229D6A5B;
+        var _s0 = s0;
+        var _s1 = s1;
+        ulong result = _s0 + _s1;
 
-        private ulong s0, s1;
+        _s1 ^= _s0;
+        // Final calculations and store back to fields
+        s0 = RotateLeft(_s0, 24) ^ _s1 ^ (_s1 << 16);
+        s1 = RotateLeft(_s1, 37);
 
-        public Xoroshiro128Plus(ulong seed)
+        return result;
+    }
+
+    /// <summary>
+    /// Gets the next previous <see cref="ulong"/>.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public ulong Prev()
+    {
+        var _s0 = s0;
+        var _s1 = s1;
+        _s1 = RotateLeft(_s1, 27);
+        _s0 = _s0 ^ _s1 ^ (_s1 << 16);
+        _s0 = RotateLeft(_s0, 40);
+        _s1 ^= _s0;
+        ulong result = _s0 + _s1;
+
+        s0 = _s0;
+        s1 = _s1;
+        return result;
+    }
+
+    /// <summary>
+    /// Gets a random value that is less than <see cref="MOD"/>
+    /// </summary>
+    /// <param name="MOD">Maximum value (exclusive). Generates a bitmask for the loop.</param>
+    /// <returns>Random value</returns>
+    public ulong NextInt(ulong MOD = 0xFFFFFFFF)
+    {
+        ulong mask = GetBitmask(MOD);
+        ulong res;
+        do
         {
-            s0 = seed;
-            s1 = XOROSHIRO_CONST;
-        }
+            res = Next() & mask;
+        } while (res >= MOD);
+        return res;
+    }
 
-        public Xoroshiro128Plus(ulong s0, ulong s1)
-        {
-            this.s0 = s0;
-            this.s1 = s1;
-        }
+    /// <summary>
+    /// Next Power of Two
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static ulong GetBitmask(ulong x)
+    {
+        x--; // comment out to always take the next biggest power of two, even if x is already a power of two
+        x |= x >> 1;
+        x |= x >> 2;
+        x |= x >> 4;
+        x |= x >> 8;
+        x |= x >> 16;
+        return x;
+    }
 
-        public (ulong s0, ulong s1) GetState() => (s0, s1);
-        public string FullState => $"{s1:X16}{s0:X16}";
-
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static ulong RotateLeft(ulong x, int k)
-        {
-            return (x << k) | (x >> (64 - k));
-        }
-
-        /// <summary>
-        /// Gets the next random <see cref="ulong"/>.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ulong Next()
-        {
-            var _s0 = s0;
-            var _s1 = s1;
-            ulong result = _s0 + _s1;
-
-            _s1 ^= _s0;
-            // Final calculations and store back to fields
-            s0 = RotateLeft(_s0, 24) ^ _s1 ^ (_s1 << 16);
-            s1 = RotateLeft(_s1, 37);
-
-            return result;
-        }
-
-        /// <summary>
-        /// Gets the next previous <see cref="ulong"/>.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ulong Prev()
-        {
-            var _s0 = s0;
-            var _s1 = s1;
-            _s1 = RotateLeft(_s1, 27);
-            _s0 = _s0 ^ _s1 ^ (_s1 << 16);
-            _s0 = RotateLeft(_s0, 40);
-            _s1 ^= _s0;
-            ulong result = _s0 + _s1;
-
-            s0 = _s0;
-            s1 = _s1;
-            return result;
-        }
-
-        /// <summary>
-        /// Gets a random value that is less than <see cref="MOD"/>
-        /// </summary>
-        /// <param name="MOD">Maximum value (exclusive). Generates a bitmask for the loop.</param>
-        /// <returns>Random value</returns>
-        public ulong NextInt(ulong MOD = 0xFFFFFFFF)
-        {
-            ulong mask = GetBitmask(MOD);
-            ulong res;
-            do
-            {
-                res = Next() & mask;
-            } while (res >= MOD);
-            return res;
-        }
-
-        /// <summary>
-        /// Next Power of Two
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static ulong GetBitmask(ulong x)
-        {
-            x--; // comment out to always take the next biggest power of two, even if x is already a power of two
-            x |= x >> 1;
-            x |= x >> 2;
-            x |= x >> 4;
-            x |= x >> 8;
-            x |= x >> 16;
-            return x;
-        }
+    /// <summary>
+    /// Gets a random float value.
+    /// </summary>
+    /// <param name="range">Range of values permitted [0,n)</param>
+    /// <param name="bias">Number to add to the resultant amplified range.</param>
+    /// <returns>Random value</returns>
+    public float NextFloat(float range, float bias = 0f)
+    {
+        const float inv_64_f = 5.421e-20f; // 1/(2^64) as a float; 0x1F800000u moved into a float register.
+        ulong next = Next();
+        return (range * (next * inv_64_f)) + bias;
     }
 }

--- a/PKHeX.Core/Legality/RNG/Overworld8aRNG.cs
+++ b/PKHeX.Core/Legality/RNG/Overworld8aRNG.cs
@@ -107,12 +107,6 @@ public static class Overworld8aRNG
         }
         pk.PID = pid;
 
-        var level = para.LevelMin;
-        var delta = para.LevelMax - level;
-        if (delta != 0)
-            level += (int)rand.NextInt((ulong)delta + 1);
-        pk.Met_Level = level;
-
         Span<int> ivs = stackalloc[] { UNSET, UNSET, UNSET, UNSET, UNSET, UNSET };
         const int MAX = 31;
         for (int i = 0; i < para.FlawlessIVs; i++)
@@ -149,26 +143,29 @@ public static class Overworld8aRNG
             PersonalInfo.RatioMagicMale => 0,
             _ => (int)rand.NextInt(252) + 1 < para.GenderRatio ? 1 : 0,
         };
-        if (gender != criteria.Gender && criteria.Gender != 2)
+        if (gender != criteria.Gender && criteria.Gender != -1)
             return false;
         pk.Gender = gender;
 
         int nature = (int)rand.NextInt(25);
         pk.StatNature = pk.Nature = nature;
 
+        var (height, weight) = para.IsAlpha
+            ? (byte.MaxValue, byte.MaxValue)
+            : ((byte)((int)rand.NextInt(0x81) + (int)rand.NextInt(0x80)),
+               (byte)((int)rand.NextInt(0x81) + (int)rand.NextInt(0x80)));
+
         if (pk is IScaledSize s)
         {
-            var height = (int)rand.NextInt(0x81) + (int)rand.NextInt(0x80);
-            var weight = (int)rand.NextInt(0x81) + (int)rand.NextInt(0x80);
             s.HeightScalar = height;
             s.WeightScalar = weight;
-
             if (pk is IScaledSizeValue a)
             {
                 a.ResetHeight();
                 a.ResetWeight();
             }
         }
+
         return true;
     }
 
@@ -202,14 +199,6 @@ public static class Overworld8aRNG
 
         if (pk.PID != pid)
             return false;
-
-        var level = para.LevelMin;
-        var delta = para.LevelMax - level;
-        if (delta != 0)
-            level += (int)rand.NextInt((ulong)delta + 1ul);
-        if (pk.Met_Level != level)
-            return false;
-
         const int MAX = 31;
         for (int i = ivs.Count(MAX); i < para.Rerolls; i++)
         {
@@ -260,12 +249,15 @@ public static class Overworld8aRNG
         if (pk.Nature != nature)
             return false;
 
+        var (height, weight) = para.IsAlpha
+            ? (byte.MaxValue, byte.MaxValue)
+            : ((byte)((int)rand.NextInt(0x81) + (int)rand.NextInt(0x80)),
+               (byte)((int)rand.NextInt(0x81) + (int)rand.NextInt(0x80)));
+
         if (pk is IScaledSize s)
         {
-            var height = (int)rand.NextInt(0x81) + (int)rand.NextInt(0x80);
             if (s.HeightScalar != height)
                 return false;
-            var weight = (int)rand.NextInt(0x81) + (int)rand.NextInt(0x80);
             if (s.WeightScalar != weight)
                 return false;
         }
@@ -291,11 +283,12 @@ public static class Overworld8aRNG
 
 public readonly record struct OverworldParam8a
 {
-    public int FlawlessIVs { get; init; }
-    public int GenderRatio { get; init; }
-    public int Rerolls { get; init; }
+    public byte GenderRatio { get; init; }
+    public bool IsAlpha { get; init; }
+    public byte LevelMin { get; init; }
+    public byte LevelMax { get; init; }
 
     public Shiny Shiny { get; init; } = Shiny.Random;
-    public int LevelMin { get; init; }
-    public int LevelMax { get; init; }
+    public byte Rerolls { get; init; }
+    public byte FlawlessIVs { get; init; }
 }

--- a/PKHeX.Core/Legality/RNG/Overworld8aRNG.cs
+++ b/PKHeX.Core/Legality/RNG/Overworld8aRNG.cs
@@ -285,8 +285,6 @@ public readonly record struct OverworldParam8a
 {
     public byte GenderRatio { get; init; }
     public bool IsAlpha { get; init; }
-    public byte LevelMin { get; init; }
-    public byte LevelMax { get; init; }
 
     public Shiny Shiny { get; init; } = Shiny.Random;
     public byte Rerolls { get; init; }

--- a/PKHeX.Core/Legality/RNG/Overworld8aRNG.cs
+++ b/PKHeX.Core/Legality/RNG/Overworld8aRNG.cs
@@ -74,7 +74,7 @@ public static class Overworld8aRNG
         bool isShiny = false;
         if (para.Shiny == Shiny.Random) // let's decide if it's shiny or not!
         {
-            for (int i = 0; i < para.Rerolls; i++)
+            for (int i = 1; i < para.RollCount; i++)
             {
                 isShiny = GetShinyXor(pid, fakeTID) < 16;
                 if (isShiny)
@@ -169,7 +169,7 @@ public static class Overworld8aRNG
         return true;
     }
 
-    private static bool Verify(PKM pk, ulong seed, Span<int> ivs, in OverworldParam8a para)
+    public static bool Verify(PKM pk, ulong seed, in OverworldParam8a para)
     {
         var rand = new Xoroshiro128Plus(seed);
         var ec = (uint)rand.NextInt();
@@ -181,7 +181,7 @@ public static class Overworld8aRNG
         bool isShiny = false;
         if (para.Shiny == Shiny.Random) // let's decide if it's shiny or not!
         {
-            for (int i = 0; i <= para.Rerolls; i++)
+            for (int i = 1; i < para.RollCount; i++)
             {
                 isShiny = GetShinyXor(pid, fakeTID) < 16;
                 if (isShiny)
@@ -199,12 +199,14 @@ public static class Overworld8aRNG
 
         if (pk.PID != pid)
             return false;
+        Span<int> ivs = stackalloc[] { UNSET, UNSET, UNSET, UNSET, UNSET, UNSET };
         const int MAX = 31;
-        for (int i = ivs.Count(MAX); i < para.Rerolls; i++)
+        for (int i = 0; i < para.FlawlessIVs; i++)
         {
-            int index = (int)rand.NextInt(6);
-            while (ivs[index] != UNSET)
-                index = (int)rand.NextInt(6);
+            int index;
+            do { index = (int)rand.NextInt(6); }
+            while (ivs[index] != UNSET);
+
             ivs[index] = MAX;
         }
 
@@ -287,6 +289,6 @@ public readonly record struct OverworldParam8a
     public bool IsAlpha { get; init; }
 
     public Shiny Shiny { get; init; } = Shiny.Random;
-    public byte Rerolls { get; init; }
+    public byte RollCount { get; init; }
     public byte FlawlessIVs { get; init; }
 }

--- a/PKHeX.Core/Legality/RNG/Overworld8aRNG.cs
+++ b/PKHeX.Core/Legality/RNG/Overworld8aRNG.cs
@@ -1,4 +1,7 @@
-﻿namespace PKHeX.Core;
+﻿using System;
+using System.Runtime.CompilerServices;
+
+namespace PKHeX.Core;
 
 /// <summary>
 /// Contains logic for the Generation 8 (Legends: Arceus) overworld spawns that walk around the overworld.
@@ -35,4 +38,264 @@ public static class Overworld8aRNG
         var xor = pid ^ oid;
         return (xor ^ (xor >> 16)) & 0xFFFF;
     }
+
+    private const int UNSET = -1;
+
+    public static void ApplyDetails(PKM pk, EncounterCriteria criteria, in OverworldParam8a para)
+    {
+        int ctr = 0;
+        const int maxAttempts = 50_000;
+        var rnd = Util.Rand;
+        do
+        {
+            ulong s0 = Util.Rand32(rnd) | (ulong)Util.Rand32(rnd) << 32;
+            ulong s1 = Util.Rand32(rnd) | (ulong)Util.Rand32(rnd) << 32;
+            var rand = new Xoroshiro128Plus(s0, s1);
+            if (TryApplyFromSeed(pk, criteria, para, rand))
+                return;
+        } while (++ctr != maxAttempts);
+
+        {
+            ulong s0 = Util.Rand32(rnd) | (ulong)Util.Rand32(rnd) << 32;
+            ulong s1 = Util.Rand32(rnd) | (ulong)Util.Rand32(rnd) << 32;
+            var rand = new Xoroshiro128Plus(s0, s1);
+            TryApplyFromSeed(pk, EncounterCriteria.Unrestricted, para, rand);
+        }
+    }
+
+    public static bool TryApplyFromSeed(PKM pk, EncounterCriteria criteria, in OverworldParam8a para, Xoroshiro128Plus rand)
+    {
+        // Encryption Constant
+        pk.EncryptionConstant = (uint)rand.NextInt();
+
+        // PID
+        var fakeTID = (uint)rand.NextInt();
+        uint pid = (uint)rand.NextInt();
+        bool isShiny = false;
+        if (para.Shiny == Shiny.Random) // let's decide if it's shiny or not!
+        {
+            for (int i = 0; i < para.Rerolls; i++)
+            {
+                isShiny = GetShinyXor(pid, fakeTID) < 16;
+                if (isShiny)
+                    break;
+                pid = (uint)rand.NextInt();
+            }
+        }
+        else
+        {
+            // no need to calculate a fake trainer
+            isShiny = para.Shiny == Shiny.Always;
+        }
+
+        ForceShinyState(pk, isShiny, ref pid);
+
+        if (para.Shiny == Shiny.Never)
+        {
+            if (GetIsShiny(pk.TID, pk.SID, pid))
+                return false;
+        }
+        else if (para.Shiny != Shiny.Random)
+        {
+            if (!GetIsShiny(pk.TID, pk.SID, pid))
+                return false;
+
+            if (para.Shiny == Shiny.AlwaysSquare && pk.ShinyXor != 0)
+                return false;
+            if (para.Shiny == Shiny.AlwaysStar && pk.ShinyXor == 0)
+                return false;
+        }
+        pk.PID = pid;
+
+        var level = para.LevelMin;
+        var delta = para.LevelMax - level;
+        if (delta != 0)
+            level += (int)rand.NextInt((ulong)delta + 1);
+        pk.Met_Level = level;
+
+        Span<int> ivs = stackalloc[] { UNSET, UNSET, UNSET, UNSET, UNSET, UNSET };
+        const int MAX = 31;
+        for (int i = 0; i < para.FlawlessIVs; i++)
+        {
+            int index;
+            do { index = (int)rand.NextInt(6); }
+            while (ivs[index] != UNSET);
+
+            ivs[index] = MAX;
+        }
+
+        for (int i = 0; i < ivs.Length; i++)
+        {
+            if (ivs[i] == UNSET)
+                ivs[i] = (int)rand.NextInt(32);
+        }
+
+        if (!criteria.IsIVsCompatible(ivs, 8))
+            return false;
+
+        pk.IV_HP = ivs[0];
+        pk.IV_ATK = ivs[1];
+        pk.IV_DEF = ivs[2];
+        pk.IV_SPA = ivs[3];
+        pk.IV_SPD = ivs[4];
+        pk.IV_SPE = ivs[5];
+
+        pk.RefreshAbility((int)rand.NextInt(2));
+
+        int gender = para.GenderRatio switch
+        {
+            PersonalInfo.RatioMagicGenderless => 2,
+            PersonalInfo.RatioMagicFemale => 1,
+            PersonalInfo.RatioMagicMale => 0,
+            _ => (int)rand.NextInt(252) + 1 < para.GenderRatio ? 1 : 0,
+        };
+        if (gender != criteria.Gender && criteria.Gender != 2)
+            return false;
+        pk.Gender = gender;
+
+        int nature = (int)rand.NextInt(25);
+        pk.StatNature = pk.Nature = nature;
+
+        if (pk is IScaledSize s)
+        {
+            var height = (int)rand.NextInt(0x81) + (int)rand.NextInt(0x80);
+            var weight = (int)rand.NextInt(0x81) + (int)rand.NextInt(0x80);
+            s.HeightScalar = height;
+            s.WeightScalar = weight;
+
+            if (pk is IScaledSizeValue a)
+            {
+                a.ResetHeight();
+                a.ResetWeight();
+            }
+        }
+        return true;
+    }
+
+    private static bool Verify(PKM pk, ulong seed, Span<int> ivs, in OverworldParam8a para)
+    {
+        var rand = new Xoroshiro128Plus(seed);
+        var ec = (uint)rand.NextInt();
+        if (ec != pk.EncryptionConstant)
+            return false;
+
+        var fakeTID = (uint)rand.NextInt();
+        uint pid = (uint)rand.NextInt();
+        bool isShiny = false;
+        if (para.Shiny == Shiny.Random) // let's decide if it's shiny or not!
+        {
+            for (int i = 0; i <= para.Rerolls; i++)
+            {
+                isShiny = GetShinyXor(pid, fakeTID) < 16;
+                if (isShiny)
+                    break;
+                pid = (uint)rand.NextInt();
+            }
+        }
+        else
+        {
+            // no need to calculate a fake trainer
+            isShiny = para.Shiny == Shiny.Always;
+        }
+
+        ForceShinyState(pk, isShiny, ref pid);
+
+        if (pk.PID != pid)
+            return false;
+
+        var level = para.LevelMin;
+        var delta = para.LevelMax - level;
+        if (delta != 0)
+            level += (int)rand.NextInt((ulong)delta + 1ul);
+        if (pk.Met_Level != level)
+            return false;
+
+        const int MAX = 31;
+        for (int i = ivs.Count(MAX); i < para.Rerolls; i++)
+        {
+            int index = (int)rand.NextInt(6);
+            while (ivs[index] != UNSET)
+                index = (int)rand.NextInt(6);
+            ivs[index] = MAX;
+        }
+
+        for (int i = 0; i < 6; i++)
+        {
+            if (ivs[i] == UNSET)
+                ivs[i] = (int)rand.NextInt(32);
+        }
+
+        if (pk.IV_HP != ivs[0])
+            return false;
+        if (pk.IV_ATK != ivs[1])
+            return false;
+        if (pk.IV_DEF != ivs[2])
+            return false;
+        if (pk.IV_SPA != ivs[3])
+            return false;
+        if (pk.IV_SPD != ivs[4])
+            return false;
+        if (pk.IV_SPE != ivs[5])
+            return false;
+
+        int abil = (int)rand.NextInt(2);
+        abil <<= 1; // 1/2/4
+
+        var current = pk.AbilityNumber;
+        if (abil == 4 && current != 4)
+            return false;
+        // else, for things that were made Hidden Ability, defer to Ability Checks (Ability Patch)
+
+        int gender = para.GenderRatio switch
+        {
+            PersonalInfo.RatioMagicGenderless => 2,
+            PersonalInfo.RatioMagicFemale => 1,
+            PersonalInfo.RatioMagicMale => 0,
+            _ => (int)rand.NextInt(252) + 1 < para.GenderRatio ? 1 : 0,
+        };
+        if (pk.Gender != gender)
+            return false;
+
+        var nature = (int)rand.NextInt(25);
+        if (pk.Nature != nature)
+            return false;
+
+        if (pk is IScaledSize s)
+        {
+            var height = (int)rand.NextInt(0x81) + (int)rand.NextInt(0x80);
+            if (s.HeightScalar != height)
+                return false;
+            var weight = (int)rand.NextInt(0x81) + (int)rand.NextInt(0x80);
+            if (s.WeightScalar != weight)
+                return false;
+        }
+
+        return true;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ForceShinyState(PKM pk, bool isShiny, ref uint pid)
+    {
+        if (isShiny)
+        {
+            if (!GetIsShiny(pk.TID, pk.SID, pid))
+                pid = GetShinyPID(pk.TID, pk.SID, pid, 0);
+        }
+        else
+        {
+            if (GetIsShiny(pk.TID, pk.SID, pid))
+                pid ^= 0x1000_0000;
+        }
+    }
+}
+
+public readonly record struct OverworldParam8a
+{
+    public int FlawlessIVs { get; init; }
+    public int GenderRatio { get; init; }
+    public int Rerolls { get; init; }
+
+    public Shiny Shiny { get; init; } = Shiny.Random;
+    public int LevelMin { get; init; }
+    public int LevelMax { get; init; }
 }

--- a/PKHeX.Core/Saves/Access/ISaveBlock8LA.cs
+++ b/PKHeX.Core/Saves/Access/ISaveBlock8LA.cs
@@ -14,4 +14,5 @@ public interface ISaveBlock8LA
     AdventureStart8a AdventureStart { get; }
     LastSaved8a LastSaved { get; }
     PlayTime8a Played { get; }
+    AreaSpawnerSet8a AreaSpawners { get; }
 }

--- a/PKHeX.Core/Saves/Access/SaveBlockAccessor8LA.cs
+++ b/PKHeX.Core/Saves/Access/SaveBlockAccessor8LA.cs
@@ -19,6 +19,7 @@ public sealed class SaveBlockAccessor8LA : SCBlockAccessor, ISaveBlock8LA
     public LastSaved8a LastSaved { get; }
     public PlayerFashion8a FashionPlayer { get; }
     public PlayTime8a Played { get; }
+    public AreaSpawnerSet8a AreaSpawners { get; }
 
     public SaveBlockAccessor8LA(SAV8LA sav)
     {
@@ -34,9 +35,7 @@ public sealed class SaveBlockAccessor8LA : SCBlockAccessor, ISaveBlock8LA
         Played = new PlayTime8a(sav, GetBlock(KPlayTime));
         Coordinates = new Coordinates8a(sav, GetBlock(KCoordinates));
         FashionPlayer = new PlayerFashion8a(sav, GetBlock(KFashionPlayer));
-        // Misc = new Misc8(sav, GetBlock(KMisc));
-        // TrainerCard = new TrainerCard8(sav, GetBlock(KTrainerCard));
-        // Fashion = new FashionUnlock8(sav, GetBlock(KFashionUnlock));
+        AreaSpawners = new AreaSpawnerSet8a(GetBlock(KSpawners));
     }
 
     // Arrays (Blocks)
@@ -58,6 +57,7 @@ public sealed class SaveBlockAccessor8LA : SCBlockAccessor, ISaveBlock8LA
     private const uint KMyStatus = 0xf25c070e; // Trainer Details
     private const uint KLastSaved = 0x1B1E3D8B; // Last Saved
     private const uint KCoordinates = 0x267DD9DA; // Coordinates
+    private const uint KSpawners = 0x511622B3; // Spawner data
     private const uint KFashionPlayer = 0x6B35BADB; // Player's Current Fashion
     private const uint KFashionUnlockedHat = 0x3ADB8A98;
     private const uint KFashionUnlockedTop = 0x82D57F17;
@@ -67,7 +67,6 @@ public sealed class SaveBlockAccessor8LA : SCBlockAccessor, ISaveBlock8LA
     private const uint KFashionUnlockedGlasses = 0x58AB6233;
     private const uint KSwarm = 0x1E0F1BA3; // 5 entries, 0x50 each
     private const uint KCaptureRecords = 0x6506EE96; // 1000 entries, 0x1C each
-    private const uint KOverworld = 0x511622B3; // 0x100 entries, 0x880 each
     private const uint KOtherPlayerSatchels = 0x05E7EBEB;
     private const uint KMyLostSatchels = 0xC5D7112B;
 

--- a/PKHeX.Core/Saves/SAV8LA.cs
+++ b/PKHeX.Core/Saves/SAV8LA.cs
@@ -130,6 +130,8 @@ public sealed class SAV8LA : SaveFile, ISaveBlock8LA, ISCBlockArray
     public AdventureStart8a AdventureStart => Blocks.AdventureStart;
     public LastSaved8a LastSaved => Blocks.LastSaved;
     public PlayTime8a Played => Blocks.Played;
+    public AreaSpawnerSet8a AreaSpawners => Blocks.AreaSpawners;
+
     public override uint SecondsToStart { get => (uint)AdventureStart.Seconds; set => AdventureStart.Seconds = value; }
     public override uint Money { get => (uint)Blocks.GetBlockValue(SaveBlockAccessor8LA.KMoney); set => Blocks.SetBlockValue(SaveBlockAccessor8LA.KMoney, value); }
     public override int MaxMoney => 9_999_999;

--- a/PKHeX.Core/Saves/Substructures/Gen8/LA/Spawners/AreaSpawnerSet8a.cs
+++ b/PKHeX.Core/Saves/Substructures/Gen8/LA/Spawners/AreaSpawnerSet8a.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using static System.Buffers.Binary.BinaryPrimitives;
+
+namespace PKHeX.Core;
+
+/// <summary>
+/// Data structure containing all the spawner objects for the area.
+/// </summary>
+public class AreaSpawnerSet8a
+{
+    public const int EntryCount = 0x200;
+    private const int MetaSize = 0x40;
+    private const int MetaOffset = EntryCount * Spawner8a.SIZE;
+    public const int SIZE = MetaOffset + MetaSize; // 0x88040
+
+    public readonly byte[] Data;
+
+    // Layout:
+    // spawner[512]
+    // metadata (count)
+
+    public AreaSpawnerSet8a(SCBlock block) => Data = block.Data;
+    public AreaSpawnerSet8a(byte[] data) => Data = data;
+
+    private Span<byte> Meta => Data.AsSpan(MetaOffset);
+
+    public int SpawnerCount => ReadInt32LittleEndian(Meta);
+
+    public Spawner8a this[int index] => GetEntry(index);
+
+    public Spawner8a GetEntry(int index)
+    {
+        if ((uint)index >= EntryCount)
+            throw new ArgumentOutOfRangeException(nameof(index));
+
+        return new Spawner8a(Data.AsSpan(Spawner8a.SIZE * index));
+    }
+
+    /// <summary>
+    /// Finds a <see cref="Spawner8a"/> index within this object.
+    /// </summary>
+    /// <param name="key">Field 01 from the Spawner FlatBuffer data.</param>
+    /// <returns>Returns -1 if no match found.</returns>
+    public int Find(ulong key)
+    {
+        var count = SpawnerCount;
+        for (int i = 0; i < count; i++)
+        {
+            var spawner = this[i];
+            if (spawner.Meta.Spawner_01 == key)
+                return i;
+        }
+        return -1;
+    }
+}

--- a/PKHeX.Core/Saves/Substructures/Gen8/LA/Spawners/Spawner8a.cs
+++ b/PKHeX.Core/Saves/Substructures/Gen8/LA/Spawners/Spawner8a.cs
@@ -1,0 +1,71 @@
+﻿using System;
+
+namespace PKHeX.Core;
+
+/// <summary>
+/// Data structure containing 8 spawn slots and extra details about the spawner.
+/// </summary>
+public readonly ref struct Spawner8a
+{
+    public const int EntryCount = 8;
+    public const int SIZE = (EntryCount * SpawnerEntry8a.SIZE) + SpawnerMeta8a.SIZE;
+    private readonly Span<byte> Data;
+
+    // Layout:
+    // entry[8]
+    // metadata
+
+    public Spawner8a(Span<byte> data) => Data = data;
+
+    public SpawnerEntry8a this[int index] => GetEntry(index);
+
+    public SpawnerEntry8a GetEntry(int index)
+    {
+        if ((uint)index >= EntryCount)
+            throw new ArgumentOutOfRangeException(nameof(index));
+
+        return new SpawnerEntry8a(Data[(SpawnerEntry8a.SIZE * index)..]);
+    }
+
+    public SpawnerMeta8a Meta => new(Data[(EntryCount * SpawnerEntry8a.SIZE)..]);
+    public int Count => Meta.Count;
+
+    /// <summary>
+    /// Single regeneration of a specific index.
+    /// </summary>
+    /// <param name="index">Entry index to regenerate.</param>
+    public void Regenerate(int index)
+    {
+        var entry = this[index];
+        (entry.Seed_00, entry.Seed_01) = Meta.Regenerate();
+    }
+
+    /// <summary>
+    /// Single specific indexes.
+    /// </summary>
+    /// <param name="indexes">Entry indexes to regenerate.</param>
+    public void Regenerate(Span<int> indexes)
+    {
+        Span<(ulong, ulong)> output = stackalloc (ulong, ulong)[indexes.Length];
+        Meta.Regenerate(output);
+        for (int index = 0; index < output.Length; index++)
+        {
+            var entry = this[index];
+            (entry.Seed_00, entry.Seed_01) = output[index];
+        }
+    }
+
+    /// <inheritdoc cref="Regenerate(Span{int})"/>
+    public void Regenerate(params int[] indexes) => Regenerate(indexes.AsSpan());
+
+    /// <summary>
+    /// Regenerates all entries for the spawner.
+    /// </summary>
+    public void RegenerateAll()
+    {
+        Span<int> indexes = stackalloc int[Count];
+        for (int i = 0; i < indexes.Length; i++)
+            indexes[i] = i;
+        Regenerate(indexes);
+    }
+}

--- a/PKHeX.Core/Saves/Substructures/Gen8/LA/Spawners/SpawnerEntry8a.cs
+++ b/PKHeX.Core/Saves/Substructures/Gen8/LA/Spawners/SpawnerEntry8a.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Buffers.Binary;
+
+namespace PKHeX.Core;
+
+/// <summary>
+/// Data structure representing a predetermined Pokémon-to-be-encountered, with fixed randomness and details like position if already determined.
+/// </summary>
+/// <remarks>
+/// The game takes the <see cref="Seed_00"/> to roll for which encounter slot, then uses the next rand() to generate the entity's data when interacted with.
+/// </remarks>
+public readonly ref struct SpawnerEntry8a
+{
+    public const int SIZE = 0x80;
+    private readonly Span<byte> Data;
+
+    public SpawnerEntry8a(Span<byte> data) => Data = data;
+
+    public float Coordinate_00 { get => ReadSingleLittleEndian(Data); set => WriteSingleLittleEndian(Data, value); }
+    public float Coordinate_04 { get => ReadSingleLittleEndian(Data[0x04..]); set => WriteSingleLittleEndian(Data[0x04..], value); }
+    public float Coordinate_08 { get => ReadSingleLittleEndian(Data[0x08..]); set => WriteSingleLittleEndian(Data[0x08..], value); }
+    // 10 - float?
+    public float Field_14 { get => ReadSingleLittleEndian(Data[0x14..]); set => WriteSingleLittleEndian(Data[0x14..], value); }
+    // 18 - float?
+    public float Field_1C { get => ReadSingleLittleEndian(Data[0x1C..]); set => WriteSingleLittleEndian(Data[0x1C..], value); }
+    public ulong Seed_00  { get => BinaryPrimitives.ReadUInt64LittleEndian(Data[0x20..]); set => BinaryPrimitives.WriteUInt64LittleEndian(Data[0x20..], value); }
+
+    public float Field_34 { get => ReadSingleLittleEndian(Data[0x34..]); set => WriteSingleLittleEndian(Data[0x34..], value); }
+    public float Field_38 { get => ReadSingleLittleEndian(Data[0x38..]); set => WriteSingleLittleEndian(Data[0x38..], value); }
+    public float Field_3C { get => ReadSingleLittleEndian(Data[0x3C..]); set => WriteSingleLittleEndian(Data[0x3C..], value); }
+
+    public byte  IsEmpty  { get => Data[0x43]; set => Data[0x43] = value; } // 0 for slots with data, 1 for empty
+    public byte  Field_45 { get => Data[0x45]; set => Data[0x45] = value; }
+    public byte  Field_46 { get => Data[0x46]; set => Data[0x46] = value; }
+    public short Field_48 { get => BinaryPrimitives.ReadInt16LittleEndian (Data[0x48..]); set => BinaryPrimitives.WriteInt16LittleEndian (Data[0x48..], value); }
+    public byte  Field_4A { get => Data[0x4A]; set => Data[0x4A] = value; }
+    public ulong Seed_01  { get => BinaryPrimitives.ReadUInt64LittleEndian(Data[0x58..]); set => BinaryPrimitives.WriteUInt64LittleEndian(Data[0x58..], value); }
+}

--- a/PKHeX.Core/Saves/Substructures/Gen8/LA/Spawners/SpawnerMeta8a.cs
+++ b/PKHeX.Core/Saves/Substructures/Gen8/LA/Spawners/SpawnerMeta8a.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Buffers.Binary;
+
+namespace PKHeX.Core;
+
+/// <summary>
+/// Data structure containing metadata about a <see cref="Spawner8a"/>.
+/// </summary>
+public readonly ref struct SpawnerMeta8a
+{
+    public const int SIZE = 0x40;
+    private readonly Span<byte> Data;
+
+    public SpawnerMeta8a(Span<byte> data) => Data = data;
+
+    public ulong Seed_00    { get => BinaryPrimitives.ReadUInt64LittleEndian(Data);         set => BinaryPrimitives.WriteUInt64LittleEndian(Data        , value); }
+
+    /// <summary> Seed that regenerates seeds for the entries as a group, regenerating multiple or single entries. </summary>
+    public ulong GroupSeed  { get => BinaryPrimitives.ReadUInt64LittleEndian(Data[0x08..]); set => BinaryPrimitives.WriteUInt64LittleEndian(Data[0x08..], value); }
+
+    // flatbuffer Field_01 to match
+    public ulong Spawner_01 { get => BinaryPrimitives.ReadUInt64LittleEndian(Data[0x10..]); set => BinaryPrimitives.WriteUInt64LittleEndian(Data[0x10..], value); }
+
+    public int Count        { get => BinaryPrimitives.ReadInt32LittleEndian (Data[0x18..]); set => BinaryPrimitives.WriteInt32LittleEndian (Data[0x18..], value); }
+    public int Flags        { get => BinaryPrimitives.ReadInt32LittleEndian (Data[0x1C..]); set => BinaryPrimitives.WriteInt32LittleEndian (Data[0x1C..], value); }
+
+    // Flags?
+    public bool IsOutbreak => (Flags & 0x40) != 0; // 0x40
+    public bool IsRegular => (Flags & 0x80) != 0; // 0x80
+    public bool IsInactive => (Flags & 0x100) != 0; // 1 for no spawns in this spawner
+
+    /// <summary>
+    /// Creates a new entry seed pair and updates the <see cref="GroupSeed"/>.
+    /// </summary>
+    public (ulong, ulong) Regenerate()
+    {
+        var rand = new Xoroshiro128Plus(GroupSeed);
+        var result = (rand.Next(), rand.Next());
+        GroupSeed = rand.Next();
+        return result;
+    }
+
+    /// <summary>
+    /// Creates new entry seed pairs and updates the <see cref="GroupSeed"/>.
+    /// </summary>
+    /// <param name="output">Result buffer</param>
+    public void Regenerate(Span<(ulong, ulong)> output)
+    {
+        var rand = new Xoroshiro128Plus(GroupSeed);
+        for (int i = 0; i < output.Length; i++)
+            output[i] = (rand.Next(), rand.Next());
+        GroupSeed = rand.Next();
+    }
+}

--- a/PKHeX.Core/Saves/Substructures/Gen8/LA/Spawners/SpawnerUtil8a.cs
+++ b/PKHeX.Core/Saves/Substructures/Gen8/LA/Spawners/SpawnerUtil8a.cs
@@ -1,0 +1,12 @@
+﻿namespace PKHeX.Core;
+
+/// <summary>
+/// Utility logic for interacting with Spawner objects.
+/// </summary>
+public static class SpawnerUtil8a
+{
+    // Abuse the fact that Group Seed -> Entry seed generation is new(u64) -> u64 next(); can infer original s0 as we already know s1 (const).
+    private static ulong ComputeGroupSeed(ulong seed) => unchecked(seed - Xoroshiro128Plus.XOROSHIRO_CONST);
+    public static ulong ComputeGroupSeed(SpawnerEntry8a entry) => ComputeGroupSeed(entry.Seed_00);
+    public static ulong ComputeGroupSeed(Spawner8a spawner) => ComputeGroupSeed(spawner[0]);
+}

--- a/Tests/PKHeX.Core.Tests/Legality/Wild8aRNGTests.cs
+++ b/Tests/PKHeX.Core.Tests/Legality/Wild8aRNGTests.cs
@@ -15,7 +15,7 @@ public static class Wild8aRNGTests
         var param = new OverworldParam8a
         {
             FlawlessIVs = 0, IsAlpha = false,
-            Shiny = Shiny.Random, Rerolls = 29,
+            Shiny = Shiny.Random, RollCount = 30,
             GenderRatio = 0x7F,
         };
 
@@ -30,5 +30,8 @@ public static class Wild8aRNGTests
         test.IV_SPE.Should().Be(25);
         test.HeightScalar.Should().Be(99);
         test.WeightScalar.Should().Be(153);
+
+        var verify = Overworld8aRNG.Verify(test, s0, param);
+        verify.Should().BeTrue();
     }
 }

--- a/Tests/PKHeX.Core.Tests/Legality/Wild8aRNGTests.cs
+++ b/Tests/PKHeX.Core.Tests/Legality/Wild8aRNGTests.cs
@@ -1,0 +1,34 @@
+﻿using FluentAssertions;
+using Xunit;
+
+namespace PKHeX.Core.Tests.Legality;
+
+public static class Wild8aRNGTests
+{
+    [Fact]
+    public static void TryGenerateShinyOutbreakZorua()
+    {
+        PA8 test = new() { Species = (int)Species.Zorua, Form = 1 };
+        const ulong s0 = 0xDF440DA44EEC4FFB;
+
+        var rand = new Xoroshiro128Plus(s0);
+        var param = new OverworldParam8a
+        {
+            FlawlessIVs = 0, IsAlpha = false,
+            Shiny = Shiny.Random, Rerolls = 29,
+            GenderRatio = 0x7F,
+        };
+
+        var result = Overworld8aRNG.TryApplyFromSeed(test, EncounterCriteria.Unrestricted, param, rand);
+        result.Should().BeTrue();
+
+        test.IV_HP.Should().Be(10);
+        test.IV_ATK.Should().Be(13);
+        test.IV_DEF.Should().Be(8);
+        test.IV_SPA.Should().Be(0);
+        test.IV_SPD.Should().Be(17);
+        test.IV_SPE.Should().Be(25);
+        test.HeightScalar.Should().Be(99);
+        test.WeightScalar.Should().Be(153);
+    }
+}


### PR DESCRIPTION
Adds structures to read/write saved spawner data such as seeds, counts.
Adds generator and validator to emulate the FixInitSpec builder used by the game logic

Similar to SW/SH raids, validating these in-process is not feasible due to the number crunching required.

This does not handle the encounter slot call or the follow-up level range call. Just the inner FixInitSpec ctor & fill.