### PR TITLE
Improved detection of old PKHeX.Core.dll

### DIFF
--- a/PKHeX.Core/PKHeX.Core.csproj
+++ b/PKHeX.Core/PKHeX.Core.csproj
@@ -12,6 +12,7 @@
     <NeutralLanguage>en</NeutralLanguage>
     <Company>Project Pokémon</Company>
     <Copyright>Kaphotics</Copyright>
+    <Version>22.06.26</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/PKHeX.WinForms/Program.cs
+++ b/PKHeX.WinForms/Program.cs
@@ -130,7 +130,7 @@ namespace PKHeX.WinForms
 
         private static bool IsOldPkhexCorePresent(Exception? ex)
         {
-            return ex is MissingMethodException
+            return ex is MissingMethodException or TypeLoadException or TypeInitializationException
                 && File.Exists("PKHeX.Core.dll")
                 && AssemblyName.GetAssemblyName("PKHeX.Core.dll").Version < Assembly.GetExecutingAssembly().GetName().Version;
         }


### PR DESCRIPTION
_IsOldPkhexCorePresent_ was missing two possible exceptions (_TypeLoadException_ and _TypeInitializationException_).
Also the version check at the end was kinda redundant. PKHeX.Core didn't have a version set in its csproj, so ```AssemblyName.GetAssemblyName("PKHeX.Core.dll").Version``` always returned 1.0.0, which made the version comparison always beeing true.