### PR TITLE
Fixed error getting Z coordinate in Gen6

### DIFF
--- a/PKHeX.Core/Saves/Substructures/Gen6/Situation6.cs
+++ b/PKHeX.Core/Saves/Substructures/Gen6/Situation6.cs
@@ -31,7 +31,7 @@ public sealed class Situation6 : SaveBlock<SAV6>
 
     public float Z
     {
-        get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x14));
+        get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x14)) / 18;
         set
         {
             var span = Data.AsSpan(Offset + 0x14);


### PR DESCRIPTION
Divide by 18 was missing when getting the Z coord. This would modify the coordinate to an unwanted number when writing map data.