### PR TITLE
Revisions for bdsp gible

### DIFF
--- a/PKHeX.Core/Legality/Moves/Breeding/MoveBreed2.cs
+++ b/PKHeX.Core/Legality/Moves/Breeding/MoveBreed2.cs
@@ -137,7 +137,7 @@ namespace PKHeX.Core
 
                 var baseIndex = baseMoves.IndexOf(moves[i]);
                 var min = moves.Length - baseMoves.Length + baseIndex;
-                if (i <= min + count)
+                if (i < min + count)
                     return false;
             }
 

--- a/PKHeX.Core/Legality/Moves/Breeding/MoveBreed3.cs
+++ b/PKHeX.Core/Legality/Moves/Breeding/MoveBreed3.cs
@@ -133,7 +133,7 @@ namespace PKHeX.Core
 
                 var baseIndex = baseMoves.IndexOf(moves[i]);
                 var min = moves.Length - baseMoves.Length + baseIndex;
-                if (i <= min + count)
+                if (i < min + count)
                     return false;
             }
 

--- a/PKHeX.Core/Legality/Moves/Breeding/MoveBreed4.cs
+++ b/PKHeX.Core/Legality/Moves/Breeding/MoveBreed4.cs
@@ -134,7 +134,7 @@ namespace PKHeX.Core
 
                 var baseIndex = baseMoves.IndexOf(moves[i]);
                 var min = moves.Length - baseMoves.Length + baseIndex;
-                if (i <= min + count)
+                if (i < min + count)
                     return false;
             }
 

--- a/PKHeX.Core/Legality/Moves/Breeding/MoveBreed5.cs
+++ b/PKHeX.Core/Legality/Moves/Breeding/MoveBreed5.cs
@@ -133,7 +133,7 @@ namespace PKHeX.Core
 
                 var baseIndex = baseMoves.IndexOf(moves[i]);
                 var min = moves.Length - baseMoves.Length + baseIndex;
-                if (i <= min + count)
+                if (i < min + count)
                     return false;
             }
 

--- a/PKHeX.Core/Legality/Moves/Breeding/MoveBreed6.cs
+++ b/PKHeX.Core/Legality/Moves/Breeding/MoveBreed6.cs
@@ -133,7 +133,7 @@ namespace PKHeX.Core
 
                 var baseIndex = baseMoves.IndexOf(info.Moves[i]);
                 var min = info.Moves.Length - baseMoves.Length + baseIndex;
-                if (i <= min + count)
+                if (i < min + count)
                     return false;
             }
 

--- a/Tests/PKHeX.Core.Tests/Legality/BreedTests.cs
+++ b/Tests/PKHeX.Core.Tests/Legality/BreedTests.cs
@@ -32,6 +32,9 @@ namespace PKHeX.Tests.Legality
         [InlineData(OR, Growlithe, 0, MorningSun, IronTail, Crunch, HeatWave)]
         [InlineData(OR, Dratini, 0, Wrap, Leer, DragonDance, ExtremeSpeed)]
         [InlineData(OR, Rotom, 0, Astonish, ThunderWave, ThunderShock, ConfuseRay)]
+        [InlineData(BD, Gible, 0, IronHead, BodySlam, SandTomb, Outrage)]
+        [InlineData(BD, Gible, 0, IronHead, BodySlam, Outrage, SandTomb)]
+        [InlineData(BD, Gible, 0, BodySlam, Outrage, SandTomb, DragonBreath)]
         public void VerifyBreed(GameVersion game, Species species, int form, params Move[] movelist)
         {
             var gen = game.GetGeneration();
@@ -63,6 +66,7 @@ namespace PKHeX.Tests.Legality
         [Theory]
         [InlineData(GD, Bulbasaur, 0, Growl, Tackle)] // swap order, two base moves
         [InlineData(UM, Charmander, 0, Ember, BellyDrum, Scratch, Growl)] // swap order, inherit + egg moves
+        [InlineData(BD, Gible, 0, BodySlam, SandTomb, Outrage, DragonBreath)]
         public void CheckFix(GameVersion game, Species species, int form, params Move[] movelist)
         {
             var gen = game.GetGeneration();


### PR DESCRIPTION
https://github.com/kwsch/PKHeX/commit/ddc6f414dfda8ec9e060f052138201258193cda0 caused it to be `<=` instead of `<`, but maybe the underlying issue was fixed a different way since all tests still pass with this reversion.