### PR TITLE
Add L:A blocks and BDSP event constants

### DIFF
--- a/PKHeX.Core/Resources/text/script/gen8/work_bdsp_en.txt
+++ b/PKHeX.Core/Resources/text/script/gen8/work_bdsp_en.txt
@@ -28,4 +28,7 @@
 331	*	WK_PLAYER_BIRTH_MOUNTH
 332	*	WK_PLAYER_BIRTH_DAY
 
+422	*	Total Battle Tower Master Class Wins
+424	*	Battle Tower Master Class Next Prize Streak
+
 436	*	SWARM_SEED	00:Doduo (Route 201),01:Zigzagoon (Route 202),02:Cubone (Route 203),03:Nosepass (Route 206),04:Phanpy (Route 207),05:Dunsparce (Route 208),06:Snubbull (Route 209),07:Absol (Route 213),08:Spoink (Route 214),09:Drowzee (Route 215),10:Delibird (Route 216),11:Swinub (Route 217),12:Voltorb (Route 218),13:Farfetch'd (Route 221),14:Skitty (Route 222),15:Natu (Route 224),16:Makuhita (Route 225),17:Krabby (Route 226),18:Spinda (Route 227),19:Beldum (Route 228),20:Pidgey (Route 229),21:Corsola (Route 230),22:Surskit (Lake Verity),23:Lickitung (Lake Valor),24:Smoochum (Lake Acuity),25:Electrike (Valley Windworks),26:Slakoth (Eterna Forest),27:Magnemite (Fuego Ironworks)

--- a/PKHeX.Core/Saves/Access/SaveBlockAccessor8LA.cs
+++ b/PKHeX.Core/Saves/Access/SaveBlockAccessor8LA.cs
@@ -67,8 +67,9 @@ public sealed class SaveBlockAccessor8LA : SCBlockAccessor, ISaveBlock8LA
     private const uint KFashionUnlockedGlasses = 0x58AB6233;
     private const uint KSwarm = 0x1E0F1BA3; // 5 entries, 0x50 each
     private const uint KCaptureRecords = 0x6506EE96; // 1000 entries, 0x1C each
-    private const uint KOtherPlayerSatchels = 0x05E7EBEB;
+    private const uint KOtherPlayerLostSatchels = 0x05E7EBEB;
     private const uint KMyLostSatchels = 0xC5D7112B;
+    private const uint KNobleRematchRecords = 0xB9252862; // Best times of Noble rematches
 
     // Values
     public const uint KCurrentBox = 0x017C3CBB; // U8 Box Index
@@ -178,6 +179,17 @@ public sealed class SaveBlockAccessor8LA : SCBlockAccessor, ISaveBlock8LA
     private const uint KHasPlayRecordsBDSP = 0x52CE2052; // FSYS_SAVEDATA_LINKAGE_DEL_01
     private const uint KHasPlayRecordsSWSH = 0x530EF0B9; // FSYS_SAVEDATA_LINKAGE_ORI_01
     private const uint KHasPlayRecordsLGPE = 0x6CFA9468; // FSYS_SAVEDATA_LINKAGE_BEL_01
+    
+    private const uint KChoseDiamondClanLeader = 0x669B325F; // Choice of Adaman over Irida
+    private const uint KHasElectricFan = 0xC734C80F; // Access to Fan-Rotom
+    private const uint KHasWashingMachine = 0x62872639; // Access to Wash-Rotom
+    private const uint KHasLawnMower = 0xFB87E941; // Access to Mow-Rotom
+    private const uint KHasMicrowaveOven = 0xD9A315A0; // Access to Heat-Rotom
+    private const uint KHasRefrigerator = 0xAE868040; // Access to Frost-Rotom
+    private const uint KReceivedRemainderStarters = 0x8D45EB90; // Got Starters that weren't chosen
+    private const uint KReceivedRemainderStarterRowlet = 0x4570A16B; // Combine with other 2 and KReceivedRemainderStarers to re-activate
+    private const uint KReceivedRemainderStarterCyndaquil = 0x602C2CD6; // Combine with other 2 and KReceivedRemainderStarers to re-activate
+    private const uint KReceivedRemainderStarterOshawott = 0xAFCE7320; // Combine with other 2 and KReceivedRemainderStarers to re-activate
 
     public const uint KUnlockedSecretBox01 = 0xF224CA8E; // FSYS_SECRET_BOX_01_OPEN
     public const uint KUnlockedSecretBox02 = 0x06924515; // FSYS_SECRET_BOX_02_OPEN


### PR DESCRIPTION
So I started a second playthrough, and was also documenting the stuff I was interested in.

-Includes the block that tells the game you chose Adaman over Irida. Nothing important seemed to change on my side during the course of the initial story other than the KDefeatedOriginDialga or KDefeatedOriginPalkia, so you may wanna revise those if you do change this I guess.
-Blocks that allow you to re-receive the unchosen starters; KStarterChoice affects the 2 you'll get.
-Blocks for the Rotom form appliances from Ginter for those who find it repetitive.
-Object block that appear to store the rematch best times for the Nobles, Origin Dialga, Origin Palkia, and Arceus.

Also included 2 BDSP event constants for the total amount of Master Class wins and the streak needed to achieve a prize in the Battle Tower.