### PR TITLE
Prompt user for clipboard directory use if present for box dump/save

### DIFF
--- a/PKHeX.Core/Util/MessageStrings.cs
+++ b/PKHeX.Core/Util/MessageStrings.cs
@@ -1,4 +1,4 @@
-﻿// ReSharper disable AutoPropertyCanBeMadeGetOnly.Global
+// ReSharper disable AutoPropertyCanBeMadeGetOnly.Global
 
 namespace PKHeX.Core;
 
@@ -152,6 +152,7 @@ public static class MessageStrings
     public static string MsgSaveBoxClearAll { get; set; } = "Clear ALL Boxes?!";
     public static string MsgSaveBoxClearAllFailBattle { get; set; } = "Battle Box slots prevent the clearing of all boxes.";
     public static string MsgSaveBoxClearAllSuccess { get; set; } = "Boxes cleared!";
+    public static string MsgSaveBoxUseClipboard { get; set; } = "Use this folder found in your clipboard? {0}";
 
     public static string MsgSaveBoxFailNone { get; set; } = "The currently loaded save file does not have boxes!";
     public static string MsgSaveBoxExportYes { get; set; } = "Yes: Export All Boxes";

--- a/PKHeX.WinForms/Controls/SAV Editor/SAVEditor.cs
+++ b/PKHeX.WinForms/Controls/SAV Editor/SAVEditor.cs
@@ -766,6 +766,17 @@ public partial class SAVEditor : UserControl, ISlotViewer<PictureBox>, ISaveFile
 
     private static bool IsFolderPath(out string path)
     {
+        if (Clipboard.ContainsText())
+        {
+            var directory = Clipboard.GetText();
+            // Ask user if they want to use clipboard directory before showing folder browser
+            if (Directory.Exists(directory) && WinFormsUtil.Prompt(MessageBoxButtons.YesNo, string.Format(MsgSaveBoxUseClipboard, directory)) == DialogResult.Yes)
+            {
+                path = directory;
+                return true;
+            }
+        }
+
         using var fbd = new FolderBrowserDialog();
         var result = fbd.ShowDialog() == DialogResult.OK;
         path = fbd.SelectedPath;


### PR DESCRIPTION
If the user has a directory copied to their clipboard, a prompt is displayed asking if they'd like to use that for box operations (dump/load) as an alternative to using the built-in FolderBrowserDialog.

![image](https://user-images.githubusercontent.com/66521620/183760891-d1897357-cd15-4248-80ad-aa632269c10f.png)
