### PR TITLE
Update .NET Framework 4.6 refs to 4.8

### DIFF
--- a/PKHeX.Core/PKHeX.Core.csproj
+++ b/PKHeX.Core/PKHeX.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net48</TargetFrameworks>
     <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/PKHeX.Core/Saves/Encryption/SwishCrypto/SwishCrypto.cs
+++ b/PKHeX.Core/Saves/Encryption/SwishCrypto/SwishCrypto.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Security.Cryptography;
@@ -56,7 +56,7 @@ public static class SwishCrypto
 
     private static byte[] ComputeHash(byte[] data)
     {
-#if !NET46
+#if !NET48
         using var h = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
         h.AppendData(IntroHashBytes);
         h.AppendData(data, 0, data.Length - SIZE_HASH);

--- a/PKHeX.Core/app.config
+++ b/PKHeX.Core/app.config
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>

--- a/PKHeX.Drawing.Misc/PKHeX.Drawing.Misc.csproj
+++ b/PKHeX.Drawing.Misc/PKHeX.Drawing.Misc.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net6.0;net46</TargetFrameworks>
+		<TargetFrameworks>net6.0;net48</TargetFrameworks>
 		<NeutralLanguage>en</NeutralLanguage>
 		<LangVersion>10</LangVersion>
 		<Nullable>enable</Nullable>

--- a/PKHeX.Drawing.PokeSprite/PKHeX.Drawing.PokeSprite.csproj
+++ b/PKHeX.Drawing.PokeSprite/PKHeX.Drawing.PokeSprite.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net6.0;net46</TargetFrameworks>
+		<TargetFrameworks>net6.0;net48</TargetFrameworks>
 		<NeutralLanguage>en</NeutralLanguage>
 		<LangVersion>10</LangVersion>
 		<Nullable>enable</Nullable>

--- a/PKHeX.Drawing/PKHeX.Drawing.csproj
+++ b/PKHeX.Drawing/PKHeX.Drawing.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net46</TargetFrameworks>
+    <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/PKHeX.WinForms/PKHeX.WinForms.csproj
+++ b/PKHeX.WinForms/PKHeX.WinForms.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net46;net6.0-windows</TargetFrameworks>
+    <TargetFrameworks>net48;net6.0-windows</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
 	<NeutralLanguage>en</NeutralLanguage>
     <PackageId>PKHeX</PackageId>

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ PKHeX expects save files that are not encrypted with console-specific keys. Use 
 
 ## Building
 
-PKHeX is a Windows Forms application which requires [.NET Framework v4.6](https://www.microsoft.com/en-us/download/details.aspx?id=48137), with experimental support for [.NET 6.0](https://dotnet.microsoft.com/download/dotnet/6.0).
+PKHeX is a Windows Forms application which requires [.NET Framework v4.8](https://support.microsoft.com/en-us/topic/microsoft-net-framework-4-8-offline-installer-for-windows-9d23f658-3b97-68ab-d013-aa3c3e7495e0), with experimental support for [.NET 6.0](https://dotnet.microsoft.com/download/dotnet/6.0).
 
 The executable can be built with any compiler that supports C# 10.
 


### PR DESCRIPTION
This PR is just to update the targets for .NET Framework 4.6 to target 4.8. I tested by building, running, and of course passing the unit tests.

I suppose you're trying to keep as wide a compatibility as possible, hence why .NET Framework is still supported, but is there any reason not to at least go to 4.8?