### PR TITLE
Fix BDSP Gen8Version Name Typo

### DIFF
--- a/PKHeX.Core/Saves/SAV8BS.cs
+++ b/PKHeX.Core/Saves/SAV8BS.cs
@@ -85,7 +85,7 @@ namespace PKHeX.Core
         Initialize();
         }
 
-        public SAV8BS() : this(new byte[SaveUtil.SIZE_G8BDSP_3], false) => SaveRevision = (int)Gem8Version.V1_3;
+        public SAV8BS() : this(new byte[SaveUtil.SIZE_G8BDSP_3], false) => SaveRevision = (int)Gen8Version.V1_3;
 
         private void Initialize()
         {
@@ -122,8 +122,8 @@ namespace PKHeX.Core
         public override int MaxGameID => Legal.MaxGameID_8b;
         public override int MaxAbilityID => Legal.MaxAbilityID_8b;
 
-        public bool HasFirstSaveFileExpansion => (Gem8Version)SaveRevision >= Gem8Version.V1_1;
-        public bool HasSecondSaveFileExpansion => (Gem8Version)SaveRevision >= Gem8Version.V1_2;
+        public bool HasFirstSaveFileExpansion => (Gen8Version)SaveRevision >= Gen8Version.V1_1;
+        public bool HasSecondSaveFileExpansion => (Gen8Version)SaveRevision >= Gen8Version.V1_2;
 
         public int SaveRevision
         {
@@ -131,7 +131,7 @@ namespace PKHeX.Core
             init => WriteInt32LittleEndian(Data.AsSpan(0), value);
         }
 
-        public string SaveRevisionString => ((Gem8Version)SaveRevision).GetSuffixString();
+        public string SaveRevisionString => ((Gen8Version)SaveRevision).GetSuffixString();
 
         public override IReadOnlyList<ushort> HeldItems => Legal.HeldItems_BS;
         protected override SaveFile CloneInternal() => new SAV8BS((byte[])(Data.Clone()));

--- a/PKHeX.Core/Saves/Substructures/Gen8/BS/Gen8Version.cs
+++ b/PKHeX.Core/Saves/Substructures/Gen8/BS/Gen8Version.cs
@@ -1,12 +1,12 @@
 ﻿using System;
-using static PKHeX.Core.Gem8Version;
+using static PKHeX.Core.Gen8Version;
 
 namespace PKHeX.Core
 {
     /// <summary>
     /// Indicates various <see cref="SAV8BS"/> revision values which change on each major patch update, updating the structure of the stored player save data.
     /// </summary>
-    public enum Gem8Version
+    public enum Gen8Version
     {
         /// <summary>
         /// Initial cartridge version shipped.
@@ -33,13 +33,13 @@ namespace PKHeX.Core
         V1_3 = 0x34, // 52
     }
 
-    public static class Gem8VersionExtensions
+    public static class Gen8VersionExtensions
     {
         /// <summary>
         /// Returns a string to append to the savedata type info, indicating the revision of the player save data.
         /// </summary>
         /// <param name="version">Stored version value in the save data.</param>
-        public static string GetSuffixString(this Gem8Version version) => version switch
+        public static string GetSuffixString(this Gen8Version version) => version switch
         {
             V1_0 => "-1.0.0", // Launch Revision
             V1_1 => "-1.1.0", // 1.1.0


### PR DESCRIPTION
Fix a typo in the Gen8Version enum's name unless this was meant to be a gem pun.