### PR TITLE
Add specialized struct for Moveset and IV specs

### DIFF
--- a/PKHeX.Core/Editing/Applicators/MoveApplicator.cs
+++ b/PKHeX.Core/Editing/Applicators/MoveApplicator.cs
@@ -81,6 +81,19 @@ public static class MoveApplicator
     /// Updates the individual PP count values for each move slot based on the maximum possible value.
     /// </summary>
     /// <param name="pk">Pokémon to modify.</param>
+    /// <param name="moves"><see cref="PKM.Moves"/> to use (if already known). Will fetch the current <see cref="PKM.Moves"/> if not provided.</param>
+    public static void SetMaximumPPCurrent(this PKM pk, Moveset moves)
+    {
+        pk.Move1_PP = moves.Move1 == 0 ? 0 : pk.GetMovePP(moves.Move1, pk.Move1_PPUps);
+        pk.Move2_PP = moves.Move2 == 0 ? 0 : pk.GetMovePP(moves.Move2, pk.Move2_PPUps);
+        pk.Move3_PP = moves.Move3 == 0 ? 0 : pk.GetMovePP(moves.Move3, pk.Move3_PPUps);
+        pk.Move4_PP = moves.Move4 == 0 ? 0 : pk.GetMovePP(moves.Move4, pk.Move4_PPUps);
+    }
+
+    /// <summary>
+    /// Updates the individual PP count values for each move slot based on the maximum possible value.
+    /// </summary>
+    /// <param name="pk">Pokémon to modify.</param>
     public static void SetMaximumPPCurrent(this PKM pk)
     {
         Span<int> moves = stackalloc int[4];

--- a/PKHeX.Core/Editing/Applicators/MoveSetApplicator.cs
+++ b/PKHeX.Core/Editing/Applicators/MoveSetApplicator.cs
@@ -107,8 +107,8 @@ public static class MoveSetApplicator
         }
 
         var encounter = EncounterSuggestion.GetSuggestedMetInfo(legal.Entity);
-        if (encounter is IRelearn {Relearn: int[] {Length: not 0} r})
-            return r;
+        if (encounter is IRelearn {Relearn: {HasMoves:true} r})
+            return r.ToArray();
 
         return m;
     }

--- a/PKHeX.Core/Legality/Areas/EncounterArea3.cs
+++ b/PKHeX.Core/Legality/Areas/EncounterArea3.cs
@@ -102,13 +102,12 @@ public sealed record EncounterArea3 : EncounterArea
         byte min = entry[4];
         byte max = entry[5];
 
-        int[] moves =
-        {
+        var moves = new Moveset(
             ReadUInt16LittleEndian(entry[06..]),
             ReadUInt16LittleEndian(entry[08..]),
             ReadUInt16LittleEndian(entry[10..]),
-            ReadUInt16LittleEndian(entry[12..]),
-        };
+            ReadUInt16LittleEndian(entry[12..])
+        );
 
         return new EncounterSlot3Swarm(this, species, min, max, slotNum, moves);
     }

--- a/PKHeX.Core/Legality/Core.cs
+++ b/PKHeX.Core/Legality/Core.cs
@@ -210,13 +210,26 @@ public static partial class Legal
         return true;
     }
 
-    public static bool GetIsFixedIVSequenceValidNoRand(ReadOnlySpan<int> IVs, PKM pk)
+    public static bool GetIsFixedIVSequenceValidSkipRand(IndividualValueSet IVs, PKM pk, int max = 31)
     {
-        for (int i = 0; i < 6; i++)
-        {
-            if (IVs[i] != pk.GetIV(i))
-                return false;
-        }
+        // Template IVs not in the [0,max] range are random. Only check for IVs within the "specified" range.
+        if ((uint)IVs.HP  <= max && IVs.HP  != pk.IV_HP ) return false;
+        if ((uint)IVs.ATK <= max && IVs.ATK != pk.IV_ATK) return false;
+        if ((uint)IVs.DEF <= max && IVs.DEF != pk.IV_DEF) return false;
+        if ((uint)IVs.SPE <= max && IVs.SPE != pk.IV_SPE) return false;
+        if ((uint)IVs.SPA <= max && IVs.SPA != pk.IV_SPA) return false;
+        if ((uint)IVs.SPD <= max && IVs.SPD != pk.IV_SPD) return false;
+        return true;
+    }
+
+    public static bool GetIsFixedIVSequenceValidNoRand(IndividualValueSet IVs, PKM pk)
+    {
+        if (IVs.HP  != pk.IV_HP ) return false;
+        if (IVs.ATK != pk.IV_ATK) return false;
+        if (IVs.DEF != pk.IV_DEF) return false;
+        if (IVs.SPE != pk.IV_SPE) return false;
+        if (IVs.SPA != pk.IV_SPA) return false;
+        if (IVs.SPD != pk.IV_SPD) return false;
         return true;
     }
 

--- a/PKHeX.Core/Legality/Encounters/Data/Encounters1.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Encounters1.cs
@@ -118,8 +118,8 @@ internal static class Encounters1
     private const string tradeRBY = "traderby";
     private static readonly string[][] TradeGift_RBY_OTs = Util.GetLanguageStrings7(tradeRBY);
 
-    private static readonly int[] Flawless15 = { 15, 15, 15, 15, 15, 15 };
-    private static readonly int[] Yoshira = { 5, 10, 1, 12, 5, 5 };
+    private static readonly IndividualValueSet Flawless15 = new(15, 15, 15, 15, 15, 15);
+    private static readonly IndividualValueSet Yoshira = new(5, 10, 1, 12, 5, 5);
     private static readonly string[] YoshiOT = { "YOSHIRA", "YOSHIRB", "YOSHIBA", "YOSHIBB" };
     private static readonly string[] TourOT = { "LINKE", "LINKW", "LUIGE", "LUIGW", "LUIGIC", "YOSHIC" };
     private static readonly string[] StadiumOT_Int = { "STADIUM", "STADE", "STADIO", "ESTADIO" };

--- a/PKHeX.Core/Legality/Encounters/Data/Encounters1.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Encounters1.cs
@@ -1,4 +1,4 @@
-﻿using static PKHeX.Core.GameVersion;
+using static PKHeX.Core.GameVersion;
 using static PKHeX.Core.EncounterGBLanguage;
 using static PKHeX.Core.EncounterUtil;
 
@@ -71,8 +71,8 @@ internal static class Encounters1
 
         new(150, 70, RBY), // Mewtwo
 
-        new(133, 25, RB) {Moves = new [] {(int)Move.Tackle, (int)Move.SandAttack}}, // Eevee
-        new(133, 25, YW) {Moves = new [] {(int)Move.TailWhip, (int)Move.SandAttack, (int)Move.Growl, (int)Move.QuickAttack}}, // Eevee (Different initial moves)
+        new(133, 25, RB) {Moves = new((int)Move.Tackle, (int)Move.SandAttack)}, // Eevee
+        new(133, 25, YW) {Moves = new((int)Move.TailWhip, (int)Move.SandAttack, (int)Move.Growl, (int)Move.QuickAttack)}, // Eevee (Different initial moves)
 
         new(100, 40, RBY), // Voltorb (Power Plant)
         new(101, 43, RBY), // Electrode (Power Plant)
@@ -135,26 +135,26 @@ internal static class Encounters1
     internal static readonly EncounterStatic1E[] StaticEventsGB =
     {
         // Stadium 1 (International)
-        new(001, 05, Stadium) {Moves = new[] {033, 045}, TID = 2000, OT_Names = StadiumOT_Int, Language = International}, // Bulbasaur
-        new(004, 05, Stadium) {Moves = new[] {010, 043}, TID = 2000, OT_Names = StadiumOT_Int, Language = International}, // Charmander
-        new(007, 05, Stadium) {Moves = new[] {033, 045}, TID = 2000, OT_Names = StadiumOT_Int, Language = International}, // Squirtle
-        new(106, 20, Stadium) {Moves = new[] {024, 096}, TID = 2000, OT_Names = StadiumOT_Int, Language = International}, // Hitmonlee
-        new(107, 20, Stadium) {Moves = new[] {004, 097}, TID = 2000, OT_Names = StadiumOT_Int, Language = International}, // Hitmonchan
-        new(133, 25, Stadium) {Moves = new[] {033, 039}, TID = 2000, OT_Names = StadiumOT_Int, Language = International}, // Eevee
-        new(138, 20, Stadium) {Moves = new[] {055, 110}, TID = 2000, OT_Names = StadiumOT_Int, Language = International}, // Omanyte
-        new(140, 20, Stadium) {Moves = new[] {010, 106}, TID = 2000, OT_Names = StadiumOT_Int, Language = International}, // Kabuto
-        new(054, 15, Stadium) {Moves = new[] {133, 010}, TID = 2000, OT_Names = StadiumOT_Int, Language = International}, // Psyduck (Amnesia)
+        new(001, 05, Stadium) {Moves = new(033, 045), TID = 2000, OT_Names = StadiumOT_Int, Language = International}, // Bulbasaur
+        new(004, 05, Stadium) {Moves = new(010, 043), TID = 2000, OT_Names = StadiumOT_Int, Language = International}, // Charmander
+        new(007, 05, Stadium) {Moves = new(033, 045), TID = 2000, OT_Names = StadiumOT_Int, Language = International}, // Squirtle
+        new(106, 20, Stadium) {Moves = new(024, 096), TID = 2000, OT_Names = StadiumOT_Int, Language = International}, // Hitmonlee
+        new(107, 20, Stadium) {Moves = new(004, 097), TID = 2000, OT_Names = StadiumOT_Int, Language = International}, // Hitmonchan
+        new(133, 25, Stadium) {Moves = new(033, 039), TID = 2000, OT_Names = StadiumOT_Int, Language = International}, // Eevee
+        new(138, 20, Stadium) {Moves = new(055, 110), TID = 2000, OT_Names = StadiumOT_Int, Language = International}, // Omanyte
+        new(140, 20, Stadium) {Moves = new(010, 106), TID = 2000, OT_Names = StadiumOT_Int, Language = International}, // Kabuto
+        new(054, 15, Stadium) {Moves = new(133, 010), TID = 2000, OT_Names = StadiumOT_Int, Language = International}, // Psyduck (Amnesia)
 
         // Stadium 2 (Japan)
-        new(001, 05, Stadium) {Moves = new[] {033, 045}, TID = 1999, OT_Name = StadiumOT_JPN}, // Bulbasaur
-        new(004, 05, Stadium) {Moves = new[] {010, 043}, TID = 1999, OT_Name = StadiumOT_JPN}, // Charmander
-        new(007, 05, Stadium) {Moves = new[] {033, 045}, TID = 1999, OT_Name = StadiumOT_JPN}, // Squirtle
-        new(106, 20, Stadium) {Moves = new[] {024, 096}, TID = 1999, OT_Name = StadiumOT_JPN}, // Hitmonlee
-        new(107, 20, Stadium) {Moves = new[] {004, 097}, TID = 1999, OT_Name = StadiumOT_JPN}, // Hitmonchan
-        new(133, 25, Stadium) {Moves = new[] {033, 039}, TID = 1999, OT_Name = StadiumOT_JPN}, // Eevee
-        new(138, 20, Stadium) {Moves = new[] {055, 110}, TID = 1999, OT_Name = StadiumOT_JPN}, // Omanyte
-        new(140, 20, Stadium) {Moves = new[] {010, 106}, TID = 1999, OT_Name = StadiumOT_JPN}, // Kabuto
-        new(054, 15, Stadium) {Moves = new[] {133, 010}, TID = 1999, OT_Name = StadiumOT_JPN}, // Psyduck (Amnesia)
+        new(001, 05, Stadium) {Moves = new(033, 045), TID = 1999, OT_Name = StadiumOT_JPN}, // Bulbasaur
+        new(004, 05, Stadium) {Moves = new(010, 043), TID = 1999, OT_Name = StadiumOT_JPN}, // Charmander
+        new(007, 05, Stadium) {Moves = new(033, 045), TID = 1999, OT_Name = StadiumOT_JPN}, // Squirtle
+        new(106, 20, Stadium) {Moves = new(024, 096), TID = 1999, OT_Name = StadiumOT_JPN}, // Hitmonlee
+        new(107, 20, Stadium) {Moves = new(004, 097), TID = 1999, OT_Name = StadiumOT_JPN}, // Hitmonchan
+        new(133, 25, Stadium) {Moves = new(033, 039), TID = 1999, OT_Name = StadiumOT_JPN}, // Eevee
+        new(138, 20, Stadium) {Moves = new(055, 110), TID = 1999, OT_Name = StadiumOT_JPN}, // Omanyte
+        new(140, 20, Stadium) {Moves = new(010, 106), TID = 1999, OT_Name = StadiumOT_JPN}, // Kabuto
+        new(054, 15, Stadium) {Moves = new(133, 010), TID = 1999, OT_Name = StadiumOT_JPN}, // Psyduck (Amnesia)
 
         new(151, 5, RB) {IVs = Yoshira, OT_Names = YoshiOT, Language = International }, // Yoshira Mew Events
         new(151, 5, RB) {IVs = Yoshira, OT_Names = TourOT, Language = International }, // Pokémon 2000 Stadium Tour Mew

--- a/PKHeX.Core/Legality/Encounters/Data/Encounters2.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Encounters2.cs
@@ -72,15 +72,15 @@ internal static class Encounters2
     {
         new(245, 40, C) { Location = 023 }, // Suicune @ Tin Tower
 
-        new EncounterStatic2Odd(172) {Moves = new[] {(int)Move.ThunderShock,(int)Move.Charm, (int)Move.DizzyPunch}}, // Pichu
-        new EncounterStatic2Odd(173) {Moves = new[] {(int)Move.Pound,       (int)Move.Charm, (int)Move.DizzyPunch}}, // Cleffa
-        new EncounterStatic2Odd(174) {Moves = new[] {(int)Move.Sing,        (int)Move.Charm, (int)Move.DizzyPunch}}, // Igglybuff
-        new EncounterStatic2Odd(236) {Moves = new[] {(int)Move.Tackle,                       (int)Move.DizzyPunch}}, // Tyrogue
-        new EncounterStatic2Odd(238) {Moves = new[] {(int)Move.Pound,       (int)Move.Lick,  (int)Move.DizzyPunch}}, // Smoochum
-        new EncounterStatic2Odd(239) {Moves = new[] {(int)Move.QuickAttack, (int)Move.Leer,  (int)Move.DizzyPunch}}, // Elekid
-        new EncounterStatic2Odd(240) {Moves = new[] {(int)Move.Ember,                        (int)Move.DizzyPunch}}, // Magby
+        new EncounterStatic2Odd(172) {Moves = new((int)Move.ThunderShock,(int)Move.Charm, (int)Move.DizzyPunch)}, // Pichu
+        new EncounterStatic2Odd(173) {Moves = new((int)Move.Pound,       (int)Move.Charm, (int)Move.DizzyPunch)}, // Cleffa
+        new EncounterStatic2Odd(174) {Moves = new((int)Move.Sing,        (int)Move.Charm, (int)Move.DizzyPunch)}, // Igglybuff
+        new EncounterStatic2Odd(236) {Moves = new((int)Move.Tackle,                       (int)Move.DizzyPunch)}, // Tyrogue
+        new EncounterStatic2Odd(238) {Moves = new((int)Move.Pound,       (int)Move.Lick,  (int)Move.DizzyPunch)}, // Smoochum
+        new EncounterStatic2Odd(239) {Moves = new((int)Move.QuickAttack, (int)Move.Leer,  (int)Move.DizzyPunch)}, // Elekid
+        new EncounterStatic2Odd(240) {Moves = new((int)Move.Ember,                        (int)Move.DizzyPunch)}, // Magby
 
-        new(147, 15, C) { Location = 042, Moves = new[] {(int)Move.ExtremeSpeed, (int)Move.Wrap, (int)Move.ThunderWave, (int)Move.Twister} }, // Dratini ExtremeSpeed
+        new(147, 15, C) { Location = 042, Moves = new((int)Move.ExtremeSpeed, (int)Move.Wrap, (int)Move.ThunderWave, (int)Move.Twister) }, // Dratini ExtremeSpeed
 
         new(249, 60, C) { Location = 031 }, // Lugia @ Whirl Islands
         new(250, 60, C) { Location = 023 }, // Ho-Oh @ Tin Tower
@@ -118,7 +118,7 @@ internal static class Encounters2
         new(178, 15, 15616) { Gender = 0, IVs = new[] {08, 09, 06, 08, 06, 06} }, // Xatu @ Pewter City for Haunter [wild]
         new(082, 05, 50082) { Gender = 2, IVs = new[] {08, 09, 06, 06, 06, 06} }, // Magneton @ Power Plant for Dugtrio [traded for Lickitung]
 
-        new(021, 10, 01001) { Moves = new[] {64,45,43} }, // Spearow @ Goldenrod City for free
+        new(021, 10, 01001) { Moves = new(64,45,43) }, // Spearow @ Goldenrod City for free
         new(213, 15, 00518), // Shuckle @ Cianwood City for free
     };
 
@@ -134,21 +134,19 @@ internal static class Encounters2
         new(251, 30, C) { Location = 014, Language = EncounterGBLanguage.Any }, // Celebi @ Ilex Forest (VC)
     };
 
-    private static readonly int[] Farfetchd = {226, 14, 97, 163};
-    private static readonly int[] Gligar = {89, 68, 17};
     private static readonly string[] PCNYx =  {"PCNYa", "PCNYb", "PCNYc", "PCNYd"};
 
     internal static readonly EncounterStatic2E[] StaticEventsGB =
     {
         // Stadium 2 Baton Pass Farfetch'd
-        new(083, 05, C) {Moves = Farfetchd, Location = 127, TID = 2000, OT_Name = "スタジアム"},
-        new(083, 05, C) {Moves = Farfetchd, Location = 127, TID = 2000, OT_Name = "Stadium", Language = International},
-        new(083, 05, C) {Moves = Farfetchd, Location = 127, TID = 2001, OT_Names = new[]{"Stade", "Stadion", "Stadio", "Estadio"}, Language = International},
+        new(083, 05, C) {Moves = new(226, 14, 97, 163), Location = 127, TID = 2000, OT_Name = "スタジアム"},
+        new(083, 05, C) {Moves = new(226, 14, 97, 163), Location = 127, TID = 2000, OT_Name = "Stadium", Language = International},
+        new(083, 05, C) {Moves = new(226, 14, 97, 163), Location = 127, TID = 2001, OT_Names = new[]{"Stade", "Stadion", "Stadio", "Estadio"}, Language = International},
 
         // Stadium 2 Earthquake Gligar
-        new(207, 05, C) {Moves = Gligar, Location = 127, TID = 2000, OT_Name = "スタジアム"},
-        new(207, 05, C) {Moves = Gligar, Location = 127, TID = 2000, OT_Name = "Stadium", Language = International},
-        new(207, 05, C) {Moves = Gligar, Location = 127, TID = 2001, OT_Names = new[]{"Stade", "Stadion", "Stadio", "Estadio"}, Language = International},
+        new(207, 05, C) {Moves = new(89, 68, 17), Location = 127, TID = 2000, OT_Name = "スタジアム"},
+        new(207, 05, C) {Moves = new(89, 68, 17), Location = 127, TID = 2000, OT_Name = "Stadium", Language = International},
+        new(207, 05, C) {Moves = new(89, 68, 17), Location = 127, TID = 2001, OT_Names = new[]{"Stade", "Stadion", "Stadio", "Estadio"}, Language = International},
 
         //New York Pokémon Center Events
 
@@ -163,32 +161,32 @@ internal static class Encounters2
         new(146, 05, C) {OT_Names = PCNYx, CurrentLevel = 50, Shiny = Shiny.Always, Location = 127, Language = International}, // Shiny Moltres
 
         // Christmas Week (December 21 to 27, 2001)
-        new(225, 05, GS) {OT_Names = PCNYx, Moves = new[] {006}, EggLocation = 256, EggCycles = 10, Language = International}, // Pay Day Delibird
+        new(225, 05, GS) {OT_Names = PCNYx, Moves = new(006), EggLocation = 256, EggCycles = 10, Language = International}, // Pay Day Delibird
         new(251, 05, C) {OT_Names = PCNYx, Location = 127, Language = International}, // Celebi
 
         // The Initial Three Set (December 28, 2001 to January 31, 2002)
-        new(001, 05, GS) {OT_Names = PCNYx, Moves = new[] {246}, EggLocation = 256, EggCycles = 10, Language = International}, // Bulbasaur Ancientpower
-        new(004, 05, GS) {OT_Names = PCNYx, Moves = new[] {242}, EggLocation = 256, EggCycles = 10, Language = International}, // Charmander Crunch
-        new(007, 05, GS) {OT_Names = PCNYx, Moves = new[] {192}, EggLocation = 256, EggCycles = 10, Language = International}, // Squirtle Zap Cannon
-        new(152, 05, GS) {OT_Names = PCNYx, Moves = new[] {080}, EggLocation = 256, EggCycles = 10, Language = International}, // Chikorita Petal Dance
-        new(155, 05, GS) {OT_Names = PCNYx, Moves = new[] {038}, EggLocation = 256, EggCycles = 10, Language = International}, // Cyndaquil Double-Edge
-        new(158, 05, GS) {OT_Names = PCNYx, Moves = new[] {066}, EggLocation = 256, EggCycles = 10, Language = International}, // Totodile Submission
+        new(001, 05, GS) {OT_Names = PCNYx, Moves = new(246), EggLocation = 256, EggCycles = 10, Language = International}, // Bulbasaur Ancientpower
+        new(004, 05, GS) {OT_Names = PCNYx, Moves = new(242), EggLocation = 256, EggCycles = 10, Language = International}, // Charmander Crunch
+        new(007, 05, GS) {OT_Names = PCNYx, Moves = new(192), EggLocation = 256, EggCycles = 10, Language = International}, // Squirtle Zap Cannon
+        new(152, 05, GS) {OT_Names = PCNYx, Moves = new(080), EggLocation = 256, EggCycles = 10, Language = International}, // Chikorita Petal Dance
+        new(155, 05, GS) {OT_Names = PCNYx, Moves = new(038), EggLocation = 256, EggCycles = 10, Language = International}, // Cyndaquil Double-Edge
+        new(158, 05, GS) {OT_Names = PCNYx, Moves = new(066), EggLocation = 256, EggCycles = 10, Language = International}, // Totodile Submission
 
         // Valentine Week (February 1 to 14, 2002)
-        new(029, 05, GS) {OT_Names = PCNYx, Moves = new[] {142}, EggLocation = 256, EggCycles = 10, Language = International}, // Nidoran (F) Lovely Kiss
-        new(029, 05, GS) {OT_Names = PCNYx, Moves = new[] {186}, EggLocation = 256, EggCycles = 10, Language = International}, // Nidoran (F) Sweet Kiss
-        new(032, 05, GS) {OT_Names = PCNYx, Moves = new[] {142}, EggLocation = 256, EggCycles = 10, Language = International}, // Nidoran (M) Lovely Kiss
-        new(032, 05, GS) {OT_Names = PCNYx, Moves = new[] {186}, EggLocation = 256, EggCycles = 10, Language = International}, // Nidoran (M) Sweet Kiss
-        new(069, 05, GS) {OT_Names = PCNYx, Moves = new[] {142}, EggLocation = 256, EggCycles = 10, Language = International}, // Bellsprout Lovely Kiss
-        new(069, 05, GS) {OT_Names = PCNYx, Moves = new[] {186}, EggLocation = 256, EggCycles = 10, Language = International}, // Bellsprout Sweet Kiss
+        new(029, 05, GS) {OT_Names = PCNYx, Moves = new(142), EggLocation = 256, EggCycles = 10, Language = International}, // Nidoran (F) Lovely Kiss
+        new(029, 05, GS) {OT_Names = PCNYx, Moves = new(186), EggLocation = 256, EggCycles = 10, Language = International}, // Nidoran (F) Sweet Kiss
+        new(032, 05, GS) {OT_Names = PCNYx, Moves = new(142), EggLocation = 256, EggCycles = 10, Language = International}, // Nidoran (M) Lovely Kiss
+        new(032, 05, GS) {OT_Names = PCNYx, Moves = new(186), EggLocation = 256, EggCycles = 10, Language = International}, // Nidoran (M) Sweet Kiss
+        new(069, 05, GS) {OT_Names = PCNYx, Moves = new(142), EggLocation = 256, EggCycles = 10, Language = International}, // Bellsprout Lovely Kiss
+        new(069, 05, GS) {OT_Names = PCNYx, Moves = new(186), EggLocation = 256, EggCycles = 10, Language = International}, // Bellsprout Sweet Kiss
 
         // Swarm Week (February 22 to March 14, 2002)
-        new(183, 05, GS) {OT_Names = PCNYx, Moves = new[] {056}, EggLocation = 256, EggCycles = 10, Language = International}, // Marill Hydro Pump
-        new(193, 05, GS) {OT_Names = PCNYx, Moves = new[] {211}, EggLocation = 256, EggCycles = 10, Language = International}, // Yanma Steel Wing
-        new(206, 05, GS) {OT_Names = PCNYx, Moves = new[] {032}, EggLocation = 256, EggCycles = 10, Language = International}, // Dunsparce Horn Drill
-        new(209, 05, GS) {OT_Names = PCNYx, Moves = new[] {142}, EggLocation = 256, EggCycles = 10, Language = International}, // Snubbull Lovely Kiss
-        new(211, 05, GS) {OT_Names = PCNYx, Moves = new[] {038}, EggLocation = 256, EggCycles = 10, Language = International}, // Qwilfish Double-Edge
-        new(223, 05, GS) {OT_Names = PCNYx, Moves = new[] {133}, EggLocation = 256, EggCycles = 10, Language = International}, // Remoraid Amnesia
+        new(183, 05, GS) {OT_Names = PCNYx, Moves = new(056), EggLocation = 256, EggCycles = 10, Language = International}, // Marill Hydro Pump
+        new(193, 05, GS) {OT_Names = PCNYx, Moves = new(211), EggLocation = 256, EggCycles = 10, Language = International}, // Yanma Steel Wing
+        new(206, 05, GS) {OT_Names = PCNYx, Moves = new(032), EggLocation = 256, EggCycles = 10, Language = International}, // Dunsparce Horn Drill
+        new(209, 05, GS) {OT_Names = PCNYx, Moves = new(142), EggLocation = 256, EggCycles = 10, Language = International}, // Snubbull Lovely Kiss
+        new(211, 05, GS) {OT_Names = PCNYx, Moves = new(038), EggLocation = 256, EggCycles = 10, Language = International}, // Qwilfish Double-Edge
+        new(223, 05, GS) {OT_Names = PCNYx, Moves = new(133), EggLocation = 256, EggCycles = 10, Language = International}, // Remoraid Amnesia
 
         // Shiny RBY Starters (March 15 to 21, 2002)
         new(003, 05, C) {OT_Names = PCNYx, CurrentLevel = 40, Shiny = Shiny.Always, Location = 127, Language = International}, // Shiny Venusaur
@@ -196,82 +194,82 @@ internal static class Encounters2
         new(009, 05, C) {OT_Names = PCNYx, CurrentLevel = 40, Shiny = Shiny.Always, Location = 127, Language = International}, // Shiny Blastoise
 
         // Babies Week (March 22 to April 11, 2002)
-        new(172, 05, GS) {OT_Names = PCNYx, Moves = new[] {047}, EggLocation = 256, EggCycles = 10, Language = International}, // Pichu Sing
-        new(173, 05, GS) {OT_Names = PCNYx, Moves = new[] {129}, EggLocation = 256, EggCycles = 10, Language = International}, // Cleffa Swift
-        new(174, 05, GS) {OT_Names = PCNYx, Moves = new[] {102}, EggLocation = 256, EggCycles = 10, Language = International}, // Igglybuff Mimic
-        new(238, 05, GS) {OT_Names = PCNYx, Moves = new[] {118}, EggLocation = 256, EggCycles = 10, Language = International}, // Smoochum Metronome
-        new(239, 05, GS) {OT_Names = PCNYx, Moves = new[] {228}, EggLocation = 256, EggCycles = 10, Language = International}, // Elekid Pursuit
-        new(240, 05, GS) {OT_Names = PCNYx, Moves = new[] {185}, EggLocation = 256, EggCycles = 10, Language = International}, // Magby Faint Attack
+        new(172, 05, GS) {OT_Names = PCNYx, Moves = new(047), EggLocation = 256, EggCycles = 10, Language = International}, // Pichu Sing
+        new(173, 05, GS) {OT_Names = PCNYx, Moves = new(129), EggLocation = 256, EggCycles = 10, Language = International}, // Cleffa Swift
+        new(174, 05, GS) {OT_Names = PCNYx, Moves = new(102), EggLocation = 256, EggCycles = 10, Language = International}, // Igglybuff Mimic
+        new(238, 05, GS) {OT_Names = PCNYx, Moves = new(118), EggLocation = 256, EggCycles = 10, Language = International}, // Smoochum Metronome
+        new(239, 05, GS) {OT_Names = PCNYx, Moves = new(228), EggLocation = 256, EggCycles = 10, Language = International}, // Elekid Pursuit
+        new(240, 05, GS) {OT_Names = PCNYx, Moves = new(185), EggLocation = 256, EggCycles = 10, Language = International}, // Magby Faint Attack
 
         // Spring Into Spring (April 12 to May 4, 2002)
-        new(054, 05, GS) {OT_Names = PCNYx, Moves = new[] {080}, EggLocation = 256, EggCycles = 10, Language = International}, // Psyduck Petal Dance
-        new(152, 05, GS) {OT_Names = PCNYx, Moves = new[] {080}, EggLocation = 256, EggCycles = 10, Language = International}, // Chikorita Petal Dance
-        new(172, 05, GS) {OT_Names = PCNYx, Moves = new[] {080}, EggLocation = 256, EggCycles = 10, Language = International}, // Pichu Petal Dance
-        new(173, 05, GS) {OT_Names = PCNYx, Moves = new[] {080}, EggLocation = 256, EggCycles = 10, Language = International}, // Cleffa Petal Dance
-        new(174, 05, GS) {OT_Names = PCNYx, Moves = new[] {080}, EggLocation = 256, EggCycles = 10, Language = International}, // Igglybuff Petal Dance
-        new(238, 05, GS) {OT_Names = PCNYx, Moves = new[] {080}, EggLocation = 256, EggCycles = 10, Language = International}, // Smoochum Petal Dance
+        new(054, 05, GS) {OT_Names = PCNYx, Moves = new(080), EggLocation = 256, EggCycles = 10, Language = International}, // Psyduck Petal Dance
+        new(152, 05, GS) {OT_Names = PCNYx, Moves = new(080), EggLocation = 256, EggCycles = 10, Language = International}, // Chikorita Petal Dance
+        new(172, 05, GS) {OT_Names = PCNYx, Moves = new(080), EggLocation = 256, EggCycles = 10, Language = International}, // Pichu Petal Dance
+        new(173, 05, GS) {OT_Names = PCNYx, Moves = new(080), EggLocation = 256, EggCycles = 10, Language = International}, // Cleffa Petal Dance
+        new(174, 05, GS) {OT_Names = PCNYx, Moves = new(080), EggLocation = 256, EggCycles = 10, Language = International}, // Igglybuff Petal Dance
+        new(238, 05, GS) {OT_Names = PCNYx, Moves = new(080), EggLocation = 256, EggCycles = 10, Language = International}, // Smoochum Petal Dance
 
         // Baby Weeks (May 5 to June 7, 2002)
-        new(194, 05, GS) {Moves = new[] {187}, EggLocation = 256, EggCycles = 10, Language = International}, // Wooper Belly Drum
+        new(194, 05, GS) {Moves = new(187), EggLocation = 256, EggCycles = 10, Language = International}, // Wooper Belly Drum
 
         // Tropical Promotion to Summer Festival 1 (June 8 to 21, 2002)
-        new(060, 05, GS) {OT_Names = PCNYx, Moves = new[] {074}, EggLocation = 256, EggCycles = 10, Language = International}, // Poliwag Growth
-        new(116, 05, GS) {OT_Names = PCNYx, Moves = new[] {114}, EggLocation = 256, EggCycles = 10, Language = International}, // Horsea Haze
-        new(118, 05, GS) {OT_Names = PCNYx, Moves = new[] {014}, EggLocation = 256, EggCycles = 10, Language = International}, // Goldeen Swords Dance
-        new(129, 05, GS) {OT_Names = PCNYx, Moves = new[] {179}, EggLocation = 256, EggCycles = 10, Language = International}, // Magikarp Reversal
-        new(183, 05, GS) {OT_Names = PCNYx, Moves = new[] {146}, EggLocation = 256, EggCycles = 10, Language = International}, // Marill Dizzy Punch
+        new(060, 05, GS) {OT_Names = PCNYx, Moves = new(074), EggLocation = 256, EggCycles = 10, Language = International}, // Poliwag Growth
+        new(116, 05, GS) {OT_Names = PCNYx, Moves = new(114), EggLocation = 256, EggCycles = 10, Language = International}, // Horsea Haze
+        new(118, 05, GS) {OT_Names = PCNYx, Moves = new(014), EggLocation = 256, EggCycles = 10, Language = International}, // Goldeen Swords Dance
+        new(129, 05, GS) {OT_Names = PCNYx, Moves = new(179), EggLocation = 256, EggCycles = 10, Language = International}, // Magikarp Reversal
+        new(183, 05, GS) {OT_Names = PCNYx, Moves = new(146), EggLocation = 256, EggCycles = 10, Language = International}, // Marill Dizzy Punch
 
         // Tropical Promotion to Summer Festival 2 (July 12 to August 8, 2002)
-        new(054, 05, GS) {OT_Names = PCNYx, Moves = new[] {161}, EggLocation = 256, EggCycles = 10, Language = International}, // Psyduck Tri Attack
-        new(072, 05, GS) {OT_Names = PCNYx, Moves = new[] {109}, EggLocation = 256, EggCycles = 10, Language = International}, // Tentacool Confuse Ray
-        new(131, 05, GS) {OT_Names = PCNYx, Moves = new[] {044}, EggLocation = 256, EggCycles = 10, Language = International}, // Lapras Bite
-        new(170, 05, GS) {OT_Names = PCNYx, Moves = new[] {113}, EggLocation = 256, EggCycles = 10, Language = International}, // Chinchou Light Screen
-        new(223, 05, GS) {OT_Names = PCNYx, Moves = new[] {054}, EggLocation = 256, EggCycles = 10, Language = International}, // Remoraid Mist
-        new(226, 05, GS) {OT_Names = PCNYx, Moves = new[] {016}, EggLocation = 256, EggCycles = 10, Language = International}, // Mantine Gust
+        new(054, 05, GS) {OT_Names = PCNYx, Moves = new(161), EggLocation = 256, EggCycles = 10, Language = International}, // Psyduck Tri Attack
+        new(072, 05, GS) {OT_Names = PCNYx, Moves = new(109), EggLocation = 256, EggCycles = 10, Language = International}, // Tentacool Confuse Ray
+        new(131, 05, GS) {OT_Names = PCNYx, Moves = new(044), EggLocation = 256, EggCycles = 10, Language = International}, // Lapras Bite
+        new(170, 05, GS) {OT_Names = PCNYx, Moves = new(113), EggLocation = 256, EggCycles = 10, Language = International}, // Chinchou Light Screen
+        new(223, 05, GS) {OT_Names = PCNYx, Moves = new(054), EggLocation = 256, EggCycles = 10, Language = International}, // Remoraid Mist
+        new(226, 05, GS) {OT_Names = PCNYx, Moves = new(016), EggLocation = 256, EggCycles = 10, Language = International}, // Mantine Gust
 
         // Safari Week (August 9 to 29, 2002)
-        new(029, 05, GS) {OT_Names = PCNYx, Moves = new[] {236}, EggLocation = 256, EggCycles = 10, Language = International}, // Nidoran (F) Moonlight
-        new(032, 05, GS) {OT_Names = PCNYx, Moves = new[] {234}, EggLocation = 256, EggCycles = 10, Language = International}, // Nidoran (M) Morning Sun
-        new(113, 05, GS) {OT_Names = PCNYx, Moves = new[] {230}, EggLocation = 256, EggCycles = 10, Language = International}, // Chansey Sweet Scent
-        new(115, 05, GS) {OT_Names = PCNYx, Moves = new[] {185}, EggLocation = 256, EggCycles = 10, Language = International}, // Kangaskhan Faint Attack
-        new(128, 05, GS) {OT_Names = PCNYx, Moves = new[] {098}, EggLocation = 256, EggCycles = 10, Language = International}, // Tauros Quick Attack
-        new(147, 05, GS) {OT_Names = PCNYx, Moves = new[] {056}, EggLocation = 256, EggCycles = 10, Language = International}, // Dratini Hydro Pump
+        new(029, 05, GS) {OT_Names = PCNYx, Moves = new(236), EggLocation = 256, EggCycles = 10, Language = International}, // Nidoran (F) Moonlight
+        new(032, 05, GS) {OT_Names = PCNYx, Moves = new(234), EggLocation = 256, EggCycles = 10, Language = International}, // Nidoran (M) Morning Sun
+        new(113, 05, GS) {OT_Names = PCNYx, Moves = new(230), EggLocation = 256, EggCycles = 10, Language = International}, // Chansey Sweet Scent
+        new(115, 05, GS) {OT_Names = PCNYx, Moves = new(185), EggLocation = 256, EggCycles = 10, Language = International}, // Kangaskhan Faint Attack
+        new(128, 05, GS) {OT_Names = PCNYx, Moves = new(098), EggLocation = 256, EggCycles = 10, Language = International}, // Tauros Quick Attack
+        new(147, 05, GS) {OT_Names = PCNYx, Moves = new(056), EggLocation = 256, EggCycles = 10, Language = International}, // Dratini Hydro Pump
 
         // Sky Week (August 30 to September 26, 2002)
-        new(021, 05, GS) {OT_Names = PCNYx, Moves = new[] {049}, EggLocation = 256, EggCycles = 10, Language = International}, // Spearow SonicBoom
-        new(083, 05, GS) {OT_Names = PCNYx, Moves = new[] {210}, EggLocation = 256, EggCycles = 10, Language = International}, // Farfetch'd Fury Cutter
-        new(084, 05, GS) {OT_Names = PCNYx, Moves = new[] {067}, EggLocation = 256, EggCycles = 10, Language = International}, // Doduo Low Kick
-        new(177, 05, GS) {OT_Names = PCNYx, Moves = new[] {219}, EggLocation = 256, EggCycles = 10, Language = International}, // Natu Safeguard
-        new(198, 05, GS) {OT_Names = PCNYx, Moves = new[] {251}, EggLocation = 256, EggCycles = 10, Language = International}, // Murkrow Beat Up
-        new(227, 05, GS) {OT_Names = PCNYx, Moves = new[] {210}, EggLocation = 256, EggCycles = 10, Language = International}, // Skarmory Fury Cutter
+        new(021, 05, GS) {OT_Names = PCNYx, Moves = new(049), EggLocation = 256, EggCycles = 10, Language = International}, // Spearow SonicBoom
+        new(083, 05, GS) {OT_Names = PCNYx, Moves = new(210), EggLocation = 256, EggCycles = 10, Language = International}, // Farfetch'd Fury Cutter
+        new(084, 05, GS) {OT_Names = PCNYx, Moves = new(067), EggLocation = 256, EggCycles = 10, Language = International}, // Doduo Low Kick
+        new(177, 05, GS) {OT_Names = PCNYx, Moves = new(219), EggLocation = 256, EggCycles = 10, Language = International}, // Natu Safeguard
+        new(198, 05, GS) {OT_Names = PCNYx, Moves = new(251), EggLocation = 256, EggCycles = 10, Language = International}, // Murkrow Beat Up
+        new(227, 05, GS) {OT_Names = PCNYx, Moves = new(210), EggLocation = 256, EggCycles = 10, Language = International}, // Skarmory Fury Cutter
 
         // The Kanto Initial Three Pokémon (September 27 to October 3, 2002)
         new(150, 05, C) {OT_Names = PCNYx, CurrentLevel = 70, Shiny = Shiny.Always, Location = 127, Language = International}, // Shiny Mewtwo
 
         // Power Plant Pokémon (October 4 to October 10, 2002)
-        new(172, 05, GS) {OT_Names = PCNYx, Moves = new[] {146}, EggLocation = 256, EggCycles = 10, Language = International}, // Pichu Dizzy Punch
-        new(081, 05, GS) {OT_Names = PCNYx, Moves = new[] {097}, EggLocation = 256, EggCycles = 10, Language = International}, // Magnemite Agility
-        new(239, 05, GS) {OT_Names = PCNYx, Moves = new[] {146}, EggLocation = 256, EggCycles = 10, Language = International}, // Elekid Dizzy Punch
-        new(100, 05, GS) {OT_Names = PCNYx, Moves = new[] {097}, EggLocation = 256, EggCycles = 10, Language = International}, // Voltorb Agility
+        new(172, 05, GS) {OT_Names = PCNYx, Moves = new(146), EggLocation = 256, EggCycles = 10, Language = International}, // Pichu Dizzy Punch
+        new(081, 05, GS) {OT_Names = PCNYx, Moves = new(097), EggLocation = 256, EggCycles = 10, Language = International}, // Magnemite Agility
+        new(239, 05, GS) {OT_Names = PCNYx, Moves = new(146), EggLocation = 256, EggCycles = 10, Language = International}, // Elekid Dizzy Punch
+        new(100, 05, GS) {OT_Names = PCNYx, Moves = new(097), EggLocation = 256, EggCycles = 10, Language = International}, // Voltorb Agility
 
         // Scary Face Pokémon (October 25 to October 31, 2002)
-        new(173, 05, GS) {OT_Names = PCNYx, Moves = new[] {184}, EggLocation = 256, EggCycles = 10, Language = International}, // Cleffa Scary Face
-        new(174, 05, GS) {OT_Names = PCNYx, Moves = new[] {184}, EggLocation = 256, EggCycles = 10, Language = International}, // Igglybuff Scary Face
-        new(183, 05, GS) {OT_Names = PCNYx, Moves = new[] {184}, EggLocation = 256, EggCycles = 10, Language = International}, // Marill Scary Face
-        new(172, 05, GS) {OT_Names = PCNYx, Moves = new[] {184}, EggLocation = 256, EggCycles = 10, Language = International}, // Pichu Scary Face
-        new(194, 05, GS) {OT_Names = PCNYx, Moves = new[] {184}, EggLocation = 256, EggCycles = 10, Language = International}, // Wooper Scary Face
+        new(173, 05, GS) {OT_Names = PCNYx, Moves = new(184), EggLocation = 256, EggCycles = 10, Language = International}, // Cleffa Scary Face
+        new(174, 05, GS) {OT_Names = PCNYx, Moves = new(184), EggLocation = 256, EggCycles = 10, Language = International}, // Igglybuff Scary Face
+        new(183, 05, GS) {OT_Names = PCNYx, Moves = new(184), EggLocation = 256, EggCycles = 10, Language = International}, // Marill Scary Face
+        new(172, 05, GS) {OT_Names = PCNYx, Moves = new(184), EggLocation = 256, EggCycles = 10, Language = International}, // Pichu Scary Face
+        new(194, 05, GS) {OT_Names = PCNYx, Moves = new(184), EggLocation = 256, EggCycles = 10, Language = International}, // Wooper Scary Face
 
         // Silver Cave (November 1 to November 7, 2002)
-        new(114, 05, GS) {OT_Names = PCNYx, Moves = new[] {235}, EggLocation = 256, EggCycles = 10, Language = International}, // Tangela Synthesis
-        new(077, 05, GS) {OT_Names = PCNYx, Moves = new[] {067}, EggLocation = 256, EggCycles = 10, Language = International}, // Ponyta Low Kick
-        new(200, 05, GS) {OT_Names = PCNYx, Moves = new[] {095}, EggLocation = 256, EggCycles = 10, Language = International}, // Misdreavus Hypnosis
-        new(246, 05, GS) {OT_Names = PCNYx, Moves = new[] {099}, EggLocation = 256, EggCycles = 10, Language = International}, // Larvitar Rage
+        new(114, 05, GS) {OT_Names = PCNYx, Moves = new(235), EggLocation = 256, EggCycles = 10, Language = International}, // Tangela Synthesis
+        new(077, 05, GS) {OT_Names = PCNYx, Moves = new(067), EggLocation = 256, EggCycles = 10, Language = International}, // Ponyta Low Kick
+        new(200, 05, GS) {OT_Names = PCNYx, Moves = new(095), EggLocation = 256, EggCycles = 10, Language = International}, // Misdreavus Hypnosis
+        new(246, 05, GS) {OT_Names = PCNYx, Moves = new(099), EggLocation = 256, EggCycles = 10, Language = International}, // Larvitar Rage
 
         // Union Cave Pokémon (November 8 to 14, 2002)
-        new(120, 05, GS) {OT_Names = PCNYx, Moves = new[] {239}, EggLocation = 256, EggCycles = 10, Language = International}, // Staryu Twister
-        new(098, 05, GS) {OT_Names = PCNYx, Moves = new[] {232}, EggLocation = 256, EggCycles = 10, Language = International}, // Krabby Metal Claw
-        new(095, 05, GS) {OT_Names = PCNYx, Moves = new[] {159}, EggLocation = 256, EggCycles = 10, Language = International}, // Onix Sharpen
-        new(131, 05, GS) {OT_Names = PCNYx, Moves = new[] {248}, EggLocation = 256, EggCycles = 10, Language = International}, // Lapras Future Sight
+        new(120, 05, GS) {OT_Names = PCNYx, Moves = new(239), EggLocation = 256, EggCycles = 10, Language = International}, // Staryu Twister
+        new(098, 05, GS) {OT_Names = PCNYx, Moves = new(232), EggLocation = 256, EggCycles = 10, Language = International}, // Krabby Metal Claw
+        new(095, 05, GS) {OT_Names = PCNYx, Moves = new(159), EggLocation = 256, EggCycles = 10, Language = International}, // Onix Sharpen
+        new(131, 05, GS) {OT_Names = PCNYx, Moves = new(248), EggLocation = 256, EggCycles = 10, Language = International}, // Lapras Future Sight
 
         // Johto Legendary (November 15 to 21, 2002)
         new(250, 05, C) {OT_Names = PCNYx, CurrentLevel = 40, Shiny = Shiny.Always, Location = 127, Language = International}, // Shiny Ho-Oh
@@ -281,10 +279,10 @@ internal static class Encounters2
         new(151, 05, C) {OT_Names = PCNYx, Shiny = Shiny.Always, Location = 127, Language = International}, // Shiny Mew
 
         // Psychic Type Pokémon (November 29 to December 5, 2002)
-        new(063, 05, GS) {OT_Names = PCNYx, Moves = new[] {193}, EggLocation = 256, EggCycles = 10, Language = International}, // Abra Foresight
-        new(096, 05, GS) {OT_Names = PCNYx, Moves = new[] {133}, EggLocation = 256, EggCycles = 10, Language = International}, // Drowzee Amnesia
-        new(102, 05, GS) {OT_Names = PCNYx, Moves = new[] {230}, EggLocation = 256, EggCycles = 10, Language = International}, // Exeggcute Sweet Scent
-        new(122, 05, GS) {OT_Names = PCNYx, Moves = new[] {170}, EggLocation = 256, EggCycles = 10, Language = International}, // Mr. Mime Mind Reader
+        new(063, 05, GS) {OT_Names = PCNYx, Moves = new(193), EggLocation = 256, EggCycles = 10, Language = International}, // Abra Foresight
+        new(096, 05, GS) {OT_Names = PCNYx, Moves = new(133), EggLocation = 256, EggCycles = 10, Language = International}, // Drowzee Amnesia
+        new(102, 05, GS) {OT_Names = PCNYx, Moves = new(230), EggLocation = 256, EggCycles = 10, Language = International}, // Exeggcute Sweet Scent
+        new(122, 05, GS) {OT_Names = PCNYx, Moves = new(170), EggLocation = 256, EggCycles = 10, Language = International}, // Mr. Mime Mind Reader
 
         // The Johto Initial Three Pokémon (December 6 to 12, 2002)
         new(154, 05, C) {OT_Names = PCNYx, CurrentLevel = 40, Shiny = Shiny.Always, Location = 127, Language = International}, // Shiny Meganium
@@ -292,67 +290,67 @@ internal static class Encounters2
         new(160, 05, C) {OT_Names = PCNYx, CurrentLevel = 40, Shiny = Shiny.Always, Location = 127, Language = International}, // Shiny Feraligatr
 
         // Rock Tunnel Pokémon (December 13 to December 19, 2002)
-        new(074, 05, GS) {OT_Names = PCNYx, Moves = new[] {229}, EggLocation = 256, EggCycles = 10, Language = International}, // Geodude Rapid Spin
-        new(041, 05, GS) {OT_Names = PCNYx, Moves = new[] {175}, EggLocation = 256, EggCycles = 10, Language = International}, // Zubat Flail
-        new(066, 05, GS) {OT_Names = PCNYx, Moves = new[] {037}, EggLocation = 256, EggCycles = 10, Language = International}, // Machop Thrash
-        new(104, 05, GS) {OT_Names = PCNYx, Moves = new[] {031}, EggLocation = 256, EggCycles = 10, Language = International}, // Cubone Fury Attack
+        new(074, 05, GS) {OT_Names = PCNYx, Moves = new(229), EggLocation = 256, EggCycles = 10, Language = International}, // Geodude Rapid Spin
+        new(041, 05, GS) {OT_Names = PCNYx, Moves = new(175), EggLocation = 256, EggCycles = 10, Language = International}, // Zubat Flail
+        new(066, 05, GS) {OT_Names = PCNYx, Moves = new(037), EggLocation = 256, EggCycles = 10, Language = International}, // Machop Thrash
+        new(104, 05, GS) {OT_Names = PCNYx, Moves = new(031), EggLocation = 256, EggCycles = 10, Language = International}, // Cubone Fury Attack
 
         // Ice Type Pokémon (December 20 to 26, 2002)
-        new(225, 05, GS) {OT_Names = PCNYx, Moves = new[] {191}, EggLocation = 256, EggCycles = 10, Language = International}, // Delibird Spikes
-        new(086, 05, GS) {OT_Names = PCNYx, Moves = new[] {175}, EggLocation = 256, EggCycles = 10, Language = International}, // Seel Flail
-        new(220, 05, GS) {OT_Names = PCNYx, Moves = new[] {018}, EggLocation = 256, EggCycles = 10, Language = International}, // Swinub Whirlwind
+        new(225, 05, GS) {OT_Names = PCNYx, Moves = new(191), EggLocation = 256, EggCycles = 10, Language = International}, // Delibird Spikes
+        new(086, 05, GS) {OT_Names = PCNYx, Moves = new(175), EggLocation = 256, EggCycles = 10, Language = International}, // Seel Flail
+        new(220, 05, GS) {OT_Names = PCNYx, Moves = new(018), EggLocation = 256, EggCycles = 10, Language = International}, // Swinub Whirlwind
 
         // Pokémon that Appear at Night only (December 27, 2002 to January 2, 2003)
-        new(163, 05, GS) {OT_Names = PCNYx, Moves = new[] {101}, EggLocation = 256, EggCycles = 10, Language = International}, // Hoothoot Night Shade
-        new(215, 05, GS) {OT_Names = PCNYx, Moves = new[] {236}, EggLocation = 256, EggCycles = 10, Language = International}, // Sneasel Moonlight
+        new(163, 05, GS) {OT_Names = PCNYx, Moves = new(101), EggLocation = 256, EggCycles = 10, Language = International}, // Hoothoot Night Shade
+        new(215, 05, GS) {OT_Names = PCNYx, Moves = new(236), EggLocation = 256, EggCycles = 10, Language = International}, // Sneasel Moonlight
 
         // Grass Type ( January 3 to 9, 2003)
-        new(191, 05, GS) {OT_Names = PCNYx, Moves = new[] {150}, EggLocation = 256, EggCycles = 10, Language = International}, // Sunkern Splash
-        new(046, 05, GS) {OT_Names = PCNYx, Moves = new[] {235}, EggLocation = 256, EggCycles = 10, Language = International}, // Paras Synthesis
-        new(187, 05, GS) {OT_Names = PCNYx, Moves = new[] {097}, EggLocation = 256, EggCycles = 10, Language = International}, // Hoppip Agility
-        new(043, 05, GS) {OT_Names = PCNYx, Moves = new[] {073}, EggLocation = 256, EggCycles = 10, Language = International}, // Oddish Leech Seed
+        new(191, 05, GS) {OT_Names = PCNYx, Moves = new(150), EggLocation = 256, EggCycles = 10, Language = International}, // Sunkern Splash
+        new(046, 05, GS) {OT_Names = PCNYx, Moves = new(235), EggLocation = 256, EggCycles = 10, Language = International}, // Paras Synthesis
+        new(187, 05, GS) {OT_Names = PCNYx, Moves = new(097), EggLocation = 256, EggCycles = 10, Language = International}, // Hoppip Agility
+        new(043, 05, GS) {OT_Names = PCNYx, Moves = new(073), EggLocation = 256, EggCycles = 10, Language = International}, // Oddish Leech Seed
 
         // Normal Pokémon (January 10 to 16, 2003)
-        new(161, 05, GS) {OT_Names = PCNYx, Moves = new[] {146}, EggLocation = 256, EggCycles = 10, Language = International}, // Sentret Dizzy Punch
-        new(234, 05, GS) {OT_Names = PCNYx, Moves = new[] {219}, EggLocation = 256, EggCycles = 10, Language = International}, // Stantler Safeguard
-        new(241, 05, GS) {OT_Names = PCNYx, Moves = new[] {025}, EggLocation = 256, EggCycles = 10, Language = International}, // Miltank Mega Kick
-        new(190, 05, GS) {OT_Names = PCNYx, Moves = new[] {102}, EggLocation = 256, EggCycles = 10, Language = International}, // Aipom Mimic
-        new(108, 05, GS) {OT_Names = PCNYx, Moves = new[] {003}, EggLocation = 256, EggCycles = 10, Language = International}, // Lickitung DoubleSlap
-        new(143, 05, GS) {OT_Names = PCNYx, Moves = new[] {150}, EggLocation = 256, EggCycles = 10, Language = International}, // Snorlax Splash
+        new(161, 05, GS) {OT_Names = PCNYx, Moves = new(146), EggLocation = 256, EggCycles = 10, Language = International}, // Sentret Dizzy Punch
+        new(234, 05, GS) {OT_Names = PCNYx, Moves = new(219), EggLocation = 256, EggCycles = 10, Language = International}, // Stantler Safeguard
+        new(241, 05, GS) {OT_Names = PCNYx, Moves = new(025), EggLocation = 256, EggCycles = 10, Language = International}, // Miltank Mega Kick
+        new(190, 05, GS) {OT_Names = PCNYx, Moves = new(102), EggLocation = 256, EggCycles = 10, Language = International}, // Aipom Mimic
+        new(108, 05, GS) {OT_Names = PCNYx, Moves = new(003), EggLocation = 256, EggCycles = 10, Language = International}, // Lickitung DoubleSlap
+        new(143, 05, GS) {OT_Names = PCNYx, Moves = new(150), EggLocation = 256, EggCycles = 10, Language = International}, // Snorlax Splash
 
         // Mt. Mortar (January 24 to 30, 2003)
-        new(066, 05, GS) {OT_Names = PCNYx, Moves = new[] {206}, EggLocation = 256, EggCycles = 10, Language = International}, // Machop False Swipe
-        new(129, 05, GS) {OT_Names = PCNYx, Moves = new[] {145}, EggLocation = 256, EggCycles = 10, Language = International}, // Magikarp Bubble
-        new(236, 05, GS) {OT_Names = PCNYx, Moves = new[] {099}, EggLocation = 256, EggCycles = 10, Language = International}, // Tyrogue Rage
+        new(066, 05, GS) {OT_Names = PCNYx, Moves = new(206), EggLocation = 256, EggCycles = 10, Language = International}, // Machop False Swipe
+        new(129, 05, GS) {OT_Names = PCNYx, Moves = new(145), EggLocation = 256, EggCycles = 10, Language = International}, // Magikarp Bubble
+        new(236, 05, GS) {OT_Names = PCNYx, Moves = new(099), EggLocation = 256, EggCycles = 10, Language = International}, // Tyrogue Rage
 
         // Dark Cave Pokémon (January 31 to February 6, 2003)
-        new(206, 05, GS) {OT_Names = PCNYx, Moves = new[] {031}, EggLocation = 256, EggCycles = 10, Language = International}, // Dunsparce Fury Attack
-        new(202, 05, GS) {OT_Names = PCNYx, Moves = new[] {102}, EggLocation = 256, EggCycles = 10, Language = International}, // Wobbuffet Mimic
-        new(231, 05, GS) {OT_Names = PCNYx, Moves = new[] {071}, EggLocation = 256, EggCycles = 10, Language = International}, // Phanpy Absorb
-        new(216, 05, GS) {OT_Names = PCNYx, Moves = new[] {230}, EggLocation = 256, EggCycles = 10, Language = International}, // Teddiursa Sweet Scent
+        new(206, 05, GS) {OT_Names = PCNYx, Moves = new(031), EggLocation = 256, EggCycles = 10, Language = International}, // Dunsparce Fury Attack
+        new(202, 05, GS) {OT_Names = PCNYx, Moves = new(102), EggLocation = 256, EggCycles = 10, Language = International}, // Wobbuffet Mimic
+        new(231, 05, GS) {OT_Names = PCNYx, Moves = new(071), EggLocation = 256, EggCycles = 10, Language = International}, // Phanpy Absorb
+        new(216, 05, GS) {OT_Names = PCNYx, Moves = new(230), EggLocation = 256, EggCycles = 10, Language = International}, // Teddiursa Sweet Scent
 
         // Valentine's Day Special (February 7 to 13, 2003)
-        new(060, 05, GS) {OT_Names = PCNYx, Moves = new[] {186}, EggLocation = 256, EggCycles = 10, Language = International}, // Poliwag Sweet Kiss
-        new(060, 05, GS) {OT_Names = PCNYx, Moves = new[] {142}, EggLocation = 256, EggCycles = 10, Language = International}, // Poliwag Lovely Kiss
-        new(143, 05, GS) {OT_Names = PCNYx, Moves = new[] {186}, EggLocation = 256, EggCycles = 10, Language = International}, // Snorlax Sweet Kiss
-        new(143, 05, GS) {OT_Names = PCNYx, Moves = new[] {142}, EggLocation = 256, EggCycles = 10, Language = International}, // Snorlax Lovely Kiss
+        new(060, 05, GS) {OT_Names = PCNYx, Moves = new(186), EggLocation = 256, EggCycles = 10, Language = International}, // Poliwag Sweet Kiss
+        new(060, 05, GS) {OT_Names = PCNYx, Moves = new(142), EggLocation = 256, EggCycles = 10, Language = International}, // Poliwag Lovely Kiss
+        new(143, 05, GS) {OT_Names = PCNYx, Moves = new(186), EggLocation = 256, EggCycles = 10, Language = International}, // Snorlax Sweet Kiss
+        new(143, 05, GS) {OT_Names = PCNYx, Moves = new(142), EggLocation = 256, EggCycles = 10, Language = International}, // Snorlax Lovely Kiss
 
         // Rare Pokémon (February 21 to 27, 2003)
-        new(140, 05, GS) {OT_Names = PCNYx, Moves = new[] {088}, EggLocation = 256, EggCycles = 10, Language = International}, // Kabuto Rock Throw
-        new(138, 05, GS) {OT_Names = PCNYx, Moves = new[] {088}, EggLocation = 256, EggCycles = 10, Language = International}, // Omanyte Rock Throw
-        new(142, 05, GS) {OT_Names = PCNYx, Moves = new[] {088}, EggLocation = 256, EggCycles = 10, Language = International}, // Aerodactyl Rock Throw
-        new(137, 05, GS) {OT_Names = PCNYx, Moves = new[] {112}, EggLocation = 256, EggCycles = 10, Language = International}, // Porygon Barrier
-        new(133, 05, GS) {OT_Names = PCNYx, Moves = new[] {074}, EggLocation = 256, EggCycles = 10, Language = International}, // Eevee Growth
-        new(185, 05, GS) {OT_Names = PCNYx, Moves = new[] {164}, EggLocation = 256, EggCycles = 10, Language = International}, // Sudowoodo Substitute
+        new(140, 05, GS) {OT_Names = PCNYx, Moves = new(088), EggLocation = 256, EggCycles = 10, Language = International}, // Kabuto Rock Throw
+        new(138, 05, GS) {OT_Names = PCNYx, Moves = new(088), EggLocation = 256, EggCycles = 10, Language = International}, // Omanyte Rock Throw
+        new(142, 05, GS) {OT_Names = PCNYx, Moves = new(088), EggLocation = 256, EggCycles = 10, Language = International}, // Aerodactyl Rock Throw
+        new(137, 05, GS) {OT_Names = PCNYx, Moves = new(112), EggLocation = 256, EggCycles = 10, Language = International}, // Porygon Barrier
+        new(133, 05, GS) {OT_Names = PCNYx, Moves = new(074), EggLocation = 256, EggCycles = 10, Language = International}, // Eevee Growth
+        new(185, 05, GS) {OT_Names = PCNYx, Moves = new(164), EggLocation = 256, EggCycles = 10, Language = International}, // Sudowoodo Substitute
 
         // Bug Type Pokémon (February 28 to March 6, 2003)
-        new(123, 05, GS) {OT_Names = PCNYx, Moves = new[] {049}, EggLocation = 256, EggCycles = 10, Language = International}, // Scyther SonicBoom
-        new(214, 05, GS) {OT_Names = PCNYx, Moves = new[] {069}, EggLocation = 256, EggCycles = 10, Language = International}, // Heracross Seismic Toss
-        new(127, 05, GS) {OT_Names = PCNYx, Moves = new[] {088}, EggLocation = 256, EggCycles = 10, Language = International}, // Pinsir Rock Throw
-        new(165, 05, GS) {OT_Names = PCNYx, Moves = new[] {112}, EggLocation = 256, EggCycles = 10, Language = International}, // Ledyba Barrier
-        new(167, 05, GS) {OT_Names = PCNYx, Moves = new[] {074}, EggLocation = 256, EggCycles = 10, Language = International}, // Spinarak Growth
-        new(193, 05, GS) {OT_Names = PCNYx, Moves = new[] {186}, EggLocation = 256, EggCycles = 10, Language = International}, // Yanma Sweet Kiss
-        new(204, 05, GS) {OT_Names = PCNYx, Moves = new[] {164}, EggLocation = 256, EggCycles = 10, Language = International}, // Pineco Substitute
+        new(123, 05, GS) {OT_Names = PCNYx, Moves = new(049), EggLocation = 256, EggCycles = 10, Language = International}, // Scyther SonicBoom
+        new(214, 05, GS) {OT_Names = PCNYx, Moves = new(069), EggLocation = 256, EggCycles = 10, Language = International}, // Heracross Seismic Toss
+        new(127, 05, GS) {OT_Names = PCNYx, Moves = new(088), EggLocation = 256, EggCycles = 10, Language = International}, // Pinsir Rock Throw
+        new(165, 05, GS) {OT_Names = PCNYx, Moves = new(112), EggLocation = 256, EggCycles = 10, Language = International}, // Ledyba Barrier
+        new(167, 05, GS) {OT_Names = PCNYx, Moves = new(074), EggLocation = 256, EggCycles = 10, Language = International}, // Spinarak Growth
+        new(193, 05, GS) {OT_Names = PCNYx, Moves = new(186), EggLocation = 256, EggCycles = 10, Language = International}, // Yanma Sweet Kiss
+        new(204, 05, GS) {OT_Names = PCNYx, Moves = new(164), EggLocation = 256, EggCycles = 10, Language = International}, // Pineco Substitute
 
         // Japanese Only (all below)
         new(251, 30, GSC) {Location = 014}, // Celebi @ Ilex Forest (GBC)
@@ -360,25 +358,25 @@ internal static class Encounters2
         // Gen2 Events
         // Egg Cycles Subject to Change. OTs for Eggs are unknown.
         // Pokémon Center Mystery Egg #1 (December 15, 2001 to January 14, 2002)
-        new(152, 05, GSC) {Moves = new[] {080}, EggLocation = 256, EggCycles = 10}, // Chikorita Petal Dance
-        new(172, 05, GSC) {Moves = new[] {047}, EggLocation = 256, EggCycles = 10}, // Pichu Sing
-        new(173, 05, GSC) {Moves = new[] {129}, EggLocation = 256, EggCycles = 10}, // Cleffa Swift
-        new(194, 05, GSC) {Moves = new[] {187}, EggLocation = 256, EggCycles = 10}, // Wooper Belly Drum
-        new(231, 05, GSC) {Moves = new[] {227}, EggLocation = 256, EggCycles = 10}, // Phanpy Encore
-        new(238, 05, GSC) {Moves = new[] {118}, EggLocation = 256, EggCycles = 10}, // Smoochum Metronome
+        new(152, 05, GSC) {Moves = new(080), EggLocation = 256, EggCycles = 10}, // Chikorita Petal Dance
+        new(172, 05, GSC) {Moves = new(047), EggLocation = 256, EggCycles = 10}, // Pichu Sing
+        new(173, 05, GSC) {Moves = new(129), EggLocation = 256, EggCycles = 10}, // Cleffa Swift
+        new(194, 05, GSC) {Moves = new(187), EggLocation = 256, EggCycles = 10}, // Wooper Belly Drum
+        new(231, 05, GSC) {Moves = new(227), EggLocation = 256, EggCycles = 10}, // Phanpy Encore
+        new(238, 05, GSC) {Moves = new(118), EggLocation = 256, EggCycles = 10}, // Smoochum Metronome
 
         // Pokémon Center Mystery Egg #2 (March 16 to April 7, 2002)
-        new(054, 05, GSC) {Moves = new[] {080}, EggLocation = 256, EggCycles = 10}, // Psyduck Petal Dance
-        new(152, 05, GSC) {Moves = new[] {080}, EggLocation = 256, EggCycles = 10}, // Chikorita Petal Dance
-        new(172, 05, GSC) {Moves = new[] {080}, EggLocation = 256, EggCycles = 10}, // Pichu Petal Dance
-        new(173, 05, GSC) {Moves = new[] {080}, EggLocation = 256, EggCycles = 10}, // Cleffa Petal Dance
-        new(174, 05, GSC) {Moves = new[] {080}, EggLocation = 256, EggCycles = 10}, // Igglybuff Petal Dance
-        new(238, 05, GSC) {Moves = new[] {080}, EggLocation = 256, EggCycles = 10}, // Smoochum Petal Dance
+        new(054, 05, GSC) {Moves = new(080), EggLocation = 256, EggCycles = 10}, // Psyduck Petal Dance
+        new(152, 05, GSC) {Moves = new(080), EggLocation = 256, EggCycles = 10}, // Chikorita Petal Dance
+        new(172, 05, GSC) {Moves = new(080), EggLocation = 256, EggCycles = 10}, // Pichu Petal Dance
+        new(173, 05, GSC) {Moves = new(080), EggLocation = 256, EggCycles = 10}, // Cleffa Petal Dance
+        new(174, 05, GSC) {Moves = new(080), EggLocation = 256, EggCycles = 10}, // Igglybuff Petal Dance
+        new(238, 05, GSC) {Moves = new(080), EggLocation = 256, EggCycles = 10}, // Smoochum Petal Dance
 
         // Pokémon Center Mystery Egg #3 (April 27 to May 12, 2002)
-        new(001, 05, GSC) {Moves = new[] {246}, EggLocation = 256, EggCycles = 10}, // Bulbasaur Ancientpower
-        new(004, 05, GSC) {Moves = new[] {242}, EggLocation = 256, EggCycles = 10}, // Charmander Crunch
-        new(158, 05, GSC) {Moves = new[] {066}, EggLocation = 256, EggCycles = 10}, // Totodile Submission
-        new(163, 05, GSC) {Moves = new[] {101}, EggLocation = 256, EggCycles = 10}, // Hoot-Hoot Night Shade
+        new(001, 05, GSC) {Moves = new(246), EggLocation = 256, EggCycles = 10}, // Bulbasaur Ancientpower
+        new(004, 05, GSC) {Moves = new(242), EggLocation = 256, EggCycles = 10}, // Charmander Crunch
+        new(158, 05, GSC) {Moves = new(066), EggLocation = 256, EggCycles = 10}, // Totodile Submission
+        new(163, 05, GSC) {Moves = new(101), EggLocation = 256, EggCycles = 10}, // Hoot-Hoot Night Shade
     };
 }

--- a/PKHeX.Core/Legality/Encounters/Data/Encounters2.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Encounters2.cs
@@ -32,7 +32,7 @@ internal static class Encounters2
         new(185, 20, GSC) { Location = 020 }, // Sudowoodo @ Route 36
         new(236, 10, GSC) { Location = 035 }, // Tyrogue @ Mt. Mortar
 
-        new(130, 30, GSC) { Location = 038, Shiny = Shiny.Always, Gender = 0, IVs = new []{0, 14, 10, 10, 10, 10} }, // Gyarados @ Lake of Rage (forcing shiny IVs result in always Male)
+        new(130, 30, GSC) { Location = 038, Shiny = Shiny.Always, Gender = 0, IVs = new(0, 14, 10, 10, 10, 10) }, // Gyarados @ Lake of Rage (forcing shiny IVs result in always Male)
         new(074, 21, GSC) { Location = 036 }, // Geodude @ Rocket Hideout (Mahogany Town)
         new(109, 21, GSC) { Location = 036 }, // Koffing @ Rocket Hideout (Mahogany Town)
         new(100, 23, GSC) { Location = 036 }, // Voltorb @ Rocket Hideout (Mahogany Town)
@@ -107,16 +107,16 @@ internal static class Encounters2
 
     internal static readonly EncounterTrade2[] TradeGift_GSC =
     {
-        new(095, 03, 48926) { Gender = 0, IVs = new[] {08, 09, 06, 06, 06, 06} }, // Onix @ Violet City for Bellsprout [wild]
-        new(066, 05, 37460) { Gender = 1, IVs = new[] {12, 03, 07, 06, 06, 06} }, // Machop @ Goldenrod City for Drowzee [wild 9, hatched egg 5]
-        new(100, 05, 29189) { Gender = 2, IVs = new[] {08, 09, 08, 08, 08, 08} }, // Voltorb @ Olivine City for Krabby [egg]
-        new(112, 10, 00283) { Gender = 1, IVs = new[] {12, 07, 07, 06, 06, 06} }, // Rhydon @ Blackthorn City for Dragonair [wild]
-        new(142, 05, 26491) { Gender = 0, IVs = new[] {08, 09, 06, 06, 06, 06}, OTGender = 1}, // Aerodactyl @ Route 14 for Chansey [egg]
-        new(078, 14, 15616) { Gender = 0, IVs = new[] {08, 09, 06, 06, 06, 06} }, // Rapidash @ Pewter City for Gloom [wild]
+        new(095, 03, 48926) { Gender = 0, IVs = new(08, 09, 06, 06, 06, 06) }, // Onix @ Violet City for Bellsprout [wild]
+        new(066, 05, 37460) { Gender = 1, IVs = new(12, 03, 07, 06, 06, 06) }, // Machop @ Goldenrod City for Drowzee [wild 9, hatched egg 5]
+        new(100, 05, 29189) { Gender = 2, IVs = new(08, 09, 08, 08, 08, 08) }, // Voltorb @ Olivine City for Krabby [egg]
+        new(112, 10, 00283) { Gender = 1, IVs = new(12, 07, 07, 06, 06, 06) }, // Rhydon @ Blackthorn City for Dragonair [wild]
+        new(142, 05, 26491) { Gender = 0, IVs = new(08, 09, 06, 06, 06, 06), OTGender = 1}, // Aerodactyl @ Route 14 for Chansey [egg]
+        new(078, 14, 15616) { Gender = 0, IVs = new(08, 09, 06, 06, 06, 06) }, // Rapidash @ Pewter City for Gloom [wild]
 
-        new(085, 10, 00283) { Gender = 1, IVs = new[] {12, 07, 07, 06, 06, 06}, OTGender = 1}, // Dodrio @ Blackthorn City for Dragonair [wild]
-        new(178, 15, 15616) { Gender = 0, IVs = new[] {08, 09, 06, 08, 06, 06} }, // Xatu @ Pewter City for Haunter [wild]
-        new(082, 05, 50082) { Gender = 2, IVs = new[] {08, 09, 06, 06, 06, 06} }, // Magneton @ Power Plant for Dugtrio [traded for Lickitung]
+        new(085, 10, 00283) { Gender = 1, IVs = new(12, 07, 07, 06, 06, 06), OTGender = 1}, // Dodrio @ Blackthorn City for Dragonair [wild]
+        new(178, 15, 15616) { Gender = 0, IVs = new(08, 09, 06, 08, 06, 06) }, // Xatu @ Pewter City for Haunter [wild]
+        new(082, 05, 50082) { Gender = 2, IVs = new(08, 09, 06, 06, 06, 06) }, // Magneton @ Power Plant for Dugtrio [traded for Lickitung]
 
         new(021, 10, 01001) { Moves = new(64,45,43) }, // Spearow @ Goldenrod City for free
         new(213, 15, 00518), // Shuckle @ Cianwood City for free

--- a/PKHeX.Core/Legality/Encounters/Data/Encounters3.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Encounters3.cs
@@ -1,4 +1,4 @@
-﻿using static PKHeX.Core.EncounterUtil;
+using static PKHeX.Core.EncounterUtil;
 using static PKHeX.Core.GameVersion;
 using static PKHeX.Core.AbilityPermission;
 
@@ -150,30 +150,30 @@ internal static class Encounters3
 
     internal static readonly EncounterTrade3[] TradeGift_RSE =
     {
-        new(RS, 0x00009C40, 296, 05) { Ability = OnlySecond, TID = 49562, SID = 00000, OTGender = 0, Gender = 0, IVs = new[] {5,5,4,4,4,4}, Contest = TradeContest_Tough }, // Slakoth (Level 5 Breeding) -> Makuhita
-        new(RS, 0x498A2E17, 300, 03) { Ability = OnlyFirst,  TID = 02259, SID = 00000, OTGender = 1, Gender = 1, IVs = new[] {5,4,4,5,4,4}, Contest = TradeContest_Cute }, // Pikachu (Level 3 Viridian Forest) -> Skitty
-        new(RS, 0x4C970B7F, 222, 21) { Ability = OnlySecond, TID = 50183, SID = 00000, OTGender = 1, Gender = 1, IVs = new[] {4,4,5,4,4,5}, Contest = TradeContest_Beauty }, // Bellossom (Level 21 Oddish -> Gloom -> Bellossom) -> Corsola
-        new(E , 0x00000084, 273, 04) { Ability = OnlySecond, TID = 38726, SID = 00000, OTGender = 0, Gender = 0, IVs = new[] {5,4,5,4,4,4}, Contest = TradeContest_Cool }, // Ralts (Level 4 Route 102) -> Seedot
-        new(E , 0x0000006F, 311, 05) { Ability = OnlyFirst,  TID = 08460, SID = 00001, OTGender = 0, Gender = 1, IVs = new[] {4,4,4,5,5,4}, Contest = TradeContest_Cute }, // Volbeat (Level 5 Breeding) -> Plusle
-        new(E , 0x0000007F, 116, 05) { Ability = OnlyFirst,  TID = 46285, SID = 00000, OTGender = 0, Gender = 0, IVs = new[] {5,4,4,4,5,4}, Contest = TradeContest_Tough }, // Bagon (Level 5 Breeding) -> Horsea*
-        new(E , 0x0000008B, 052, 03) { Ability = OnlyFirst,  TID = 25945, SID = 00001, OTGender = 1, Gender = 0, IVs = new[] {4,5,4,5,4,4}, Contest = TradeContest_Clever }, // Skitty (Level 3 Trade)-> Meowth*
+        new(RS, 0x00009C40, 296, 05) { Ability = OnlySecond, TID = 49562, SID = 00000, OTGender = 0, Gender = 0, IVs = new(5,5,4,4,4,4), Contest = TradeContest_Tough }, // Slakoth (Level 5 Breeding) -> Makuhita
+        new(RS, 0x498A2E17, 300, 03) { Ability = OnlyFirst,  TID = 02259, SID = 00000, OTGender = 1, Gender = 1, IVs = new(5,4,4,5,4,4), Contest = TradeContest_Cute }, // Pikachu (Level 3 Viridian Forest) -> Skitty
+        new(RS, 0x4C970B7F, 222, 21) { Ability = OnlySecond, TID = 50183, SID = 00000, OTGender = 1, Gender = 1, IVs = new(4,4,5,4,4,5), Contest = TradeContest_Beauty }, // Bellossom (Level 21 Oddish -> Gloom -> Bellossom) -> Corsola
+        new(E , 0x00000084, 273, 04) { Ability = OnlySecond, TID = 38726, SID = 00000, OTGender = 0, Gender = 0, IVs = new(5,4,5,4,4,4), Contest = TradeContest_Cool }, // Ralts (Level 4 Route 102) -> Seedot
+        new(E , 0x0000006F, 311, 05) { Ability = OnlyFirst,  TID = 08460, SID = 00001, OTGender = 0, Gender = 1, IVs = new(4,4,4,5,5,4), Contest = TradeContest_Cute }, // Volbeat (Level 5 Breeding) -> Plusle
+        new(E , 0x0000007F, 116, 05) { Ability = OnlyFirst,  TID = 46285, SID = 00000, OTGender = 0, Gender = 0, IVs = new(5,4,4,4,5,4), Contest = TradeContest_Tough }, // Bagon (Level 5 Breeding) -> Horsea*
+        new(E , 0x0000008B, 052, 03) { Ability = OnlyFirst,  TID = 25945, SID = 00001, OTGender = 1, Gender = 0, IVs = new(4,5,4,5,4,4), Contest = TradeContest_Clever }, // Skitty (Level 3 Trade)-> Meowth*
         //  If Pokémon with * is evolved in a Generation IV or V game, its Ability will become its second Ability.
     };
 
     internal static readonly EncounterTrade3[] TradeGift_FRLG =
     {
-        new(FRLG, 0x00009CAE, 122, 05) { Ability = OnlyFirst,  TID = 01985, SID = 00000, OTGender = 0, Gender = 0, IVs = new[] {20,15,17,24,23,22}, Contest = TradeContest_Clever }, // Abra (Level 5 Breeding) -> Mr. Mime
-        new(FR  , 0x4C970B89, 029, 05) { Ability = OnlyFirst,  TID = 63184, SID = 00000, OTGender = 1, Gender = 1, IVs = new[] {22,18,25,19,15,22}, Contest = TradeContest_Tough }, // Nidoran♀
-        new(  LG, 0x4C970B9E, 032, 05) { Ability = OnlyFirst,  TID = 63184, SID = 00000, OTGender = 1, Gender = 0, IVs = new[] {19,25,18,22,22,15}, Contest = TradeContest_Cool }, // Nidoran♂ *
-        new(FR  , 0x00EECA15, 030, 16) { Ability = OnlyFirst,  TID = 13637, SID = 00000, OTGender = 0, Gender = 1, IVs = new[] {22,25,18,19,22,15}, Contest = TradeContest_Cute }, // Nidorina *
-        new(  LG, 0x00EECA19, 033, 16) { Ability = OnlyFirst,  TID = 13637, SID = 00000, OTGender = 0, Gender = 0, IVs = new[] {19,18,25,22,15,22}, Contest = TradeContest_Tough }, // Nidorino  *
-        new(FR  , 0x451308AB, 108, 25) { Ability = OnlyFirst,  TID = 01239, SID = 00000, OTGender = 0, Gender = 0, IVs = new[] {24,19,21,15,23,21}, Contest = TradeContest_Tough }, // Golduck (Level 25) -> Lickitung  *
-        new(  LG, 0x451308AB, 108, 25) { Ability = OnlyFirst,  TID = 01239, SID = 00000, OTGender = 0, Gender = 0, IVs = new[] {24,19,21,15,23,21}, Contest = TradeContest_Tough }, // Slowbro (Level 25) -> Lickitung  *
-        new(FRLG, 0x498A2E1D, 124, 20) { Ability = OnlyFirst,  TID = 36728, SID = 00000, OTGender = 0, Gender = 1, IVs = new[] {18,17,18,22,25,21}, Contest = TradeContest_Beauty }, // Poliwhirl (Level 20) -> Jynx
-        new(FRLG, 0x151943D7, 083, 03) { Ability = OnlyFirst,  TID = 08810, SID = 00000, OTGender = 0, Gender = 0, IVs = new[] {20,25,21,24,15,20}, Contest = TradeContest_Cool }, // Spearow (Level 3 Capture) -> Farfetch'd
-        new(FRLG, 0x06341016, 101, 03) { Ability = OnlySecond, TID = 50298, SID = 00000, OTGender = 0, Gender = 2, IVs = new[] {19,16,18,25,25,19}, Contest = TradeContest_Cool }, // Raichu (Level 3) -> Electrode
-        new(FRLG, 0x5C77ECFA, 114, 05) { Ability = OnlyFirst,  TID = 60042, SID = 00000, OTGender = 1, Gender = 0, IVs = new[] {22,17,25,16,23,20}, Contest = TradeContest_Cute }, // Venonat (Level 5 Breeding) -> Tangela
-        new(FRLG, 0x482CAC89, 086, 05) { Ability = OnlyFirst,  TID = 09853, SID = 00000, OTGender = 0, Gender = 0, IVs = new[] {24,15,22,16,23,22}, Contest = TradeContest_Tough }, // Ponyta (Level 5 Breeding) -> Seel *
+        new(FRLG, 0x00009CAE, 122, 05) { Ability = OnlyFirst,  TID = 01985, SID = 00000, OTGender = 0, Gender = 0, IVs = new(20,15,17,24,23,22), Contest = TradeContest_Clever }, // Abra (Level 5 Breeding) -> Mr. Mime
+        new(FR  , 0x4C970B89, 029, 05) { Ability = OnlyFirst,  TID = 63184, SID = 00000, OTGender = 1, Gender = 1, IVs = new(22,18,25,19,15,22), Contest = TradeContest_Tough }, // Nidoran♀
+        new(  LG, 0x4C970B9E, 032, 05) { Ability = OnlyFirst,  TID = 63184, SID = 00000, OTGender = 1, Gender = 0, IVs = new(19,25,18,22,22,15), Contest = TradeContest_Cool }, // Nidoran♂ *
+        new(FR  , 0x00EECA15, 030, 16) { Ability = OnlyFirst,  TID = 13637, SID = 00000, OTGender = 0, Gender = 1, IVs = new(22,25,18,19,22,15), Contest = TradeContest_Cute }, // Nidorina *
+        new(  LG, 0x00EECA19, 033, 16) { Ability = OnlyFirst,  TID = 13637, SID = 00000, OTGender = 0, Gender = 0, IVs = new(19,18,25,22,15,22), Contest = TradeContest_Tough }, // Nidorino  *
+        new(FR  , 0x451308AB, 108, 25) { Ability = OnlyFirst,  TID = 01239, SID = 00000, OTGender = 0, Gender = 0, IVs = new(24,19,21,15,23,21), Contest = TradeContest_Tough }, // Golduck (Level 25) -> Lickitung  *
+        new(  LG, 0x451308AB, 108, 25) { Ability = OnlyFirst,  TID = 01239, SID = 00000, OTGender = 0, Gender = 0, IVs = new(24,19,21,15,23,21), Contest = TradeContest_Tough }, // Slowbro (Level 25) -> Lickitung  *
+        new(FRLG, 0x498A2E1D, 124, 20) { Ability = OnlyFirst,  TID = 36728, SID = 00000, OTGender = 0, Gender = 1, IVs = new(18,17,18,22,25,21), Contest = TradeContest_Beauty }, // Poliwhirl (Level 20) -> Jynx
+        new(FRLG, 0x151943D7, 083, 03) { Ability = OnlyFirst,  TID = 08810, SID = 00000, OTGender = 0, Gender = 0, IVs = new(20,25,21,24,15,20), Contest = TradeContest_Cool }, // Spearow (Level 3 Capture) -> Farfetch'd
+        new(FRLG, 0x06341016, 101, 03) { Ability = OnlySecond, TID = 50298, SID = 00000, OTGender = 0, Gender = 2, IVs = new(19,16,18,25,25,19), Contest = TradeContest_Cool }, // Raichu (Level 3) -> Electrode
+        new(FRLG, 0x5C77ECFA, 114, 05) { Ability = OnlyFirst,  TID = 60042, SID = 00000, OTGender = 1, Gender = 0, IVs = new(22,17,25,16,23,20), Contest = TradeContest_Cute }, // Venonat (Level 5 Breeding) -> Tangela
+        new(FRLG, 0x482CAC89, 086, 05) { Ability = OnlyFirst,  TID = 09853, SID = 00000, OTGender = 0, Gender = 0, IVs = new(24,15,22,16,23,22), Contest = TradeContest_Tough }, // Ponyta (Level 5 Breeding) -> Seel *
         //  If Pokémon with * is evolved in a Generation IV or V game, its Ability will become its second Ability.
     };
 

--- a/PKHeX.Core/Legality/Encounters/Data/Encounters3GC.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Encounters3GC.cs
@@ -1,4 +1,4 @@
-﻿using static PKHeX.Core.Encounters3Teams;
+using static PKHeX.Core.Encounters3Teams;
 
 namespace PKHeX.Core;
 
@@ -10,100 +10,100 @@ internal static class Encounters3GC
     {
         // Colosseum Starters: Gender locked to male
         new(196, 25, GameVersion.COLO) { Gift = true, Location = 254, Gender = 0 }, // Espeon
-        new(197, 26, GameVersion.COLO) { Gift = true, Location = 254, Gender = 0, Moves = new[] {044} }, // Umbreon (Bite)
+        new(197, 26, GameVersion.COLO) { Gift = true, Location = 254, Gender = 0, Moves = new(044) }, // Umbreon (Bite)
     };
 
     private static readonly EncounterStaticShadow[] Encounter_Colo =
     {
-        new(GameVersion.COLO, 01, 03000, ColoMakuhita) { Species = 296, Level = 30, Moves = new[] {193,116,233,238}, Location = 005 }, // Makuhita: Miror B.Peon Trudly @ Phenac City
+        new(GameVersion.COLO, 01, 03000, ColoMakuhita) { Species = 296, Level = 30, Moves = new(193,116,233,238), Location = 005 }, // Makuhita: Miror B.Peon Trudly @ Phenac City
 
-        new(GameVersion.COLO, 02, 03000, First)     { Species = 153, Level = 30, Moves = new[] {241,235,075,034}, Location = 003  }, // Bayleef: Cipher Peon Verde @ Phenac City
-        new(GameVersion.COLO, 02, 03000, First)     { Species = 153, Level = 30, Moves = new[] {241,235,075,034}, Location = 069  }, // Bayleef: Cipher Peon Verde @ Shadow PKMN Lab
-        new(GameVersion.COLO, 02, 03000, First)     { Species = 153, Level = 30, Moves = new[] {241,235,075,034}, Location = 115  }, // Bayleef: Cipher Peon Verde @ Realgam Tower
-        new(GameVersion.COLO, 02, 03000, First)     { Species = 153, Level = 30, Moves = new[] {241,235,075,034}, Location = 132  }, // Bayleef: Cipher Peon Verde @ Snagem Hideout
-        new(GameVersion.COLO, 03, 03000, First)     { Species = 156, Level = 30, Moves = new[] {241,108,091,172}, Location = 003  }, // Quilava: Cipher Peon Rosso @ Phenac City
-        new(GameVersion.COLO, 03, 03000, First)     { Species = 156, Level = 30, Moves = new[] {241,108,091,172}, Location = 069  }, // Quilava: Cipher Peon Rosso @ Shadow PKMN Lab
-        new(GameVersion.COLO, 03, 03000, First)     { Species = 156, Level = 30, Moves = new[] {241,108,091,172}, Location = 115  }, // Quilava: Cipher Peon Rosso @ Realgam Tower
-        new(GameVersion.COLO, 03, 03000, First)     { Species = 156, Level = 30, Moves = new[] {241,108,091,172}, Location = 132  }, // Quilava: Cipher Peon Rosso @ Snagem Hideout
-        new(GameVersion.COLO, 04, 03000, First)     { Species = 159, Level = 30, Moves = new[] {240,184,044,057}, Location = 003  }, // Croconaw: Cipher Peon Bluno @ Phenac City
-        new(GameVersion.COLO, 04, 03000, First)     { Species = 159, Level = 30, Moves = new[] {240,184,044,057}, Location = 069  }, // Croconaw: Cipher Peon Bluno @ Shadow PKMN Lab
-        new(GameVersion.COLO, 04, 03000, First)     { Species = 159, Level = 30, Moves = new[] {240,184,044,057}, Location = 115  }, // Croconaw: Cipher Peon Bluno @ Realgam Tower
-        new(GameVersion.COLO, 04, 03000, First)     { Species = 159, Level = 30, Moves = new[] {240,184,044,057}, Location = 132  }, // Croconaw: Cipher Peon Bluno @ Snagem Hideout
-        new(GameVersion.COLO, 05, 03000, First)     { Species = 164, Level = 30, Moves = new[] {211,095,115,019}, Location = 015 }, // Noctowl: Rider Nover @ Pyrite Town
-        new(GameVersion.COLO, 06, 03000, First)     { Species = 180, Level = 30, Moves = new[] {085,086,178,084}, Location = 015 }, // Flaaffy: St.Performer Diogo @ Pyrite Town
-        new(GameVersion.COLO, 07, 03000, First)     { Species = 188, Level = 30, Moves = new[] {235,079,178,072}, Location = 015 }, // Skiploom: Rider Leba @ Pyrite Town
-        new(GameVersion.COLO, 08, 04000, First)     { Species = 195, Level = 30, Moves = new[] {341,133,021,057}, Location = 015 }, // Quagsire: Bandana Guy Divel @ Pyrite Town
-        new(GameVersion.COLO, 09, 04000, First)     { Species = 200, Level = 30, Moves = new[] {060,109,212,247}, Location = 015 }, // Misdreavus: Rider Vant @ Pyrite Town
-        new(GameVersion.COLO, 10, 05000, First)     { Species = 193, Level = 33, Moves = new[] {197,048,049,253}, Location = 025  }, // Yanma: Cipher Peon Nore @ Pyrite Bldg
-        new(GameVersion.COLO, 10, 05000, First)     { Species = 193, Level = 33, Moves = new[] {197,048,049,253}, Location = 132  }, // Yanma: Cipher Peon Nore @ Snagem Hideout
-        new(GameVersion.COLO, 11, 05000, First)     { Species = 162, Level = 33, Moves = new[] {231,270,098,070}, Location = 015  }, // Furret: Rogue Cail @ Pyrite Town
-        new(GameVersion.COLO, 12, 04000, First)     { Species = 218, Level = 30, Moves = new[] {241,281,088,053}, Location = 015  }, // Slugma: Roller Boy Lon @ Pyrite Town
-        new(GameVersion.COLO, 13, 04000, First)     { Species = 223, Level = 20, Moves = new[] {061,199,060,062}, Location = 028 }, // Remoraid: Miror B.Peon Reath @ Pyrite Bldg
-        new(GameVersion.COLO, 13, 04000, First)     { Species = 223, Level = 20, Moves = new[] {061,199,060,062}, Location = 030 }, // Remoraid: Miror B.Peon Reath @ Pyrite Cave
-        new(GameVersion.COLO, 14, 05000, First)     { Species = 226, Level = 33, Moves = new[] {017,048,061,036}, Location = 028 }, // Mantine: Miror B.Peon Ferma @ Pyrite Bldg
-        new(GameVersion.COLO, 14, 05000, First)     { Species = 226, Level = 33, Moves = new[] {017,048,061,036}, Location = 030 }, // Mantine: Miror B.Peon Ferma @ Pyrite Cave
-        new(GameVersion.COLO, 15, 05000, First)     { Species = 211, Level = 33, Moves = new[] {042,107,040,057}, Location = 015 }, // Qwilfish: Hunter Doken @ Pyrite Bldg
-        new(GameVersion.COLO, 16, 05000, First)     { Species = 307, Level = 33, Moves = new[] {197,347,093,136}, Location = 031 }, // Meditite: Rider Twan @ Pyrite Cave
-        new(GameVersion.COLO, 17, 05000, First)     { Species = 206, Level = 33, Moves = new[] {180,137,281,036}, Location = 029 }, // Dunsparce: Rider Sosh @ Pyrite Cave
-        new(GameVersion.COLO, 18, 05000, First)     { Species = 333, Level = 33, Moves = new[] {119,047,219,019}, Location = 032 }, // Swablu: Hunter Zalo @ Pyrite Cave
-        new(GameVersion.COLO, 19, 10000, First)     { Species = 185, Level = 35, Moves = new[] {175,335,067,157}, Location = 104 }, // Sudowoodo: Cipher Admin Miror B. @ Realgam Tower
-        new(GameVersion.COLO, 19, 10000, First)     { Species = 185, Level = 35, Moves = new[] {175,335,067,157}, Location = 125 }, // Sudowoodo: Cipher Admin Miror B. @ Deep Colosseum
-        new(GameVersion.COLO, 19, 10000, First)     { Species = 185, Level = 35, Moves = new[] {175,335,067,157}, Location = 030 }, // Sudowoodo: Cipher Admin Miror B. @ Pyrite Cave
-        new(GameVersion.COLO, 20, 06000, First)     { Species = 237, Level = 38, Moves = new[] {097,116,167,229}, Location = 039 }, // Hitmontop: Cipher Peon Skrub @ Agate Village
-        new(GameVersion.COLO, 20, 06000, First)     { Species = 237, Level = 38, Moves = new[] {097,116,167,229}, Location = 132 }, // Hitmontop: Cipher Peon Skrub @ Snagem Hideout
-        new(GameVersion.COLO, 20, 06000, First)     { Species = 237, Level = 38, Moves = new[] {097,116,167,229}, Location = 068 }, // Hitmontop: Cipher Peon Skrub @ Shadow PKMN Lab
-        new(GameVersion.COLO, 21, 13000, First)     { Species = 244, Level = 40, Moves = new[] {241,043,044,126}, Location = 106 }, // Entei: Cipher Admin Dakim @ Realgam Tower
-        new(GameVersion.COLO, 21, 13000, First)     { Species = 244, Level = 40, Moves = new[] {241,043,044,126}, Location = 125 }, // Entei: Cipher Admin Dakim @ Deep Colosseum
-        new(GameVersion.COLO, 21, 13000, First)     { Species = 244, Level = 40, Moves = new[] {241,043,044,126}, Location = 076 }, // Entei: Cipher Admin Dakim @ Mt. Battle
-        new(GameVersion.COLO, 22, 06000, First)     { Species = 166, Level = 40, Moves = new[] {226,219,048,004}, Location = 047 }, // Ledian: Cipher Peon Kloak @ The Under
-        new(GameVersion.COLO, 22, 06000, First)     { Species = 166, Level = 40, Moves = new[] {226,219,048,004}, Location = 132 }, // Ledian: Cipher Peon Kloak @ Snagem Hideout
-        new(GameVersion.COLO, 23, 13000, First)     { Species = 245, Level = 40, Moves = new[] {240,043,016,057}, Location = 110 }, // Suicune (Surf): Cipher Admin Venus @ Realgam Tower
-        new(GameVersion.COLO, 23, 13000, First)     { Species = 245, Level = 40, Moves = new[] {240,043,016,056}, Location = 125 }, // Suicune (Hydro Pump): Cipher Admin Venus @ Deep Colosseum
-        new(GameVersion.COLO, 23, 13000, First)     { Species = 245, Level = 40, Moves = new[] {240,043,016,057}, Location = 055 }, // Suicune (Surf): Cipher Admin Venus @ The Under
-        new(GameVersion.COLO, 24, 06000, Gligar)    { Species = 207, Level = 43, Moves = new[] {185,028,040,163}, Location = 058 }, // Gligar: Hunter Frena @ The Under Subway
-        new(GameVersion.COLO, 24, 06000, Gligar)    { Species = 207, Level = 43, Moves = new[] {185,028,040,163}, Location = 133 }, // Gligar: Hunter Frena @ Snagem Hideout
-        new(GameVersion.COLO, 25, 06000, First)     { Species = 234, Level = 43, Moves = new[] {310,095,043,036}, Location = 058 }, // Stantler: Chaser Liaks @ The Under Subway
-        new(GameVersion.COLO, 25, 06000, First)     { Species = 234, Level = 43, Moves = new[] {310,095,043,036}, Location = 133 }, // Stantler: Chaser Liaks @ Snagem Hideout
-        new(GameVersion.COLO, 25, 06000, First)     { Species = 221, Level = 43, Moves = new[] {203,316,091,059}, Location = 058 }, // Piloswine: Bodybuilder Lonia @ The Under Subway
-        new(GameVersion.COLO, 26, 06000, First)     { Species = 221, Level = 43, Moves = new[] {203,316,091,059}, Location = 134 }, // Piloswine: Bodybuilder Lonia @ Snagem Hideout
-        new(GameVersion.COLO, 27, 06000, First)     { Species = 215, Level = 43, Moves = new[] {185,103,154,196}, Location = 058 }, // Sneasel: Rider Nelis @ The Under Subway
-        new(GameVersion.COLO, 27, 06000, First)     { Species = 215, Level = 43, Moves = new[] {185,103,154,196}, Location = 134 }, // Sneasel: Rider Nelis @ Snagem Hideout
-        new(GameVersion.COLO, 28, 06000, First)     { Species = 190, Level = 43, Moves = new[] {226,321,154,129}, Location = 067 }, // Aipom: Cipher Peon Cole @ Shadow PKMN Lab
-        new(GameVersion.COLO, 29, 06000, Murkrow)   { Species = 198, Level = 43, Moves = new[] {185,212,101,019}, Location = 067 }, // Murkrow: Cipher Peon Lare @ Shadow PKMN Lab
-        new(GameVersion.COLO, 30, 06000, First)     { Species = 205, Level = 43, Moves = new[] {153,182,117,229}, Location = 067 }, // Forretress: Cipher Peon Vana @ Shadow PKMN Lab
-        new(GameVersion.COLO, 31, 06000, First)     { Species = 210, Level = 43, Moves = new[] {044,184,046,070}, Location = 069 }, // Granbull: Cipher Peon Tanie @ Shadow PKMN Lab
-        new(GameVersion.COLO, 32, 06000, First)     { Species = 329, Level = 43, Moves = new[] {242,103,328,225}, Location = 068 }, // Vibrava: Cipher Peon Remil @ Shadow PKMN Lab
-        new(GameVersion.COLO, 33, 06000, First)     { Species = 168, Level = 43, Moves = new[] {169,184,141,188}, Location = 069 }, // Ariados: Cipher Peon Lesar @ Shadow PKMN Lab
+        new(GameVersion.COLO, 02, 03000, First)     { Species = 153, Level = 30, Moves = new(241,235,075,034), Location = 003  }, // Bayleef: Cipher Peon Verde @ Phenac City
+        new(GameVersion.COLO, 02, 03000, First)     { Species = 153, Level = 30, Moves = new(241,235,075,034), Location = 069  }, // Bayleef: Cipher Peon Verde @ Shadow PKMN Lab
+        new(GameVersion.COLO, 02, 03000, First)     { Species = 153, Level = 30, Moves = new(241,235,075,034), Location = 115  }, // Bayleef: Cipher Peon Verde @ Realgam Tower
+        new(GameVersion.COLO, 02, 03000, First)     { Species = 153, Level = 30, Moves = new(241,235,075,034), Location = 132  }, // Bayleef: Cipher Peon Verde @ Snagem Hideout
+        new(GameVersion.COLO, 03, 03000, First)     { Species = 156, Level = 30, Moves = new(241,108,091,172), Location = 003  }, // Quilava: Cipher Peon Rosso @ Phenac City
+        new(GameVersion.COLO, 03, 03000, First)     { Species = 156, Level = 30, Moves = new(241,108,091,172), Location = 069  }, // Quilava: Cipher Peon Rosso @ Shadow PKMN Lab
+        new(GameVersion.COLO, 03, 03000, First)     { Species = 156, Level = 30, Moves = new(241,108,091,172), Location = 115  }, // Quilava: Cipher Peon Rosso @ Realgam Tower
+        new(GameVersion.COLO, 03, 03000, First)     { Species = 156, Level = 30, Moves = new(241,108,091,172), Location = 132  }, // Quilava: Cipher Peon Rosso @ Snagem Hideout
+        new(GameVersion.COLO, 04, 03000, First)     { Species = 159, Level = 30, Moves = new(240,184,044,057), Location = 003  }, // Croconaw: Cipher Peon Bluno @ Phenac City
+        new(GameVersion.COLO, 04, 03000, First)     { Species = 159, Level = 30, Moves = new(240,184,044,057), Location = 069  }, // Croconaw: Cipher Peon Bluno @ Shadow PKMN Lab
+        new(GameVersion.COLO, 04, 03000, First)     { Species = 159, Level = 30, Moves = new(240,184,044,057), Location = 115  }, // Croconaw: Cipher Peon Bluno @ Realgam Tower
+        new(GameVersion.COLO, 04, 03000, First)     { Species = 159, Level = 30, Moves = new(240,184,044,057), Location = 132  }, // Croconaw: Cipher Peon Bluno @ Snagem Hideout
+        new(GameVersion.COLO, 05, 03000, First)     { Species = 164, Level = 30, Moves = new(211,095,115,019), Location = 015 }, // Noctowl: Rider Nover @ Pyrite Town
+        new(GameVersion.COLO, 06, 03000, First)     { Species = 180, Level = 30, Moves = new(085,086,178,084), Location = 015 }, // Flaaffy: St.Performer Diogo @ Pyrite Town
+        new(GameVersion.COLO, 07, 03000, First)     { Species = 188, Level = 30, Moves = new(235,079,178,072), Location = 015 }, // Skiploom: Rider Leba @ Pyrite Town
+        new(GameVersion.COLO, 08, 04000, First)     { Species = 195, Level = 30, Moves = new(341,133,021,057), Location = 015 }, // Quagsire: Bandana Guy Divel @ Pyrite Town
+        new(GameVersion.COLO, 09, 04000, First)     { Species = 200, Level = 30, Moves = new(060,109,212,247), Location = 015 }, // Misdreavus: Rider Vant @ Pyrite Town
+        new(GameVersion.COLO, 10, 05000, First)     { Species = 193, Level = 33, Moves = new(197,048,049,253), Location = 025  }, // Yanma: Cipher Peon Nore @ Pyrite Bldg
+        new(GameVersion.COLO, 10, 05000, First)     { Species = 193, Level = 33, Moves = new(197,048,049,253), Location = 132  }, // Yanma: Cipher Peon Nore @ Snagem Hideout
+        new(GameVersion.COLO, 11, 05000, First)     { Species = 162, Level = 33, Moves = new(231,270,098,070), Location = 015  }, // Furret: Rogue Cail @ Pyrite Town
+        new(GameVersion.COLO, 12, 04000, First)     { Species = 218, Level = 30, Moves = new(241,281,088,053), Location = 015  }, // Slugma: Roller Boy Lon @ Pyrite Town
+        new(GameVersion.COLO, 13, 04000, First)     { Species = 223, Level = 20, Moves = new(061,199,060,062), Location = 028 }, // Remoraid: Miror B.Peon Reath @ Pyrite Bldg
+        new(GameVersion.COLO, 13, 04000, First)     { Species = 223, Level = 20, Moves = new(061,199,060,062), Location = 030 }, // Remoraid: Miror B.Peon Reath @ Pyrite Cave
+        new(GameVersion.COLO, 14, 05000, First)     { Species = 226, Level = 33, Moves = new(017,048,061,036), Location = 028 }, // Mantine: Miror B.Peon Ferma @ Pyrite Bldg
+        new(GameVersion.COLO, 14, 05000, First)     { Species = 226, Level = 33, Moves = new(017,048,061,036), Location = 030 }, // Mantine: Miror B.Peon Ferma @ Pyrite Cave
+        new(GameVersion.COLO, 15, 05000, First)     { Species = 211, Level = 33, Moves = new(042,107,040,057), Location = 015 }, // Qwilfish: Hunter Doken @ Pyrite Bldg
+        new(GameVersion.COLO, 16, 05000, First)     { Species = 307, Level = 33, Moves = new(197,347,093,136), Location = 031 }, // Meditite: Rider Twan @ Pyrite Cave
+        new(GameVersion.COLO, 17, 05000, First)     { Species = 206, Level = 33, Moves = new(180,137,281,036), Location = 029 }, // Dunsparce: Rider Sosh @ Pyrite Cave
+        new(GameVersion.COLO, 18, 05000, First)     { Species = 333, Level = 33, Moves = new(119,047,219,019), Location = 032 }, // Swablu: Hunter Zalo @ Pyrite Cave
+        new(GameVersion.COLO, 19, 10000, First)     { Species = 185, Level = 35, Moves = new(175,335,067,157), Location = 104 }, // Sudowoodo: Cipher Admin Miror B. @ Realgam Tower
+        new(GameVersion.COLO, 19, 10000, First)     { Species = 185, Level = 35, Moves = new(175,335,067,157), Location = 125 }, // Sudowoodo: Cipher Admin Miror B. @ Deep Colosseum
+        new(GameVersion.COLO, 19, 10000, First)     { Species = 185, Level = 35, Moves = new(175,335,067,157), Location = 030 }, // Sudowoodo: Cipher Admin Miror B. @ Pyrite Cave
+        new(GameVersion.COLO, 20, 06000, First)     { Species = 237, Level = 38, Moves = new(097,116,167,229), Location = 039 }, // Hitmontop: Cipher Peon Skrub @ Agate Village
+        new(GameVersion.COLO, 20, 06000, First)     { Species = 237, Level = 38, Moves = new(097,116,167,229), Location = 132 }, // Hitmontop: Cipher Peon Skrub @ Snagem Hideout
+        new(GameVersion.COLO, 20, 06000, First)     { Species = 237, Level = 38, Moves = new(097,116,167,229), Location = 068 }, // Hitmontop: Cipher Peon Skrub @ Shadow PKMN Lab
+        new(GameVersion.COLO, 21, 13000, First)     { Species = 244, Level = 40, Moves = new(241,043,044,126), Location = 106 }, // Entei: Cipher Admin Dakim @ Realgam Tower
+        new(GameVersion.COLO, 21, 13000, First)     { Species = 244, Level = 40, Moves = new(241,043,044,126), Location = 125 }, // Entei: Cipher Admin Dakim @ Deep Colosseum
+        new(GameVersion.COLO, 21, 13000, First)     { Species = 244, Level = 40, Moves = new(241,043,044,126), Location = 076 }, // Entei: Cipher Admin Dakim @ Mt. Battle
+        new(GameVersion.COLO, 22, 06000, First)     { Species = 166, Level = 40, Moves = new(226,219,048,004), Location = 047 }, // Ledian: Cipher Peon Kloak @ The Under
+        new(GameVersion.COLO, 22, 06000, First)     { Species = 166, Level = 40, Moves = new(226,219,048,004), Location = 132 }, // Ledian: Cipher Peon Kloak @ Snagem Hideout
+        new(GameVersion.COLO, 23, 13000, First)     { Species = 245, Level = 40, Moves = new(240,043,016,057), Location = 110 }, // Suicune (Surf): Cipher Admin Venus @ Realgam Tower
+        new(GameVersion.COLO, 23, 13000, First)     { Species = 245, Level = 40, Moves = new(240,043,016,056), Location = 125 }, // Suicune (Hydro Pump): Cipher Admin Venus @ Deep Colosseum
+        new(GameVersion.COLO, 23, 13000, First)     { Species = 245, Level = 40, Moves = new(240,043,016,057), Location = 055 }, // Suicune (Surf): Cipher Admin Venus @ The Under
+        new(GameVersion.COLO, 24, 06000, Gligar)    { Species = 207, Level = 43, Moves = new(185,028,040,163), Location = 058 }, // Gligar: Hunter Frena @ The Under Subway
+        new(GameVersion.COLO, 24, 06000, Gligar)    { Species = 207, Level = 43, Moves = new(185,028,040,163), Location = 133 }, // Gligar: Hunter Frena @ Snagem Hideout
+        new(GameVersion.COLO, 25, 06000, First)     { Species = 234, Level = 43, Moves = new(310,095,043,036), Location = 058 }, // Stantler: Chaser Liaks @ The Under Subway
+        new(GameVersion.COLO, 25, 06000, First)     { Species = 234, Level = 43, Moves = new(310,095,043,036), Location = 133 }, // Stantler: Chaser Liaks @ Snagem Hideout
+        new(GameVersion.COLO, 25, 06000, First)     { Species = 221, Level = 43, Moves = new(203,316,091,059), Location = 058 }, // Piloswine: Bodybuilder Lonia @ The Under Subway
+        new(GameVersion.COLO, 26, 06000, First)     { Species = 221, Level = 43, Moves = new(203,316,091,059), Location = 134 }, // Piloswine: Bodybuilder Lonia @ Snagem Hideout
+        new(GameVersion.COLO, 27, 06000, First)     { Species = 215, Level = 43, Moves = new(185,103,154,196), Location = 058 }, // Sneasel: Rider Nelis @ The Under Subway
+        new(GameVersion.COLO, 27, 06000, First)     { Species = 215, Level = 43, Moves = new(185,103,154,196), Location = 134 }, // Sneasel: Rider Nelis @ Snagem Hideout
+        new(GameVersion.COLO, 28, 06000, First)     { Species = 190, Level = 43, Moves = new(226,321,154,129), Location = 067 }, // Aipom: Cipher Peon Cole @ Shadow PKMN Lab
+        new(GameVersion.COLO, 29, 06000, Murkrow)   { Species = 198, Level = 43, Moves = new(185,212,101,019), Location = 067 }, // Murkrow: Cipher Peon Lare @ Shadow PKMN Lab
+        new(GameVersion.COLO, 30, 06000, First)     { Species = 205, Level = 43, Moves = new(153,182,117,229), Location = 067 }, // Forretress: Cipher Peon Vana @ Shadow PKMN Lab
+        new(GameVersion.COLO, 31, 06000, First)     { Species = 210, Level = 43, Moves = new(044,184,046,070), Location = 069 }, // Granbull: Cipher Peon Tanie @ Shadow PKMN Lab
+        new(GameVersion.COLO, 32, 06000, First)     { Species = 329, Level = 43, Moves = new(242,103,328,225), Location = 068 }, // Vibrava: Cipher Peon Remil @ Shadow PKMN Lab
+        new(GameVersion.COLO, 33, 06000, First)     { Species = 168, Level = 43, Moves = new(169,184,141,188), Location = 069 }, // Ariados: Cipher Peon Lesar @ Shadow PKMN Lab
 
-        new(GameVersion.COLO, 34, 13000, First)     { Species = 243, Level = 40, Moves = new[] {240,043,098,087}, Location = 113 }, // Raikou: Cipher Admin Ein @ Realgam Tower
-        new(GameVersion.COLO, 34, 13000, First)     { Species = 243, Level = 40, Moves = new[] {240,043,098,087}, Location = 125 }, // Raikou: Cipher Admin Ein @ Deep Colosseum
-        new(GameVersion.COLO, 34, 13000, First)     { Species = 243, Level = 40, Moves = new[] {240,043,098,087}, Location = 069 }, // Raikou: Cipher Admin Ein @ Shadow PKMN Lab
+        new(GameVersion.COLO, 34, 13000, First)     { Species = 243, Level = 40, Moves = new(240,043,098,087), Location = 113 }, // Raikou: Cipher Admin Ein @ Realgam Tower
+        new(GameVersion.COLO, 34, 13000, First)     { Species = 243, Level = 40, Moves = new(240,043,098,087), Location = 125 }, // Raikou: Cipher Admin Ein @ Deep Colosseum
+        new(GameVersion.COLO, 34, 13000, First)     { Species = 243, Level = 40, Moves = new(240,043,098,087), Location = 069 }, // Raikou: Cipher Admin Ein @ Shadow PKMN Lab
 
-        new(GameVersion.COLO, 35, 07000, First)     { Species = 192, Level = 45, Moves = new[] {241,074,275,076}, Location = 109 }, // Sunflora: Cipher Peon Baila @ Realgam Tower
-        new(GameVersion.COLO, 35, 07000, First)     { Species = 192, Level = 45, Moves = new[] {241,074,275,076}, Location = 132 }, // Sunflora: Cipher Peon Baila @ Snagem Hideout
-        new(GameVersion.COLO, 36, 07000, First)     { Species = 225, Level = 45, Moves = new[] {059,213,217,019}, Location = 109 }, // Delibird: Cipher Peon Arton @ Realgam Tower
-        new(GameVersion.COLO, 36, 07000, First)     { Species = 225, Level = 45, Moves = new[] {059,213,217,019}, Location = 132 }, // Delibird: Cipher Peon Arton @ Snagem Hideout
-        new(GameVersion.COLO, 37, 07000, Heracross) { Species = 214, Level = 45, Moves = new[] {179,203,068,280}, Location = 111 }, // Heracross: Cipher Peon Dioge @ Realgam Tower
-        new(GameVersion.COLO, 37, 07000, Heracross) { Species = 214, Level = 45, Moves = new[] {179,203,068,280}, Location = 132 }, // Heracross: Cipher Peon Dioge @ Snagem Hideout
-        new(GameVersion.COLO, 38, 13000, First)     { Species = 227, Level = 47, Moves = new[] {065,319,314,211}, Location = 117 }, // Skarmory: Snagem Head Gonzap @ Realgam Tower
-        new(GameVersion.COLO, 38, 13000, First)     { Species = 227, Level = 47, Moves = new[] {065,319,314,211}, Location = 133 }, // Skarmory: Snagem Head Gonzap @ Snagem Hideout
+        new(GameVersion.COLO, 35, 07000, First)     { Species = 192, Level = 45, Moves = new(241,074,275,076), Location = 109 }, // Sunflora: Cipher Peon Baila @ Realgam Tower
+        new(GameVersion.COLO, 35, 07000, First)     { Species = 192, Level = 45, Moves = new(241,074,275,076), Location = 132 }, // Sunflora: Cipher Peon Baila @ Snagem Hideout
+        new(GameVersion.COLO, 36, 07000, First)     { Species = 225, Level = 45, Moves = new(059,213,217,019), Location = 109 }, // Delibird: Cipher Peon Arton @ Realgam Tower
+        new(GameVersion.COLO, 36, 07000, First)     { Species = 225, Level = 45, Moves = new(059,213,217,019), Location = 132 }, // Delibird: Cipher Peon Arton @ Snagem Hideout
+        new(GameVersion.COLO, 37, 07000, Heracross) { Species = 214, Level = 45, Moves = new(179,203,068,280), Location = 111 }, // Heracross: Cipher Peon Dioge @ Realgam Tower
+        new(GameVersion.COLO, 37, 07000, Heracross) { Species = 214, Level = 45, Moves = new(179,203,068,280), Location = 132 }, // Heracross: Cipher Peon Dioge @ Snagem Hideout
+        new(GameVersion.COLO, 38, 13000, First)     { Species = 227, Level = 47, Moves = new(065,319,314,211), Location = 117 }, // Skarmory: Snagem Head Gonzap @ Realgam Tower
+        new(GameVersion.COLO, 38, 13000, First)     { Species = 227, Level = 47, Moves = new(065,319,314,211), Location = 133 }, // Skarmory: Snagem Head Gonzap @ Snagem Hideout
 
-        new(GameVersion.COLO, 39, 07000, First)     { Species = 241, Level = 48, Moves = new[] {208,111,205,034}, Location = 118 }, // Miltank: Bodybuilder Jomas @ Tower Colosseum
-        new(GameVersion.COLO, 40, 07000, First)     { Species = 359, Level = 48, Moves = new[] {195,014,163,185}, Location = 118 }, // Absol: Rider Delan @ Tower Colosseum
-        new(GameVersion.COLO, 41, 07000, First)     { Species = 229, Level = 48, Moves = new[] {185,336,123,053}, Location = 118 }, // Houndoom: Cipher Peon Nella @ Tower Colosseum
-        new(GameVersion.COLO, 42, 07000, First)     { Species = 357, Level = 49, Moves = new[] {076,235,345,019}, Location = 118 }, // Tropius: Cipher Peon Ston @ Tower Colosseum
-        new(GameVersion.COLO, 43, 15000, First)     { Species = 376, Level = 50, Moves = new[] {063,334,232,094}, Location = 118 }, // Metagross: Cipher Nascour @ Tower Colosseum
-        new(GameVersion.COLO, 44, 20000, First)     { Species = 248, Level = 55, Moves = new[] {242,087,157,059}, Location = 118 }, // Tyranitar: Cipher Head Evice @ Tower Colosseum
+        new(GameVersion.COLO, 39, 07000, First)     { Species = 241, Level = 48, Moves = new(208,111,205,034), Location = 118 }, // Miltank: Bodybuilder Jomas @ Tower Colosseum
+        new(GameVersion.COLO, 40, 07000, First)     { Species = 359, Level = 48, Moves = new(195,014,163,185), Location = 118 }, // Absol: Rider Delan @ Tower Colosseum
+        new(GameVersion.COLO, 41, 07000, First)     { Species = 229, Level = 48, Moves = new(185,336,123,053), Location = 118 }, // Houndoom: Cipher Peon Nella @ Tower Colosseum
+        new(GameVersion.COLO, 42, 07000, First)     { Species = 357, Level = 49, Moves = new(076,235,345,019), Location = 118 }, // Tropius: Cipher Peon Ston @ Tower Colosseum
+        new(GameVersion.COLO, 43, 15000, First)     { Species = 376, Level = 50, Moves = new(063,334,232,094), Location = 118 }, // Metagross: Cipher Nascour @ Tower Colosseum
+        new(GameVersion.COLO, 44, 20000, First)     { Species = 248, Level = 55, Moves = new(242,087,157,059), Location = 118 }, // Tyranitar: Cipher Head Evice @ Tower Colosseum
 
-        new(GameVersion.COLO, 55, 07000, First)     { Species = 235, Level = 45, Moves = new[] {166,039,003,231}, Location = 132 }, // Smeargle: Team Snagem Biden @ Snagem Hideout
-        new(GameVersion.COLO, 56, 07000, Ursaring)  { Species = 217, Level = 45, Moves = new[] {185,313,122,163}, Location = 132 }, // Ursaring: Team Snagem Agrev @ Snagem Hideout
-        new(GameVersion.COLO, 57, 07000, First)     { Species = 213, Level = 45, Moves = new[] {219,227,156,117}, Location = 125 }, // Shuckle: Deep King Agnol @ Deep Colosseum
+        new(GameVersion.COLO, 55, 07000, First)     { Species = 235, Level = 45, Moves = new(166,039,003,231), Location = 132 }, // Smeargle: Team Snagem Biden @ Snagem Hideout
+        new(GameVersion.COLO, 56, 07000, Ursaring)  { Species = 217, Level = 45, Moves = new(185,313,122,163), Location = 132 }, // Ursaring: Team Snagem Agrev @ Snagem Hideout
+        new(GameVersion.COLO, 57, 07000, First)     { Species = 213, Level = 45, Moves = new(219,227,156,117), Location = 125 }, // Shuckle: Deep King Agnol @ Deep Colosseum
 
-        new(GameVersion.COLO, 67, 05000, First)     { Species = 176, Level = 20, Moves = new[] {118,204,186,281}, Location = 001 }, // Togetic: Cipher Peon Fein @ Outskirt Stand
+        new(GameVersion.COLO, 67, 05000, First)     { Species = 176, Level = 20, Moves = new(118,204,186,281), Location = 001 }, // Togetic: Cipher Peon Fein @ Outskirt Stand
 
-        new(GameVersion.COLO, 00, 00000, CTogepi)   { Species = 175, Level = 20, Moves = new[] {118,204,186,281}, Location = 128, IVs = EncounterStaticShadow.EReaderEmpty }, // Togepi: Chaser ボデス @ Card e Room (Japanese games only)
-        new(GameVersion.COLO, 00, 00000, CMareep)   { Species = 179, Level = 37, Moves = new[] {087,084,086,178}, Location = 128, IVs = EncounterStaticShadow.EReaderEmpty }, // Mareep: Hunter ホル @ Card e Room (Japanese games only)
-        new(GameVersion.COLO, 00, 00000, CScizor)   { Species = 212, Level = 50, Moves = new[] {210,232,014,163}, Location = 128, IVs = EncounterStaticShadow.EReaderEmpty }, // Scizor: Bodybuilder ワーバン @ Card e Room (Japanese games only)
+        new(GameVersion.COLO, 00, 00000, CTogepi)   { Species = 175, Level = 20, Moves = new(118,204,186,281), Location = 128, IVs = EncounterStaticShadow.EReaderEmpty }, // Togepi: Chaser ボデス @ Card e Room (Japanese games only)
+        new(GameVersion.COLO, 00, 00000, CMareep)   { Species = 179, Level = 37, Moves = new(087,084,086,178), Location = 128, IVs = EncounterStaticShadow.EReaderEmpty }, // Mareep: Hunter ホル @ Card e Room (Japanese games only)
+        new(GameVersion.COLO, 00, 00000, CScizor)   { Species = 212, Level = 50, Moves = new(210,232,014,163), Location = 128, IVs = EncounterStaticShadow.EReaderEmpty }, // Scizor: Bodybuilder ワーバン @ Card e Room (Japanese games only)
     };
     #endregion
 
@@ -111,104 +111,104 @@ internal static class Encounters3GC
 
     private static readonly EncounterStatic3[] Encounter_XDGift =
     {
-        new(133, 10, GameVersion.XD) { Fateful = true, Gift = true, Location = 000, Moves = new[] {044} }, // Eevee (Bite)
-        new(152, 05, GameVersion.XD) { Fateful = true, Gift = true, Location = 016, Moves = new[] {246,033,045,338} }, // Chikorita
-        new(155, 05, GameVersion.XD) { Fateful = true, Gift = true, Location = 016, Moves = new[] {179,033,043,307} }, // Cyndaquil
-        new(158, 05, GameVersion.XD) { Fateful = true, Gift = true, Location = 016, Moves = new[] {242,010,043,308} }, // Totodile
+        new(133, 10, GameVersion.XD) { Fateful = true, Gift = true, Location = 000, Moves = new(044) }, // Eevee (Bite)
+        new(152, 05, GameVersion.XD) { Fateful = true, Gift = true, Location = 016, Moves = new(246,033,045,338) }, // Chikorita
+        new(155, 05, GameVersion.XD) { Fateful = true, Gift = true, Location = 016, Moves = new(179,033,043,307) }, // Cyndaquil
+        new(158, 05, GameVersion.XD) { Fateful = true, Gift = true, Location = 016, Moves = new(242,010,043,308) }, // Totodile
     };
 
     private static readonly EncounterStaticShadow[] Encounter_XD =
     {
-        new(GameVersion.XD, 01, 03000, First)     { Fateful = true, Species = 216, Level = 11, Moves = new[] {216,287,122,232}, Location = 143, Gift = true }, // Teddiursa: Cipher Peon Naps @ Pokémon HQ Lab -- treat as Gift as it can only be captured in a Poké Ball
-        new(GameVersion.XD, 02, 02000, Vulpix)    { Fateful = true, Species = 037, Level = 18, Moves = new[] {257,204,052,091}, Location = 109 }, // Vulpix: Cipher Peon Mesin @ ONBS Building
-        new(GameVersion.XD, 03, 01500, Spheal)    { Fateful = true, Species = 363, Level = 17, Moves = new[] {062,204,055,189}, Location = 011 }, // Spheal: Cipher Peon Blusix @ Cipher Lab
-        new(GameVersion.XD, 03, 01500, Spheal)    { Fateful = true, Species = 363, Level = 17, Moves = new[] {062,204,055,189}, Location = 100 }, // Spheal: Cipher Peon Blusix  @ Phenac City
-        new(GameVersion.XD, 04, 01500, First)     { Fateful = true, Species = 343, Level = 17, Moves = new[] {317,287,189,060}, Location = 011 }, // Baltoy: Cipher Peon Browsix @ Cipher Lab
-        new(GameVersion.XD, 04, 01500, First)     { Fateful = true, Species = 343, Level = 17, Moves = new[] {317,287,189,060}, Location = 096 }, // Baltoy: Cipher Peon Browsix  @ Phenac City
-        new(GameVersion.XD, 05, 01500, First)     { Fateful = true, Species = 179, Level = 17, Moves = new[] {034,215,084,086}, Location = 011 }, // Mareep: Cipher Peon Yellosix @ Cipher Lab
-        new(GameVersion.XD, 05, 01500, First)     { Fateful = true, Species = 179, Level = 17, Moves = new[] {034,215,084,086}, Location = 096 }, // Mareep: Cipher Peon Yellosix @ Phenac City
-        new(GameVersion.XD, 06, 01500, Gulpin)    { Fateful = true, Species = 316, Level = 17, Moves = new[] {351,047,124,092}, Location = 011 }, // Gulpin: Cipher Peon Purpsix @ Cipher Lab
-        new(GameVersion.XD, 06, 01500, Gulpin)    { Fateful = true, Species = 316, Level = 17, Moves = new[] {351,047,124,092}, Location = 100 }, // Gulpin: Cipher Peon Purpsix @ Phenac City
-        new(GameVersion.XD, 07, 01500, Seedot)    { Fateful = true, Species = 273, Level = 17, Moves = new[] {202,287,331,290}, Location = 011 }, // Seedot: Cipher Peon Greesix @ Cipher Lab
-        new(GameVersion.XD, 07, 01500, Seedot)    { Fateful = true, Species = 273, Level = 17, Moves = new[] {202,287,331,290}, Location = 100 }, // Seedot: Cipher Peon Greesix @ Phenac City
-        new(GameVersion.XD, 08, 01500, Spinarak)  { Fateful = true, Species = 167, Level = 14, Moves = new[] {091,287,324,101}, Location = 010 }, // Spinarak: Cipher Peon Nexir @ Cipher Lab
-        new(GameVersion.XD, 09, 01500, Numel)     { Fateful = true, Species = 322, Level = 14, Moves = new[] {036,204,091,052}, Location = 009 }, // Numel: Cipher Peon Solox @ Cipher Lab
-        new(GameVersion.XD, 10, 01700, First)     { Fateful = true, Species = 318, Level = 15, Moves = new[] {352,287,184,044}, Location = 008 }, // Carvanha: Cipher Peon Cabol @ Cipher Lab
-        new(GameVersion.XD, 11, 03000, Roselia)   { Fateful = true, Species = 315, Level = 22, Moves = new[] {345,186,320,073}, Location = 094 }, // Roselia: Cipher Peon Fasin @ Phenac City
-        new(GameVersion.XD, 12, 02500, Delcatty)  { Fateful = true, Species = 301, Level = 18, Moves = new[] {290,186,213,351}, Location = 008 }, // Delcatty: Cipher Admin Lovrina @ Cipher Lab
-        new(GameVersion.XD, 13, 04000, Nosepass)  { Fateful = true, Species = 299, Level = 26, Moves = new[] {085,270,086,157}, Location = 090 }, // Nosepass: Wanderer Miror B. @ Poké Spots
-        new(GameVersion.XD, 14, 01500, First)     { Fateful = true, Species = 228, Level = 17, Moves = new[] {185,204,052,046}, Location = 100 }, // Houndour: Cipher Peon Resix  @ Phenac City
-        new(GameVersion.XD, 14, 01500, First)     { Fateful = true, Species = 228, Level = 17, Moves = new[] {185,204,052,046}, Location = 011 }, // Houndour: Cipher Peon Resix @ Cipher Lab
-        new(GameVersion.XD, 15, 02000, Makuhita)  { Fateful = true, Species = 296, Level = 18, Moves = new[] {280,287,292,317}, Location = 109 }, // Makuhita: Cipher Peon Torkin @ ONBS Building
-        new(GameVersion.XD, 16, 02200, Duskull)   { Fateful = true, Species = 355, Level = 19, Moves = new[] {247,270,310,109}, Location = 110 }, // Duskull: Cipher Peon Lobar @ ONBS Building
-        new(GameVersion.XD, 17, 02200, Ralts)     { Fateful = true, Species = 280, Level = 20, Moves = new[] {351,047,115,093}, Location = 119 }, // Ralts: Cipher Peon Feldas @ ONBS Building
-        new(GameVersion.XD, 18, 02500, Mawile)    { Fateful = true, Species = 303, Level = 22, Moves = new[] {206,047,011,334}, Location = 111 }, // Mawile: Cipher Cmdr Exol @ ONBS Building
-        new(GameVersion.XD, 19, 02500, Snorunt)   { Fateful = true, Species = 361, Level = 20, Moves = new[] {352,047,044,196}, Location = 097 }, // Snorunt: Cipher Peon Exinn @ Phenac City
-        new(GameVersion.XD, 20, 02500, Pineco)    { Fateful = true, Species = 204, Level = 20, Moves = new[] {042,287,191,068}, Location = 096 }, // Pineco: Cipher Peon Gonrap @ Phenac City
-        new(GameVersion.XD, 21, 02500, Swinub)    { Fateful = true, Species = 220, Level = 22, Moves = new[] {246,204,054,341}, Location = 100 }, // Swinub: Cipher Peon Greck @ Phenac City
-        new(GameVersion.XD, 22, 02500, Natu)      { Fateful = true, Species = 177, Level = 22, Moves = new[] {248,226,101,332}, Location = 094 }, // Natu: Cipher Peon Eloin @ Phenac City
-        new(GameVersion.XD, 23, 01800, Shroomish) { Fateful = true, Species = 285, Level = 15, Moves = new[] {206,287,072,078}, Location = 008 }, // Shroomish: Cipher R&D Klots @ Cipher Lab
-        new(GameVersion.XD, 24, 03500, Meowth)    { Fateful = true, Species = 052, Level = 22, Moves = new[] {163,047,006,044}, Location = 094 }, // Meowth: Cipher Peon Fostin @ Phenac City
-        new(GameVersion.XD, 25, 04500, Spearow)   { Fateful = true, Species = 021, Level = 22, Moves = new[] {206,226,043,332}, Location = 107 }, // Spearow: Cipher Peon Ezin @ Phenac Stadium
-        new(GameVersion.XD, 26, 03000, Grimer)    { Fateful = true, Species = 088, Level = 23, Moves = new[] {188,270,325,107}, Location = 107 }, // Grimer: Cipher Peon Faltly @ Phenac Stadium
-        new(GameVersion.XD, 27, 03500, Seel)      { Fateful = true, Species = 086, Level = 23, Moves = new[] {057,270,219,058}, Location = 107 }, // Seel: Cipher Peon Egrog @ Phenac Stadium
-        new(GameVersion.XD, 28, 05000, Lunatone)  { Fateful = true, Species = 337, Level = 25, Moves = new[] {094,226,240,317}, Location = 107 }, // Lunatone: Cipher Admin Snattle @ Phenac Stadium
-        new(GameVersion.XD, 29, 02500, Voltorb)   { Fateful = true, Species = 100, Level = 19, Moves = new[] {243,287,209,129}, Location = 092 }, // Voltorb: Wanderer Miror B. @ Cave Poké Spot
-        new(GameVersion.XD, 30, 05000, First)     { Fateful = true, Species = 335, Level = 28, Moves = new[] {280,287,068,306}, Location = 071 }, // Zangoose: Thug Zook @ Cipher Key Lair
-        new(GameVersion.XD, 31, 04000, Growlithe) { Fateful = true, Species = 058, Level = 28, Moves = new[] {053,204,044,036}, Location = 064 }, // Growlithe: Cipher Peon Humah @ Cipher Key Lair
-        new(GameVersion.XD, 32, 04000, Paras)     { Fateful = true, Species = 046, Level = 28, Moves = new[] {147,287,163,206}, Location = 064 }, // Paras: Cipher Peon Humah @ Cipher Key Lair
-        new(GameVersion.XD, 33, 04000, First)     { Fateful = true, Species = 090, Level = 29, Moves = new[] {036,287,057,062}, Location = 065 }, // Shellder: Cipher Peon Gorog @ Cipher Key Lair
-        new(GameVersion.XD, 34, 04500, First)     { Fateful = true, Species = 015, Level = 30, Moves = new[] {188,226,041,014}, Location = 066 }, // Beedrill: Cipher Peon Lok @ Cipher Key Lair
-        new(GameVersion.XD, 35, 04000, Pidgeotto) { Fateful = true, Species = 017, Level = 30, Moves = new[] {017,287,211,297}, Location = 066 }, // Pidgeotto: Cipher Peon Lok @ Cipher Key Lair
-        new(GameVersion.XD, 36, 04000, Butterfree){ Fateful = true, Species = 012, Level = 30, Moves = new[] {094,234,079,332}, Location = 067 }, // Butterfree: Cipher Peon Targ @ Cipher Key Lair
-        new(GameVersion.XD, 37, 04000, Tangela)   { Fateful = true, Species = 114, Level = 30, Moves = new[] {076,234,241,275}, Location = 067 }, // Tangela: Cipher Peon Targ @ Cipher Key Lair
-        new(GameVersion.XD, 38, 06000, Raticate)  { Fateful = true, Species = 020, Level = 34, Moves = new[] {162,287,184,158}, Location = 076 }, // Raticate: Chaser Furgy @ Citadark Isle
-        new(GameVersion.XD, 39, 04000, Venomoth)  { Fateful = true, Species = 049, Level = 32, Moves = new[] {318,287,164,094}, Location = 070 }, // Venomoth: Cipher Peon Angic @ Cipher Key Lair
-        new(GameVersion.XD, 40, 04000, Weepinbell){ Fateful = true, Species = 070, Level = 32, Moves = new[] {345,234,188,230}, Location = 070 }, // Weepinbell: Cipher Peon Angic @ Cipher Key Lair
-        new(GameVersion.XD, 41, 05000, Arbok)     { Fateful = true, Species = 024, Level = 33, Moves = new[] {188,287,137,044}, Location = 070 }, // Arbok: Cipher Peon Smarton @ Cipher Key Lair
-        new(GameVersion.XD, 42, 06000, Primeape)  { Fateful = true, Species = 057, Level = 34, Moves = new[] {238,270,116,179}, Location = 069 }, // Primeape: Cipher Admin Gorigan @ Cipher Key Lair
-        new(GameVersion.XD, 43, 05500, Hypno)     { Fateful = true, Species = 097, Level = 34, Moves = new[] {094,226,096,247}, Location = 069 }, // Hypno: Cipher Admin Gorigan @ Cipher Key Lair
-        new(GameVersion.XD, 44, 06500, Golduck)   { Fateful = true, Species = 055, Level = 33, Moves = new[] {127,204,244,280}, Location = 088 }, // Golduck: Navigator Abson @ Citadark Isle
-        new(GameVersion.XD, 45, 07000, Sableye)   { Fateful = true, Species = 302, Level = 33, Moves = new[] {247,270,185,105}, Location = 088 }, // Sableye: Navigator Abson @ Citadark Isle
-        new(GameVersion.XD, 46, 04500, Magneton)  { Fateful = true, Species = 082, Level = 30, Moves = new[] {038,287,240,087}, Location = 067 }, // Magneton: Cipher Peon Snidle @ Cipher Key Lair
-        new(GameVersion.XD, 47, 08000, Dodrio)    { Fateful = true, Species = 085, Level = 34, Moves = new[] {065,226,097,161}, Location = 076 }, // Dodrio: Chaser Furgy @ Citadark Isle
-        new(GameVersion.XD, 48, 05500, Farfetchd) { Fateful = true, Species = 083, Level = 36, Moves = new[] {163,226,014,332}, Location = 076 }, // Farfetch'd: Cipher Admin Lovrina @ Citadark Isle
-        new(GameVersion.XD, 49, 06500, Altaria)   { Fateful = true, Species = 334, Level = 36, Moves = new[] {225,215,076,332}, Location = 076 }, // Altaria: Cipher Admin Lovrina @ Citadark Isle
-        new(GameVersion.XD, 50, 06000, Kangaskhan){ Fateful = true, Species = 115, Level = 35, Moves = new[] {089,047,039,146}, Location = 085 }, // Kangaskhan: Cipher Peon Litnar @ Citadark Isle
-        new(GameVersion.XD, 51, 07000, Banette)   { Fateful = true, Species = 354, Level = 37, Moves = new[] {185,270,247,174}, Location = 085 }, // Banette: Cipher Peon Litnar @ Citadark Isle
-        new(GameVersion.XD, 52, 07000, Magmar)    { Fateful = true, Species = 126, Level = 36, Moves = new[] {126,266,238,009}, Location = 077 }, // Magmar: Cipher Peon Grupel @ Citadark Isle
-        new(GameVersion.XD, 53, 07000, Pinsir)    { Fateful = true, Species = 127, Level = 35, Moves = new[] {012,270,206,066}, Location = 077 }, // Pinsir: Cipher Peon Grupel @ Citadark Isle
-        new(GameVersion.XD, 54, 05500, Magcargo)  { Fateful = true, Species = 219, Level = 38, Moves = new[] {257,287,089,053}, Location = 080 }, // Magcargo: Cipher Peon Kolest @ Citadark Isle
-        new(GameVersion.XD, 55, 06000, Rapidash)  { Fateful = true, Species = 078, Level = 40, Moves = new[] {076,226,241,053}, Location = 080 }, // Rapidash: Cipher Peon Kolest @ Citadark Isle
-        new(GameVersion.XD, 56, 06000, Hitmonchan){ Fateful = true, Species = 107, Level = 38, Moves = new[] {005,270,170,327}, Location = 081 }, // Hitmonchan: Cipher Peon Karbon @ Citadark Isle
-        new(GameVersion.XD, 57, 07000, Hitmonlee) { Fateful = true, Species = 106, Level = 38, Moves = new[] {136,287,170,025}, Location = 081 }, // Hitmonlee: Cipher Peon Petro @ Citadark Isle
-        new(GameVersion.XD, 58, 05000, Lickitung) { Fateful = true, Species = 108, Level = 38, Moves = new[] {038,270,111,205}, Location = 084 }, // Lickitung: Cipher Peon Geftal @ Citadark Isle
-        new(GameVersion.XD, 59, 08000, Scyther)   { Fateful = true, Species = 123, Level = 40, Moves = new[] {013,234,318,163}, Location = 084 }, // Scyther: Cipher Peon Leden @ Citadark Isle
-        new(GameVersion.XD, 60, 04000, Chansey)   { Fateful = true, Species = 113, Level = 39, Moves = new[] {085,186,135,285}, Location = 084 }, // Chansey: Cipher Peon Leden @ Citadark Isle
-        new(GameVersion.XD, 60, 04000, Chansey)   { Fateful = true, Species = 113, Level = 39, Moves = new[] {085,186,135,285}, Location = 087 }, // Chansey: Cipher Peon Leden @ Citadark Isle
-        new(GameVersion.XD, 61, 07500, Solrock)   { Fateful = true, Species = 338, Level = 41, Moves = new[] {094,226,241,322}, Location = 087 }, // Solrock: Cipher Admin Snattle @ Citadark Isle
-        new(GameVersion.XD, 62, 07500, Starmie)   { Fateful = true, Species = 121, Level = 41, Moves = new[] {127,287,058,105}, Location = 087 }, // Starmie: Cipher Admin Snattle @ Citadark Isle
-        new(GameVersion.XD, 63, 07000, Electabuzz){ Fateful = true, Species = 125, Level = 43, Moves = new[] {238,266,086,085}, Location = 087 }, // Electabuzz: Cipher Admin Ardos @ Citadark Isle
-        new(GameVersion.XD, 64, 07000, First)     { Fateful = true, Species = 277, Level = 43, Moves = new[] {143,226,097,263}, Location = 087 }, // Swellow: Cipher Admin Ardos @ Citadark Isle
-        new(GameVersion.XD, 65, 09000, Snorlax)   { Fateful = true, Species = 143, Level = 43, Moves = new[] {090,287,174,034}, Location = 087 }, // Snorlax: Cipher Admin Ardos @ Citadark Isle
-        new(GameVersion.XD, 66, 07500, Poliwrath) { Fateful = true, Species = 062, Level = 42, Moves = new[] {056,270,240,280}, Location = 087 }, // Poliwrath: Cipher Admin Gorigan @ Citadark Isle
-        new(GameVersion.XD, 67, 06500, MrMime)    { Fateful = true, Species = 122, Level = 42, Moves = new[] {094,266,227,009}, Location = 087 }, // Mr. Mime: Cipher Admin Gorigan @ Citadark Isle
-        new(GameVersion.XD, 68, 05000, Dugtrio)   { Fateful = true, Species = 051, Level = 40, Moves = new[] {089,204,201,161}, Location = 075 }, // Dugtrio: Cipher Peon Kolax @ Citadark Isle
-        new(GameVersion.XD, 69, 07000, Manectric) { Fateful = true, Species = 310, Level = 44, Moves = new[] {087,287,240,044}, Location = 073 }, // Manectric: Cipher Admin Eldes @ Citadark Isle
-        new(GameVersion.XD, 70, 09000, Salamence) { Fateful = true, Species = 373, Level = 50, Moves = new[] {337,287,349,332}, Location = 073 }, // Salamence: Cipher Admin Eldes @ Citadark Isle
-        new(GameVersion.XD, 71, 06500, Marowak)   { Fateful = true, Species = 105, Level = 44, Moves = new[] {089,047,014,157}, Location = 073 }, // Marowak: Cipher Admin Eldes @ Citadark Isle
-        new(GameVersion.XD, 72, 06000, Lapras)    { Fateful = true, Species = 131, Level = 44, Moves = new[] {056,215,240,059}, Location = 073 }, // Lapras: Cipher Admin Eldes @ Citadark Isle
-        new(GameVersion.XD, 73, 12000, First)     { Fateful = true, Species = 249, Level = 50, Moves = new[] {354,297,089,056}, Location = 074 }, // Lugia: Grand Master Greevil @ Citadark Isle
-        new(GameVersion.XD, 74, 10000, Zapdos)    { Fateful = true, Species = 145, Level = 50, Moves = new[] {326,226,319,085}, Location = 074 }, // Zapdos: Grand Master Greevil @ Citadark Isle
-        new(GameVersion.XD, 75, 10000, Moltres)   { Fateful = true, Species = 146, Level = 50, Moves = new[] {326,234,261,053}, Location = 074 }, // Moltres: Grand Master Greevil @ Citadark Isle
-        new(GameVersion.XD, 76, 10000, Articuno)  { Fateful = true, Species = 144, Level = 50, Moves = new[] {326,215,114,058}, Location = 074 }, // Articuno: Grand Master Greevil @ Citadark Isle
-        new(GameVersion.XD, 77, 09000, Tauros)    { Fateful = true, Species = 128, Level = 46, Moves = new[] {089,287,039,034}, Location = 074 }, // Tauros: Grand Master Greevil @ Citadark Isle
-        new(GameVersion.XD, 78, 07000, First)     { Fateful = true, Species = 112, Level = 46, Moves = new[] {224,270,184,089}, Location = 074 }, // Rhydon: Grand Master Greevil @ Citadark Isle
-        new(GameVersion.XD, 79, 09000, Exeggutor) { Fateful = true, Species = 103, Level = 46, Moves = new[] {094,287,095,246}, Location = 074 }, // Exeggutor: Grand Master Greevil @ Citadark Isle
-        new(GameVersion.XD, 80, 09000, Dragonite) { Fateful = true, Species = 149, Level = 55, Moves = new[] {063,215,349,089}, Location = 162 }, // Dragonite: Wanderer Miror B. @ Gateon Port
-        new(GameVersion.XD, 81, 04500, First)     { Fateful = true, Species = 175, Level = 25, Moves = new[] {266,161,246,270}, Location = 164, Gift = true }, // Togepi: Pokémon Trainer Hordel @ Outskirt Stand
-        new(GameVersion.XD, 82, 02500, Poochyena) { Fateful = true, Species = 261, Level = 10, Moves = new[] {091,215,305,336}, Location = 162 }, // Poochyena: Bodybuilder Kilen @ Gateon Port
-        new(GameVersion.XD, 83, 02500, Ledyba)    { Fateful = true, Species = 165, Level = 10, Moves = new[] {060,287,332,048}, Location = 153 }, // Ledyba: Casual Guy Cyle @ Gateon Port
+        new(GameVersion.XD, 01, 03000, First)     { Fateful = true, Species = 216, Level = 11, Moves = new(216,287,122,232), Location = 143, Gift = true }, // Teddiursa: Cipher Peon Naps @ Pokémon HQ Lab -- treat as Gift as it can only be captured in a Poké Ball
+        new(GameVersion.XD, 02, 02000, Vulpix)    { Fateful = true, Species = 037, Level = 18, Moves = new(257,204,052,091), Location = 109 }, // Vulpix: Cipher Peon Mesin @ ONBS Building
+        new(GameVersion.XD, 03, 01500, Spheal)    { Fateful = true, Species = 363, Level = 17, Moves = new(062,204,055,189), Location = 011 }, // Spheal: Cipher Peon Blusix @ Cipher Lab
+        new(GameVersion.XD, 03, 01500, Spheal)    { Fateful = true, Species = 363, Level = 17, Moves = new(062,204,055,189), Location = 100 }, // Spheal: Cipher Peon Blusix  @ Phenac City
+        new(GameVersion.XD, 04, 01500, First)     { Fateful = true, Species = 343, Level = 17, Moves = new(317,287,189,060), Location = 011 }, // Baltoy: Cipher Peon Browsix @ Cipher Lab
+        new(GameVersion.XD, 04, 01500, First)     { Fateful = true, Species = 343, Level = 17, Moves = new(317,287,189,060), Location = 096 }, // Baltoy: Cipher Peon Browsix  @ Phenac City
+        new(GameVersion.XD, 05, 01500, First)     { Fateful = true, Species = 179, Level = 17, Moves = new(034,215,084,086), Location = 011 }, // Mareep: Cipher Peon Yellosix @ Cipher Lab
+        new(GameVersion.XD, 05, 01500, First)     { Fateful = true, Species = 179, Level = 17, Moves = new(034,215,084,086), Location = 096 }, // Mareep: Cipher Peon Yellosix @ Phenac City
+        new(GameVersion.XD, 06, 01500, Gulpin)    { Fateful = true, Species = 316, Level = 17, Moves = new(351,047,124,092), Location = 011 }, // Gulpin: Cipher Peon Purpsix @ Cipher Lab
+        new(GameVersion.XD, 06, 01500, Gulpin)    { Fateful = true, Species = 316, Level = 17, Moves = new(351,047,124,092), Location = 100 }, // Gulpin: Cipher Peon Purpsix @ Phenac City
+        new(GameVersion.XD, 07, 01500, Seedot)    { Fateful = true, Species = 273, Level = 17, Moves = new(202,287,331,290), Location = 011 }, // Seedot: Cipher Peon Greesix @ Cipher Lab
+        new(GameVersion.XD, 07, 01500, Seedot)    { Fateful = true, Species = 273, Level = 17, Moves = new(202,287,331,290), Location = 100 }, // Seedot: Cipher Peon Greesix @ Phenac City
+        new(GameVersion.XD, 08, 01500, Spinarak)  { Fateful = true, Species = 167, Level = 14, Moves = new(091,287,324,101), Location = 010 }, // Spinarak: Cipher Peon Nexir @ Cipher Lab
+        new(GameVersion.XD, 09, 01500, Numel)     { Fateful = true, Species = 322, Level = 14, Moves = new(036,204,091,052), Location = 009 }, // Numel: Cipher Peon Solox @ Cipher Lab
+        new(GameVersion.XD, 10, 01700, First)     { Fateful = true, Species = 318, Level = 15, Moves = new(352,287,184,044), Location = 008 }, // Carvanha: Cipher Peon Cabol @ Cipher Lab
+        new(GameVersion.XD, 11, 03000, Roselia)   { Fateful = true, Species = 315, Level = 22, Moves = new(345,186,320,073), Location = 094 }, // Roselia: Cipher Peon Fasin @ Phenac City
+        new(GameVersion.XD, 12, 02500, Delcatty)  { Fateful = true, Species = 301, Level = 18, Moves = new(290,186,213,351), Location = 008 }, // Delcatty: Cipher Admin Lovrina @ Cipher Lab
+        new(GameVersion.XD, 13, 04000, Nosepass)  { Fateful = true, Species = 299, Level = 26, Moves = new(085,270,086,157), Location = 090 }, // Nosepass: Wanderer Miror B. @ Poké Spots
+        new(GameVersion.XD, 14, 01500, First)     { Fateful = true, Species = 228, Level = 17, Moves = new(185,204,052,046), Location = 100 }, // Houndour: Cipher Peon Resix  @ Phenac City
+        new(GameVersion.XD, 14, 01500, First)     { Fateful = true, Species = 228, Level = 17, Moves = new(185,204,052,046), Location = 011 }, // Houndour: Cipher Peon Resix @ Cipher Lab
+        new(GameVersion.XD, 15, 02000, Makuhita)  { Fateful = true, Species = 296, Level = 18, Moves = new(280,287,292,317), Location = 109 }, // Makuhita: Cipher Peon Torkin @ ONBS Building
+        new(GameVersion.XD, 16, 02200, Duskull)   { Fateful = true, Species = 355, Level = 19, Moves = new(247,270,310,109), Location = 110 }, // Duskull: Cipher Peon Lobar @ ONBS Building
+        new(GameVersion.XD, 17, 02200, Ralts)     { Fateful = true, Species = 280, Level = 20, Moves = new(351,047,115,093), Location = 119 }, // Ralts: Cipher Peon Feldas @ ONBS Building
+        new(GameVersion.XD, 18, 02500, Mawile)    { Fateful = true, Species = 303, Level = 22, Moves = new(206,047,011,334), Location = 111 }, // Mawile: Cipher Cmdr Exol @ ONBS Building
+        new(GameVersion.XD, 19, 02500, Snorunt)   { Fateful = true, Species = 361, Level = 20, Moves = new(352,047,044,196), Location = 097 }, // Snorunt: Cipher Peon Exinn @ Phenac City
+        new(GameVersion.XD, 20, 02500, Pineco)    { Fateful = true, Species = 204, Level = 20, Moves = new(042,287,191,068), Location = 096 }, // Pineco: Cipher Peon Gonrap @ Phenac City
+        new(GameVersion.XD, 21, 02500, Swinub)    { Fateful = true, Species = 220, Level = 22, Moves = new(246,204,054,341), Location = 100 }, // Swinub: Cipher Peon Greck @ Phenac City
+        new(GameVersion.XD, 22, 02500, Natu)      { Fateful = true, Species = 177, Level = 22, Moves = new(248,226,101,332), Location = 094 }, // Natu: Cipher Peon Eloin @ Phenac City
+        new(GameVersion.XD, 23, 01800, Shroomish) { Fateful = true, Species = 285, Level = 15, Moves = new(206,287,072,078), Location = 008 }, // Shroomish: Cipher R&D Klots @ Cipher Lab
+        new(GameVersion.XD, 24, 03500, Meowth)    { Fateful = true, Species = 052, Level = 22, Moves = new(163,047,006,044), Location = 094 }, // Meowth: Cipher Peon Fostin @ Phenac City
+        new(GameVersion.XD, 25, 04500, Spearow)   { Fateful = true, Species = 021, Level = 22, Moves = new(206,226,043,332), Location = 107 }, // Spearow: Cipher Peon Ezin @ Phenac Stadium
+        new(GameVersion.XD, 26, 03000, Grimer)    { Fateful = true, Species = 088, Level = 23, Moves = new(188,270,325,107), Location = 107 }, // Grimer: Cipher Peon Faltly @ Phenac Stadium
+        new(GameVersion.XD, 27, 03500, Seel)      { Fateful = true, Species = 086, Level = 23, Moves = new(057,270,219,058), Location = 107 }, // Seel: Cipher Peon Egrog @ Phenac Stadium
+        new(GameVersion.XD, 28, 05000, Lunatone)  { Fateful = true, Species = 337, Level = 25, Moves = new(094,226,240,317), Location = 107 }, // Lunatone: Cipher Admin Snattle @ Phenac Stadium
+        new(GameVersion.XD, 29, 02500, Voltorb)   { Fateful = true, Species = 100, Level = 19, Moves = new(243,287,209,129), Location = 092 }, // Voltorb: Wanderer Miror B. @ Cave Poké Spot
+        new(GameVersion.XD, 30, 05000, First)     { Fateful = true, Species = 335, Level = 28, Moves = new(280,287,068,306), Location = 071 }, // Zangoose: Thug Zook @ Cipher Key Lair
+        new(GameVersion.XD, 31, 04000, Growlithe) { Fateful = true, Species = 058, Level = 28, Moves = new(053,204,044,036), Location = 064 }, // Growlithe: Cipher Peon Humah @ Cipher Key Lair
+        new(GameVersion.XD, 32, 04000, Paras)     { Fateful = true, Species = 046, Level = 28, Moves = new(147,287,163,206), Location = 064 }, // Paras: Cipher Peon Humah @ Cipher Key Lair
+        new(GameVersion.XD, 33, 04000, First)     { Fateful = true, Species = 090, Level = 29, Moves = new(036,287,057,062), Location = 065 }, // Shellder: Cipher Peon Gorog @ Cipher Key Lair
+        new(GameVersion.XD, 34, 04500, First)     { Fateful = true, Species = 015, Level = 30, Moves = new(188,226,041,014), Location = 066 }, // Beedrill: Cipher Peon Lok @ Cipher Key Lair
+        new(GameVersion.XD, 35, 04000, Pidgeotto) { Fateful = true, Species = 017, Level = 30, Moves = new(017,287,211,297), Location = 066 }, // Pidgeotto: Cipher Peon Lok @ Cipher Key Lair
+        new(GameVersion.XD, 36, 04000, Butterfree){ Fateful = true, Species = 012, Level = 30, Moves = new(094,234,079,332), Location = 067 }, // Butterfree: Cipher Peon Targ @ Cipher Key Lair
+        new(GameVersion.XD, 37, 04000, Tangela)   { Fateful = true, Species = 114, Level = 30, Moves = new(076,234,241,275), Location = 067 }, // Tangela: Cipher Peon Targ @ Cipher Key Lair
+        new(GameVersion.XD, 38, 06000, Raticate)  { Fateful = true, Species = 020, Level = 34, Moves = new(162,287,184,158), Location = 076 }, // Raticate: Chaser Furgy @ Citadark Isle
+        new(GameVersion.XD, 39, 04000, Venomoth)  { Fateful = true, Species = 049, Level = 32, Moves = new(318,287,164,094), Location = 070 }, // Venomoth: Cipher Peon Angic @ Cipher Key Lair
+        new(GameVersion.XD, 40, 04000, Weepinbell){ Fateful = true, Species = 070, Level = 32, Moves = new(345,234,188,230), Location = 070 }, // Weepinbell: Cipher Peon Angic @ Cipher Key Lair
+        new(GameVersion.XD, 41, 05000, Arbok)     { Fateful = true, Species = 024, Level = 33, Moves = new(188,287,137,044), Location = 070 }, // Arbok: Cipher Peon Smarton @ Cipher Key Lair
+        new(GameVersion.XD, 42, 06000, Primeape)  { Fateful = true, Species = 057, Level = 34, Moves = new(238,270,116,179), Location = 069 }, // Primeape: Cipher Admin Gorigan @ Cipher Key Lair
+        new(GameVersion.XD, 43, 05500, Hypno)     { Fateful = true, Species = 097, Level = 34, Moves = new(094,226,096,247), Location = 069 }, // Hypno: Cipher Admin Gorigan @ Cipher Key Lair
+        new(GameVersion.XD, 44, 06500, Golduck)   { Fateful = true, Species = 055, Level = 33, Moves = new(127,204,244,280), Location = 088 }, // Golduck: Navigator Abson @ Citadark Isle
+        new(GameVersion.XD, 45, 07000, Sableye)   { Fateful = true, Species = 302, Level = 33, Moves = new(247,270,185,105), Location = 088 }, // Sableye: Navigator Abson @ Citadark Isle
+        new(GameVersion.XD, 46, 04500, Magneton)  { Fateful = true, Species = 082, Level = 30, Moves = new(038,287,240,087), Location = 067 }, // Magneton: Cipher Peon Snidle @ Cipher Key Lair
+        new(GameVersion.XD, 47, 08000, Dodrio)    { Fateful = true, Species = 085, Level = 34, Moves = new(065,226,097,161), Location = 076 }, // Dodrio: Chaser Furgy @ Citadark Isle
+        new(GameVersion.XD, 48, 05500, Farfetchd) { Fateful = true, Species = 083, Level = 36, Moves = new(163,226,014,332), Location = 076 }, // Farfetch'd: Cipher Admin Lovrina @ Citadark Isle
+        new(GameVersion.XD, 49, 06500, Altaria)   { Fateful = true, Species = 334, Level = 36, Moves = new(225,215,076,332), Location = 076 }, // Altaria: Cipher Admin Lovrina @ Citadark Isle
+        new(GameVersion.XD, 50, 06000, Kangaskhan){ Fateful = true, Species = 115, Level = 35, Moves = new(089,047,039,146), Location = 085 }, // Kangaskhan: Cipher Peon Litnar @ Citadark Isle
+        new(GameVersion.XD, 51, 07000, Banette)   { Fateful = true, Species = 354, Level = 37, Moves = new(185,270,247,174), Location = 085 }, // Banette: Cipher Peon Litnar @ Citadark Isle
+        new(GameVersion.XD, 52, 07000, Magmar)    { Fateful = true, Species = 126, Level = 36, Moves = new(126,266,238,009), Location = 077 }, // Magmar: Cipher Peon Grupel @ Citadark Isle
+        new(GameVersion.XD, 53, 07000, Pinsir)    { Fateful = true, Species = 127, Level = 35, Moves = new(012,270,206,066), Location = 077 }, // Pinsir: Cipher Peon Grupel @ Citadark Isle
+        new(GameVersion.XD, 54, 05500, Magcargo)  { Fateful = true, Species = 219, Level = 38, Moves = new(257,287,089,053), Location = 080 }, // Magcargo: Cipher Peon Kolest @ Citadark Isle
+        new(GameVersion.XD, 55, 06000, Rapidash)  { Fateful = true, Species = 078, Level = 40, Moves = new(076,226,241,053), Location = 080 }, // Rapidash: Cipher Peon Kolest @ Citadark Isle
+        new(GameVersion.XD, 56, 06000, Hitmonchan){ Fateful = true, Species = 107, Level = 38, Moves = new(005,270,170,327), Location = 081 }, // Hitmonchan: Cipher Peon Karbon @ Citadark Isle
+        new(GameVersion.XD, 57, 07000, Hitmonlee) { Fateful = true, Species = 106, Level = 38, Moves = new(136,287,170,025), Location = 081 }, // Hitmonlee: Cipher Peon Petro @ Citadark Isle
+        new(GameVersion.XD, 58, 05000, Lickitung) { Fateful = true, Species = 108, Level = 38, Moves = new(038,270,111,205), Location = 084 }, // Lickitung: Cipher Peon Geftal @ Citadark Isle
+        new(GameVersion.XD, 59, 08000, Scyther)   { Fateful = true, Species = 123, Level = 40, Moves = new(013,234,318,163), Location = 084 }, // Scyther: Cipher Peon Leden @ Citadark Isle
+        new(GameVersion.XD, 60, 04000, Chansey)   { Fateful = true, Species = 113, Level = 39, Moves = new(085,186,135,285), Location = 084 }, // Chansey: Cipher Peon Leden @ Citadark Isle
+        new(GameVersion.XD, 60, 04000, Chansey)   { Fateful = true, Species = 113, Level = 39, Moves = new(085,186,135,285), Location = 087 }, // Chansey: Cipher Peon Leden @ Citadark Isle
+        new(GameVersion.XD, 61, 07500, Solrock)   { Fateful = true, Species = 338, Level = 41, Moves = new(094,226,241,322), Location = 087 }, // Solrock: Cipher Admin Snattle @ Citadark Isle
+        new(GameVersion.XD, 62, 07500, Starmie)   { Fateful = true, Species = 121, Level = 41, Moves = new(127,287,058,105), Location = 087 }, // Starmie: Cipher Admin Snattle @ Citadark Isle
+        new(GameVersion.XD, 63, 07000, Electabuzz){ Fateful = true, Species = 125, Level = 43, Moves = new(238,266,086,085), Location = 087 }, // Electabuzz: Cipher Admin Ardos @ Citadark Isle
+        new(GameVersion.XD, 64, 07000, First)     { Fateful = true, Species = 277, Level = 43, Moves = new(143,226,097,263), Location = 087 }, // Swellow: Cipher Admin Ardos @ Citadark Isle
+        new(GameVersion.XD, 65, 09000, Snorlax)   { Fateful = true, Species = 143, Level = 43, Moves = new(090,287,174,034), Location = 087 }, // Snorlax: Cipher Admin Ardos @ Citadark Isle
+        new(GameVersion.XD, 66, 07500, Poliwrath) { Fateful = true, Species = 062, Level = 42, Moves = new(056,270,240,280), Location = 087 }, // Poliwrath: Cipher Admin Gorigan @ Citadark Isle
+        new(GameVersion.XD, 67, 06500, MrMime)    { Fateful = true, Species = 122, Level = 42, Moves = new(094,266,227,009), Location = 087 }, // Mr. Mime: Cipher Admin Gorigan @ Citadark Isle
+        new(GameVersion.XD, 68, 05000, Dugtrio)   { Fateful = true, Species = 051, Level = 40, Moves = new(089,204,201,161), Location = 075 }, // Dugtrio: Cipher Peon Kolax @ Citadark Isle
+        new(GameVersion.XD, 69, 07000, Manectric) { Fateful = true, Species = 310, Level = 44, Moves = new(087,287,240,044), Location = 073 }, // Manectric: Cipher Admin Eldes @ Citadark Isle
+        new(GameVersion.XD, 70, 09000, Salamence) { Fateful = true, Species = 373, Level = 50, Moves = new(337,287,349,332), Location = 073 }, // Salamence: Cipher Admin Eldes @ Citadark Isle
+        new(GameVersion.XD, 71, 06500, Marowak)   { Fateful = true, Species = 105, Level = 44, Moves = new(089,047,014,157), Location = 073 }, // Marowak: Cipher Admin Eldes @ Citadark Isle
+        new(GameVersion.XD, 72, 06000, Lapras)    { Fateful = true, Species = 131, Level = 44, Moves = new(056,215,240,059), Location = 073 }, // Lapras: Cipher Admin Eldes @ Citadark Isle
+        new(GameVersion.XD, 73, 12000, First)     { Fateful = true, Species = 249, Level = 50, Moves = new(354,297,089,056), Location = 074 }, // Lugia: Grand Master Greevil @ Citadark Isle
+        new(GameVersion.XD, 74, 10000, Zapdos)    { Fateful = true, Species = 145, Level = 50, Moves = new(326,226,319,085), Location = 074 }, // Zapdos: Grand Master Greevil @ Citadark Isle
+        new(GameVersion.XD, 75, 10000, Moltres)   { Fateful = true, Species = 146, Level = 50, Moves = new(326,234,261,053), Location = 074 }, // Moltres: Grand Master Greevil @ Citadark Isle
+        new(GameVersion.XD, 76, 10000, Articuno)  { Fateful = true, Species = 144, Level = 50, Moves = new(326,215,114,058), Location = 074 }, // Articuno: Grand Master Greevil @ Citadark Isle
+        new(GameVersion.XD, 77, 09000, Tauros)    { Fateful = true, Species = 128, Level = 46, Moves = new(089,287,039,034), Location = 074 }, // Tauros: Grand Master Greevil @ Citadark Isle
+        new(GameVersion.XD, 78, 07000, First)     { Fateful = true, Species = 112, Level = 46, Moves = new(224,270,184,089), Location = 074 }, // Rhydon: Grand Master Greevil @ Citadark Isle
+        new(GameVersion.XD, 79, 09000, Exeggutor) { Fateful = true, Species = 103, Level = 46, Moves = new(094,287,095,246), Location = 074 }, // Exeggutor: Grand Master Greevil @ Citadark Isle
+        new(GameVersion.XD, 80, 09000, Dragonite) { Fateful = true, Species = 149, Level = 55, Moves = new(063,215,349,089), Location = 162 }, // Dragonite: Wanderer Miror B. @ Gateon Port
+        new(GameVersion.XD, 81, 04500, First)     { Fateful = true, Species = 175, Level = 25, Moves = new(266,161,246,270), Location = 164, Gift = true }, // Togepi: Pokémon Trainer Hordel @ Outskirt Stand
+        new(GameVersion.XD, 82, 02500, Poochyena) { Fateful = true, Species = 261, Level = 10, Moves = new(091,215,305,336), Location = 162 }, // Poochyena: Bodybuilder Kilen @ Gateon Port
+        new(GameVersion.XD, 83, 02500, Ledyba)    { Fateful = true, Species = 165, Level = 10, Moves = new(060,287,332,048), Location = 153 }, // Ledyba: Casual Guy Cyle @ Gateon Port
     };
 
     internal static readonly EncounterArea3XD[] SlotsXD =

--- a/PKHeX.Core/Legality/Encounters/Data/Encounters3GC.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Encounters3GC.cs
@@ -101,9 +101,9 @@ internal static class Encounters3GC
 
         new(GameVersion.COLO, 67, 05000, First)     { Species = 176, Level = 20, Moves = new(118,204,186,281), Location = 001 }, // Togetic: Cipher Peon Fein @ Outskirt Stand
 
-        new(GameVersion.COLO, 00, 00000, CTogepi)   { Species = 175, Level = 20, Moves = new(118,204,186,281), Location = 128, IVs = EncounterStaticShadow.EReaderEmpty }, // Togepi: Chaser ボデス @ Card e Room (Japanese games only)
-        new(GameVersion.COLO, 00, 00000, CMareep)   { Species = 179, Level = 37, Moves = new(087,084,086,178), Location = 128, IVs = EncounterStaticShadow.EReaderEmpty }, // Mareep: Hunter ホル @ Card e Room (Japanese games only)
-        new(GameVersion.COLO, 00, 00000, CScizor)   { Species = 212, Level = 50, Moves = new(210,232,014,163), Location = 128, IVs = EncounterStaticShadow.EReaderEmpty }, // Scizor: Bodybuilder ワーバン @ Card e Room (Japanese games only)
+        new(GameVersion.COLO, 00, 00000, CTogepi)   { Species = 175, Level = 20, Moves = new(118,204,186,281), Location = 128, IVs = new(0, 0, 0, 0, 0, 0) }, // Togepi: Chaser ボデス @ Card e Room (Japanese games only)
+        new(GameVersion.COLO, 00, 00000, CMareep)   { Species = 179, Level = 37, Moves = new(087,084,086,178), Location = 128, IVs = new(0, 0, 0, 0, 0, 0) }, // Mareep: Hunter ホル @ Card e Room (Japanese games only)
+        new(GameVersion.COLO, 00, 00000, CScizor)   { Species = 212, Level = 50, Moves = new(210,232,014,163), Location = 128, IVs = new(0, 0, 0, 0, 0, 0) }, // Scizor: Bodybuilder ワーバン @ Card e Room (Japanese games only)
     };
     #endregion
 

--- a/PKHeX.Core/Legality/Encounters/Data/Encounters4.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Encounters4.cs
@@ -398,30 +398,30 @@ internal static class Encounters4
 
     private static readonly EncounterTrade4PID[] TradeGift_DPPtIngame =
     {
-        new(DPPt, 0x0000008E, 063, 01) { Ability = OnlyFirst,  TID = 25643, SID = 00000, OTGender = 1, Gender = 0, IVs = new[] {15,15,15,20,25,25} }, // Machop -> Abra
-        new(DPPt, 0x00000867, 441, 01) { Ability = OnlySecond, TID = 44142, SID = 00000, OTGender = 0, Gender = 1, IVs = new[] {15,20,15,25,25,15}, Contest = 20 }, // Buizel -> Chatot
-        new(DPPt, 0x00000088, 093, 35) { Ability = OnlyFirst,  TID = 19248, SID = 00000, OTGender = 1, Gender = 0, IVs = new[] {20,25,15,25,15,15} }, // Medicham (35 from Route 217) -> Haunter
-        new(DPPt, 0x0000045C, 129, 01) { Ability = OnlyFirst,  TID = 53277, SID = 00000, OTGender = 0, Gender = 1, IVs = new[] {15,25,15,20,25,15} }, // Finneon -> Magikarp
+        new(DPPt, 0x0000008E, 063, 01) { Ability = OnlyFirst,  TID = 25643, SID = 00000, OTGender = 1, Gender = 0, IVs = new(15,15,15,20,25,25) }, // Machop -> Abra
+        new(DPPt, 0x00000867, 441, 01) { Ability = OnlySecond, TID = 44142, SID = 00000, OTGender = 0, Gender = 1, IVs = new(15,20,15,25,25,15), Contest = 20 }, // Buizel -> Chatot
+        new(DPPt, 0x00000088, 093, 35) { Ability = OnlyFirst,  TID = 19248, SID = 00000, OTGender = 1, Gender = 0, IVs = new(20,25,15,25,15,15) }, // Medicham (35 from Route 217) -> Haunter
+        new(DPPt, 0x0000045C, 129, 01) { Ability = OnlyFirst,  TID = 53277, SID = 00000, OTGender = 0, Gender = 1, IVs = new(15,25,15,20,25,15) }, // Finneon -> Magikarp
     };
 
     internal static readonly EncounterTrade4[] TradeGift_DPPt = ArrayUtil.ConcatAll(TradeGift_DPPtIngame, RanchGifts);
 
     internal static readonly EncounterTrade4PID[] TradeGift_HGSS =
     {
-        new(HGSS, 0x000025EF, 095, 01) { Ability = OnlySecond, TID = 48926, SID = 00000, OTGender = 0, Gender = 0, IVs = new[] {25,20,25,15,15,15} }, // Bellsprout -> Onix
-        new(HGSS, 0x00002310, 066, 01) { Ability = OnlyFirst,  TID = 37460, SID = 00000, OTGender = 0, Gender = 1, IVs = new[] {15,25,20,20,15,15} }, // Drowzee -> Machop
-        new(HGSS, 0x000001DB, 100, 01) { Ability = OnlySecond, TID = 29189, SID = 00000, OTGender = 0, Gender = 2, IVs = new[] {15,20,15,25,25,15} }, // Krabby -> Voltorb
-        new(HGSS, 0x0001FC0A, 085, 15) { Ability = OnlyFirst,  TID = 00283, SID = 00000, OTGender = 1, Gender = 1, IVs = new[] {20,20,20,15,15,15} }, // Dragonair (15 from DPPt) -> Dodrio
-        new(HGSS, 0x0000D136, 082, 19) { Ability = OnlyFirst,  TID = 50082, SID = 00000, OTGender = 0, Gender = 2, IVs = new[] {15,20,15,20,20,20} }, // Dugtrio (19 from Diglett's Cave) -> Magneton
-        new(HGSS, 0x000034E4, 178, 16) { Ability = OnlyFirst,  TID = 15616, SID = 00000, OTGender = 0, Gender = 0, IVs = new[] {15,20,15,20,20,20} }, // Haunter (16 from Old Chateau) -> Xatu
-        new(HGSS, 0x00485876, 025, 02) { Ability = OnlyFirst,  TID = 33038, SID = 00000, OTGender = 0, Gender = 1, IVs = new[] {20,25,18,31,25,13} }, // Pikachu
-        new(HGSS, 0x0012B6D4, 374, 31) { Ability = OnlyFirst,  TID = 23478, SID = 00000, OTGender = 0, Gender = 2, IVs = new[] {28,29,24,23,24,25} }, // Forretress -> Beldum
-        new(HGSS, 0x0012971C, 111, 01) { Ability = OnlyFirst,  TID = 06845, SID = 00000, OTGender = 0, Gender = 1, IVs = new[] {22,31,13,00,22,09}, Moves = new(422) }, // Bonsly -> Rhyhorn
-        new(HGSS, 0x00101596, 208, 01) { Ability = OnlyFirst,  TID = 26491, SID = 00000, OTGender = 1, Gender = 0, IVs = new[] {08,30,28,06,18,20} }, // Any -> Steelix
+        new(HGSS, 0x000025EF, 095, 01) { Ability = OnlySecond, TID = 48926, SID = 00000, OTGender = 0, Gender = 0, IVs = new(25,20,25,15,15,15) }, // Bellsprout -> Onix
+        new(HGSS, 0x00002310, 066, 01) { Ability = OnlyFirst,  TID = 37460, SID = 00000, OTGender = 0, Gender = 1, IVs = new(15,25,20,20,15,15) }, // Drowzee -> Machop
+        new(HGSS, 0x000001DB, 100, 01) { Ability = OnlySecond, TID = 29189, SID = 00000, OTGender = 0, Gender = 2, IVs = new(15,20,15,25,25,15) }, // Krabby -> Voltorb
+        new(HGSS, 0x0001FC0A, 085, 15) { Ability = OnlyFirst,  TID = 00283, SID = 00000, OTGender = 1, Gender = 1, IVs = new(20,20,20,15,15,15) }, // Dragonair (15 from DPPt) -> Dodrio
+        new(HGSS, 0x0000D136, 082, 19) { Ability = OnlyFirst,  TID = 50082, SID = 00000, OTGender = 0, Gender = 2, IVs = new(15,20,15,20,20,20) }, // Dugtrio (19 from Diglett's Cave) -> Magneton
+        new(HGSS, 0x000034E4, 178, 16) { Ability = OnlyFirst,  TID = 15616, SID = 00000, OTGender = 0, Gender = 0, IVs = new(15,20,15,20,20,20) }, // Haunter (16 from Old Chateau) -> Xatu
+        new(HGSS, 0x00485876, 025, 02) { Ability = OnlyFirst,  TID = 33038, SID = 00000, OTGender = 0, Gender = 1, IVs = new(20,25,18,31,25,13) }, // Pikachu
+        new(HGSS, 0x0012B6D4, 374, 31) { Ability = OnlyFirst,  TID = 23478, SID = 00000, OTGender = 0, Gender = 2, IVs = new(28,29,24,23,24,25) }, // Forretress -> Beldum
+        new(HGSS, 0x0012971C, 111, 01) { Ability = OnlyFirst,  TID = 06845, SID = 00000, OTGender = 0, Gender = 1, IVs = new(22,31,13,00,22,09), Moves = new(422) }, // Bonsly -> Rhyhorn
+        new(HGSS, 0x00101596, 208, 01) { Ability = OnlyFirst,  TID = 26491, SID = 00000, OTGender = 1, Gender = 0, IVs = new(08,30,28,06,18,20) }, // Any -> Steelix
 
         //Gift
-        new(HGSS, 0x00006B5E, 021, 20) { Ability = OnlyFirst,  TID = 01001, SID = 00000, OTGender = 0, Gender = 1, IVs = new[] {15,20,15,20,20,20}, MetLocation = 183, Moves = new(043,031,228,332) },// Webster's Spearow
-        new(HGSS, 0x000214D7, 213, 20) { Ability = OnlySecond, TID = 04336, SID = 00001, OTGender = 0, Gender = 0, IVs = new[] {15,20,15,20,20,20}, MetLocation = 130, Moves = new(132,117,227,219) },// Kirk's Shuckle
+        new(HGSS, 0x00006B5E, 021, 20) { Ability = OnlyFirst,  TID = 01001, SID = 00000, OTGender = 0, Gender = 1, IVs = new(15,20,15,20,20,20), MetLocation = 183, Moves = new(043,031,228,332) },// Webster's Spearow
+        new(HGSS, 0x000214D7, 213, 20) { Ability = OnlySecond, TID = 04336, SID = 00001, OTGender = 0, Gender = 0, IVs = new(15,20,15,20,20,20), MetLocation = 130, Moves = new(132,117,227,219) },// Kirk's Shuckle
     };
 
     private const string tradeDPPt = "tradedppt";

--- a/PKHeX.Core/Legality/Encounters/Data/Encounters4.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Encounters4.cs
@@ -41,10 +41,10 @@ internal static class Encounters4
         new(021, 0, 05), // Spearow
         new(043, 1, 05), // Oddish
         new(095, 0, 09), // Onix
-        new(240, 0, 09) { Moves = new[]{241} }, // Magby: Sunny Day
+        new(240, 0, 09) { Moves = new(241) }, // Magby: Sunny Day
         new(066, 1, 07), // Machop
         new(077, 1, 07), // Ponyta
-        new(074, 1, 08) { Moves = new[]{189} }, // Geodude: Mud-Slap
+        new(074, 1, 08) { Moves = new(189) }, // Geodude: Mud-Slap
         new(163, 1, 06), // Hoothoot
         new(054, 1, 10), // Psyduck
         new(120, 2, 10), // Staryu
@@ -53,27 +53,27 @@ internal static class Encounters4
         new(191, 1, 06), // Sunkern
         new(194, 0, 06), // Wooper
         new(081, 2, 11), // Magnemite
-        new(239, 0, 11) { Moves = new[]{009} }, // Elekid: Thunder Punch
+        new(239, 0, 11) { Moves = new(009) }, // Elekid: Thunder Punch
         new(081, 2, 08), // Magnemite
         new(198, 1, 11), // Murkrow
         new(019, 1, 07), // Rattata
         new(163, 1, 07), // Hoothoot
-        new(092, 1, 15) { Moves = new[]{194} }, // Gastly: Destiny Bond
-        new(238, 1, 12) { Moves = new[]{419} }, // Smoochum: Avalanche
+        new(092, 1, 15) { Moves = new(194) }, // Gastly: Destiny Bond
+        new(238, 1, 12) { Moves = new(419) }, // Smoochum: Avalanche
         new(092, 1, 10), // Gastly
         new(095, 0, 10), // Onix
         new(041, 0, 08), // Zubat
         new(066, 0, 08), // Machop
-        new(060, 1, 15) { Moves = new[]{187} }, // Poliwag: Belly Drum
+        new(060, 1, 15) { Moves = new(187) }, // Poliwag: Belly Drum
         new(147, 1, 10), // Dratini
         new(090, 1, 12), // Shellder
-        new(098, 0, 12) { Moves = new[]{152} }, // Krabby: Crabhammer
+        new(098, 0, 12) { Moves = new(152) }, // Krabby: Crabhammer
         new(072, 1, 09), // Tentacool
         new(118, 1, 09), // Goldeen
         new(063, 1, 15), // Abra
         new(100, 2, 15), // Voltorb
         new(088, 0, 13), // Grimer
-        new(109, 1, 13) { Moves = new[]{120} }, // Koffing: Self-Destruct
+        new(109, 1, 13) { Moves = new(120) }, // Koffing: Self-Destruct
         new(019, 1, 16), // Rattata
         new(162, 0, 15), // Furret
         // Hoenn Courses
@@ -87,7 +87,7 @@ internal static class Encounters4
         new(320, 1, 31), // Wailmer
         new(116, 1, 20), // Horsea
         new(318, 1, 26), // Carvanha
-        new(118, 1, 22) { Moves = new[]{401} }, // Goldeen: Aqua Tail
+        new(118, 1, 22) { Moves = new(401) }, // Goldeen: Aqua Tail
         new(129, 1, 15), // Magikarp
         new(218, 1, 31), // Slugma
         new(307, 0, 32), // Meditite
@@ -101,11 +101,11 @@ internal static class Encounters4
         new(234, 1, 28), // Stantler
         new(044, 1, 14), // Gloom
         new(070, 0, 13), // Weepinbell
-        new(105, 1, 30) { Moves = new[]{037} }, // Marowak: Thrash
+        new(105, 1, 30) { Moves = new(037) }, // Marowak: Thrash
         new(128, 0, 30), // Tauros
         new(042, 0, 33), // Golbat
         new(177, 1, 24), // Natu
-        new(066, 0, 13) { Moves = new[]{418} }, // Machop: Bullet Punch
+        new(066, 0, 13) { Moves = new(418) }, // Machop: Bullet Punch
         new(092, 1, 15), // Gastly
         // Sinnoh Courses
         new(415, 0, 30), // Combee
@@ -115,8 +115,8 @@ internal static class Encounters4
         new(399, 1, 13), // Bidoof
         new(401, 0, 15), // Kricketot
         new(361, 1, 28), // Snorunt
-        new(459, 0, 31) { Moves = new[]{452} }, // Snover: Wood Hammer
-        new(215, 0, 28) { Moves = new[]{306} }, // Sneasel: Crash Claw
+        new(459, 0, 31) { Moves = new(452) }, // Snover: Wood Hammer
+        new(215, 0, 28) { Moves = new(306) }, // Sneasel: Crash Claw
         new(436, 2, 20), // Bronzor
         new(179, 1, 15), // Mareep
         new(220, 1, 16), // Swinub
@@ -126,20 +126,20 @@ internal static class Encounters4
         new(400, 1, 30), // Bibarel
         new(102, 1, 17), // Exeggcute
         new(179, 0, 19), // Mareep
-        new(200, 1, 32) { Moves = new[]{194} }, // Misdreavus: Destiny Bond
-        new(433, 0, 22) { Moves = new[]{105} }, // Chingling: Recover
+        new(200, 1, 32) { Moves = new(194) }, // Misdreavus: Destiny Bond
+        new(433, 0, 22) { Moves = new(105) }, // Chingling: Recover
         new(093, 0, 25), // Haunter
-        new(418, 0, 28) { Moves = new[]{226} }, // Buizel: Baton Pass
+        new(418, 0, 28) { Moves = new(226) }, // Buizel: Baton Pass
         new(170, 1, 17), // Chinchou
         new(223, 1, 19), // Remoraid
-        new(422, 1, 30) { Moves = new[]{243} }, // Shellos: Mirror Coat
+        new(422, 1, 30) { Moves = new(243) }, // Shellos: Mirror Coat
         new(456, 1, 26), // Finneon
         new(086, 1, 27), // Seel
         new(129, 1, 30), // Magikarp
-        new(054, 1, 22) { Moves = new[]{281} }, // Psyduck: Yawn
+        new(054, 1, 22) { Moves = new(281) }, // Psyduck: Yawn
         new(090, 0, 20), // Shellder
         new(025, 1, 30), // Pikachu
-        new(417, 1, 33) { Moves = new[]{175} }, // Pachirisu: Flail
+        new(417, 1, 33) { Moves = new(175) }, // Pachirisu: Flail
         new(035, 1, 31), // Clefairy
         new(039, 1, 30), // Jigglypuff
         new(183, 1, 25), // Marill
@@ -151,22 +151,22 @@ internal static class Encounters4
         new(042, 0, 33), // Golbat
         new(164, 1, 30), // Noctowl
         // Special Courses
-        new(120, 2, 18) { Moves = new[]{113} }, // Staryu: Light Screen
-        new(224, 1, 19) { Moves = new[]{324} }, // Octillery: Signal Beam
+        new(120, 2, 18) { Moves = new(113) }, // Staryu: Light Screen
+        new(224, 1, 19) { Moves = new(324) }, // Octillery: Signal Beam
         new(116, 0, 15), // Horsea
         new(222, 1, 16), // Corsola
         new(170, 1, 12), // Chinchou
         new(223, 0, 14), // Remoraid
-        new(035, 0, 08) { Moves = new[]{236} }, // Clefairy: Moonlight
+        new(035, 0, 08) { Moves = new(236) }, // Clefairy: Moonlight
         new(039, 0, 10), // Jigglypuff
         new(041, 0, 09), // Zubat
         new(163, 1, 06), // Hoothoot
         new(074, 0, 05), // Geodude
-        new(095, 1, 05) { Moves = new[]{088} }, // Onix: Rock Throw
-        new(025, 0, 15) { Moves = new[]{019} }, // Pikachu: Fly
-        new(025, 1, 14) { Moves = new[]{057} }, // Pikachu: Surf
-        new(025, 1, 12) { Moves = new[]{344, 252} }, // Pikachu: Volt Tackle, Fake Out
-        new(025, 0, 13) { Moves = new[]{175} }, // Pikachu: Flail
+        new(095, 1, 05) { Moves = new(088) }, // Onix: Rock Throw
+        new(025, 0, 15) { Moves = new(019) }, // Pikachu: Fly
+        new(025, 1, 14) { Moves = new(057) }, // Pikachu: Surf
+        new(025, 1, 12) { Moves = new(344, 252) }, // Pikachu: Volt Tackle, Fake Out
+        new(025, 0, 13) { Moves = new(175) }, // Pikachu: Flail
         new(025, 0, 10), // Pikachu
         new(025, 1, 10), // Pikachu
         new(302, 1, 15), // Sableye
@@ -177,22 +177,22 @@ internal static class Encounters4
         new(427, 1, 05), // Buneary
         new(133, 0, 10), // Eevee
         new(255, 0, 10), // Torchic
-        new(061, 1, 15) { Moves = new[]{003} }, // Poliwhirl: Double Slap
+        new(061, 1, 15) { Moves = new(003) }, // Poliwhirl: Double Slap
         new(279, 0, 15), // Pelipper
         new(025, 1, 08), // Pikachu
         new(052, 0, 10), // Meowth
-        new(374, 2, 05) { Moves = new[]{428,334,442} }, // Beldum: Zen Headbutt, Iron Defense & Iron Head.
-        new(446, 0, 05) { Moves = new[]{120} }, // Munchlax: Self-Destruct
-        new(116, 0, 05) { Moves = new[]{330} }, // Horsea: Muddy Water
-        new(355, 0, 05) { Moves = new[]{286} }, // Duskull: Imprison
-        new(129, 0, 05) { Moves = new[]{340} }, // Magikarp: Bounce
-        new(436, 2, 05) { Moves = new[]{433} }, // Bronzor: Trick Room
-        new(239, 0, 05) { Moves = new[]{9}}, // Elekid: Thunder Punch (can be tutored)
-        new(240, 0, 05) { Moves = new[]{7}}, // Magby: Fire Punch (can be tutored)
-        new(238, 1, 05) { Moves = new[]{8}}, // Smoochum: Ice Punch (can be tutored)
-        new(440, 1, 05) { Moves = new[]{215}}, // Happiny: Heal Bell
-        new(173, 1, 05) { Moves = new[]{118}}, // Cleffa: Metronome
-        new(174, 0, 05) { Moves = new[]{273}}, // Igglybuff: Wish
+        new(374, 2, 05) { Moves = new(428,334,442) }, // Beldum: Zen Headbutt, Iron Defense & Iron Head.
+        new(446, 0, 05) { Moves = new(120) }, // Munchlax: Self-Destruct
+        new(116, 0, 05) { Moves = new(330) }, // Horsea: Muddy Water
+        new(355, 0, 05) { Moves = new(286) }, // Duskull: Imprison
+        new(129, 0, 05) { Moves = new(340) }, // Magikarp: Bounce
+        new(436, 2, 05) { Moves = new(433) }, // Bronzor: Trick Room
+        new(239, 0, 05) { Moves = new(9) }, // Elekid: Thunder Punch (can be tutored)
+        new(240, 0, 05) { Moves = new(7) }, // Magby: Fire Punch (can be tutored)
+        new(238, 1, 05) { Moves = new(8) }, // Smoochum: Ice Punch (can be tutored)
+        new(440, 1, 05) { Moves = new(215) }, // Happiny: Heal Bell
+        new(173, 1, 05) { Moves = new(118) }, // Cleffa: Metronome
+        new(174, 0, 05) { Moves = new(273) }, // Igglybuff: Wish
     };
     #endregion
     #region Static Encounter/Gift Tables
@@ -295,9 +295,9 @@ internal static class Encounters4
         // Gift
         new(HGSS) { Gift = true, Species = 072, Level = 15, Location = 130, GroundTile = Max_Pt }, // Tentacool @ Cianwood City
         new(HGSS) { Gift = true, Species = 133, Level = 05, Location = 131, GroundTile = Max_Pt }, // Eevee @ Goldenrod City
-        new(HGSS) { Gift = true, Species = 147, Level = 15, Location = 222, GroundTile = Max_Pt, Moves = new[] {245} }, // Dratini @ Dragon's Den (ExtremeSpeed)
+        new(HGSS) { Gift = true, Species = 147, Level = 15, Location = 222, GroundTile = Max_Pt, Moves = new(245) }, // Dratini @ Dragon's Den (ExtremeSpeed)
         new(HGSS) { Gift = true, Species = 236, Level = 10, Location = 216, GroundTile = Max_Pt }, // Tyrogue @ Mt. Mortar
-        new(HGSS) { Gift = true, Species = 175, Level = 01, EggLocation = 2013, Moves = new[] {(int)Move.Growl, (int)Move.Charm, (int)Move.Extrasensory} }, // Togepi Egg from Mr. Pokemon (Extrasensory as Egg move)
+        new(HGSS) { Gift = true, Species = 175, Level = 01, EggLocation = 2013, Moves = new((int)Move.Growl, (int)Move.Charm, (int)Move.Extrasensory) }, // Togepi Egg from Mr. Pokemon (Extrasensory as Egg move)
         new(HGSS) { Gift = true, Species = 179, Level = 01, EggLocation = 2014 }, // Mareep Egg from Primo
         new(HGSS) { Gift = true, Species = 194, Level = 01, EggLocation = 2014 }, // Wooper Egg from Primo
         new(HGSS) { Gift = true, Species = 218, Level = 01, EggLocation = 2014 }, // Slugma Egg from Primo
@@ -334,7 +334,7 @@ internal static class Encounters4
             Form = 1,
             Nature = Nature.Naughty,
             Location = 214,
-            Moves = new[] { 344, 270, 207, 220 },
+            Moves = new(344, 270, 207, 220),
             GroundTile = Max_Pt,
             Shiny = Shiny.Never,
         },
@@ -372,28 +372,28 @@ internal static class Encounters4
 
     private static readonly EncounterTrade4[] RanchGifts =
     {
-        new EncounterTrade4RanchGift(323975838, 025, 18) { Moves = new[] {447,085,148,104}, TID = 1000, SID = 19840, OTGender = 1, MetLocation = 0068, Gender = 0, Ability = OnlyFirst,  CurrentLevel = 20 }, // Pikachu
-        new EncounterTrade4RanchGift(323977664, 037, 16) { Moves = new[] {412,109,053,219}, TID = 1000, SID = 21150, OTGender = 1, MetLocation = 3000, Gender = 0, Ability = OnlyFirst,  CurrentLevel = 30 }, // Vulpix
-        new EncounterTrade4RanchGift(323975579, 077, 13) { Moves = new[] {036,033,039,052}, TID = 1000, SID = 01123, OTGender = 1, MetLocation = 3000, Gender = 0, Ability = OnlySecond, CurrentLevel = 16 }, // Ponyta
-        new EncounterTrade4RanchGift(323975564, 108, 34) { Moves = new[] {076,111,014,205}, TID = 1000, SID = 03050, OTGender = 1, MetLocation = 0077, Gender = 0, Ability = OnlyFirst,  CurrentLevel = 40 }, // Lickitung
-        new EncounterTrade4RanchGift(323977579, 114, 01) { Moves = new[] {437,438,079,246}, TID = 1000, SID = 49497, OTGender = 1, MetLocation = 3000, Gender = 1, Ability = OnlySecond }, // Tangela
-        new EncounterTrade4RanchGift(323977675, 133, 16) { Moves = new[] {363,270,098,247}, TID = 1000, SID = 47710, OTGender = 1, MetLocation = 0068, Gender = 0, Ability = OnlySecond, CurrentLevel = 30 }, // Eevee
-        new EncounterTrade4RanchGift(323977588, 142, 20) { Moves = new[] {363,089,444,332}, TID = 1000, SID = 43066, OTGender = 1, MetLocation = 0094, Gender = 0, Ability = OnlyFirst,  CurrentLevel = 50 }, // Aerodactyl
-        new EncounterTrade4RanchGift(232975554, 193, 22) { Moves = new[] {318,095,246,138}, TID = 1000, SID = 42301, OTGender = 1, MetLocation = 0052, Gender = 0, Ability = OnlyFirst,  CurrentLevel = 45, Ball = 5 }, // Yanma
-        new EncounterTrade4RanchGift(323975570, 241, 16) { Moves = new[] {208,215,360,359}, TID = 1000, SID = 02707, OTGender = 1, MetLocation = 3000, Gender = 1, Ability = OnlyFirst,  CurrentLevel = 48 }, // Miltank
-        new EncounterTrade4RanchGift(323975563, 285, 22) { Moves = new[] {402,147,206,078}, TID = 1000, SID = 02788, OTGender = 1, MetLocation = 3000, Gender = 0, Ability = OnlySecond, CurrentLevel = 45, Ball = 5 }, // Shroomish
-        new EncounterTrade4RanchGift(323975559, 320, 30) { Moves = new[] {156,323,133,058}, TID = 1000, SID = 27046, OTGender = 1, MetLocation = 0038, Gender = 0, Ability = OnlySecond, CurrentLevel = 45 }, // Wailmer
-        new EncounterTrade4RanchGift(323977657, 360, 01) { Moves = new[] {204,150,227,000}, TID = 1000, SID = 01788, OTGender = 1, MetLocation = 0004, Gender = 0, Ability = OnlySecond, EggLocation = 2000 }, // Wynaut
-        new EncounterTrade4RanchGift(323975563, 397, 02) { Moves = new[] {355,017,283,018}, TID = 1000, SID = 59298, OTGender = 1, MetLocation = 0016, Gender = 0, Ability = OnlySecond, CurrentLevel = 23 }, // Staravia
-        new EncounterTrade4RanchGift(323970584, 415, 05) { Moves = new[] {230,016,000,000}, TID = 1000, SID = 54140, OTGender = 1, MetLocation = 0020, Gender = 1, Ability = OnlyFirst,  CurrentLevel = 20 }, // Combee
-        new EncounterTrade4RanchGift(323977539, 417, 09) { Moves = new[] {447,045,351,098}, TID = 1000, SID = 18830, OTGender = 1, MetLocation = 0020, Gender = 1, Ability = OnlySecond, CurrentLevel = 10 }, // Pachirisu
-        new EncounterTrade4RanchGift(323974107, 422, 20) { Moves = new[] {363,352,426,104}, TID = 1000, SID = 39272, OTGender = 1, MetLocation = 0028, Gender = 0, Ability = OnlySecond, CurrentLevel = 25, Form = 1 }, // Shellos
-        new EncounterTrade4RanchGift(323977566, 427, 10) { Moves = new[] {204,193,409,098}, TID = 1000, SID = 31045, OTGender = 1, MetLocation = 3000, Gender = 1, Ability = OnlyFirst,  CurrentLevel = 16 }, // Buneary
-        new EncounterTrade4RanchGift(323975579, 453, 22) { Moves = new[] {310,207,426,389}, TID = 1000, SID = 41342, OTGender = 1, MetLocation = 0052, Gender = 0, Ability = OnlySecond, CurrentLevel = 31, Ball = 5 }, // Croagunk
-        new EncounterTrade4RanchGift(323977566, 456, 15) { Moves = new[] {213,352,219,392}, TID = 1000, SID = 48348, OTGender = 1, MetLocation = 0020, Gender = 1, Ability = OnlyFirst,  CurrentLevel = 35 }, // Finneon
-        new EncounterTrade4RanchGift(323975582, 459, 32) { Moves = new[] {452,420,275,059}, TID = 1000, SID = 23360, OTGender = 1, MetLocation = 0031, Gender = 0, Ability = OnlyFirst,  CurrentLevel = 41 }, // Snover
-        new EncounterTrade4RanchSpecial(151, 50) { Moves = new[] {235,216,095,100}, TID = 1000, SID = 59228, OTGender = 1, Ball = 0x10, Gender = 2 }, // Mew
-        new EncounterTrade4RanchSpecial(489, 01) { Moves = new[] {447,240,156,057}, TID = 1000, SID = 09248, OTGender = 1, Ball = 0x10, Gender = 2, CurrentLevel = 50, EggLocation = 3000 }, // Phione
+        new EncounterTrade4RanchGift(323975838, 025, 18) { Moves = new(447,085,148,104), TID = 1000, SID = 19840, OTGender = 1, MetLocation = 0068, Gender = 0, Ability = OnlyFirst,  CurrentLevel = 20 }, // Pikachu
+        new EncounterTrade4RanchGift(323977664, 037, 16) { Moves = new(412,109,053,219), TID = 1000, SID = 21150, OTGender = 1, MetLocation = 3000, Gender = 0, Ability = OnlyFirst,  CurrentLevel = 30 }, // Vulpix
+        new EncounterTrade4RanchGift(323975579, 077, 13) { Moves = new(036,033,039,052), TID = 1000, SID = 01123, OTGender = 1, MetLocation = 3000, Gender = 0, Ability = OnlySecond, CurrentLevel = 16 }, // Ponyta
+        new EncounterTrade4RanchGift(323975564, 108, 34) { Moves = new(076,111,014,205), TID = 1000, SID = 03050, OTGender = 1, MetLocation = 0077, Gender = 0, Ability = OnlyFirst,  CurrentLevel = 40 }, // Lickitung
+        new EncounterTrade4RanchGift(323977579, 114, 01) { Moves = new(437,438,079,246), TID = 1000, SID = 49497, OTGender = 1, MetLocation = 3000, Gender = 1, Ability = OnlySecond }, // Tangela
+        new EncounterTrade4RanchGift(323977675, 133, 16) { Moves = new(363,270,098,247), TID = 1000, SID = 47710, OTGender = 1, MetLocation = 0068, Gender = 0, Ability = OnlySecond, CurrentLevel = 30 }, // Eevee
+        new EncounterTrade4RanchGift(323977588, 142, 20) { Moves = new(363,089,444,332), TID = 1000, SID = 43066, OTGender = 1, MetLocation = 0094, Gender = 0, Ability = OnlyFirst,  CurrentLevel = 50 }, // Aerodactyl
+        new EncounterTrade4RanchGift(232975554, 193, 22) { Moves = new(318,095,246,138), TID = 1000, SID = 42301, OTGender = 1, MetLocation = 0052, Gender = 0, Ability = OnlyFirst,  CurrentLevel = 45, Ball = 5 }, // Yanma
+        new EncounterTrade4RanchGift(323975570, 241, 16) { Moves = new(208,215,360,359), TID = 1000, SID = 02707, OTGender = 1, MetLocation = 3000, Gender = 1, Ability = OnlyFirst,  CurrentLevel = 48 }, // Miltank
+        new EncounterTrade4RanchGift(323975563, 285, 22) { Moves = new(402,147,206,078), TID = 1000, SID = 02788, OTGender = 1, MetLocation = 3000, Gender = 0, Ability = OnlySecond, CurrentLevel = 45, Ball = 5 }, // Shroomish
+        new EncounterTrade4RanchGift(323975559, 320, 30) { Moves = new(156,323,133,058), TID = 1000, SID = 27046, OTGender = 1, MetLocation = 0038, Gender = 0, Ability = OnlySecond, CurrentLevel = 45 }, // Wailmer
+        new EncounterTrade4RanchGift(323977657, 360, 01) { Moves = new(204,150,227,000), TID = 1000, SID = 01788, OTGender = 1, MetLocation = 0004, Gender = 0, Ability = OnlySecond, EggLocation = 2000 }, // Wynaut
+        new EncounterTrade4RanchGift(323975563, 397, 02) { Moves = new(355,017,283,018), TID = 1000, SID = 59298, OTGender = 1, MetLocation = 0016, Gender = 0, Ability = OnlySecond, CurrentLevel = 23 }, // Staravia
+        new EncounterTrade4RanchGift(323970584, 415, 05) { Moves = new(230,016,000,000), TID = 1000, SID = 54140, OTGender = 1, MetLocation = 0020, Gender = 1, Ability = OnlyFirst,  CurrentLevel = 20 }, // Combee
+        new EncounterTrade4RanchGift(323977539, 417, 09) { Moves = new(447,045,351,098), TID = 1000, SID = 18830, OTGender = 1, MetLocation = 0020, Gender = 1, Ability = OnlySecond, CurrentLevel = 10 }, // Pachirisu
+        new EncounterTrade4RanchGift(323974107, 422, 20) { Moves = new(363,352,426,104), TID = 1000, SID = 39272, OTGender = 1, MetLocation = 0028, Gender = 0, Ability = OnlySecond, CurrentLevel = 25, Form = 1 }, // Shellos
+        new EncounterTrade4RanchGift(323977566, 427, 10) { Moves = new(204,193,409,098), TID = 1000, SID = 31045, OTGender = 1, MetLocation = 3000, Gender = 1, Ability = OnlyFirst,  CurrentLevel = 16 }, // Buneary
+        new EncounterTrade4RanchGift(323975579, 453, 22) { Moves = new(310,207,426,389), TID = 1000, SID = 41342, OTGender = 1, MetLocation = 0052, Gender = 0, Ability = OnlySecond, CurrentLevel = 31, Ball = 5 }, // Croagunk
+        new EncounterTrade4RanchGift(323977566, 456, 15) { Moves = new(213,352,219,392), TID = 1000, SID = 48348, OTGender = 1, MetLocation = 0020, Gender = 1, Ability = OnlyFirst,  CurrentLevel = 35 }, // Finneon
+        new EncounterTrade4RanchGift(323975582, 459, 32) { Moves = new(452,420,275,059), TID = 1000, SID = 23360, OTGender = 1, MetLocation = 0031, Gender = 0, Ability = OnlyFirst,  CurrentLevel = 41 }, // Snover
+        new EncounterTrade4RanchSpecial(151, 50) { Moves = new(235,216,095,100), TID = 1000, SID = 59228, OTGender = 1, Ball = 0x10, Gender = 2 }, // Mew
+        new EncounterTrade4RanchSpecial(489, 01) { Moves = new(447,240,156,057), TID = 1000, SID = 09248, OTGender = 1, Ball = 0x10, Gender = 2, CurrentLevel = 50, EggLocation = 3000 }, // Phione
     };
 
     private static readonly EncounterTrade4PID[] TradeGift_DPPtIngame =
@@ -416,12 +416,12 @@ internal static class Encounters4
         new(HGSS, 0x000034E4, 178, 16) { Ability = OnlyFirst,  TID = 15616, SID = 00000, OTGender = 0, Gender = 0, IVs = new[] {15,20,15,20,20,20} }, // Haunter (16 from Old Chateau) -> Xatu
         new(HGSS, 0x00485876, 025, 02) { Ability = OnlyFirst,  TID = 33038, SID = 00000, OTGender = 0, Gender = 1, IVs = new[] {20,25,18,31,25,13} }, // Pikachu
         new(HGSS, 0x0012B6D4, 374, 31) { Ability = OnlyFirst,  TID = 23478, SID = 00000, OTGender = 0, Gender = 2, IVs = new[] {28,29,24,23,24,25} }, // Forretress -> Beldum
-        new(HGSS, 0x0012971C, 111, 01) { Ability = OnlyFirst,  TID = 06845, SID = 00000, OTGender = 0, Gender = 1, IVs = new[] {22,31,13,00,22,09}, Moves = new[]{422} }, // Bonsly -> Rhyhorn
-        new(HGSS, 0x00101596, 208, 01) { Ability = OnlyFirst,  TID = 26491, SID = 00000, OTGender = 1, Gender = 0, IVs = new[] {08,30,28,06,18,20}}, // Any -> Steelix
+        new(HGSS, 0x0012971C, 111, 01) { Ability = OnlyFirst,  TID = 06845, SID = 00000, OTGender = 0, Gender = 1, IVs = new[] {22,31,13,00,22,09}, Moves = new(422) }, // Bonsly -> Rhyhorn
+        new(HGSS, 0x00101596, 208, 01) { Ability = OnlyFirst,  TID = 26491, SID = 00000, OTGender = 1, Gender = 0, IVs = new[] {08,30,28,06,18,20} }, // Any -> Steelix
 
         //Gift
-        new(HGSS, 0x00006B5E, 021, 20) { Ability = OnlyFirst,  TID = 01001, SID = 00000, OTGender = 0, Gender = 1, IVs = new[] {15,20,15,20,20,20}, MetLocation = 183, Moves = new[]{043,031,228,332} },// Webster's Spearow
-        new(HGSS, 0x000214D7, 213, 20) { Ability = OnlySecond, TID = 04336, SID = 00001, OTGender = 0, Gender = 0, IVs = new[] {15,20,15,20,20,20}, MetLocation = 130, Moves = new[]{132,117,227,219} },// Kirk's Shuckle
+        new(HGSS, 0x00006B5E, 021, 20) { Ability = OnlyFirst,  TID = 01001, SID = 00000, OTGender = 0, Gender = 1, IVs = new[] {15,20,15,20,20,20}, MetLocation = 183, Moves = new(043,031,228,332) },// Webster's Spearow
+        new(HGSS, 0x000214D7, 213, 20) { Ability = OnlySecond, TID = 04336, SID = 00001, OTGender = 0, Gender = 0, IVs = new[] {15,20,15,20,20,20}, MetLocation = 130, Moves = new(132,117,227,219) },// Kirk's Shuckle
     };
 
     private const string tradeDPPt = "tradedppt";

--- a/PKHeX.Core/Legality/Encounters/Data/Encounters5.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Encounters5.cs
@@ -1,4 +1,4 @@
-﻿using static PKHeX.Core.EncounterUtil;
+using static PKHeX.Core.EncounterUtil;
 using static PKHeX.Core.GameVersion;
 using static PKHeX.Core.AbilityPermission;
 
@@ -546,24 +546,24 @@ public static class Encounters5
 
     internal static readonly EncounterTrade5PID[] TradeGift_BW =
     {
-        new(B , 0x64000000) { Species = 548, Level = 15, Ability = OnlyFirst,  TID = 39922, SID = 00000, OTGender = 1, Gender = 1, IVs = new[] {20,20,20,20,31,20}, Nature = Nature.Modest }, // Petilil
-        new( W, 0x6400007E) { Species = 546, Level = 15, Ability = OnlyFirst,  TID = 39922, SID = 00000, OTGender = 1, Gender = 1, IVs = new[] {20,20,20,20,31,20}, Nature = Nature.Modest }, // Cottonee
-        new(B , 0x9400007F) { Species = 550, Level = 25, Ability = OnlyFirst,  TID = 27646, SID = 00000, OTGender = 0, Gender = 0, IVs = new[] {20,31,20,20,20,20}, Nature = Nature.Adamant, Form = 0 }, // Basculin-Red
-        new( W, 0x9400007F) { Species = 550, Level = 25, Ability = OnlyFirst,  TID = 27646, SID = 00000, OTGender = 0, Gender = 0, IVs = new[] {20,31,20,20,20,20}, Nature = Nature.Adamant, Form = 1 }, // Basculin-Blue
-        new(BW, 0xD400007F) { Species = 587, Level = 30, Ability = OnlyFirst,  TID = 11195, SID = 00000, OTGender = 0, Gender = 0, IVs = new[] {20,20,31,20,20,20}, Nature = Nature.Lax }, // Emolga
-        new(BW, 0x2A000000) { Species = 479, Level = 60, Ability = OnlyFirst,  TID = 54673, SID = 00000, OTGender = 1, Gender = 2, IVs = new[] {20,20,20,20,20,31}, Nature = Nature.Gentle }, // Rotom
-        new(BW, 0x6200001F) { Species = 446, Level = 60, Ability = OnlySecond, TID = 40217, SID = 00000, OTGender = 0, Gender = 0, IVs = new[] {31,20,20,20,20,20}, Nature = Nature.Serious }, // Munchlax
+        new(B , 0x64000000) { Species = 548, Level = 15, Ability = OnlyFirst,  TID = 39922, SID = 00000, OTGender = 1, Gender = 1, IVs = new(20,20,20,20,31,20), Nature = Nature.Modest }, // Petilil
+        new( W, 0x6400007E) { Species = 546, Level = 15, Ability = OnlyFirst,  TID = 39922, SID = 00000, OTGender = 1, Gender = 1, IVs = new(20,20,20,20,31,20), Nature = Nature.Modest }, // Cottonee
+        new(B , 0x9400007F) { Species = 550, Level = 25, Ability = OnlyFirst,  TID = 27646, SID = 00000, OTGender = 0, Gender = 0, IVs = new(20,31,20,20,20,20), Nature = Nature.Adamant, Form = 0 }, // Basculin-Red
+        new( W, 0x9400007F) { Species = 550, Level = 25, Ability = OnlyFirst,  TID = 27646, SID = 00000, OTGender = 0, Gender = 0, IVs = new(20,31,20,20,20,20), Nature = Nature.Adamant, Form = 1 }, // Basculin-Blue
+        new(BW, 0xD400007F) { Species = 587, Level = 30, Ability = OnlyFirst,  TID = 11195, SID = 00000, OTGender = 0, Gender = 0, IVs = new(20,20,31,20,20,20), Nature = Nature.Lax }, // Emolga
+        new(BW, 0x2A000000) { Species = 479, Level = 60, Ability = OnlyFirst,  TID = 54673, SID = 00000, OTGender = 1, Gender = 2, IVs = new(20,20,20,20,20,31), Nature = Nature.Gentle }, // Rotom
+        new(BW, 0x6200001F) { Species = 446, Level = 60, Ability = OnlySecond, TID = 40217, SID = 00000, OTGender = 0, Gender = 0, IVs = new(31,20,20,20,20,20), Nature = Nature.Serious }, // Munchlax
     };
 
     internal static readonly EncounterTrade5[] TradeGift_B2W2_Regular =
     {
-        new(B2  ) { Species = 548, Level = 20, Ability = OnlySecond, TID = 65217, SID = 00000, OTGender = 1, Gender = 1, IVs = new[] {20,20,20,20,31,20}, Nature = Nature.Timid }, // Petilil
-        new(  W2) { Species = 546, Level = 20, Ability = OnlyFirst,  TID = 05720, SID = 00001, OTGender = 0, Gender = 0, IVs = new[] {20,20,20,20,31,20}, Nature = Nature.Modest }, // Cottonee
-        new(B2W2) { Species = 526, Level = 35, Ability = OnlyFirst,  TID = 11195, SID = 00000, OTGender = 0, Gender = 0, IVs = new[] {20,31,20,20,20,20}, Nature = Nature.Adamant, IsNicknamed = false }, // Gigalith
-        new(B2W2) { Species = 465, Level = 45, Ability = OnlyFirst,  TID = 27658, SID = 00001, OTGender = 0, Gender = 0, IVs = new[] {31,20,20,20,20,20}, Nature = Nature.Hardy }, // Tangrowth
-        new(B2W2) { Species = 479, Level = 60, Ability = OnlyFirst,  TID = 54673, SID = 00000, OTGender = 1, Gender = 2, IVs = new[] {20,20,20,20,20,31}, Nature = Nature.Calm }, // Rotom
-        new(B2W2) { Species = 424, Level = 40, Ability = OnlySecond, TID = 17074, SID = 00001, OTGender = 1, Gender = 0, IVs = new[] {20,20,20,31,20,20}, Nature = Nature.Jolly }, // Ambipom
-        new(B2W2) { Species = 065, Level = 40, Ability = OnlyFirst,  TID = 17074, SID = 00001, OTGender = 1, Gender = 0, IVs = new[] {20,20,20,31,20,20}, Nature = Nature.Timid }, // Alakazam
+        new(B2  ) { Species = 548, Level = 20, Ability = OnlySecond, TID = 65217, SID = 00000, OTGender = 1, Gender = 1, IVs = new(20,20,20,20,31,20), Nature = Nature.Timid }, // Petilil
+        new(  W2) { Species = 546, Level = 20, Ability = OnlyFirst,  TID = 05720, SID = 00001, OTGender = 0, Gender = 0, IVs = new(20,20,20,20,31,20), Nature = Nature.Modest }, // Cottonee
+        new(B2W2) { Species = 526, Level = 35, Ability = OnlyFirst,  TID = 11195, SID = 00000, OTGender = 0, Gender = 0, IVs = new(20,31,20,20,20,20), Nature = Nature.Adamant, IsNicknamed = false }, // Gigalith
+        new(B2W2) { Species = 465, Level = 45, Ability = OnlyFirst,  TID = 27658, SID = 00001, OTGender = 0, Gender = 0, IVs = new(31,20,20,20,20,20), Nature = Nature.Hardy }, // Tangrowth
+        new(B2W2) { Species = 479, Level = 60, Ability = OnlyFirst,  TID = 54673, SID = 00000, OTGender = 1, Gender = 2, IVs = new(20,20,20,20,20,31), Nature = Nature.Calm }, // Rotom
+        new(B2W2) { Species = 424, Level = 40, Ability = OnlySecond, TID = 17074, SID = 00001, OTGender = 1, Gender = 0, IVs = new(20,20,20,31,20,20), Nature = Nature.Jolly }, // Ambipom
+        new(B2W2) { Species = 065, Level = 40, Ability = OnlyFirst,  TID = 17074, SID = 00001, OTGender = 1, Gender = 0, IVs = new(20,20,20,31,20,20), Nature = Nature.Timid }, // Alakazam
     };
 
     internal const int YancyTID = 10303;

--- a/PKHeX.Core/Legality/Encounters/Data/Encounters6.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Encounters6.cs
@@ -53,8 +53,8 @@ internal static class Encounters6
         new(XY) { Gift = true, Species = 698, Level = 20, Location = 44 }, // Amaura
 
         // Gift
-        new(XY) { Gift = true, Species = 448, Level = 32, Location = 60, Ability = OnlyFirst,  IVs = new[] {06,25,16,31,25,19}, Nature = Nature.Hasty, Gender = 0, Shiny = Shiny.Never }, // Lucario
-        new(XY) { Gift = true, Species = 131, Level = 30, Location = 62, Ability = OnlyFirst,  IVs = new[] {31,20,20,20,20,20}, Nature = Nature.Docile }, // Lapras
+        new(XY) { Gift = true, Species = 448, Level = 32, Location = 60, Ability = OnlyFirst,  IVs = new(06,25,16,31,25,19), Nature = Nature.Hasty, Gender = 0, Shiny = Shiny.Never }, // Lucario
+        new(XY) { Gift = true, Species = 131, Level = 30, Location = 62, Ability = OnlyFirst,  IVs = new(31,20,20,20,20,20), Nature = Nature.Docile }, // Lapras
 
         // Stationary
         new(XY) { Species = 143, Level = 15, Location = 038, Shiny = Shiny.Never }, // Snorlax
@@ -143,8 +143,8 @@ internal static class Encounters6
         new(ORAS) { Gift = true, Species = 175, Level = 1, EggLocation = 60004, Ability = OnlyFirst,  EggCycles = 70 }, // Togepi
 
         // Gift
-        new(ORAS) { Species = 374, Level = 01, Location = 196, Ability = OnlyFirst,  Gift = true, IVs = new[] {-1,-1,31,-1,-1,31} }, // Beldum
-        new(ORAS) { Species = 351, Level = 30, Location = 240, Ability = OnlyFirst,  Gift = true, IVs = new[] {-1,-1,-1,-1,31,-1}, CNT_Beauty = 100, Gender = 1, Nature = Nature.Lax }, // Castform
+        new(ORAS) { Species = 374, Level = 01, Location = 196, Ability = OnlyFirst,  Gift = true, IVs = new(-1,-1,31,-1,-1,31) }, // Beldum
+        new(ORAS) { Species = 351, Level = 30, Location = 240, Ability = OnlyFirst,  Gift = true, IVs = new(-1,-1,-1,-1,31,-1), CNT_Beauty = 100, Gender = 1, Nature = Nature.Lax }, // Castform
         new(ORAS) { Species = 319, Level = 40, Location = 318, Ability = OnlyFirst,  Gift = true, Gender = 1, Nature = Nature.Adamant }, // Sharpedo
         new(ORAS) { Species = 323, Level = 40, Location = 318, Ability = OnlyFirst,  Gift = true, Gender = 1, Nature = Nature.Quiet }, // Camerupt
         new(  AS) { Species = 380, Level = 30, Location = 320, Ability = OnlyFirst,  Gift = true, FlawlessIVCount = 3 }, // Latias
@@ -223,24 +223,24 @@ internal static class Encounters6
     #region Trade Tables
     internal static readonly EncounterTrade6[] TradeGift_XY =
     {
-        new(XY, 01,3,23,049) { Species = 129, Level = 05, Ability = OnlyFirst,  TID = 44285, IVs = new[] {-1,31,-1,-1,31,-1}, Gender = 0, Nature = Nature.Adamant }, // Magikarp
+        new(XY, 01,3,23,049) { Species = 129, Level = 05, Ability = OnlyFirst,  TID = 44285, IVs = new(-1,31,-1,-1,31,-1), Gender = 0, Nature = Nature.Adamant }, // Magikarp
         new(XY, 10,3,00,000) { Species = 133, Level = 05, Ability = OnlyFirst,  TID = 29294, Gender = 1, Nature = Nature.Docile }, // Eevee
 
-        new(XY, 15,4,13,017) { Species = 083, Level = 10, Ability = OnlyFirst,  TID = 00185, IVs = new[] {-1,-1,-1,31,-1,-1}, Gender = 0, Nature = Nature.Jolly }, // Farfetch'd
-        new(XY, 17,5,08,025) { Species = 208, Level = 20, Ability = OnlyFirst,  TID = 19250, IVs = new[] {-1,-1,31,-1,-1,-1}, Gender = 1, Nature = Nature.Impish }, // Steelix
-        new(XY, 18,7,20,709) { Species = 625, Level = 50, Ability = OnlyFirst,  TID = 03447, IVs = new[] {-1,31,-1,-1,-1,-1}, Gender = 0, Nature = Nature.Adamant }, // Bisharp
+        new(XY, 15,4,13,017) { Species = 083, Level = 10, Ability = OnlyFirst,  TID = 00185, IVs = new(-1,-1,-1,31,-1,-1), Gender = 0, Nature = Nature.Jolly }, // Farfetch'd
+        new(XY, 17,5,08,025) { Species = 208, Level = 20, Ability = OnlyFirst,  TID = 19250, IVs = new(-1,-1,31,-1,-1,-1), Gender = 1, Nature = Nature.Impish }, // Steelix
+        new(XY, 18,7,20,709) { Species = 625, Level = 50, Ability = OnlyFirst,  TID = 03447, IVs = new(-1,31,-1,-1,-1,-1), Gender = 0, Nature = Nature.Adamant }, // Bisharp
 
-        new(XY, 02,3,11,005) { Species = 656, Level = 05, Ability = OnlyFirst,  TID = 00037, IVs = new[] {20,20,20,31,20,20}, Gender = 0, Nature = Nature.Jolly }, // Froakie
-        new(XY, 02,3,09,005) { Species = 650, Level = 05, Ability = OnlyFirst,  TID = 00037, IVs = new[] {20,31,20,20,20,20}, Gender = 0, Nature = Nature.Adamant }, // Chespin
-        new(XY, 02,3,18,005) { Species = 653, Level = 05, Ability = OnlyFirst,  TID = 00037, IVs = new[] {20,20,20,20,31,20}, Gender = 0, Nature = Nature.Modest }, // Fennekin
-        new(XY, 51,4,04,033) { Species = 280, Level = 05, Ability = OnlyFirst,  TID = 37110, IVs = new[] {20,20,20,31,31,20}, Gender = 1, Nature = Nature.Modest, IsNicknamed = false }, // Ralts
+        new(XY, 02,3,11,005) { Species = 656, Level = 05, Ability = OnlyFirst,  TID = 00037, IVs = new(20,20,20,31,20,20), Gender = 0, Nature = Nature.Jolly }, // Froakie
+        new(XY, 02,3,09,005) { Species = 650, Level = 05, Ability = OnlyFirst,  TID = 00037, IVs = new(20,31,20,20,20,20), Gender = 0, Nature = Nature.Adamant }, // Chespin
+        new(XY, 02,3,18,005) { Species = 653, Level = 05, Ability = OnlyFirst,  TID = 00037, IVs = new(20,20,20,20,31,20), Gender = 0, Nature = Nature.Modest }, // Fennekin
+        new(XY, 51,4,04,033) { Species = 280, Level = 05, Ability = OnlyFirst,  TID = 37110, IVs = new(20,20,20,31,31,20), Gender = 1, Nature = Nature.Modest, IsNicknamed = false }, // Ralts
     };
 
     internal static readonly EncounterTrade6[] TradeGift_AO =
     {
-        new(ORAS, 01,3,05,040) { Species = 296, Level = 09, Ability = OnlySecond, TID = 30724, IVs = new[] {-1,31,-1,-1,-1,-1}, Gender = 0, Nature = Nature.Brave }, // Makuhita
-        new(ORAS, 34,3,13,176) { Species = 300, Level = 30, Ability = OnlyFirst,  TID = 03239, IVs = new[] {-1,-1,-1,31,-1,-1}, Gender = 1, Nature = Nature.Naughty }, // Skitty
-        new(ORAS, 07,4,10,319) { Species = 222, Level = 50, Ability = OnlyHidden, TID = 00325, IVs = new[] {31,-1,-1,-1,-1,31}, Gender = 1, Nature = Nature.Calm }, // Corsola
+        new(ORAS, 01,3,05,040) { Species = 296, Level = 09, Ability = OnlySecond, TID = 30724, IVs = new(-1,31,-1,-1,-1,-1), Gender = 0, Nature = Nature.Brave }, // Makuhita
+        new(ORAS, 34,3,13,176) { Species = 300, Level = 30, Ability = OnlyFirst,  TID = 03239, IVs = new(-1,-1,-1,31,-1,-1), Gender = 1, Nature = Nature.Naughty }, // Skitty
+        new(ORAS, 07,4,10,319) { Species = 222, Level = 50, Ability = OnlyHidden, TID = 00325, IVs = new(31,-1,-1,-1,-1,31), Gender = 1, Nature = Nature.Calm }, // Corsola
     };
     #endregion
 

--- a/PKHeX.Core/Legality/Encounters/Data/Encounters6.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Encounters6.cs
@@ -1,4 +1,4 @@
-﻿using static PKHeX.Core.EncounterUtil;
+using static PKHeX.Core.EncounterUtil;
 using static PKHeX.Core.GameVersion;
 using static PKHeX.Core.AbilityPermission;
 
@@ -209,11 +209,11 @@ internal static class Encounters6
         new(ORAS) { Species = 425, Level = 45, Location = 348 }, // Drifloon
         new(ORAS) { Species = 628, Level = 45, Location = 348 }, // Braviary
 
-        BaseCosplay with {Form = 1, Moves = new [] {098, 486, 086, (int)Move.MeteorMash}}, // Rock Star
-        BaseCosplay with {Form = 2, Moves = new [] {098, 486, 086, (int)Move.IcicleCrash}}, // Belle
-        BaseCosplay with {Form = 3, Moves = new [] {098, 486, 086, (int)Move.DrainingKiss}}, // Pop Star
-        BaseCosplay with {Form = 4, Moves = new [] {098, 486, 086, (int)Move.ElectricTerrain}}, // Ph.D.
-        BaseCosplay with {Form = 5, Moves = new [] {098, 486, 086, (int)Move.FlyingPress}}, // Libre
+        BaseCosplay with {Form = 1, Moves = new(098, 486, 086, (int)Move.MeteorMash)}, // Rock Star
+        BaseCosplay with {Form = 2, Moves = new(098, 486, 086, (int)Move.IcicleCrash)}, // Belle
+        BaseCosplay with {Form = 3, Moves = new(098, 486, 086, (int)Move.DrainingKiss)}, // Pop Star
+        BaseCosplay with {Form = 4, Moves = new(098, 486, 086, (int)Move.ElectricTerrain)}, // Ph.D.
+        BaseCosplay with {Form = 5, Moves = new(098, 486, 086, (int)Move.FlyingPress)}, // Libre
         BaseCosplay, // Cosplay, same 3 level up moves.
     };
 

--- a/PKHeX.Core/Legality/Encounters/Data/Encounters7.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Encounters7.cs
@@ -1,4 +1,4 @@
-﻿using static PKHeX.Core.EncounterUtil;
+using static PKHeX.Core.EncounterUtil;
 using static PKHeX.Core.GameVersion;
 using static PKHeX.Core.AbilityPermission;
 
@@ -57,15 +57,15 @@ internal static class Encounters7
         new(SM) // Magearna (Bottle Cap) 00 FF
         {
             Gift = true, Species = 801, Level = 50, Location = 40001, Shiny = Shiny.Never, FlawlessIVCount = 3, HeldItem = 795, Ability = OnlySecond,
-            Fateful = true, Relearn = new [] {705, 430, 381, 270}, Ball = 0x10, // Cherish
+            Fateful = true, Relearn = new(705, 430, 381, 270), Ball = 0x10, // Cherish
         },
 
         // Static Encounters - 1.bin
         new(SM) { Species = 746, Level = 17, Location = 086, Shiny = Shiny.Never, Ability = OnlyFirst }, // Wishiwashi
         new(SM) { Species = 746, Level = 18, Location = 086, Shiny = Shiny.Never, Ability = OnlyFirst }, // Wishiwashi
 
-        new(SN) { Species = 791, Level = 55, Location = 176, Shiny = Shiny.Never, Ability = OnlyFirst,  FlawlessIVCount = 3, Relearn = new[]{713, 322, 242, 428} }, // Solgaleo
-        new(MN) { Species = 792, Level = 55, Location = 178, Shiny = Shiny.Never, Ability = OnlyFirst,  FlawlessIVCount = 3, Relearn = new[]{714, 322, 539, 247} }, // Lunala
+        new(SN) { Species = 791, Level = 55, Location = 176, Shiny = Shiny.Never, Ability = OnlyFirst,  FlawlessIVCount = 3, Relearn = new(713, 322, 242, 428) }, // Solgaleo
+        new(MN) { Species = 792, Level = 55, Location = 178, Shiny = Shiny.Never, Ability = OnlyFirst,  FlawlessIVCount = 3, Relearn = new(714, 322, 539, 247) }, // Lunala
 
         new(SM) { Species = 785, Level = 60, Location = 030, Shiny = Shiny.Never, Ability = OnlyFirst,  FlawlessIVCount = 3 }, // Tapu Koko
         new(SM) { Species = 786, Level = 60, Location = 092, Shiny = Shiny.Never, Ability = OnlyFirst,  FlawlessIVCount = 3 }, // Tapu Lele
@@ -87,40 +87,40 @@ internal static class Encounters7
 
         // QR Scan: Su/M/Tu/W/Th/F/Sa
         // Melemele Island
-        new(SM) { Species = 155, Level = 12, Location = 010, Relearn = new[]{024, 052, 108, 043} }, // Cyndaquil @ Route 3
-        new(SM) { Species = 158, Level = 12, Location = 042, Relearn = new[]{232, 099, 055, 043} }, // Totodile @ Seaward Cave
-        new(SM) { Species = 633, Level = 13, Location = 034, Relearn = new[]{372, 029, 044, 116} }, // Deino @ Ten Carat Hill
-        new(SM) { Species = 116, Level = 18, Location = 014, Relearn = new[]{225, 239, 055, 043} }, // Horsea @ Kala'e Bay
-        new(SM) { Species = 599, Level = 08, Location = 020, Relearn = new[]{268, 011, 000, 000} }, // Klink @ Hau'oli City
-        new(SM) { Species = 152, Level = 10, Location = 012, Relearn = new[]{073, 077, 075, 045} }, // Chikorita @ Route 2
-        new(SM) { Species = 607, Level = 10, Location = 038, Relearn = new[]{051, 109, 083, 123} }, // Litwick @ Hau'oli Cemetery
+        new(SM) { Species = 155, Level = 12, Location = 010, Relearn = new(024, 052, 108, 043) }, // Cyndaquil @ Route 3
+        new(SM) { Species = 158, Level = 12, Location = 042, Relearn = new(232, 099, 055, 043) }, // Totodile @ Seaward Cave
+        new(SM) { Species = 633, Level = 13, Location = 034, Relearn = new(372, 029, 044, 116) }, // Deino @ Ten Carat Hill
+        new(SM) { Species = 116, Level = 18, Location = 014, Relearn = new(225, 239, 055, 043) }, // Horsea @ Kala'e Bay
+        new(SM) { Species = 599, Level = 08, Location = 020, Relearn = new(268, 011, 000, 000) }, // Klink @ Hau'oli City
+        new(SM) { Species = 152, Level = 10, Location = 012, Relearn = new(073, 077, 075, 045) }, // Chikorita @ Route 2
+        new(SM) { Species = 607, Level = 10, Location = 038, Relearn = new(051, 109, 083, 123) }, // Litwick @ Hau'oli Cemetery
 
         // Akala Island
-        new(SM) { Species = 574, Level = 17, Location = 054, Relearn = new[]{399, 060, 003, 313} }, // Gothita @ Route 6
-        new(SM) { Species = 363, Level = 19, Location = 056, Relearn = new[]{392, 362, 301, 227} }, // Spheal @ Route 7
-        new(SM) { Species = 404, Level = 20, Location = 058, Relearn = new[]{598, 044, 209, 268} }, // Luxio @ Route 8
-        new(SM) { Species = 679, Level = 23, Location = 094, Relearn = new[]{194, 332, 425, 475} }, // Honedge @ Akala Outskirts
-        new(SM) { Species = 543, Level = 14, Location = 050, Relearn = new[]{390, 228, 103, 040} }, // Venipede @ Route 4
-        new(SM) { Species = 069, Level = 16, Location = 052, Relearn = new[]{491, 077, 079, 035} }, // Bellsprout @ Route 5
-        new(SM) { Species = 183, Level = 17, Location = 086, Relearn = new[]{453, 270, 061, 205} }, // Marill @ Brooklet Hill
+        new(SM) { Species = 574, Level = 17, Location = 054, Relearn = new(399, 060, 003, 313) }, // Gothita @ Route 6
+        new(SM) { Species = 363, Level = 19, Location = 056, Relearn = new(392, 362, 301, 227) }, // Spheal @ Route 7
+        new(SM) { Species = 404, Level = 20, Location = 058, Relearn = new(598, 044, 209, 268) }, // Luxio @ Route 8
+        new(SM) { Species = 679, Level = 23, Location = 094, Relearn = new(194, 332, 425, 475) }, // Honedge @ Akala Outskirts
+        new(SM) { Species = 543, Level = 14, Location = 050, Relearn = new(390, 228, 103, 040) }, // Venipede @ Route 4
+        new(SM) { Species = 069, Level = 16, Location = 052, Relearn = new(491, 077, 079, 035) }, // Bellsprout @ Route 5
+        new(SM) { Species = 183, Level = 17, Location = 086, Relearn = new(453, 270, 061, 205) }, // Marill @ Brooklet Hill
 
         // Ula'ula Island
-        new(SM) { Species = 111, Level = 30, Location = 138, Relearn = new[]{130, 350, 498, 523} }, // Rhyhorn @ Blush Mountain
-        new(SM) { Species = 220, Level = 31, Location = 114, Relearn = new[]{573, 036, 420, 196} }, // Swinub @ Tapu Village
-        new(SM) { Species = 578, Level = 33, Location = 118, Relearn = new[]{101, 248, 283, 473} }, // Duosion @ Route 16
-        new(SM) { Species = 315, Level = 34, Location = 128, Relearn = new[]{437, 275, 230, 390} }, // Roselia @ Ula'ula Meadow
-        new(SM) { Species = 397, Level = 27, Location = 106, Relearn = new[]{355, 018, 283, 104} }, // Staravia @ Route 10
-        new(SM) { Species = 288, Level = 27, Location = 108, Relearn = new[]{359, 498, 163, 203} }, // Vigoroth @ Route 11
-        new(SM) { Species = 610, Level = 28, Location = 136, Relearn = new[]{231, 337, 206, 163} }, // Axew @ Mount Hokulani
+        new(SM) { Species = 111, Level = 30, Location = 138, Relearn = new(130, 350, 498, 523) }, // Rhyhorn @ Blush Mountain
+        new(SM) { Species = 220, Level = 31, Location = 114, Relearn = new(573, 036, 420, 196) }, // Swinub @ Tapu Village
+        new(SM) { Species = 578, Level = 33, Location = 118, Relearn = new(101, 248, 283, 473) }, // Duosion @ Route 16
+        new(SM) { Species = 315, Level = 34, Location = 128, Relearn = new(437, 275, 230, 390) }, // Roselia @ Ula'ula Meadow
+        new(SM) { Species = 397, Level = 27, Location = 106, Relearn = new(355, 018, 283, 104) }, // Staravia @ Route 10
+        new(SM) { Species = 288, Level = 27, Location = 108, Relearn = new(359, 498, 163, 203) }, // Vigoroth @ Route 11
+        new(SM) { Species = 610, Level = 28, Location = 136, Relearn = new(231, 337, 206, 163) }, // Axew @ Mount Hokulani
 
         // Poni Island
-        new(SM) { Species = 604, Level = 55, Location = 164, Relearn = new[]{435, 051, 029, 306} }, // Eelektross @ Poni Grove
-        new(SM) { Species = 534, Level = 57, Location = 166, Relearn = new[]{409, 276, 264, 444} }, // Conkeldurr @ Poni Plains
-        new(SM) { Species = 468, Level = 59, Location = 170, Relearn = new[]{248, 403, 396, 245} }, // Togekiss @ Poni Gauntlet
-        new(SM) { Species = 542, Level = 57, Location = 156, Relearn = new[]{382, 437, 014, 494} }, // Leavanny @ Poni Meadow
-        new(SM) { Species = 497, Level = 43, Location = 184, Relearn = new[]{137, 489, 348, 021} }, // Serperior @ Exeggutor Island
-        new(SM) { Species = 503, Level = 43, Location = 158, Relearn = new[]{362, 227, 453, 279} }, // Samurott @ Poni Wilds
-        new(SM) { Species = 500, Level = 43, Location = 160, Relearn = new[]{276, 053, 372, 535} }, // Emboar @ Ancient Poni Path
+        new(SM) { Species = 604, Level = 55, Location = 164, Relearn = new(435, 051, 029, 306) }, // Eelektross @ Poni Grove
+        new(SM) { Species = 534, Level = 57, Location = 166, Relearn = new(409, 276, 264, 444) }, // Conkeldurr @ Poni Plains
+        new(SM) { Species = 468, Level = 59, Location = 170, Relearn = new(248, 403, 396, 245) }, // Togekiss @ Poni Gauntlet
+        new(SM) { Species = 542, Level = 57, Location = 156, Relearn = new(382, 437, 014, 494) }, // Leavanny @ Poni Meadow
+        new(SM) { Species = 497, Level = 43, Location = 184, Relearn = new(137, 489, 348, 021) }, // Serperior @ Exeggutor Island
+        new(SM) { Species = 503, Level = 43, Location = 158, Relearn = new(362, 227, 453, 279) }, // Samurott @ Poni Wilds
+        new(SM) { Species = 500, Level = 43, Location = 160, Relearn = new(276, 053, 372, 535) }, // Emboar @ Ancient Poni Path
     };
 
     internal static readonly EncounterTrade7[] TradeGift_SM = // @ a\1\5\5
@@ -158,7 +158,7 @@ internal static class Encounters7
         new(US  ) { Gift = true, Species = 789, Level = 05, Location = 142, FlawlessIVCount = 3, Shiny = Shiny.Never, Ability = OnlySecond }, // Cosmog @ Lake of the Sunne
         new(  UM) { Gift = true, Species = 789, Level = 05, Location = 144, FlawlessIVCount = 3, Shiny = Shiny.Never, Ability = OnlySecond }, // Cosmog @ Lake of the Moone
         new(USUM) { Gift = true, Species = 142, Level = 40, Location = 172 }, // Aerodactyl @ Seafolk Village
-        new(USUM) { Gift = true, Species = 025, Level = 40, Location = 070, FlawlessIVCount = 3, HeldItem = 796, Relearn = new[] {57,0,0,0} }, // Pikachu @ Heahea City
+        new(USUM) { Gift = true, Species = 025, Level = 40, Location = 070, FlawlessIVCount = 3, HeldItem = 796, Relearn = new(57) }, // Pikachu @ Heahea City
         new(USUM) { Gift = true, Species = 803, Level = 40, Location = 208, FlawlessIVCount = 3 }, // Poipole @ Megalo Tower
         new(USUM) { Gift = true, Species = 803, Level = 40, Location = 206, FlawlessIVCount = 3 }, // Poipole @ Ultra Megalopolis
 
@@ -180,7 +180,7 @@ internal static class Encounters7
         new(USUM) // Magearna (Bottle Cap)
         {
             Gift = true, Species = 801, Level = 50, Location = 40001, Shiny = Shiny.Never, FlawlessIVCount = 3, HeldItem = 795, Ability = OnlySecond,
-            Fateful = true, Relearn = new [] {705, 430, 381, 270}, Ball = 0x10, // Cherish
+            Fateful = true, Relearn = new(705, 430, 381, 270), Ball = 0x10, // Cherish
         },
 
         new(USUM) { Gift = true, Species = 718, Form = 0, Level = 50, Shiny = Shiny.Never, Location = 118, FlawlessIVCount = 3 }, // Zygarde (50%)
@@ -188,45 +188,45 @@ internal static class Encounters7
         new(USUM) { Gift = true, Species = 718, Form = 2, Level = 50, Shiny = Shiny.Never, Location = 118, FlawlessIVCount = 3 }, // Zygarde (10%-C)
         new(USUM) { Gift = true, Species = 718, Form = 3, Level = 50, Shiny = Shiny.Never, Location = 118, FlawlessIVCount = 3 }, // Zygarde (50%-C)
 
-        new(US  ) { Species = 791, Level = 60, Location = 028, Ability = OnlyFirst,  Shiny = Shiny.Never, FlawlessIVCount = 3, Relearn = new[] {713,322,242,428} }, // Solgaleo @ Mahalo Trail (Plank Bridge)
-        new(  UM) { Species = 792, Level = 60, Location = 028, Ability = OnlyFirst,  Shiny = Shiny.Never, FlawlessIVCount = 3, Relearn = new[] {714,322,539,585} }, // Lunala @ Mahalo Trail (Plank Bridge)
+        new(US  ) { Species = 791, Level = 60, Location = 028, Ability = OnlyFirst,  Shiny = Shiny.Never, FlawlessIVCount = 3, Relearn = new(713,322,242,428) }, // Solgaleo @ Mahalo Trail (Plank Bridge)
+        new(  UM) { Species = 792, Level = 60, Location = 028, Ability = OnlyFirst,  Shiny = Shiny.Never, FlawlessIVCount = 3, Relearn = new(714,322,539,585) }, // Lunala @ Mahalo Trail (Plank Bridge)
 
         // QR Scan: Su/M/Tu/W/Th/F/Sa
         // Melemele Island
-        new(USUM) { Species = 004, Level = 12, Location = 010, Relearn = new[] {068,108,052,010} }, // Charmander @ Route 3
-        new(USUM) { Species = 007, Level = 12, Location = 042, Relearn = new[] {453,110,055,033} }, // Squirtle @ Seaward Cave
-        new(USUM) { Species = 095, Level = 14, Location = 034, Relearn = new[] {563,099,317,088} }, // Onix @ Ten Carat Hill
-        new(USUM) { Species = 116, Level = 18, Location = 014, Relearn = new[] {352,239,055,043} }, // Horsea @ Kala'e Bay
-        new(USUM) { Species = 664, Level = 09, Location = 020, Relearn = new[] {476,081,078,033}, Form = EncounterStatic.FormVivillon }, // Scatterbug @ Hau'oli City
-        new(USUM) { Species = 001, Level = 10, Location = 012, Relearn = new[] {580,022,045,033} }, // Bulbasaur @ Route 2
-        new(USUM) { Species = 607, Level = 09, Location = 038, Relearn = new[] {203,052,083,123} }, // Litwick @ Hau'oli Cemetery
+        new(USUM) { Species = 004, Level = 12, Location = 010, Relearn = new(068,108,052,010) }, // Charmander @ Route 3
+        new(USUM) { Species = 007, Level = 12, Location = 042, Relearn = new(453,110,055,033) }, // Squirtle @ Seaward Cave
+        new(USUM) { Species = 095, Level = 14, Location = 034, Relearn = new(563,099,317,088) }, // Onix @ Ten Carat Hill
+        new(USUM) { Species = 116, Level = 18, Location = 014, Relearn = new(352,239,055,043) }, // Horsea @ Kala'e Bay
+        new(USUM) { Species = 664, Level = 09, Location = 020, Relearn = new(476,081,078,033), Form = EncounterStatic.FormVivillon }, // Scatterbug @ Hau'oli City
+        new(USUM) { Species = 001, Level = 10, Location = 012, Relearn = new(580,022,045,033) }, // Bulbasaur @ Route 2
+        new(USUM) { Species = 607, Level = 09, Location = 038, Relearn = new(203,052,083,123) }, // Litwick @ Hau'oli Cemetery
 
         // Akala Island
-        new(USUM) { Species = 280, Level = 17, Location = 054, Relearn = new[] {581,345,381,574} }, // Ralts @ Route 6
-        new(USUM) { Species = 363, Level = 19, Location = 056, Relearn = new[] {187,362,301,227} }, // Spheal @ Route 7
-        new(USUM) { Species = 256, Level = 20, Location = 058, Relearn = new[] {067,488,064,028} }, // Combusken @ Route 8
-        new(USUM) { Species = 679, Level = 24, Location = 094, Relearn = new[] {469,332,425,475} }, // Honedge @ Akala Outskirts
-        new(USUM) { Species = 015, Level = 14, Location = 050, Relearn = new[] {099,031,041,000} }, // Beedrill @ Route 4
-        new(USUM) { Species = 253, Level = 16, Location = 052, Relearn = new[] {580,072,098,071} }, // Grovyle @ Route 5
-        new(USUM) { Species = 259, Level = 17, Location = 086, Relearn = new[] {068,193,189,055} }, // Marshtomp @ Brooklet Hill
+        new(USUM) { Species = 280, Level = 17, Location = 054, Relearn = new(581,345,381,574) }, // Ralts @ Route 6
+        new(USUM) { Species = 363, Level = 19, Location = 056, Relearn = new(187,362,301,227) }, // Spheal @ Route 7
+        new(USUM) { Species = 256, Level = 20, Location = 058, Relearn = new(067,488,064,028) }, // Combusken @ Route 8
+        new(USUM) { Species = 679, Level = 24, Location = 094, Relearn = new(469,332,425,475) }, // Honedge @ Akala Outskirts
+        new(USUM) { Species = 015, Level = 14, Location = 050, Relearn = new(099,031,041,000) }, // Beedrill @ Route 4
+        new(USUM) { Species = 253, Level = 16, Location = 052, Relearn = new(580,072,098,071) }, // Grovyle @ Route 5
+        new(USUM) { Species = 259, Level = 17, Location = 086, Relearn = new(068,193,189,055) }, // Marshtomp @ Brooklet Hill
 
         // Ula'ula Island
-        new(USUM) { Species = 111, Level = 32, Location = 138, Relearn = new[] {470,350,498,523} }, // Rhyhorn @ Blush Mountain
-        new(USUM) { Species = 220, Level = 33, Location = 114, Relearn = new[] {333,036,420,196} }, // Swinub @ Tapu Village
-        new(USUM) { Species = 394, Level = 35, Location = 118, Relearn = new[] {681,362,031,117} }, // Prinplup @ Route 16
-        new(USUM) { Species = 388, Level = 36, Location = 128, Relearn = new[] {484,073,072,044} }, // Grotle @ Ula'ula Meadow
-        new(USUM) { Species = 018, Level = 29, Location = 106, Relearn = new[] {211,297,239,098} }, // Pidgeot @ Route 10
-        new(USUM) { Species = 391, Level = 29, Location = 108, Relearn = new[] {612,172,154,259} }, // Monferno @ Route 11
-        new(USUM) { Species = 610, Level = 30, Location = 136, Relearn = new[] {068,337,206,163} }, // Axew @ Mount Hokulani
+        new(USUM) { Species = 111, Level = 32, Location = 138, Relearn = new(470,350,498,523) }, // Rhyhorn @ Blush Mountain
+        new(USUM) { Species = 220, Level = 33, Location = 114, Relearn = new(333,036,420,196) }, // Swinub @ Tapu Village
+        new(USUM) { Species = 394, Level = 35, Location = 118, Relearn = new(681,362,031,117) }, // Prinplup @ Route 16
+        new(USUM) { Species = 388, Level = 36, Location = 128, Relearn = new(484,073,072,044) }, // Grotle @ Ula'ula Meadow
+        new(USUM) { Species = 018, Level = 29, Location = 106, Relearn = new(211,297,239,098) }, // Pidgeot @ Route 10
+        new(USUM) { Species = 391, Level = 29, Location = 108, Relearn = new(612,172,154,259) }, // Monferno @ Route 11
+        new(USUM) { Species = 610, Level = 30, Location = 136, Relearn = new(068,337,206,163) }, // Axew @ Mount Hokulani
 
         // Poni Island
-        new(USUM) { Species = 604, Level = 55, Location = 164, Relearn = new[] {242,435,029,306} }, // Eelektross @ Poni Grove
-        new(USUM) { Species = 306, Level = 57, Location = 166, Relearn = new[] {179,484,038,334} }, // Aggron @ Poni Plains
-        new(USUM) { Species = 479, Level = 61, Location = 170, Relearn = new[] {268,506,486,164} }, // Rotom @ Poni Gauntlet
-        new(USUM) { Species = 542, Level = 57, Location = 156, Relearn = new[] {580,437,014,494} }, // Leavanny @ Poni Meadow
-        new(USUM) { Species = 652, Level = 45, Location = 184, Relearn = new[] {191,341,402,596} }, // Chesnaught @ Exeggutor Island
-        new(USUM) { Species = 658, Level = 44, Location = 158, Relearn = new[] {516,164,185,594} }, // Greninja @ Poni Wilds
-        new(USUM) { Species = 655, Level = 44, Location = 160, Relearn = new[] {273,473,113,595} }, // Delphox @ Ancient Poni Path
+        new(USUM) { Species = 604, Level = 55, Location = 164, Relearn = new(242,435,029,306) }, // Eelektross @ Poni Grove
+        new(USUM) { Species = 306, Level = 57, Location = 166, Relearn = new(179,484,038,334) }, // Aggron @ Poni Plains
+        new(USUM) { Species = 479, Level = 61, Location = 170, Relearn = new(268,506,486,164) }, // Rotom @ Poni Gauntlet
+        new(USUM) { Species = 542, Level = 57, Location = 156, Relearn = new(580,437,014,494) }, // Leavanny @ Poni Meadow
+        new(USUM) { Species = 652, Level = 45, Location = 184, Relearn = new(191,341,402,596) }, // Chesnaught @ Exeggutor Island
+        new(USUM) { Species = 658, Level = 44, Location = 158, Relearn = new(516,164,185,594) }, // Greninja @ Poni Wilds
+        new(USUM) { Species = 655, Level = 44, Location = 160, Relearn = new(273,473,113,595) }, // Delphox @ Ancient Poni Path
 
         new(USUM) { Species = 785, Level = 60, Location = 030, Ability = OnlyFirst,  Shiny = Shiny.Never, FlawlessIVCount = 3 }, // Tapu Koko @ Ruins of Conflict
         new(USUM) { Species = 786, Level = 60, Location = 092, Ability = OnlyFirst,  Shiny = Shiny.Never, FlawlessIVCount = 3 }, // Tapu Lele @ Ruins of Life
@@ -237,47 +237,47 @@ internal static class Encounters7
 
         new(USUM) { Species = 127, Level = 42, Location = 184, Shiny = Shiny.Never }, // Pinsir @ Exeggutor Island
         new(USUM) { Species = 127, Level = 43, Location = 184, Shiny = Shiny.Never }, // Pinsir @ Exeggutor Island
-        new(USUM) { Species = 800, Level = 65, Location = 146, Ability = OnlyFirst,  Shiny = Shiny.Never, FlawlessIVCount = 3, Relearn = new[] {722,334,408,400}, HeldItem = 923 }, // Necrozma @ Mount Lanakila
+        new(USUM) { Species = 800, Level = 65, Location = 146, Ability = OnlyFirst,  Shiny = Shiny.Never, FlawlessIVCount = 3, Relearn = new(722,334,408,400), HeldItem = 923 }, // Necrozma @ Mount Lanakila
 
         // Legendaries
-        new(USUM) { Species = 144, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3, Relearn = new[] {246,573,115,258} }, // Articuno
-        new(USUM) { Species = 145, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3, Relearn = new[] {246,435,365,240} }, // Zapdos
-        new(USUM) { Species = 146, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3, Relearn = new[] {246,053,403,241} }, // Moltres
-        new(USUM) { Species = 150, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3, Relearn = new[] {094,105,129,427} }, // Mewtwo
+        new(USUM) { Species = 144, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3, Relearn = new(246,573,115,258) }, // Articuno
+        new(USUM) { Species = 145, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3, Relearn = new(246,435,365,240) }, // Zapdos
+        new(USUM) { Species = 146, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3, Relearn = new(246,053,403,241) }, // Moltres
+        new(USUM) { Species = 150, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3, Relearn = new(094,105,129,427) }, // Mewtwo
         new(US  ) { Species = 243, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3 }, // Raikou
-        new(  UM) { Species = 244, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3, Relearn = new[] {023,044,207,436} }, // Entei
-        new(USUM) { Species = 245, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3, Relearn = new[] {061,062,054,240} }, // Suicune
-        new(  UM) { Species = 249, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3, Relearn = new[] {285,177,326,246} }, // Lugia
-        new(US  ) { Species = 250, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3, Relearn = new[] {682,221,326,246}, HeldItem = 044 }, // Ho-Oh
+        new(  UM) { Species = 244, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3, Relearn = new(023,044,207,436) }, // Entei
+        new(USUM) { Species = 245, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3, Relearn = new(061,062,054,240) }, // Suicune
+        new(  UM) { Species = 249, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3, Relearn = new(285,177,326,246) }, // Lugia
+        new(US  ) { Species = 250, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3, Relearn = new(682,221,326,246), HeldItem = 044 }, // Ho-Oh
         new(USUM) { Species = 377, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3 }, // Regirock
         new(USUM) { Species = 378, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3 }, // Regice
         new(USUM) { Species = 379, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3 }, // Registeel
-        new(  UM) { Species = 380, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3, Relearn = new[] {296,406,375,273}, Gender = 1 }, // Latias
-        new(US  ) { Species = 381, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3, Relearn = new[] {295,406,375,225}, Gender = 0 }, // Latios
-        new(  UM) { Species = 382, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3, Relearn = new[] {058,618,347,330} }, // Kyogre
-        new(US  ) { Species = 383, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3, Relearn = new[] {089,619,339,076} }, // Groudon
+        new(  UM) { Species = 380, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3, Relearn = new(296,406,375,273), Gender = 1 }, // Latias
+        new(US  ) { Species = 381, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3, Relearn = new(295,406,375,225), Gender = 0 }, // Latios
+        new(  UM) { Species = 382, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3, Relearn = new(058,618,347,330) }, // Kyogre
+        new(US  ) { Species = 383, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3, Relearn = new(089,619,339,076) }, // Groudon
         new(USUM) { Species = 384, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3 }, // Rayquaza
-        new(USUM) { Species = 480, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3, Relearn = new[] {326,281,133,129} }, // Uxie
-        new(USUM) { Species = 481, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3, Relearn = new[] {326,204,248,129} }, // Mesprit
-        new(USUM) { Species = 482, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3, Relearn = new[] {326,417,253,129} }, // Azelf
+        new(USUM) { Species = 480, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3, Relearn = new(326,281,133,129) }, // Uxie
+        new(USUM) { Species = 481, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3, Relearn = new(326,204,248,129) }, // Mesprit
+        new(USUM) { Species = 482, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3, Relearn = new(326,417,253,129) }, // Azelf
         new(US  ) { Species = 483, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3 }, // Dialga
         new(  UM) { Species = 484, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3 }, // Palkia
         new(US  ) { Species = 485, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3 }, // Heatran
-        new(  UM) { Species = 486, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3, Relearn = new[] {428,279,146,109} }, // Regigigas
-        new(USUM) { Species = 487, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3, Relearn = new[] {467,396,414,337} }, // Giratina
+        new(  UM) { Species = 486, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3, Relearn = new(428,279,146,109) }, // Regigigas
+        new(USUM) { Species = 487, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3, Relearn = new(467,396,414,337) }, // Giratina
         new(USUM) { Species = 488, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3, Gender = 1 }, // Cresselia
-        new(USUM) { Species = 638, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3, Relearn = new[] {533,014,098,442} }, // Cobalion
-        new(USUM) { Species = 639, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3, Relearn = new[] {533,014,157,444} }, // Terrakion
-        new(USUM) { Species = 640, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3, Relearn = new[] {533,014,202,348} }, // Virizion
+        new(USUM) { Species = 638, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3, Relearn = new(533,014,098,442) }, // Cobalion
+        new(USUM) { Species = 639, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3, Relearn = new(533,014,157,444) }, // Terrakion
+        new(USUM) { Species = 640, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3, Relearn = new(533,014,202,348) }, // Virizion
         new(US  ) { Species = 641, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3, Gender = 0 }, // Tornadus
         new(  UM) { Species = 642, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3, Gender = 0 }, // Thundurus
         new(US  ) { Species = 643, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3 }, // Reshiram
         new(  UM) { Species = 644, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3 }, // Zekrom
         new(USUM) { Species = 645, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3, Gender = 0 }, // Landorus
         new(USUM) { Species = 646, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3 }, // Kyurem
-        new(US  ) { Species = 716, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3, Relearn = new[] {601,532,400,585} }, // Xerneas
-        new(  UM) { Species = 717, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3, Relearn = new[] {613,399,566,094} }, // Yveltal
-        new(USUM) { Species = 718, Level = 60, Location = 182, Ability = OnlyFirst,  Shiny = Shiny.Never, FlawlessIVCount = 3, Relearn = new[] {616,137,219,225} }, // Zygarde @ Resolution Cave
+        new(US  ) { Species = 716, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3, Relearn = new(601,532,400,585) }, // Xerneas
+        new(  UM) { Species = 717, Level = 60, Location = 222, Ability = OnlyFirst,  FlawlessIVCount = 3, Relearn = new(613,399,566,094) }, // Yveltal
+        new(USUM) { Species = 718, Level = 60, Location = 182, Ability = OnlyFirst,  Shiny = Shiny.Never, FlawlessIVCount = 3, Relearn = new(616,137,219,225) }, // Zygarde @ Resolution Cave
 
         // Ultra Space Wilds
         new(USUM) { Species = 334, Level = 60, Location = 222, FlawlessIVCount = 3 }, // Altaria
@@ -302,7 +302,7 @@ internal static class Encounters7
         new(USUM) { Species = 195, Level = 60, Location = 222, FlawlessIVCount = 3 }, // Quagsire
 
         // Ultra Beasts
-        new(USUM) { Species = 793, Level = 60, Location = 190, Ability = OnlyFirst,  FlawlessIVCount = 3, Relearn = new[] {408,491,446,243} }, // Nihilego @ Ultra Deep Sea
+        new(USUM) { Species = 793, Level = 60, Location = 190, Ability = OnlyFirst,  FlawlessIVCount = 3, Relearn = new(408,491,446,243) }, // Nihilego @ Ultra Deep Sea
         new(US  ) { Species = 794, Level = 60, Location = 218, Ability = OnlyFirst,  FlawlessIVCount = 3 }, // Buzzwole @ Ultra Jungle
         new(  UM) { Species = 795, Level = 60, Location = 214, Ability = OnlyFirst,  FlawlessIVCount = 3 }, // Pheromosa @ Ultra Desert
         new(USUM) { Species = 796, Level = 60, Location = 210, Ability = OnlyFirst,  FlawlessIVCount = 3 }, // Xurkitree @ Ultra Plant
@@ -321,12 +321,12 @@ internal static class Encounters7
 
         // Miscellaneous Static
         new(USUM) { Species = 760, Level = 28, Location = 020, Shiny = Shiny.Never }, // Bewear @ Hau’oli City (Shopping District)
-        new(USUM) { Species = 097, Level = 29, Location = 020, Shiny = Shiny.Never, Relearn = new[] {095,171,139,029} }, // Hypno @ Hau'oli City Police Station
-        new(USUM) { Species = 097, Level = 29, Location = 020, Shiny = Shiny.Never, Relearn = new[] {417,060,050,139} }, // Hypno @ Hau'oli City Police Station
-        new(USUM) { Species = 097, Level = 29, Location = 020, Shiny = Shiny.Never, Relearn = new[] {093,050,001,096} }, // Hypno @ Hau'oli City Police Station
-        new(USUM) { Species = 092, Level = 19, Location = 230, Shiny = Shiny.Never, Relearn = new[] {174,109,122,101} }, // Gastly @ Route 1 (Trainers’ School)
-        new(USUM) { Species = 425, Level = 19, Location = 230, Shiny = Shiny.Never, Relearn = new[] {310,132,016,371} }, // Drifloon @ Route 1 (Trainers’ School)
-        new(  UM) { Species = 769, Level = 30, Location = 116, Shiny = Shiny.Never, Relearn = new[] {310,523,072,328} }, // Sandygast @ Route 15
+        new(USUM) { Species = 097, Level = 29, Location = 020, Shiny = Shiny.Never, Relearn = new(095,171,139,029) }, // Hypno @ Hau'oli City Police Station
+        new(USUM) { Species = 097, Level = 29, Location = 020, Shiny = Shiny.Never, Relearn = new(417,060,050,139) }, // Hypno @ Hau'oli City Police Station
+        new(USUM) { Species = 097, Level = 29, Location = 020, Shiny = Shiny.Never, Relearn = new(093,050,001,096) }, // Hypno @ Hau'oli City Police Station
+        new(USUM) { Species = 092, Level = 19, Location = 230, Shiny = Shiny.Never, Relearn = new(174,109,122,101) }, // Gastly @ Route 1 (Trainers’ School)
+        new(USUM) { Species = 425, Level = 19, Location = 230, Shiny = Shiny.Never, Relearn = new(310,132,016,371) }, // Drifloon @ Route 1 (Trainers’ School)
+        new(  UM) { Species = 769, Level = 30, Location = 116, Shiny = Shiny.Never, Relearn = new(310,523,072,328) }, // Sandygast @ Route 15
         new(USUM) { Species = 592, Level = 34, Location = 126, Shiny = Shiny.Never, Gender = 1 }, // Frillish @ Route 14
         new(USUM) { Species = 101, Level = 60, Location = 224, Ability = OnlyFirst,  Shiny = Shiny.Never }, // Electrode @ Team Rocket's Castle
 

--- a/PKHeX.Core/Legality/Encounters/Data/Encounters7.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Encounters7.cs
@@ -126,13 +126,13 @@ internal static class Encounters7
     internal static readonly EncounterTrade7[] TradeGift_SM = // @ a\1\5\5
     {
         // Trades - 4.bin
-        new(SM) { Species = 066, Form = 0, Level = 09, Ability = OnlySecond, TID = 00410, SID = 00000, IVs = new[] {-1,31,-1,-1,-1,-1}, OTGender = 1, Gender = 0, Nature = Nature.Brave }, // Machop
-        new(SM) { Species = 761, Form = 0, Level = 16, Ability = OnlyFirst,  TID = 20683, SID = 00009, IVs = new[] {-1,31,-1,-1,-1,-1}, OTGender = 0, Gender = 1, Nature = Nature.Adamant }, // Bounsweet
-        new(SM) { Species = 061, Form = 0, Level = 22, Ability = OnlySecond, TID = 01092, SID = 00009, IVs = new[] {31,-1,-1,-1,-1,-1}, OTGender = 1, Gender = 1, Nature = Nature.Naughty }, // Poliwhirl
-        new(SM) { Species = 440, Form = 0, Level = 27, Ability = OnlySecond, TID = 10913, SID = 00000, IVs = new[] {-1,-1,-1,-1,31,-1}, OTGender = 1, Gender = 1, Nature = Nature.Calm }, // Happiny
-        new(SM) { Species = 075, Form = 1, Level = 32, Ability = OnlyFirst,  TID = 20778, SID = 00009, IVs = new[] {-1,-1,31,-1,-1,-1}, OTGender = 0, Gender = 0, Nature = Nature.Impish, EvolveOnTrade = true }, // Graveler-1
-        new(SM) { Species = 762, Form = 0, Level = 43, Ability = OnlyFirst,  TID = 20679, SID = 00009, IVs = new[] {-1,-1,-1,-1,-1,31}, OTGender = 1, Gender = 1, Nature = Nature.Careful }, // Steenee
-        new(SM) { Species = 663, Form = 0, Level = 59, Ability = OnlyHidden, TID = 56734, SID = 00008, IVs = new[] {-1,-1,-1,31,-1,-1}, OTGender = 0, Gender = 0, Nature = Nature.Jolly }, // Talonflame
+        new(SM) { Species = 066, Form = 0, Level = 09, Ability = OnlySecond, TID = 00410, SID = 00000, IVs = new(-1,31,-1,-1,-1,-1), OTGender = 1, Gender = 0, Nature = Nature.Brave }, // Machop
+        new(SM) { Species = 761, Form = 0, Level = 16, Ability = OnlyFirst,  TID = 20683, SID = 00009, IVs = new(-1,31,-1,-1,-1,-1), OTGender = 0, Gender = 1, Nature = Nature.Adamant }, // Bounsweet
+        new(SM) { Species = 061, Form = 0, Level = 22, Ability = OnlySecond, TID = 01092, SID = 00009, IVs = new(31,-1,-1,-1,-1,-1), OTGender = 1, Gender = 1, Nature = Nature.Naughty }, // Poliwhirl
+        new(SM) { Species = 440, Form = 0, Level = 27, Ability = OnlySecond, TID = 10913, SID = 00000, IVs = new(-1,-1,-1,-1,31,-1), OTGender = 1, Gender = 1, Nature = Nature.Calm }, // Happiny
+        new(SM) { Species = 075, Form = 1, Level = 32, Ability = OnlyFirst,  TID = 20778, SID = 00009, IVs = new(-1,-1,31,-1,-1,-1), OTGender = 0, Gender = 0, Nature = Nature.Impish, EvolveOnTrade = true }, // Graveler-1
+        new(SM) { Species = 762, Form = 0, Level = 43, Ability = OnlyFirst,  TID = 20679, SID = 00009, IVs = new(-1,-1,-1,-1,-1,31), OTGender = 1, Gender = 1, Nature = Nature.Careful }, // Steenee
+        new(SM) { Species = 663, Form = 0, Level = 59, Ability = OnlyHidden, TID = 56734, SID = 00008, IVs = new(-1,-1,-1,31,-1,-1), OTGender = 0, Gender = 0, Nature = Nature.Jolly }, // Talonflame
     };
 
     private static readonly EncounterStatic7[] Encounter_USUM =
@@ -313,11 +313,11 @@ internal static class Encounters7
         new(US  ) { Species = 806, Level = 60, Location = 164, Ability = OnlyFirst,  FlawlessIVCount = 3 }, // Blacephalon @ Poni Grove
 
         // Ditto Five
-        new(USUM) { Species = 132, Level = 29, Location = 060, IVs = new[] {-1,-1,31,00,30,-1}, Nature = Nature.Bold }, // Ditto @ Route 9
-        new(USUM) { Species = 132, Level = 29, Location = 072, IVs = new[] {-1,-1,30,31,30,-1}, Nature = Nature.Jolly }, // Ditto @ Konikoni City
-        new(USUM) { Species = 132, Level = 29, Location = 072, IVs = new[] {-1,31,30,30,-1,-1}, Nature = Nature.Adamant }, // Ditto @ Konikoni City
-        new(USUM) { Species = 132, Level = 29, Location = 072, IVs = new[] {-1,00,-1,-1,31,30}, Nature = Nature.Modest }, // Ditto @ Konikoni City
-        new(USUM) { Species = 132, Level = 29, Location = 072, IVs = new[] {-1,30,-1,31,-1,30}, Nature = Nature.Timid }, // Ditto @ Konikoni City
+        new(USUM) { Species = 132, Level = 29, Location = 060, IVs = new(-1,-1,31,00,30,-1), Nature = Nature.Bold }, // Ditto @ Route 9
+        new(USUM) { Species = 132, Level = 29, Location = 072, IVs = new(-1,-1,30,31,30,-1), Nature = Nature.Jolly }, // Ditto @ Konikoni City
+        new(USUM) { Species = 132, Level = 29, Location = 072, IVs = new(-1,31,30,30,-1,-1), Nature = Nature.Adamant }, // Ditto @ Konikoni City
+        new(USUM) { Species = 132, Level = 29, Location = 072, IVs = new(-1,00,-1,-1,31,30), Nature = Nature.Modest }, // Ditto @ Konikoni City
+        new(USUM) { Species = 132, Level = 29, Location = 072, IVs = new(-1,30,-1,31,-1,30), Nature = Nature.Timid }, // Ditto @ Konikoni City
 
         // Miscellaneous Static
         new(USUM) { Species = 760, Level = 28, Location = 020, Shiny = Shiny.Never }, // Bewear @ Hau’oli City (Shopping District)
@@ -340,13 +340,13 @@ internal static class Encounters7
     internal static readonly EncounterTrade7[] TradeGift_USUM =
     {
         // Trades - 4.bin
-        new(USUM) { Species = 701, Form = 0, Level = 08, Ability = OnlySecond, TID = 00410, SID = 00000, IVs = new[] {-1,31,-1,-1,-1,-1}, OTGender = 1, Gender = 0, Nature = Nature.Brave }, // Hawlucha
-        new(USUM) { Species = 714, Form = 0, Level = 19, Ability = OnlyFirst,  TID = 20683, SID = 00009, IVs = new[] {-1,-1,-1,-1,31,-1}, OTGender = 0, Gender = 0, Nature = Nature.Modest }, // Noibat
-        new(USUM) { Species = 339, Form = 0, Level = 21, Ability = OnlySecond, TID = 01092, SID = 00009, IVs = new[] {31,-1,-1,-1,-1,-1}, OTGender = 0, Gender = 1, Nature = Nature.Naughty }, // Barboach
-        new(USUM) { Species = 024, Form = 0, Level = 22, Ability = OnlyFirst,  TID = 10913, SID = 00000, IVs = new[] {-1,-1,31,-1,-1,-1}, OTGender = 1, Gender = 1, Nature = Nature.Impish }, // Arbok
-        new(USUM) { Species = 708, Form = 0, Level = 33, Ability = OnlyFirst,  TID = 20778, SID = 00009, IVs = new[] {-1,-1,-1,-1,-1,31}, OTGender = 0, Gender = 0, Nature = Nature.Calm, EvolveOnTrade = true }, // Phantump
-        new(USUM) { Species = 422, Form = 0, Level = 44, Ability = OnlySecond, TID = 20679, SID = 00009, IVs = new[] {-1,-1,31,-1,-1,-1}, OTGender = 1, Gender = 1, Nature = Nature.Quiet }, // Shellos
-        new(USUM) { Species = 128, Form = 0, Level = 59, Ability = OnlyFirst,  TID = 56734, SID = 00008, IVs = new[] {-1,-1,-1,31,-1,-1}, OTGender = 0, Gender = 0, Nature = Nature.Jolly }, // Tauros
+        new(USUM) { Species = 701, Form = 0, Level = 08, Ability = OnlySecond, TID = 00410, SID = 00000, IVs = new(-1,31,-1,-1,-1,-1), OTGender = 1, Gender = 0, Nature = Nature.Brave }, // Hawlucha
+        new(USUM) { Species = 714, Form = 0, Level = 19, Ability = OnlyFirst,  TID = 20683, SID = 00009, IVs = new(-1,-1,-1,-1,31,-1), OTGender = 0, Gender = 0, Nature = Nature.Modest }, // Noibat
+        new(USUM) { Species = 339, Form = 0, Level = 21, Ability = OnlySecond, TID = 01092, SID = 00009, IVs = new(31,-1,-1,-1,-1,-1), OTGender = 0, Gender = 1, Nature = Nature.Naughty }, // Barboach
+        new(USUM) { Species = 024, Form = 0, Level = 22, Ability = OnlyFirst,  TID = 10913, SID = 00000, IVs = new(-1,-1,31,-1,-1,-1), OTGender = 1, Gender = 1, Nature = Nature.Impish }, // Arbok
+        new(USUM) { Species = 708, Form = 0, Level = 33, Ability = OnlyFirst,  TID = 20778, SID = 00009, IVs = new(-1,-1,-1,-1,-1,31), OTGender = 0, Gender = 0, Nature = Nature.Calm, EvolveOnTrade = true }, // Phantump
+        new(USUM) { Species = 422, Form = 0, Level = 44, Ability = OnlySecond, TID = 20679, SID = 00009, IVs = new(-1,-1,31,-1,-1,-1), OTGender = 1, Gender = 1, Nature = Nature.Quiet }, // Shellos
+        new(USUM) { Species = 128, Form = 0, Level = 59, Ability = OnlyFirst,  TID = 56734, SID = 00008, IVs = new(-1,-1,-1,31,-1,-1), OTGender = 0, Gender = 0, Nature = Nature.Jolly }, // Tauros
     };
 
     private const string tradeSM = "tradesm";

--- a/PKHeX.Core/Legality/Encounters/Data/Encounters7b.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Encounters7b.cs
@@ -1,4 +1,4 @@
-﻿using static PKHeX.Core.EncounterUtil;
+using static PKHeX.Core.EncounterUtil;
 using static PKHeX.Core.GameVersion;
 
 namespace PKHeX.Core;
@@ -21,24 +21,24 @@ internal static class Encounters7b
         // collision new EncounterStatic7b { Species = 101, Level = 42, Location = 42, FlawlessIVCount = 3 }, // Electrode @ Power Plant
 
         // gifts
-        new(GP) { Species = 025, Level = 05, Location = 28, Gift = true, IVs = new[] {31,31,31,31,31,31}, Shiny = Shiny.Never, Form = 8 }, // Pikachu @ Pallet Town
-        new(GE) { Species = 133, Level = 05, Location = 28, Gift = true, IVs = new[] {31,31,31,31,31,31}, Shiny = Shiny.Never, Form = 1 }, // Eevee @ Pallet Town
+        new(GP) { Species = 025, Level = 05, Location = 28, Gift = true, IVs = new(31,31,31,31,31,31), Shiny = Shiny.Never, Form = 8 }, // Pikachu @ Pallet Town
+        new(GE) { Species = 133, Level = 05, Location = 28, Gift = true, IVs = new(31,31,31,31,31,31), Shiny = Shiny.Never, Form = 1 }, // Eevee @ Pallet Town
 
-        new(GG) { Species = 129, Level = 05, Location = 06, Gift = true, IVs = new[] {30,31,25,30,25,25} }, // Magikarp @ Route 4
+        new(GG) { Species = 129, Level = 05, Location = 06, Gift = true, IVs = new(30,31,25,30,25,25) }, // Magikarp @ Route 4
 
         // unused new EncounterStatic7b { Species = 133, Level = 30, Location = 34, Gift = true }, // Eevee @ Celadon City
-        new(GG) { Species = 131, Level = 34, Location = 52, Gift = true, IVs = new[] {31,25,25,25,30,30} }, // Lapras @ Saffron City (Silph Co. Employee, inside)
-        new(GG) { Species = 106, Level = 30, Location = 38, Gift = true, IVs = new[] {25,30,25,31,25,30} }, // Hitmonlee @ Saffron City (Karate Master)
-        new(GG) { Species = 107, Level = 30, Location = 38, Gift = true, IVs = new[] {25,31,30,25,25,30} }, // Hitmonchan @ Saffron City (Karate Master)
+        new(GG) { Species = 131, Level = 34, Location = 52, Gift = true, IVs = new(31,25,25,25,30,30) }, // Lapras @ Saffron City (Silph Co. Employee, inside)
+        new(GG) { Species = 106, Level = 30, Location = 38, Gift = true, IVs = new(25,30,25,31,25,30) }, // Hitmonlee @ Saffron City (Karate Master)
+        new(GG) { Species = 107, Level = 30, Location = 38, Gift = true, IVs = new(25,31,30,25,25,30) }, // Hitmonchan @ Saffron City (Karate Master)
         new(GG) { Species = 140, Level = 44, Location = 36, Gift = true, FlawlessIVCount = 3 }, // Kabuto @ Cinnabar Island (Cinnabar Pokémon Lab)
         new(GG) { Species = 138, Level = 44, Location = 36, Gift = true, FlawlessIVCount = 3 }, // Omanyte @ Cinnabar Island (Cinnabar Pokémon Lab)
         new(GG) { Species = 142, Level = 44, Location = 36, Gift = true, FlawlessIVCount = 3 }, // Aerodactyl @ Cinnabar Island (Cinnabar Pokémon Lab)
-        new(GG) { Species = 001, Level = 12, Location = 31, Gift = true, IVs = new[] {31,25,30,25,25,30} }, // Bulbasaur @ Cerulean City
-        new(GG) { Species = 004, Level = 14, Location = 26, Gift = true, IVs = new[] {25,30,25,31,30,25} }, // Charmander @ Route 24
-        new(GG) { Species = 007, Level = 16, Location = 33, Gift = true, IVs = new[] {25,25,30,25,31,30} }, // Squirtle @ Vermillion City
-        new(GG) { Species = 137, Level = 34, Location = 38, Gift = true, IVs = new[] {25,25,30,25,31,30} }, // Porygon @ Saffron City (Silph Co. Employee, outside)
-        new(GP) { Species = 053, Level = 16, Location = 33, Gift = true, IVs = new[] {30,30,25,31,25,25} }, // Persian @ Vermillion City (Outside Fan Club)
-        new(GE) { Species = 059, Level = 16, Location = 33, Gift = true, IVs = new[] {25,30,25,31,30,25} }, // Arcanine @ Vermillion City (Outside Fan Club)
+        new(GG) { Species = 001, Level = 12, Location = 31, Gift = true, IVs = new(31,25,30,25,25,30) }, // Bulbasaur @ Cerulean City
+        new(GG) { Species = 004, Level = 14, Location = 26, Gift = true, IVs = new(25,30,25,31,30,25) }, // Charmander @ Route 24
+        new(GG) { Species = 007, Level = 16, Location = 33, Gift = true, IVs = new(25,25,30,25,31,30) }, // Squirtle @ Vermillion City
+        new(GG) { Species = 137, Level = 34, Location = 38, Gift = true, IVs = new(25,25,30,25,31,30) }, // Porygon @ Saffron City (Silph Co. Employee, outside)
+        new(GP) { Species = 053, Level = 16, Location = 33, Gift = true, IVs = new(30,30,25,31,25,25) }, // Persian @ Vermillion City (Outside Fan Club)
+        new(GE) { Species = 059, Level = 16, Location = 33, Gift = true, IVs = new(25,30,25,31,30,25) }, // Arcanine @ Vermillion City (Outside Fan Club)
     };
 
     private static readonly string[] T1 = { string.Empty, "ミニコ", "Tatianna", "BarbaRatatta", "Addoloratta", "Barbaratt", string.Empty, "Tatiana", "미니꼬", "小幂妮", "小幂妮" };
@@ -53,16 +53,16 @@ internal static class Encounters7b
     internal static readonly EncounterTrade7b[] TradeGift_GG =
     {
         // Random candy values! They can be zero so no impact on legality even though statistically rare.
-        new(GG) { Species = 019, Form = 1, Level = 12, TrainerNames = T1, TID7 = 121106, OTGender = 1, IVs = new[] {31,31,-1,-1,-1,-1} }, // Rattata @ Cerulean City, AV rand [0-5)
-        new(GP) { Species = 027, Form = 1, Level = 27, TrainerNames = T2, TID7 = 703019, OTGender = 0, IVs = new[] {-1,31,31,-1,-1,-1} }, // Sandshrew @ Celadon City, AV rand [0-5)
-        new(GE) { Species = 037, Form = 1, Level = 27, TrainerNames = T2, TID7 = 703019, OTGender = 0, IVs = new[] {-1,-1,-1,31,31,-1} }, // Vulpix @ Celadon City, AV rand [0-5)
-        new(GG) { Species = 050, Form = 1, Level = 25, TrainerNames = T3, TID7 = 520159, OTGender = 1, IVs = new[] {-1,31,-1,31,-1,-1} }, // Diglett @ Lavender Town, AV rand [0-5)
-        new(GE) { Species = 052, Form = 1, Level = 44, TrainerNames = T4, TID7 = 000219, OTGender = 0, IVs = new[] {31,-1,-1,31,-1,-1} }, // Meowth @ Cinnabar Island, AV rand [0-10)
-        new(GP) { Species = 088, Form = 1, Level = 44, TrainerNames = T4, TID7 = 000219, OTGender = 0, IVs = new[] {31,31,-1,-1,-1,-1} }, // Grimer @ Cinnabar Island, AV rand [0-10)
-        new(GG) { Species = 026, Form = 1, Level = 30, TrainerNames = T5, TID7 = 940711, OTGender = 1, IVs = new[] {-1,-1,-1,31,31,-1} }, // Raichu @ Saffron City, AV rand [0-10)
-        new(GG) { Species = 105, Form = 1, Level = 38, TrainerNames = T6, TID7 = 102595, OTGender = 0, IVs = new[] {-1,31,31,-1,-1,-1} }, // Marowak @ Fuchsia City, AV rand [0-10)
-        new(GG) { Species = 103, Form = 1, Level = 46, TrainerNames = T7, TID7 = 060310, OTGender = 0, IVs = new[] {-1,31,-1,-1,31,-1} }, // Exeggutor @ Indigo Plateau, AV rand [0-15)
-        new(GG) { Species = 074, Form = 1, Level = 16, TrainerNames = T8, TID7 = 551873, OTGender = 0, IVs = new[] {31,31,-1,-1,-1,-1} }, // Geodude @ Vermilion City, AV rand [0-5)
+        new(GG) { Species = 019, Form = 1, Level = 12, TrainerNames = T1, TID7 = 121106, OTGender = 1, IVs = new(31,31,-1,-1,-1,-1) }, // Rattata @ Cerulean City, AV rand [0-5)
+        new(GP) { Species = 027, Form = 1, Level = 27, TrainerNames = T2, TID7 = 703019, OTGender = 0, IVs = new(-1,31,31,-1,-1,-1) }, // Sandshrew @ Celadon City, AV rand [0-5)
+        new(GE) { Species = 037, Form = 1, Level = 27, TrainerNames = T2, TID7 = 703019, OTGender = 0, IVs = new(-1,-1,-1,31,31,-1) }, // Vulpix @ Celadon City, AV rand [0-5)
+        new(GG) { Species = 050, Form = 1, Level = 25, TrainerNames = T3, TID7 = 520159, OTGender = 1, IVs = new(-1,31,-1,31,-1,-1) }, // Diglett @ Lavender Town, AV rand [0-5)
+        new(GE) { Species = 052, Form = 1, Level = 44, TrainerNames = T4, TID7 = 000219, OTGender = 0, IVs = new(31,-1,-1,31,-1,-1) }, // Meowth @ Cinnabar Island, AV rand [0-10)
+        new(GP) { Species = 088, Form = 1, Level = 44, TrainerNames = T4, TID7 = 000219, OTGender = 0, IVs = new(31,31,-1,-1,-1,-1) }, // Grimer @ Cinnabar Island, AV rand [0-10)
+        new(GG) { Species = 026, Form = 1, Level = 30, TrainerNames = T5, TID7 = 940711, OTGender = 1, IVs = new(-1,-1,-1,31,31,-1) }, // Raichu @ Saffron City, AV rand [0-10)
+        new(GG) { Species = 105, Form = 1, Level = 38, TrainerNames = T6, TID7 = 102595, OTGender = 0, IVs = new(-1,31,31,-1,-1,-1) }, // Marowak @ Fuchsia City, AV rand [0-10)
+        new(GG) { Species = 103, Form = 1, Level = 46, TrainerNames = T7, TID7 = 060310, OTGender = 0, IVs = new(-1,31,-1,-1,31,-1) }, // Exeggutor @ Indigo Plateau, AV rand [0-15)
+        new(GG) { Species = 074, Form = 1, Level = 16, TrainerNames = T8, TID7 = 551873, OTGender = 0, IVs = new(31,31,-1,-1,-1,-1) }, // Geodude @ Vermilion City, AV rand [0-5)
     };
 
     internal static readonly EncounterStatic7b[] StaticGP = GetEncounters(Encounter_GG, GP);

--- a/PKHeX.Core/Legality/Encounters/Data/Encounters8.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Encounters8.cs
@@ -70,14 +70,14 @@ internal static class Encounters8
         new(SWSH) { Gift = true, Species = 803, Level = 20, Location = 244, FlawlessIVCount = 3, Shiny = Never, Ability = OnlyFirst,  Ball = 26 }, // Poipole
 
         // Technically a gift, but copies ball from Calyrex.
-        new(SWSH) { Species = 896, Level = 75, Location = 220, ScriptedNoMarks = true, FlawlessIVCount = 3, Shiny = Never, Ability = OnlyFirst,  Relearn = new[] {556,0,0,0} }, // Glastrier
-        new(SWSH) { Species = 897, Level = 75, Location = 220, ScriptedNoMarks = true, FlawlessIVCount = 3, Shiny = Never, Ability = OnlyFirst,  Relearn = new[] {247,0,0,0} }, // Spectrier
+        new(SWSH) { Species = 896, Level = 75, Location = 220, ScriptedNoMarks = true, FlawlessIVCount = 3, Shiny = Never, Ability = OnlyFirst,  Relearn = new(556) }, // Glastrier
+        new(SWSH) { Species = 897, Level = 75, Location = 220, ScriptedNoMarks = true, FlawlessIVCount = 3, Shiny = Never, Ability = OnlyFirst,  Relearn = new(247) }, // Spectrier
 
         #region Static Part 1
         // encounters
-        new(SW  ) { Species = 888, Level = 70, Location = 66, ScriptedNoMarks = true, Moves = new[] {533,014,442,242}, Shiny = Never, Ability = OnlyFirst,  FlawlessIVCount = 3 }, // Zacian
-        new(  SH) { Species = 889, Level = 70, Location = 66, ScriptedNoMarks = true, Moves = new[] {163,242,442,334}, Shiny = Never, Ability = OnlyFirst,  FlawlessIVCount = 3 }, // Zamazenta
-        new(SWSH) { Species = 890, Level = 60, Location = 66, ScriptedNoMarks = true, Moves = new[] {440,406,053,744}, Shiny = Never, Ability = OnlyFirst,  FlawlessIVCount = 3 }, // Eternatus-1 (reverts to form 0)
+        new(SW  ) { Species = 888, Level = 70, Location = 66, ScriptedNoMarks = true, Moves = new(533,014,442,242), Shiny = Never, Ability = OnlyFirst,  FlawlessIVCount = 3 }, // Zacian
+        new(  SH) { Species = 889, Level = 70, Location = 66, ScriptedNoMarks = true, Moves = new(163,242,442,334), Shiny = Never, Ability = OnlyFirst,  FlawlessIVCount = 3 }, // Zamazenta
+        new(SWSH) { Species = 890, Level = 60, Location = 66, ScriptedNoMarks = true, Moves = new(440,406,053,744), Shiny = Never, Ability = OnlyFirst,  FlawlessIVCount = 3 }, // Eternatus-1 (reverts to form 0)
 
         // Motostoke Stadium Static Encounters
         new(SWSH) { Species = 037, Level = 24, Location = 24, ScriptedNoMarks = true }, // Vulpix at Motostoke Stadium
@@ -85,30 +85,30 @@ internal static class Encounters8
         new(SWSH) { Species = 607, Level = 25, Location = 24, ScriptedNoMarks = true }, // Litwick at Motostoke Stadium
         new(SWSH) { Species = 850, Level = 25, Location = 24, ScriptedNoMarks = true, FlawlessIVCount = 3 }, // Sizzlipede at Motostoke Stadium
 
-        new(SWSH) { Species = 618, Level = 25, Location = 054, Moves = new[] {389,319,279,341}, Form = 01, Ability = OnlyFirst }, // Stunfisk in Galar Mine No. 2
-        new(SWSH) { Species = 618, Level = 48, Location = 008, Moves = new[] {779,330,340,334}, Form = 01 }, // Stunfisk in the Slumbering Weald
-        new(SWSH) { Species = 527, Level = 16, Location = 030, Moves = new[] {000,000,000,000} }, // Woobat in Galar Mine
-        new(SWSH) { Species = 838, Level = 18, Location = 030, Moves = new[] {488,397,229,033} }, // Carkol in Galar Mine
-        new(SWSH) { Species = 834, Level = 24, Location = 054, Moves = new[] {317,029,055,044} }, // Drednaw in Galar Mine No. 2
-        new(SWSH) { Species = 423, Level = 50, Location = 054, Moves = new[] {240,414,330,246}, FlawlessIVCount = 3, Form = 01 }, // Gastrodon in Galar Mine No. 2
-        new(SWSH) { Species = 859, Level = 31, Location = 076, ScriptedNoMarks = true, Moves = new[] {259,389,207,372} }, // Impidimp in Glimwood Tangle
-        new(SWSH) { Species = 860, Level = 38, Location = 076, ScriptedNoMarks = true, Moves = new[] {793,399,259,389} }, // Morgrem in Glimwood Tangle
-        new(SWSH) { Species = 835, Level = 08, Location = 018, Moves = new[] {039,033,609,000} }, // Yamper on Route 2
-        new(SWSH) { Species = 834, Level = 50, Location = 018, Moves = new[] {710,746,068,317}, FlawlessIVCount = 3 }, // Drednaw on Route 2
-        new(SWSH) { Species = 833, Level = 08, Location = 018, Moves = new[] {044,055,000,000} }, // Chewtle on Route 2
-        new(SWSH) { Species = 131, Level = 55, Location = 018, Moves = new[] {056,240,058,034}, FlawlessIVCount = 3 }, // Lapras on Route 2
-        new(SWSH) { Species = 862, Level = 50, Location = 018, Moves = new[] {269,068,792,184} }, // Obstagoon on Route 2
-        new(SWSH) { Species = 822, Level = 18, Location = 028, Moves = new[] {681,468,031,365}, Shiny = Never }, // Corvisquire on Route 3
-        new(SWSH) { Species = 050, Level = 17, Location = 032, Moves = new[] {523,189,310,045} }, // Diglett on Route 4
-        new(SWSH) { Species = 830, Level = 22, Location = 040, Moves = new[] {178,496,075,047} }, // Eldegoss on Route 5
-        new(SWSH) { Species = 558, Level = 40, Location = 086, Moves = new[] {404,350,446,157} }, // Crustle on Route 8
-        new(SWSH) { Species = 870, Level = 40, Location = 086, Moves = new[] {748,660,179,203} }, // Falinks on Route 8
-        new(SWSH) { Species = 362, Level = 55, Location = 090, Moves = new[] {573,329,104,182}, FlawlessIVCount = 3, Weather = Snowing }, // Glalie on Route 9
-        new(SWSH) { Species = 853, Level = 50, Location = 092, Moves = new[] {753,576,276,179}, Weather = Snowing }, // Grapploct on Route 9 (in Circhester Bay)
-        //new(SWSH) { Species = 822, Level = 35, Location =  -1, Moves = new[] {065,184,269,365} }, // Corvisquire
-        new(SWSH) { Species = 614, Level = 55, Location = 106, Moves = new[] {276,059,156,329}, Weather = Snowstorm }, // Beartic on Route 10
-        new(SWSH) { Species = 460, Level = 55, Location = 106, Moves = new[] {008,059,452,275}, Weather = Snowstorm }, // Abomasnow on Route 10
-        new(SWSH) { Species = 342, Level = 50, Location = 034, Moves = new[] {242,014,534,400}, FlawlessIVCount = 3 }, // Crawdaunt in the town of Turffield
+        new(SWSH) { Species = 618, Level = 25, Location = 054, Moves = new(389,319,279,341), Form = 01, Ability = OnlyFirst }, // Stunfisk in Galar Mine No. 2
+        new(SWSH) { Species = 618, Level = 48, Location = 008, Moves = new(779,330,340,334), Form = 01 }, // Stunfisk in the Slumbering Weald
+        new(SWSH) { Species = 527, Level = 16, Location = 030, Moves = new(000) }, // Woobat in Galar Mine
+        new(SWSH) { Species = 838, Level = 18, Location = 030, Moves = new(488,397,229,033) }, // Carkol in Galar Mine
+        new(SWSH) { Species = 834, Level = 24, Location = 054, Moves = new(317,029,055,044) }, // Drednaw in Galar Mine No. 2
+        new(SWSH) { Species = 423, Level = 50, Location = 054, Moves = new(240,414,330,246), FlawlessIVCount = 3, Form = 01 }, // Gastrodon in Galar Mine No. 2
+        new(SWSH) { Species = 859, Level = 31, Location = 076, ScriptedNoMarks = true, Moves = new(259,389,207,372) }, // Impidimp in Glimwood Tangle
+        new(SWSH) { Species = 860, Level = 38, Location = 076, ScriptedNoMarks = true, Moves = new(793,399,259,389) }, // Morgrem in Glimwood Tangle
+        new(SWSH) { Species = 835, Level = 08, Location = 018, Moves = new(039,033,609,000) }, // Yamper on Route 2
+        new(SWSH) { Species = 834, Level = 50, Location = 018, Moves = new(710,746,068,317), FlawlessIVCount = 3 }, // Drednaw on Route 2
+        new(SWSH) { Species = 833, Level = 08, Location = 018, Moves = new(044,055,000,000) }, // Chewtle on Route 2
+        new(SWSH) { Species = 131, Level = 55, Location = 018, Moves = new(056,240,058,034), FlawlessIVCount = 3 }, // Lapras on Route 2
+        new(SWSH) { Species = 862, Level = 50, Location = 018, Moves = new(269,068,792,184) }, // Obstagoon on Route 2
+        new(SWSH) { Species = 822, Level = 18, Location = 028, Moves = new(681,468,031,365), Shiny = Never }, // Corvisquire on Route 3
+        new(SWSH) { Species = 050, Level = 17, Location = 032, Moves = new(523,189,310,045) }, // Diglett on Route 4
+        new(SWSH) { Species = 830, Level = 22, Location = 040, Moves = new(178,496,075,047) }, // Eldegoss on Route 5
+        new(SWSH) { Species = 558, Level = 40, Location = 086, Moves = new(404,350,446,157) }, // Crustle on Route 8
+        new(SWSH) { Species = 870, Level = 40, Location = 086, Moves = new(748,660,179,203) }, // Falinks on Route 8
+        new(SWSH) { Species = 362, Level = 55, Location = 090, Moves = new(573,329,104,182), FlawlessIVCount = 3, Weather = Snowing }, // Glalie on Route 9
+        new(SWSH) { Species = 853, Level = 50, Location = 092, Moves = new(753,576,276,179), Weather = Snowing }, // Grapploct on Route 9 (in Circhester Bay)
+        //new(SWSH) { Species = 822, Level = 35, Location =  -1, Moves = new(065,184,269,365) }, // Corvisquire
+        new(SWSH) { Species = 614, Level = 55, Location = 106, Moves = new(276,059,156,329), Weather = Snowstorm }, // Beartic on Route 10
+        new(SWSH) { Species = 460, Level = 55, Location = 106, Moves = new(008,059,452,275), Weather = Snowstorm }, // Abomasnow on Route 10
+        new(SWSH) { Species = 342, Level = 50, Location = 034, Moves = new(242,014,534,400), FlawlessIVCount = 3 }, // Crawdaunt in the town of Turffield
         #endregion
 
         #region Static Part 2
@@ -543,11 +543,11 @@ internal static class Encounters8
         new(SW  ) { Species = 628, Level = 42, Location = 184, Weather = Normal | Overcast | Raining | Sandstorm | Intense_Sun | Heavy_Fog }, // Braviary in the Potbottom Desert
         new(  SH) { Species = 630, Level = 42, Location = 184, Weather = Normal | Overcast | Raining | Sandstorm | Intense_Sun | Heavy_Fog }, // Mandibuzz in the Potbottom Desert
         new(SWSH) { Species = 479, Level = 50, Location = 186, FlawlessIVCount = 3 }, // Rotom in the Workout Sea
-        new(SWSH) { Species = 479, Level = 50, Location = 186, Moves = new[] {435,506,268}, Form = 01, Weather = Normal | Stormy | Intense_Sun | Heavy_Fog }, // Rotom-1 in the Workout Sea
-        new(SWSH) { Species = 479, Level = 50, Location = 186, Moves = new[] {435,506,268}, Form = 02, Weather = Normal | Stormy | Intense_Sun | Heavy_Fog }, // Rotom-2 in the Workout Sea
-        new(SWSH) { Species = 479, Level = 50, Location = 186, Moves = new[] {435,506,268}, Form = 03, Weather = Normal | Stormy | Intense_Sun | Heavy_Fog }, // Rotom-3 in the Workout Sea
-        new(SWSH) { Species = 479, Level = 50, Location = 186, Moves = new[] {435,506,268}, Form = 04, Weather = Normal | Stormy | Intense_Sun | Heavy_Fog }, // Rotom-4 in the Workout Sea
-        new(SWSH) { Species = 479, Level = 50, Location = 186, Moves = new[] {435,506,268}, Form = 05, Weather = Normal | Stormy | Intense_Sun | Heavy_Fog }, // Rotom-5 in the Workout Sea
+        new(SWSH) { Species = 479, Level = 50, Location = 186, Moves = new(435,506,268), Form = 01, Weather = Normal | Stormy | Intense_Sun | Heavy_Fog }, // Rotom-1 in the Workout Sea
+        new(SWSH) { Species = 479, Level = 50, Location = 186, Moves = new(435,506,268), Form = 02, Weather = Normal | Stormy | Intense_Sun | Heavy_Fog }, // Rotom-2 in the Workout Sea
+        new(SWSH) { Species = 479, Level = 50, Location = 186, Moves = new(435,506,268), Form = 03, Weather = Normal | Stormy | Intense_Sun | Heavy_Fog }, // Rotom-3 in the Workout Sea
+        new(SWSH) { Species = 479, Level = 50, Location = 186, Moves = new(435,506,268), Form = 04, Weather = Normal | Stormy | Intense_Sun | Heavy_Fog }, // Rotom-4 in the Workout Sea
+        new(SWSH) { Species = 479, Level = 50, Location = 186, Moves = new(435,506,268), Form = 05, Weather = Normal | Stormy | Intense_Sun | Heavy_Fog }, // Rotom-5 in the Workout Sea
         new(SWSH) { Species = 132, Level = 50, Location = 186, FlawlessIVCount = 3 }, // Ditto in the Workout Sea
         //new(SWSH) { Species = 242, Level = 50, Location = -1 }, // Blissey
         new(SWSH) { Species = 103, Level = 50, Location = 190, Weather = Normal | Raining | Intense_Sun }, // Exeggutor in the Insular Sea
@@ -564,22 +564,22 @@ internal static class Encounters8
         #endregion
 
         #region R2 Static Encounters
-        new EncounterStatic8S(SWSH) { Species = 144, Level = 70, Locations = new[] {208, 210, 212, 214}, Moves = new[] {821,542,427,375}, FlawlessIVCount = 3, Shiny = Never, Ability = OnlyFirst,  Form = 01, Weather = All_CT }, // Articuno-1 in the Crown Tundra
-        new EncounterStatic8S(SWSH) { Species = 145, Level = 70, Locations = new[] {122, 124, 126, 128, 130}, Moves = new[] {823,065,179,116}, FlawlessIVCount = 3, Shiny = Never, Ability = OnlyFirst,  Form = 01, Weather = All }, // Zapdos-1 in a Wild Area
-        new EncounterStatic8S(SWSH) { Species = 146, Level = 70, Locations = new[] {164, 166, 170, 178, 186, 188, 190, 192}, Moves = new[] {822,542,389,417}, FlawlessIVCount = 3, Shiny = Never, Ability = OnlyFirst,  Form = 01, Weather = All_IoA }, // Moltres-1 on the Isle of Armor
-        new(SWSH) { Species = 377, Level = 70, Location = 236, ScriptedNoMarks = true, Moves = new[] {276,444,359,174}, FlawlessIVCount = 3, Ability = OnlyFirst }, // Regirock
-        new(SWSH) { Species = 378, Level = 70, Location = 238, ScriptedNoMarks = true, Moves = new[] {058,192,133,196}, FlawlessIVCount = 3, Ability = OnlyFirst }, // Regice
-        new(SWSH) { Species = 379, Level = 70, Location = 240, ScriptedNoMarks = true, Moves = new[] {484,430,334,451}, FlawlessIVCount = 3, Ability = OnlyFirst }, // Registeel
-        new(SWSH) { Species = 894, Level = 70, Location = 242, ScriptedNoMarks = true, Moves = new[] {819,527,245,393}, FlawlessIVCount = 3, Ability = OnlyFirst }, // Regieleki
-        new(SWSH) { Species = 895, Level = 70, Location = 242, ScriptedNoMarks = true, Moves = new[] {820,337,359,673}, FlawlessIVCount = 3, Ability = OnlyFirst }, // Regidrago
-        new(SWSH) { Species = 486, Level =100, Location = 210, ScriptedNoMarks = true, Moves = new[] {416,428,359,462}, FlawlessIVCount = 3, Ability = OnlyFirst,  DynamaxLevel = 10 }, // Regigigas in the Giant’s Bed
+        new EncounterStatic8S(SWSH) { Species = 144, Level = 70, Locations = new[] {208, 210, 212, 214}, Moves = new(821,542,427, 375), FlawlessIVCount = 3, Shiny = Never, Ability = OnlyFirst,  Form = 01, Weather = All_CT }, // Articuno-1 in the Crown Tundra
+        new EncounterStatic8S(SWSH) { Species = 145, Level = 70, Locations = new[] {122, 124, 126, 128, 130}, Moves = new(823,065,179,116), FlawlessIVCount = 3, Shiny = Never, Ability = OnlyFirst,  Form = 01, Weather = All }, // Zapdos-1 in a Wild Area
+        new EncounterStatic8S(SWSH) { Species = 146, Level = 70, Locations = new[] {164, 166, 170, 178, 186, 188, 190, 192}, Moves = new(822,542,389,417), FlawlessIVCount = 3, Shiny = Never, Ability = OnlyFirst,  Form = 01, Weather = All_IoA }, // Moltres-1 on the Isle of Armor
+        new(SWSH) { Species = 377, Level = 70, Location = 236, ScriptedNoMarks = true, Moves = new(276,444,359,174), FlawlessIVCount = 3, Ability = OnlyFirst }, // Regirock
+        new(SWSH) { Species = 378, Level = 70, Location = 238, ScriptedNoMarks = true, Moves = new(058,192,133,196), FlawlessIVCount = 3, Ability = OnlyFirst }, // Regice
+        new(SWSH) { Species = 379, Level = 70, Location = 240, ScriptedNoMarks = true, Moves = new(484,430,334,451), FlawlessIVCount = 3, Ability = OnlyFirst }, // Registeel
+        new(SWSH) { Species = 894, Level = 70, Location = 242, ScriptedNoMarks = true, Moves = new(819,527,245,393), FlawlessIVCount = 3, Ability = OnlyFirst }, // Regieleki
+        new(SWSH) { Species = 895, Level = 70, Location = 242, ScriptedNoMarks = true, Moves = new(820,337,359,673), FlawlessIVCount = 3, Ability = OnlyFirst }, // Regidrago
+        new(SWSH) { Species = 486, Level =100, Location = 210, ScriptedNoMarks = true, Moves = new(416,428,359,462), FlawlessIVCount = 3, Ability = OnlyFirst,  DynamaxLevel = 10 }, // Regigigas in the Giant’s Bed
         new(SWSH) { Species = 638, Level = 70, Location = 226, FlawlessIVCount = 3, Ability = OnlyFirst,  Weather = No_Sun_Sand }, // Cobalion at the Frigid Sea
         new(SWSH) { Species = 639, Level = 70, Location = 232, FlawlessIVCount = 3, Ability = OnlyFirst,  Weather = Overcast }, // Terrakion in Lakeside Cavern
         new(SWSH) { Species = 640, Level = 70, Location = 210, FlawlessIVCount = 3, Ability = OnlyFirst,  Weather = All_CT }, // Virizion at Giant's Bed
-        new(SWSH) { Species = 647, Level = 65, Location = 230, Moves = new[] {548,533,014,056}, FlawlessIVCount = 3, Shiny = Never, Ability = OnlyFirst,  Form = 01, Fateful = true, Weather = All_Ballimere }, // Keldeo-1 at Ballimere Lake
-        //new(SWSH) { Species = 896, Level = 75, Location = -1, Moves = new[] {556,037,419,023}, FlawlessIVCount = 3, Shiny = Never, Ability = OnlyFirst }, // Glastrier
-        //new(SWSH) { Species = 897, Level = 75, Location = -1, Moves = new[] {247,037,506,024}, FlawlessIVCount = 3, Shiny = Never, Ability = OnlyFirst }, // Spectrier
-        new(SWSH) { Species = 898, Level = 80, Location = 220, Moves = new[] {202,094,473,505}, FlawlessIVCount = 3, Shiny = Never, Ability = OnlyFirst,  ScriptedNoMarks = true }, // Calyrex
+        new(SWSH) { Species = 647, Level = 65, Location = 230, Moves = new(548,533,014,056), FlawlessIVCount = 3, Shiny = Never, Ability = OnlyFirst,  Form = 01, Fateful = true, Weather = All_Ballimere }, // Keldeo-1 at Ballimere Lake
+        //new(SWSH) { Species = 896, Level = 75, Location = -1, Moves = new(556,037,419,023}, FlawlessIVCount = 3, Shiny = Never, Ability = OnlyFirst }, // Glastrier
+        //new(SWSH) { Species = 897, Level = 75, Location = -1, Moves = new(247,037,506,024}, FlawlessIVCount = 3, Shiny = Never, Ability = OnlyFirst }, // Spectrier
+        new(SWSH) { Species = 898, Level = 80, Location = 220, Moves = new(202,094,473,505), FlawlessIVCount = 3, Shiny = Never, Ability = OnlyFirst,  ScriptedNoMarks = true }, // Calyrex
         new(SWSH) { Species = 442, Level = 72, Location = 230, FlawlessIVCount = 3, Ability = OnlyHidden, Weather = All_Ballimere }, // Spiritomb at Ballimere Lake
 
         // suspected unused or uncatchable
@@ -768,32 +768,32 @@ internal static class Encounters8
 
     private static readonly EncounterTrade8[] TradeGift_Regular =
     {
-        new(SWSH, 052,18,08,000,04,5) { Ability = OnlySecond, TID7 = 263455, IVs = TradeIVs, DynamaxLevel = 1, OTGender = 0, Gender = 0, Nature = Nature.Timid, Relearn = new[] {387,000,000,000}   }, // Meowth
-        new(SWSH, 819,10,01,044,01,2) { Ability = OnlyFirst,  TID7 = 648753, IVs = TradeIVs, DynamaxLevel = 1, OTGender = 1, Gender = 0, Nature = Nature.Mild                                       }, // Skwovet
-        new(SWSH, 546,23,11,000,09,5) { Ability = OnlyFirst,  TID7 = 101154, IVs = TradeIVs, DynamaxLevel = 1, OTGender = 1, Gender = 1, Nature = Nature.Modest                                     }, // Cottonee
-        new(SWSH, 175,25,02,010,10,6) { Ability = OnlySecond, TID7 = 109591, IVs = TradeIVs, DynamaxLevel = 1, OTGender = 1, Gender = 0, Nature = Nature.Timid, Relearn = new[] {791,000,000,000}   }, // Togepi
-        new(SW  , 856,30,09,859,08,3) { Ability = OnlySecond, TID7 = 101101, IVs = TradeIVs, DynamaxLevel = 1, OTGender = 0, Gender = 1, Nature = Nature.Quiet                                      }, // Hatenna
-        new(  SH, 859,30,43,000,07,6) { Ability = OnlyFirst,  TID7 = 256081, IVs = TradeIVs, DynamaxLevel = 1, OTGender = 0, Gender = 0, Nature = Nature.Brave, Relearn = new[] {252,000,000,000}   }, // Impidimp
-        new(SWSH, 562,35,16,310,15,5) { Ability = OnlyFirst,  TID7 = 102534, IVs = TradeIVs, DynamaxLevel = 2, OTGender = 1, Gender = 0, Nature = Nature.Bold, Relearn = new[] {261,000,000,000}    }, // Yamask
-        new(SW  , 538,37,17,129,20,7) { Ability = OnlySecond, TID7 = 768945, IVs = TradeIVs, DynamaxLevel = 2, OTGender = 0, Gender = 0, Nature = Nature.Adamant                                    }, // Throh
-        new(  SH, 539,37,17,129,14,6) { Ability = OnlyFirst,  TID7 = 881426, IVs = TradeIVs, DynamaxLevel = 2, OTGender = 0, Gender = 0, Nature = Nature.Adamant                                    }, // Sawk
-        new(SWSH, 122,40,56,000,12,4) { Ability = OnlyFirst,  TID7 = 891846, IVs = TradeIVs, DynamaxLevel = 1, OTGender = 0, Gender = 0, Nature = Nature.Calm                                       }, // Mr. Mime
-        new(SWSH, 884,50,15,038,06,2) { Ability = OnlySecond, TID7 = 101141, IVs = TradeIVs, DynamaxLevel = 3, OTGender = 0, Gender = 0, Nature = Nature.Adamant, Relearn = new[] {400,000,000,000} }, // Duraludon
+        new(SWSH, 052,18,08,000,04,5) { Ability = OnlySecond, TID7 = 263455, IVs = TradeIVs, DynamaxLevel = 1, OTGender = 0, Gender = 0, Nature = Nature.Timid, Relearn = new(387)   }, // Meowth
+        new(SWSH, 819,10,01,044,01,2) { Ability = OnlyFirst,  TID7 = 648753, IVs = TradeIVs, DynamaxLevel = 1, OTGender = 1, Gender = 0, Nature = Nature.Mild                              }, // Skwovet
+        new(SWSH, 546,23,11,000,09,5) { Ability = OnlyFirst,  TID7 = 101154, IVs = TradeIVs, DynamaxLevel = 1, OTGender = 1, Gender = 1, Nature = Nature.Modest                            }, // Cottonee
+        new(SWSH, 175,25,02,010,10,6) { Ability = OnlySecond, TID7 = 109591, IVs = TradeIVs, DynamaxLevel = 1, OTGender = 1, Gender = 0, Nature = Nature.Timid, Relearn = new(791)   }, // Togepi
+        new(SW  , 856,30,09,859,08,3) { Ability = OnlySecond, TID7 = 101101, IVs = TradeIVs, DynamaxLevel = 1, OTGender = 0, Gender = 1, Nature = Nature.Quiet                             }, // Hatenna
+        new(  SH, 859,30,43,000,07,6) { Ability = OnlyFirst,  TID7 = 256081, IVs = TradeIVs, DynamaxLevel = 1, OTGender = 0, Gender = 0, Nature = Nature.Brave, Relearn = new(252)   }, // Impidimp
+        new(SWSH, 562,35,16,310,15,5) { Ability = OnlyFirst,  TID7 = 102534, IVs = TradeIVs, DynamaxLevel = 2, OTGender = 1, Gender = 0, Nature = Nature.Bold, Relearn = new(261)    }, // Yamask
+        new(SW  , 538,37,17,129,20,7) { Ability = OnlySecond, TID7 = 768945, IVs = TradeIVs, DynamaxLevel = 2, OTGender = 0, Gender = 0, Nature = Nature.Adamant                           }, // Throh
+        new(  SH, 539,37,17,129,14,6) { Ability = OnlyFirst,  TID7 = 881426, IVs = TradeIVs, DynamaxLevel = 2, OTGender = 0, Gender = 0, Nature = Nature.Adamant                           }, // Sawk
+        new(SWSH, 122,40,56,000,12,4) { Ability = OnlyFirst,  TID7 = 891846, IVs = TradeIVs, DynamaxLevel = 1, OTGender = 0, Gender = 0, Nature = Nature.Calm                              }, // Mr. Mime
+        new(SWSH, 884,50,15,038,06,2) { Ability = OnlySecond, TID7 = 101141, IVs = TradeIVs, DynamaxLevel = 3, OTGender = 0, Gender = 0, Nature = Nature.Adamant, Relearn = new(400) }, // Duraludon
     };
 
     private static readonly EncounterTrade8[] TradeGift_R1 =
     {
-        new(SWSH, 052,15,01,033,04,2, Random) { Ability = OnlyHidden, TID7 = 101141, FlawlessIVCount = 3, DynamaxLevel = 5, OTGender = 1, IsNicknamed = false, Relearn = new[] {387,000,000,000}               }, // Meowth
-        new(SW  , 083,15,01,013,10,2, Random) { Ability = OnlyHidden, TID7 = 101141, FlawlessIVCount = 3, DynamaxLevel = 5, OTGender = 1, IsNicknamed = false, Relearn = new[] {098,000,000,000}               }, // Farfetch’d
-        new(  SH, 222,15,01,069,12,2, Random) { Ability = OnlyHidden, TID7 = 101141, FlawlessIVCount = 3, DynamaxLevel = 5, OTGender = 1, IsNicknamed = false, Relearn = new[] {457,000,000,000}               }, // Corsola
-        new(  SH, 077,15,01,047,06,2, Random) { Ability = OnlyHidden, TID7 = 101141, FlawlessIVCount = 3, DynamaxLevel = 5, OTGender = 1, IsNicknamed = false, Relearn = new[] {234,000,000,000}               }, // Ponyta
-        new(SWSH, 122,15,01,005,04,2, Random) { Ability = OnlyHidden, TID7 = 101141, FlawlessIVCount = 3, DynamaxLevel = 5, OTGender = 1, IsNicknamed = false, Relearn = new[] {252,000,000,000}               }, // Mr. Mime
-        new(SW  , 554,15,01,040,12,2, Random) { Ability = OnlyHidden, TID7 = 101141, FlawlessIVCount = 3, DynamaxLevel = 5, OTGender = 1, IsNicknamed = false, Relearn = new[] {326,000,000,000}               }, // Darumaka
-        new(SWSH, 263,15,01,045,04,2, Random) { Ability = OnlyHidden, TID7 = 101141, FlawlessIVCount = 3, DynamaxLevel = 5, OTGender = 1, IsNicknamed = false, Relearn = new[] {245,000,000,000}               }, // Zigzagoon
-        new(SWSH, 618,15,01,050,05,2, Random) { Ability = OnlyHidden, TID7 = 101141, FlawlessIVCount = 3, DynamaxLevel = 5, OTGender = 1, IsNicknamed = false, Relearn = new[] {281,000,000,000}               }, // Stunfisk
-        new(SWSH, 110,15,01,040,12,2, Random) { Ability = Any12H,     TID7 = 101141, FlawlessIVCount = 3, DynamaxLevel = 5, OTGender = 1, IsNicknamed = false, Relearn = new[] {220,000,000,000}               }, // Weezing
-        new(SWSH, 103,15,01,038,06,2, Random) {                       TID7 = 101141, FlawlessIVCount = 3, DynamaxLevel = 5, OTGender = 1, IsNicknamed = false, Relearn = new[] {246,000,000,000}, Form = 1     }, // Exeggutor-1
-        new(SWSH, 105,15,01,038,06,2, Random) {                       TID7 = 101141, FlawlessIVCount = 3, DynamaxLevel = 5, OTGender = 1, IsNicknamed = false, Relearn = new[] {174,000,000,000}, Form = 1     }, // Marowak-1
+        new(SWSH, 052,15,01,033,04,2, Random) { Ability = OnlyHidden, TID7 = 101141, FlawlessIVCount = 3, DynamaxLevel = 5, OTGender = 1, IsNicknamed = false, Relearn = new(387)               }, // Meowth
+        new(SW  , 083,15,01,013,10,2, Random) { Ability = OnlyHidden, TID7 = 101141, FlawlessIVCount = 3, DynamaxLevel = 5, OTGender = 1, IsNicknamed = false, Relearn = new(098)               }, // Farfetch’d
+        new(  SH, 222,15,01,069,12,2, Random) { Ability = OnlyHidden, TID7 = 101141, FlawlessIVCount = 3, DynamaxLevel = 5, OTGender = 1, IsNicknamed = false, Relearn = new(457)               }, // Corsola
+        new(  SH, 077,15,01,047,06,2, Random) { Ability = OnlyHidden, TID7 = 101141, FlawlessIVCount = 3, DynamaxLevel = 5, OTGender = 1, IsNicknamed = false, Relearn = new(234)               }, // Ponyta
+        new(SWSH, 122,15,01,005,04,2, Random) { Ability = OnlyHidden, TID7 = 101141, FlawlessIVCount = 3, DynamaxLevel = 5, OTGender = 1, IsNicknamed = false, Relearn = new(252)               }, // Mr. Mime
+        new(SW  , 554,15,01,040,12,2, Random) { Ability = OnlyHidden, TID7 = 101141, FlawlessIVCount = 3, DynamaxLevel = 5, OTGender = 1, IsNicknamed = false, Relearn = new(326)               }, // Darumaka
+        new(SWSH, 263,15,01,045,04,2, Random) { Ability = OnlyHidden, TID7 = 101141, FlawlessIVCount = 3, DynamaxLevel = 5, OTGender = 1, IsNicknamed = false, Relearn = new(245)               }, // Zigzagoon
+        new(SWSH, 618,15,01,050,05,2, Random) { Ability = OnlyHidden, TID7 = 101141, FlawlessIVCount = 3, DynamaxLevel = 5, OTGender = 1, IsNicknamed = false, Relearn = new(281)               }, // Stunfisk
+        new(SWSH, 110,15,01,040,12,2, Random) { Ability = Any12H,     TID7 = 101141, FlawlessIVCount = 3, DynamaxLevel = 5, OTGender = 1, IsNicknamed = false, Relearn = new(220)               }, // Weezing
+        new(SWSH, 103,15,01,038,06,2, Random) {                       TID7 = 101141, FlawlessIVCount = 3, DynamaxLevel = 5, OTGender = 1, IsNicknamed = false, Relearn = new(246), Form = 1     }, // Exeggutor-1
+        new(SWSH, 105,15,01,038,06,2, Random) {                       TID7 = 101141, FlawlessIVCount = 3, DynamaxLevel = 5, OTGender = 1, IsNicknamed = false, Relearn = new(174), Form = 1     }, // Marowak-1
     };
 
     internal static readonly EncounterTrade8[] TradeGift_SWSH = ArrayUtil.ConcatAll(TradeGift_Regular, TradeGift_R1);

--- a/PKHeX.Core/Legality/Encounters/Data/Encounters8.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Encounters8.cs
@@ -37,7 +37,7 @@ internal static class Encounters8
         new(SWSH) { Gift = true, Species = 816, Shiny = Never, Level = 05, Location = 006 }, // Sobble
 
         new(SWSH) { Gift = true, Species = 772, Shiny = Never, Level = 50, Location = 158, FlawlessIVCount = 3 }, // Type: Null
-        new(SWSH) { Gift = true, Species = 848, Shiny = Never, Level = 01, Location = 040, IVs = new[]{-1,31,-1,-1,31,-1}, Ball = 11 }, // Toxel, Attack flawless
+        new(SWSH) { Gift = true, Species = 848, Shiny = Never, Level = 01, Location = 040, IVs = new(-1,31,-1,-1,31,-1), Ball = 11 }, // Toxel, Attack flawless
 
         new(SWSH) { Gift = true, Species = 880, FlawlessIVCount = 3, Level = 10, Location = 068 }, // Dracozolt @ Route 6
         new(SWSH) { Gift = true, Species = 881, FlawlessIVCount = 3, Level = 10, Location = 068 }, // Arctozolt @ Route 6
@@ -764,7 +764,7 @@ internal static class Encounters8
     private const string tradeSWSH = "tradeswsh";
     private static readonly string[][] TradeSWSH = Util.GetLanguageStrings10(tradeSWSH, "zh2");
     private static readonly string[] TradeOT_R1 = { string.Empty, "チホコ", "Regina", "Régiona", "Regionalia", "Regine", string.Empty, "Tatiana", "지민", "易蒂", "易蒂" };
-    private static readonly int[] TradeIVs = {15, 15, 15, 15, 15, 15};
+    private static readonly IndividualValueSet TradeIVs = new(15, 15, 15, 15, 15, 15);
 
     private static readonly EncounterTrade8[] TradeGift_Regular =
     {

--- a/PKHeX.Core/Legality/Encounters/Data/Encounters8NestCrystal.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Encounters8NestCrystal.cs
@@ -8,19 +8,19 @@ internal static partial class Encounters8Nest
     #region Dynamax Crystal Distributions
     internal static readonly EncounterStatic8NC[] Crystal_SWSH =
     {
-        new(SWSH) { Species = 782, Level = 16, Ability = A3, Location = 126, IVs = new[] {31,31,31,-1,-1,-1}, DynamaxLevel = 2, Moves = new(033,029,525,043) }, // ★And458 Jangmo-o
-        new(SWSH) { Species = 246, Level = 16, Ability = A3, Location = 126, IVs = new[] {31,31,31,-1,-1,-1}, DynamaxLevel = 2, Moves = new(033,157,371,044) }, // ★And15 Larvitar
-        new(SWSH) { Species = 823, Level = 50, Ability = A2, Location = 126, IVs = new[] {31,31,31,-1,-1,31}, DynamaxLevel = 5, Moves = new(065,442,034,796), CanGigantamax = true }, // ★And337 Gigantamax Corviknight
-        new(SWSH) { Species = 875, Level = 15, Ability = A3, Location = 126, IVs = new[] {31,31,-1,31,-1,-1}, DynamaxLevel = 2, Moves = new(181,311,054,556) }, // ★And603 Eiscue
-        new(SWSH) { Species = 874, Level = 15, Ability = A3, Location = 126, IVs = new[] {31,31,31,-1,-1,-1}, DynamaxLevel = 2, Moves = new(397,317,335,157) }, // ★And390 Stonjourner
-        new(SWSH) { Species = 879, Level = 35, Ability = A3, Location = 126, IVs = new[] {31,31,-1, 0,31,-1}, DynamaxLevel = 4, Moves = new(484,174,776,583), CanGigantamax = true }, // ★Sgr6879 Gigantamax Copperajah
-        new(SWSH) { Species = 851, Level = 35, Ability = A2, Location = 126, IVs = new[] {31,31,31,-1,-1,-1}, DynamaxLevel = 5, Moves = new(680,679,489,438), CanGigantamax = true }, // ★Sgr6859 Gigantamax Centiskorch
-        new(SW  ) { Species = 842, Level = 40, Ability = A0, Location = 126, IVs = new[] {31,-1,31,-1,31,-1}, DynamaxLevel = 5, Moves = new(787,412,406,076), CanGigantamax = true }, // ★Sgr6913 Gigantamax Appletun
-        new(  SH) { Species = 841, Level = 40, Ability = A0, Location = 126, IVs = new[] {31,31,-1,31,-1,-1}, DynamaxLevel = 5, Moves = new(788,491,412,406), CanGigantamax = true }, // ★Sgr6913 Gigantamax Flapple
-        new(SWSH) { Species = 844, Level = 40, Ability = A0, Location = 126, IVs = new[] {31,31,31,-1,-1,-1}, DynamaxLevel = 5, Moves = new(523,776,489,157), CanGigantamax = true }, // ★Sgr7348 Gigantamax Sandaconda
-        new(SWSH) { Species = 884, Level = 40, Ability = A2, Location = 126, IVs = new[] {31,-1,-1,31,31,-1}, DynamaxLevel = 5, Moves = new(796,063,784,319), CanGigantamax = true }, // ★Sgr7121 Gigantamax Duraludon
-        new(SWSH) { Species = 025, Level = 25, Ability = A2, Location = 126, IVs = new[] {31,31,31,-1,-1,-1}, DynamaxLevel = 5, Moves = new(606,273,104,085), CanGigantamax = true }, // ★Sgr6746 Gigantamax Pikachu
-        new(SWSH) { Species = 133, Level = 25, Ability = A2, Location = 126, IVs = new[] {31,31,31,-1,-1,-1}, DynamaxLevel = 5, Moves = new(606,273,038,129), CanGigantamax = true }, // ★Sgr7194 Gigantamax Eevee
+        new(SWSH) { Species = 782, Level = 16, Ability = A3, Location = 126, IVs = new(31,31,31,-1,-1,-1), DynamaxLevel = 2, Moves = new(033,029,525,043) }, // ★And458 Jangmo-o
+        new(SWSH) { Species = 246, Level = 16, Ability = A3, Location = 126, IVs = new(31,31,31,-1,-1,-1), DynamaxLevel = 2, Moves = new(033,157,371,044) }, // ★And15 Larvitar
+        new(SWSH) { Species = 823, Level = 50, Ability = A2, Location = 126, IVs = new(31,31,31,-1,-1,31), DynamaxLevel = 5, Moves = new(065,442,034,796), CanGigantamax = true }, // ★And337 Gigantamax Corviknight
+        new(SWSH) { Species = 875, Level = 15, Ability = A3, Location = 126, IVs = new(31,31,-1,31,-1,-1), DynamaxLevel = 2, Moves = new(181,311,054,556) }, // ★And603 Eiscue
+        new(SWSH) { Species = 874, Level = 15, Ability = A3, Location = 126, IVs = new(31,31,31,-1,-1,-1), DynamaxLevel = 2, Moves = new(397,317,335,157) }, // ★And390 Stonjourner
+        new(SWSH) { Species = 879, Level = 35, Ability = A3, Location = 126, IVs = new(31,31,-1, 0,31,-1), DynamaxLevel = 4, Moves = new(484,174,776,583), CanGigantamax = true }, // ★Sgr6879 Gigantamax Copperajah
+        new(SWSH) { Species = 851, Level = 35, Ability = A2, Location = 126, IVs = new(31,31,31,-1,-1,-1), DynamaxLevel = 5, Moves = new(680,679,489,438), CanGigantamax = true }, // ★Sgr6859 Gigantamax Centiskorch
+        new(SW  ) { Species = 842, Level = 40, Ability = A0, Location = 126, IVs = new(31,-1,31,-1,31,-1), DynamaxLevel = 5, Moves = new(787,412,406,076), CanGigantamax = true }, // ★Sgr6913 Gigantamax Appletun
+        new(  SH) { Species = 841, Level = 40, Ability = A0, Location = 126, IVs = new(31,31,-1,31,-1,-1), DynamaxLevel = 5, Moves = new(788,491,412,406), CanGigantamax = true }, // ★Sgr6913 Gigantamax Flapple
+        new(SWSH) { Species = 844, Level = 40, Ability = A0, Location = 126, IVs = new(31,31,31,-1,-1,-1), DynamaxLevel = 5, Moves = new(523,776,489,157), CanGigantamax = true }, // ★Sgr7348 Gigantamax Sandaconda
+        new(SWSH) { Species = 884, Level = 40, Ability = A2, Location = 126, IVs = new(31,-1,-1,31,31,-1), DynamaxLevel = 5, Moves = new(796,063,784,319), CanGigantamax = true }, // ★Sgr7121 Gigantamax Duraludon
+        new(SWSH) { Species = 025, Level = 25, Ability = A2, Location = 126, IVs = new(31,31,31,-1,-1,-1), DynamaxLevel = 5, Moves = new(606,273,104,085), CanGigantamax = true }, // ★Sgr6746 Gigantamax Pikachu
+        new(SWSH) { Species = 133, Level = 25, Ability = A2, Location = 126, IVs = new(31,31,31,-1,-1,-1), DynamaxLevel = 5, Moves = new(606,273,038,129), CanGigantamax = true }, // ★Sgr7194 Gigantamax Eevee
     };
     #endregion
 }

--- a/PKHeX.Core/Legality/Encounters/Data/Encounters8NestCrystal.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Encounters8NestCrystal.cs
@@ -8,19 +8,19 @@ internal static partial class Encounters8Nest
     #region Dynamax Crystal Distributions
     internal static readonly EncounterStatic8NC[] Crystal_SWSH =
     {
-        new(SWSH) { Species = 782, Level = 16, Ability = A3, Location = 126, IVs = new[] {31,31,31,-1,-1,-1}, DynamaxLevel = 2, Moves = new[] {033,029,525,043} }, // ★And458 Jangmo-o
-        new(SWSH) { Species = 246, Level = 16, Ability = A3, Location = 126, IVs = new[] {31,31,31,-1,-1,-1}, DynamaxLevel = 2, Moves = new[] {033,157,371,044} }, // ★And15 Larvitar
-        new(SWSH) { Species = 823, Level = 50, Ability = A2, Location = 126, IVs = new[] {31,31,31,-1,-1,31}, DynamaxLevel = 5, Moves = new[] {065,442,034,796}, CanGigantamax = true }, // ★And337 Gigantamax Corviknight
-        new(SWSH) { Species = 875, Level = 15, Ability = A3, Location = 126, IVs = new[] {31,31,-1,31,-1,-1}, DynamaxLevel = 2, Moves = new[] {181,311,054,556} }, // ★And603 Eiscue
-        new(SWSH) { Species = 874, Level = 15, Ability = A3, Location = 126, IVs = new[] {31,31,31,-1,-1,-1}, DynamaxLevel = 2, Moves = new[] {397,317,335,157} }, // ★And390 Stonjourner
-        new(SWSH) { Species = 879, Level = 35, Ability = A3, Location = 126, IVs = new[] {31,31,-1, 0,31,-1}, DynamaxLevel = 4, Moves = new[] {484,174,776,583}, CanGigantamax = true }, // ★Sgr6879 Gigantamax Copperajah
-        new(SWSH) { Species = 851, Level = 35, Ability = A2, Location = 126, IVs = new[] {31,31,31,-1,-1,-1}, DynamaxLevel = 5, Moves = new[] {680,679,489,438}, CanGigantamax = true }, // ★Sgr6859 Gigantamax Centiskorch
-        new(SW  ) { Species = 842, Level = 40, Ability = A0, Location = 126, IVs = new[] {31,-1,31,-1,31,-1}, DynamaxLevel = 5, Moves = new[] {787,412,406,076}, CanGigantamax = true }, // ★Sgr6913 Gigantamax Appletun
-        new(  SH) { Species = 841, Level = 40, Ability = A0, Location = 126, IVs = new[] {31,31,-1,31,-1,-1}, DynamaxLevel = 5, Moves = new[] {788,491,412,406}, CanGigantamax = true }, // ★Sgr6913 Gigantamax Flapple
-        new(SWSH) { Species = 844, Level = 40, Ability = A0, Location = 126, IVs = new[] {31,31,31,-1,-1,-1}, DynamaxLevel = 5, Moves = new[] {523,776,489,157}, CanGigantamax = true }, // ★Sgr7348 Gigantamax Sandaconda
-        new(SWSH) { Species = 884, Level = 40, Ability = A2, Location = 126, IVs = new[] {31,-1,-1,31,31,-1}, DynamaxLevel = 5, Moves = new[] {796,063,784,319}, CanGigantamax = true }, // ★Sgr7121 Gigantamax Duraludon
-        new(SWSH) { Species = 025, Level = 25, Ability = A2, Location = 126, IVs = new[] {31,31,31,-1,-1,-1}, DynamaxLevel = 5, Moves = new[] {606,273,104,085}, CanGigantamax = true }, // ★Sgr6746 Gigantamax Pikachu
-        new(SWSH) { Species = 133, Level = 25, Ability = A2, Location = 126, IVs = new[] {31,31,31,-1,-1,-1}, DynamaxLevel = 5, Moves = new[] {606,273,038,129}, CanGigantamax = true }, // ★Sgr7194 Gigantamax Eevee
+        new(SWSH) { Species = 782, Level = 16, Ability = A3, Location = 126, IVs = new[] {31,31,31,-1,-1,-1}, DynamaxLevel = 2, Moves = new(033,029,525,043) }, // ★And458 Jangmo-o
+        new(SWSH) { Species = 246, Level = 16, Ability = A3, Location = 126, IVs = new[] {31,31,31,-1,-1,-1}, DynamaxLevel = 2, Moves = new(033,157,371,044) }, // ★And15 Larvitar
+        new(SWSH) { Species = 823, Level = 50, Ability = A2, Location = 126, IVs = new[] {31,31,31,-1,-1,31}, DynamaxLevel = 5, Moves = new(065,442,034,796), CanGigantamax = true }, // ★And337 Gigantamax Corviknight
+        new(SWSH) { Species = 875, Level = 15, Ability = A3, Location = 126, IVs = new[] {31,31,-1,31,-1,-1}, DynamaxLevel = 2, Moves = new(181,311,054,556) }, // ★And603 Eiscue
+        new(SWSH) { Species = 874, Level = 15, Ability = A3, Location = 126, IVs = new[] {31,31,31,-1,-1,-1}, DynamaxLevel = 2, Moves = new(397,317,335,157) }, // ★And390 Stonjourner
+        new(SWSH) { Species = 879, Level = 35, Ability = A3, Location = 126, IVs = new[] {31,31,-1, 0,31,-1}, DynamaxLevel = 4, Moves = new(484,174,776,583), CanGigantamax = true }, // ★Sgr6879 Gigantamax Copperajah
+        new(SWSH) { Species = 851, Level = 35, Ability = A2, Location = 126, IVs = new[] {31,31,31,-1,-1,-1}, DynamaxLevel = 5, Moves = new(680,679,489,438), CanGigantamax = true }, // ★Sgr6859 Gigantamax Centiskorch
+        new(SW  ) { Species = 842, Level = 40, Ability = A0, Location = 126, IVs = new[] {31,-1,31,-1,31,-1}, DynamaxLevel = 5, Moves = new(787,412,406,076), CanGigantamax = true }, // ★Sgr6913 Gigantamax Appletun
+        new(  SH) { Species = 841, Level = 40, Ability = A0, Location = 126, IVs = new[] {31,31,-1,31,-1,-1}, DynamaxLevel = 5, Moves = new(788,491,412,406), CanGigantamax = true }, // ★Sgr6913 Gigantamax Flapple
+        new(SWSH) { Species = 844, Level = 40, Ability = A0, Location = 126, IVs = new[] {31,31,31,-1,-1,-1}, DynamaxLevel = 5, Moves = new(523,776,489,157), CanGigantamax = true }, // ★Sgr7348 Gigantamax Sandaconda
+        new(SWSH) { Species = 884, Level = 40, Ability = A2, Location = 126, IVs = new[] {31,-1,-1,31,31,-1}, DynamaxLevel = 5, Moves = new(796,063,784,319), CanGigantamax = true }, // ★Sgr7121 Gigantamax Duraludon
+        new(SWSH) { Species = 025, Level = 25, Ability = A2, Location = 126, IVs = new[] {31,31,31,-1,-1,-1}, DynamaxLevel = 5, Moves = new(606,273,104,085), CanGigantamax = true }, // ★Sgr6746 Gigantamax Pikachu
+        new(SWSH) { Species = 133, Level = 25, Ability = A2, Location = 126, IVs = new[] {31,31,31,-1,-1,-1}, DynamaxLevel = 5, Moves = new(606,273,038,129), CanGigantamax = true }, // ★Sgr7194 Gigantamax Eevee
     };
     #endregion
 }

--- a/PKHeX.Core/Legality/Encounters/Data/Encounters8NestDistBase.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Encounters8NestDistBase.cs
@@ -1,4 +1,4 @@
-﻿using static PKHeX.Core.GameVersion;
+using static PKHeX.Core.GameVersion;
 
 namespace PKHeX.Core;
 
@@ -10,655 +10,655 @@ internal static partial class Encounters8Nest
     /// </summary>
     internal static readonly EncounterStatic8ND[] Dist_Base =
     {
-        new(17,01,1) { Species = 052, Ability = A4, Moves = new[]{ 252, 044, 010, 364 }, Index = 23, CanGigantamax = true }, // Meowth
-        new(17,01,1) { Species = 052, Ability = A4, Moves = new[]{ 006, 044, 010, 364 }, Index = 23, CanGigantamax = true }, // Meowth
-        new(30,03,2) { Species = 052, Ability = A4, Moves = new[]{ 252, 044, 269, 154 }, Index = 23, CanGigantamax = true }, // Meowth
-        new(30,03,2) { Species = 052, Ability = A4, Moves = new[]{ 006, 044, 269, 154 }, Index = 23, CanGigantamax = true }, // Meowth
-        new(40,05,3) { Species = 052, Ability = A4, Moves = new[]{ 252, 044, 417, 163 }, Index = 23, CanGigantamax = true }, // Meowth
-        new(40,05,3) { Species = 052, Ability = A4, Moves = new[]{ 006, 044, 417, 163 }, Index = 23, CanGigantamax = true }, // Meowth
-        new(50,08,4) { Species = 052, Ability = A4, Moves = new[]{ 252, 583, 417, 163 }, Index = 23, CanGigantamax = true }, // Meowth
-        new(50,08,4) { Species = 052, Ability = A4, Moves = new[]{ 006, 583, 417, 163 }, Index = 23, CanGigantamax = true }, // Meowth
-        new(60,10,5) { Species = 052, Ability = A4, Moves = new[]{ 252, 583, 417, 034 }, Index = 23, CanGigantamax = true }, // Meowth
-        new(60,10,5) { Species = 052, Ability = A4, Moves = new[]{ 006, 583, 417, 034 }, Index = 23, CanGigantamax = true }, // Meowth
+        new(17,01,1) { Species = 052, Ability = A4, Moves = new(252, 044, 010, 364), Index = 23, CanGigantamax = true }, // Meowth
+        new(17,01,1) { Species = 052, Ability = A4, Moves = new(006, 044, 010, 364), Index = 23, CanGigantamax = true }, // Meowth
+        new(30,03,2) { Species = 052, Ability = A4, Moves = new(252, 044, 269, 154), Index = 23, CanGigantamax = true }, // Meowth
+        new(30,03,2) { Species = 052, Ability = A4, Moves = new(006, 044, 269, 154), Index = 23, CanGigantamax = true }, // Meowth
+        new(40,05,3) { Species = 052, Ability = A4, Moves = new(252, 044, 417, 163), Index = 23, CanGigantamax = true }, // Meowth
+        new(40,05,3) { Species = 052, Ability = A4, Moves = new(006, 044, 417, 163), Index = 23, CanGigantamax = true }, // Meowth
+        new(50,08,4) { Species = 052, Ability = A4, Moves = new(252, 583, 417, 163), Index = 23, CanGigantamax = true }, // Meowth
+        new(50,08,4) { Species = 052, Ability = A4, Moves = new(006, 583, 417, 163), Index = 23, CanGigantamax = true }, // Meowth
+        new(60,10,5) { Species = 052, Ability = A4, Moves = new(252, 583, 417, 034), Index = 23, CanGigantamax = true }, // Meowth
+        new(60,10,5) { Species = 052, Ability = A4, Moves = new(006, 583, 417, 034), Index = 23, CanGigantamax = true }, // Meowth
 
-        new(17,01,1) { Species = 133, Ability = A4, Moves = new[]{ 098, 270, 608, 028 }, Index = 22, CanGigantamax = true }, // Eevee
-        new(30,03,2) { Species = 133, Ability = A4, Moves = new[]{ 129, 270, 608, 044 }, Index = 22, CanGigantamax = true }, // Eevee
-        new(40,05,3) { Species = 133, Ability = A4, Moves = new[]{ 036, 270, 608, 044 }, Index = 22, CanGigantamax = true }, // Eevee
-        new(40,05,3) { Species = 133, Ability = A4, Moves = new[]{ 036, 270, 608, 231 }, Index = 22, CanGigantamax = true }, // Eevee
-        new(50,08,4) { Species = 133, Ability = A4, Moves = new[]{ 038, 270, 204, 044 }, Index = 22, CanGigantamax = true }, // Eevee
-        new(50,08,4) { Species = 133, Ability = A4, Moves = new[]{ 038, 203, 204, 231 }, Index = 22, CanGigantamax = true }, // Eevee
-        new(60,10,5) { Species = 133, Ability = A4, Moves = new[]{ 038, 270, 204, 231 }, Index = 22, CanGigantamax = true }, // Eevee
-        new(60,10,5) { Species = 133, Ability = A4, Moves = new[]{ 387, 203, 204, 231 }, Index = 22, CanGigantamax = true }, // Eevee
+        new(17,01,1) { Species = 133, Ability = A4, Moves = new(098, 270, 608, 028), Index = 22, CanGigantamax = true }, // Eevee
+        new(30,03,2) { Species = 133, Ability = A4, Moves = new(129, 270, 608, 044), Index = 22, CanGigantamax = true }, // Eevee
+        new(40,05,3) { Species = 133, Ability = A4, Moves = new(036, 270, 608, 044), Index = 22, CanGigantamax = true }, // Eevee
+        new(40,05,3) { Species = 133, Ability = A4, Moves = new(036, 270, 608, 231), Index = 22, CanGigantamax = true }, // Eevee
+        new(50,08,4) { Species = 133, Ability = A4, Moves = new(038, 270, 204, 044), Index = 22, CanGigantamax = true }, // Eevee
+        new(50,08,4) { Species = 133, Ability = A4, Moves = new(038, 203, 204, 231), Index = 22, CanGigantamax = true }, // Eevee
+        new(60,10,5) { Species = 133, Ability = A4, Moves = new(038, 270, 204, 231), Index = 22, CanGigantamax = true }, // Eevee
+        new(60,10,5) { Species = 133, Ability = A4, Moves = new(387, 203, 204, 231), Index = 22, CanGigantamax = true }, // Eevee
 
-        new(17,01,1) { Species = 025, Ability = A4, Moves = new[]{ 084, 104, 486, 364 }, Index = 21, CanGigantamax = true }, // Pikachu
-        new(30,03,2) { Species = 025, Ability = A4, Moves = new[]{ 021, 209, 097, 364 }, Index = 21, CanGigantamax = true }, // Pikachu
-        new(40,05,3) { Species = 025, Ability = A4, Moves = new[]{ 021, 113, 085, 364 }, Index = 21, CanGigantamax = true }, // Pikachu
-        new(50,08,4) { Species = 025, Ability = A4, Moves = new[]{ 087, 113, 085, 364 }, Index = 21, CanGigantamax = true }, // Pikachu
-        new(50,08,4) { Species = 025, Ability = A4, Moves = new[]{ 087, 113, 057, 085 }, Index = 21, CanGigantamax = true }, // Pikachu
-        new(60,10,5) { Species = 025, Ability = A4, Moves = new[]{ 087, 113, 057, 364 }, Index = 21, CanGigantamax = true }, // Pikachu
-        new(60,10,5) { Species = 025, Ability = A4, Moves = new[]{ 087, 113, 057, 344 }, Index = 21, CanGigantamax = true }, // Pikachu
+        new(17,01,1) { Species = 025, Ability = A4, Moves = new(084, 104, 486, 364), Index = 21, CanGigantamax = true }, // Pikachu
+        new(30,03,2) { Species = 025, Ability = A4, Moves = new(021, 209, 097, 364), Index = 21, CanGigantamax = true }, // Pikachu
+        new(40,05,3) { Species = 025, Ability = A4, Moves = new(021, 113, 085, 364), Index = 21, CanGigantamax = true }, // Pikachu
+        new(50,08,4) { Species = 025, Ability = A4, Moves = new(087, 113, 085, 364), Index = 21, CanGigantamax = true }, // Pikachu
+        new(50,08,4) { Species = 025, Ability = A4, Moves = new(087, 113, 057, 085), Index = 21, CanGigantamax = true }, // Pikachu
+        new(60,10,5) { Species = 025, Ability = A4, Moves = new(087, 113, 057, 364), Index = 21, CanGigantamax = true }, // Pikachu
+        new(60,10,5) { Species = 025, Ability = A4, Moves = new(087, 113, 057, 344), Index = 21, CanGigantamax = true }, // Pikachu
 
-        new(17,01,1) { Species = 246, Ability = A4, Moves = new[]{ 157, 044, 184, 033 }, Index = 20 }, // Larvitar
-        new(17,01,1) { Species = 529, Ability = A4, Moves = new[]{ 189, 232, 010, 468 }, Index = 20 }, // Drilbur
-        new(17,01,1) { Species = 546, Ability = A4, Moves = new[]{ 584, 078, 075, 071 }, Index = 20 }, // Cottonee
-        new(17,01,1) { Species = 885, Ability = A4, Moves = new[]{ 611, 098, 310, 044 }, Index = 20 }, // Dreepy
-        new(17,01,1) { Species = 175, Ability = A4, Moves = new[]{ 204, 577, 113, 791 }, Index = 20 }, // Togepi
-        new(30,03,2) { Species = 247, Ability = A4, Moves = new[]{ 157, 242, 334, 707 }, Index = 20 }, // Pupitar
-        new(30,03,2) { Species = 529, Ability = A4, Moves = new[]{ 189, 232, 157, 306 }, Index = 20 }, // Drilbur
-        new(30,03,2) { Species = 546, Ability = A4, Moves = new[]{ 202, 075, 204, 077 }, Index = 20 }, // Cottonee
-        new(30,03,2) { Species = 886, Ability = A4, Moves = new[]{ 097, 506, 372, 458 }, Index = 20 }, // Drakloak
-        new(30,03,2) { Species = 176, Ability = A4, Moves = new[]{ 584, 038, 113, 791 }, Index = 20 }, // Togetic
-        new(40,05,3) { Species = 248, Ability = A4, Moves = new[]{ 444, 242, 334, 089 }, Index = 20 }, // Tyranitar
-        new(40,05,3) { Species = 530, Ability = A4, Moves = new[]{ 529, 232, 157, 032 }, Index = 20 }, // Excadrill
-        new(40,05,3) { Species = 547, Ability = A4, Moves = new[]{ 283, 585, 077, 366 }, Index = 20 }, // Whimsicott
-        new(40,05,3) { Species = 887, Ability = A4, Moves = new[]{ 751, 506, 349, 458 }, Index = 20 }, // Dragapult
-        new(40,05,3) { Species = 468, Ability = A4, Moves = new[]{ 605, 038, 246, 403 }, Index = 20 }, // Togekiss
-        new(50,08,4) { Species = 248, Ability = A4, Moves = new[]{ 444, 242, 442, 089 }, Index = 20 }, // Tyranitar
-        new(50,08,4) { Species = 530, Ability = A4, Moves = new[]{ 529, 442, 157, 032 }, Index = 20 }, // Excadrill
-        new(50,08,4) { Species = 547, Ability = A4, Moves = new[]{ 283, 585, 073, 366 }, Index = 20 }, // Whimsicott
-        new(50,08,4) { Species = 887, Ability = A4, Moves = new[]{ 751, 506, 349, 211 }, Index = 20 }, // Dragapult
-        new(50,08,4) { Species = 468, Ability = A4, Moves = new[]{ 605, 219, 246, 403 }, Index = 20 }, // Togekiss
-        new(60,10,5) { Species = 248, Ability = A4, Moves = new[]{ 444, 242, 442, 276 }, Index = 20 }, // Tyranitar
-        new(60,10,5) { Species = 530, Ability = A4, Moves = new[]{ 089, 442, 157, 032 }, Index = 20 }, // Excadrill
-        new(60,10,5) { Species = 547, Ability = A4, Moves = new[]{ 538, 585, 073, 366 }, Index = 20 }, // Whimsicott
-        new(60,10,5) { Species = 887, Ability = A4, Moves = new[]{ 751, 566, 349, 211 }, Index = 20 }, // Dragapult
-        new(60,10,5) { Species = 468, Ability = A4, Moves = new[]{ 605, 219, 246, 053 }, Index = 20 }, // Togekiss
-        new(17,01,1,SW) { Species = 479, Ability = A4, Moves = new[]{ 104, 315, 084, 109 }, Index = 20, Form = 1 }, // Rotom-1
-        new(30,03,2,SW) { Species = 479, Ability = A4, Moves = new[]{ 104, 315, 085, 109 }, Index = 20, Form = 1 }, // Rotom-1
-        new(40,05,3,SW) { Species = 479, Ability = A4, Moves = new[]{ 521, 315, 085, 506 }, Index = 20, Form = 1 }, // Rotom-1
-        new(50,08,4,SW) { Species = 479, Ability = A4, Moves = new[]{ 521, 315, 085, 261 }, Index = 20, Form = 1 }, // Rotom-1
-        new(60,10,5,SW) { Species = 479, Ability = A4, Moves = new[]{ 521, 315, 435, 261 }, Index = 20, Form = 1 }, // Rotom-1
-        new(17,01,1,SH) { Species = 479, Ability = A4, Moves = new[]{ 104, 056, 084, 109 }, Index = 20, Form = 2 }, // Rotom-2
-        new(30,03,2,SH) { Species = 479, Ability = A4, Moves = new[]{ 104, 056, 085, 109 }, Index = 20, Form = 2 }, // Rotom-2
-        new(40,05,3,SH) { Species = 479, Ability = A4, Moves = new[]{ 521, 435, 085, 056 }, Index = 20, Form = 2 }, // Rotom-2
-        new(50,08,4,SH) { Species = 479, Ability = A4, Moves = new[]{ 521, 435, 247, 056 }, Index = 20, Form = 2 }, // Rotom-2
-        new(60,10,5,SH) { Species = 479, Ability = A4, Moves = new[]{ 521, 056, 247, 261 }, Index = 20, Form = 2 }, // Rotom-2
+        new(17,01,1) { Species = 246, Ability = A4, Moves = new(157, 044, 184, 033), Index = 20 }, // Larvitar
+        new(17,01,1) { Species = 529, Ability = A4, Moves = new(189, 232, 010, 468), Index = 20 }, // Drilbur
+        new(17,01,1) { Species = 546, Ability = A4, Moves = new(584, 078, 075, 071), Index = 20 }, // Cottonee
+        new(17,01,1) { Species = 885, Ability = A4, Moves = new(611, 098, 310, 044), Index = 20 }, // Dreepy
+        new(17,01,1) { Species = 175, Ability = A4, Moves = new(204, 577, 113, 791), Index = 20 }, // Togepi
+        new(30,03,2) { Species = 247, Ability = A4, Moves = new(157, 242, 334, 707), Index = 20 }, // Pupitar
+        new(30,03,2) { Species = 529, Ability = A4, Moves = new(189, 232, 157, 306), Index = 20 }, // Drilbur
+        new(30,03,2) { Species = 546, Ability = A4, Moves = new(202, 075, 204, 077), Index = 20 }, // Cottonee
+        new(30,03,2) { Species = 886, Ability = A4, Moves = new(097, 506, 372, 458), Index = 20 }, // Drakloak
+        new(30,03,2) { Species = 176, Ability = A4, Moves = new(584, 038, 113, 791), Index = 20 }, // Togetic
+        new(40,05,3) { Species = 248, Ability = A4, Moves = new(444, 242, 334, 089), Index = 20 }, // Tyranitar
+        new(40,05,3) { Species = 530, Ability = A4, Moves = new(529, 232, 157, 032), Index = 20 }, // Excadrill
+        new(40,05,3) { Species = 547, Ability = A4, Moves = new(283, 585, 077, 366), Index = 20 }, // Whimsicott
+        new(40,05,3) { Species = 887, Ability = A4, Moves = new(751, 506, 349, 458), Index = 20 }, // Dragapult
+        new(40,05,3) { Species = 468, Ability = A4, Moves = new(605, 038, 246, 403), Index = 20 }, // Togekiss
+        new(50,08,4) { Species = 248, Ability = A4, Moves = new(444, 242, 442, 089), Index = 20 }, // Tyranitar
+        new(50,08,4) { Species = 530, Ability = A4, Moves = new(529, 442, 157, 032), Index = 20 }, // Excadrill
+        new(50,08,4) { Species = 547, Ability = A4, Moves = new(283, 585, 073, 366), Index = 20 }, // Whimsicott
+        new(50,08,4) { Species = 887, Ability = A4, Moves = new(751, 506, 349, 211), Index = 20 }, // Dragapult
+        new(50,08,4) { Species = 468, Ability = A4, Moves = new(605, 219, 246, 403), Index = 20 }, // Togekiss
+        new(60,10,5) { Species = 248, Ability = A4, Moves = new(444, 242, 442, 276), Index = 20 }, // Tyranitar
+        new(60,10,5) { Species = 530, Ability = A4, Moves = new(089, 442, 157, 032), Index = 20 }, // Excadrill
+        new(60,10,5) { Species = 547, Ability = A4, Moves = new(538, 585, 073, 366), Index = 20 }, // Whimsicott
+        new(60,10,5) { Species = 887, Ability = A4, Moves = new(751, 566, 349, 211), Index = 20 }, // Dragapult
+        new(60,10,5) { Species = 468, Ability = A4, Moves = new(605, 219, 246, 053), Index = 20 }, // Togekiss
+        new(17,01,1,SW) { Species = 479, Ability = A4, Moves = new(104, 315, 084, 109), Index = 20, Form = 1 }, // Rotom-1
+        new(30,03,2,SW) { Species = 479, Ability = A4, Moves = new(104, 315, 085, 109), Index = 20, Form = 1 }, // Rotom-1
+        new(40,05,3,SW) { Species = 479, Ability = A4, Moves = new(521, 315, 085, 506), Index = 20, Form = 1 }, // Rotom-1
+        new(50,08,4,SW) { Species = 479, Ability = A4, Moves = new(521, 315, 085, 261), Index = 20, Form = 1 }, // Rotom-1
+        new(60,10,5,SW) { Species = 479, Ability = A4, Moves = new(521, 315, 435, 261), Index = 20, Form = 1 }, // Rotom-1
+        new(17,01,1,SH) { Species = 479, Ability = A4, Moves = new(104, 056, 084, 109), Index = 20, Form = 2 }, // Rotom-2
+        new(30,03,2,SH) { Species = 479, Ability = A4, Moves = new(104, 056, 085, 109), Index = 20, Form = 2 }, // Rotom-2
+        new(40,05,3,SH) { Species = 479, Ability = A4, Moves = new(521, 435, 085, 056), Index = 20, Form = 2 }, // Rotom-2
+        new(50,08,4,SH) { Species = 479, Ability = A4, Moves = new(521, 435, 247, 056), Index = 20, Form = 2 }, // Rotom-2
+        new(60,10,5,SH) { Species = 479, Ability = A4, Moves = new(521, 056, 247, 261), Index = 20, Form = 2 }, // Rotom-2
 
-        new(17,01,1) { Species = 246, Ability = A4, Moves = new[]{ 157, 044, 184, 033 }, Index = 19 }, // Larvitar
-        new(17,01,1) { Species = 546, Ability = A4, Moves = new[]{ 584, 078, 075, 071 }, Index = 19 }, // Cottonee
-        new(17,01,1) { Species = 885, Ability = A4, Moves = new[]{ 611, 098, 310, 044 }, Index = 19 }, // Dreepy
-        new(17,01,1) { Species = 175, Ability = A4, Moves = new[]{ 204, 577, 113, 791 }, Index = 19 }, // Togepi
-        new(30,03,2) { Species = 247, Ability = A4, Moves = new[]{ 157, 242, 334, 707 }, Index = 19 }, // Pupitar
-        new(30,03,2) { Species = 529, Ability = A4, Moves = new[]{ 189, 232, 157, 306 }, Index = 19 }, // Drilbur
-        new(30,03,2) { Species = 546, Ability = A4, Moves = new[]{ 202, 075, 204, 077 }, Index = 19 }, // Cottonee
-        new(30,03,2) { Species = 886, Ability = A4, Moves = new[]{ 097, 506, 372, 458 }, Index = 19 }, // Drakloak
-        new(30,03,2) { Species = 176, Ability = A4, Moves = new[]{ 584, 038, 113, 791 }, Index = 19 }, // Togetic
-        new(40,05,3) { Species = 248, Ability = A4, Moves = new[]{ 444, 242, 334, 089 }, Index = 19 }, // Tyranitar
-        new(40,05,3) { Species = 530, Ability = A4, Moves = new[]{ 529, 232, 157, 032 }, Index = 19 }, // Excadrill
-        new(40,05,3) { Species = 547, Ability = A4, Moves = new[]{ 283, 585, 077, 366 }, Index = 19 }, // Whimsicott
-        new(40,05,3) { Species = 887, Ability = A4, Moves = new[]{ 751, 506, 349, 458 }, Index = 19 }, // Dragapult
-        new(40,05,3) { Species = 468, Ability = A4, Moves = new[]{ 605, 038, 246, 403 }, Index = 19 }, // Togekiss
-        new(50,08,4) { Species = 248, Ability = A4, Moves = new[]{ 444, 242, 442, 089 }, Index = 19 }, // Tyranitar
-        new(50,08,4) { Species = 530, Ability = A4, Moves = new[]{ 529, 442, 157, 032 }, Index = 19 }, // Excadrill
-        new(50,08,4) { Species = 547, Ability = A4, Moves = new[]{ 283, 585, 073, 366 }, Index = 19 }, // Whimsicott
-        new(50,08,4) { Species = 887, Ability = A4, Moves = new[]{ 751, 506, 349, 211 }, Index = 19 }, // Dragapult
-        new(50,08,4) { Species = 468, Ability = A4, Moves = new[]{ 605, 219, 246, 403 }, Index = 19 }, // Togekiss
-        new(60,10,5) { Species = 248, Ability = A4, Moves = new[]{ 444, 242, 442, 276 }, Index = 19 }, // Tyranitar
-        new(60,10,5) { Species = 530, Ability = A4, Moves = new[]{ 089, 442, 157, 032 }, Index = 19 }, // Excadrill
-        new(60,10,5) { Species = 547, Ability = A4, Moves = new[]{ 538, 585, 073, 366 }, Index = 19 }, // Whimsicott
-        new(60,10,5) { Species = 887, Ability = A4, Moves = new[]{ 751, 566, 349, 211 }, Index = 19 }, // Dragapult
-        new(60,10,5) { Species = 468, Ability = A4, Moves = new[]{ 605, 219, 246, 053 }, Index = 19 }, // Togekiss
-        new(17,01,1,SW) { Species = 479, Ability = A4, Moves = new[]{ 104, 315, 084, 109 }, Index = 19, Form = 1 }, // Rotom-1
-        new(17,01,1,SW) { Species = 529, Ability = A4, Moves = new[]{ 189, 232, 010, 468 }, Index = 19 }, // Drilbur
-        new(30,03,2,SW) { Species = 479, Ability = A4, Moves = new[]{ 104, 315, 085, 109 }, Index = 19, Form = 1 }, // Rotom-1
-        new(40,05,3,SW) { Species = 479, Ability = A4, Moves = new[]{ 521, 315, 085, 506 }, Index = 19, Form = 1 }, // Rotom-1
-        new(50,08,4,SW) { Species = 479, Ability = A4, Moves = new[]{ 521, 315, 085, 261 }, Index = 19, Form = 1 }, // Rotom-1
-        new(60,10,5,SW) { Species = 479, Ability = A4, Moves = new[]{ 521, 315, 435, 261 }, Index = 19, Form = 1 }, // Rotom-1
-        new(17,01,1,SH) { Species = 479, Ability = A4, Moves = new[]{ 104, 435, 084, 109 }, Index = 19, Form = 2 }, // Rotom-2
-        //new(17,01,1,SH) { Species = 529, Ability = A4, Moves = new[]{ 189, 232, 056, 468 }, Index = 19 }, // Drilbur - From initial revision: treat this as illegal.
-        new(30,03,2,SH) { Species = 479, Ability = A4, Moves = new[]{ 104, 056, 085, 109 }, Index = 19, Form = 2 }, // Rotom-2
-        new(40,05,3,SH) { Species = 479, Ability = A4, Moves = new[]{ 521, 435, 085, 056 }, Index = 19, Form = 2 }, // Rotom-2
-        new(50,08,4,SH) { Species = 479, Ability = A4, Moves = new[]{ 521, 435, 247, 056 }, Index = 19, Form = 2 }, // Rotom-2
-        new(60,10,5,SH) { Species = 479, Ability = A4, Moves = new[]{ 521, 056, 247, 261 }, Index = 19, Form = 2 }, // Rotom-2
+        new(17,01,1) { Species = 246, Ability = A4, Moves = new(157, 044, 184, 033), Index = 19 }, // Larvitar
+        new(17,01,1) { Species = 546, Ability = A4, Moves = new(584, 078, 075, 071), Index = 19 }, // Cottonee
+        new(17,01,1) { Species = 885, Ability = A4, Moves = new(611, 098, 310, 044), Index = 19 }, // Dreepy
+        new(17,01,1) { Species = 175, Ability = A4, Moves = new(204, 577, 113, 791), Index = 19 }, // Togepi
+        new(30,03,2) { Species = 247, Ability = A4, Moves = new(157, 242, 334, 707), Index = 19 }, // Pupitar
+        new(30,03,2) { Species = 529, Ability = A4, Moves = new(189, 232, 157, 306), Index = 19 }, // Drilbur
+        new(30,03,2) { Species = 546, Ability = A4, Moves = new(202, 075, 204, 077), Index = 19 }, // Cottonee
+        new(30,03,2) { Species = 886, Ability = A4, Moves = new(097, 506, 372, 458), Index = 19 }, // Drakloak
+        new(30,03,2) { Species = 176, Ability = A4, Moves = new(584, 038, 113, 791), Index = 19 }, // Togetic
+        new(40,05,3) { Species = 248, Ability = A4, Moves = new(444, 242, 334, 089), Index = 19 }, // Tyranitar
+        new(40,05,3) { Species = 530, Ability = A4, Moves = new(529, 232, 157, 032), Index = 19 }, // Excadrill
+        new(40,05,3) { Species = 547, Ability = A4, Moves = new(283, 585, 077, 366), Index = 19 }, // Whimsicott
+        new(40,05,3) { Species = 887, Ability = A4, Moves = new(751, 506, 349, 458), Index = 19 }, // Dragapult
+        new(40,05,3) { Species = 468, Ability = A4, Moves = new(605, 038, 246, 403), Index = 19 }, // Togekiss
+        new(50,08,4) { Species = 248, Ability = A4, Moves = new(444, 242, 442, 089), Index = 19 }, // Tyranitar
+        new(50,08,4) { Species = 530, Ability = A4, Moves = new(529, 442, 157, 032), Index = 19 }, // Excadrill
+        new(50,08,4) { Species = 547, Ability = A4, Moves = new(283, 585, 073, 366), Index = 19 }, // Whimsicott
+        new(50,08,4) { Species = 887, Ability = A4, Moves = new(751, 506, 349, 211), Index = 19 }, // Dragapult
+        new(50,08,4) { Species = 468, Ability = A4, Moves = new(605, 219, 246, 403), Index = 19 }, // Togekiss
+        new(60,10,5) { Species = 248, Ability = A4, Moves = new(444, 242, 442, 276), Index = 19 }, // Tyranitar
+        new(60,10,5) { Species = 530, Ability = A4, Moves = new(089, 442, 157, 032), Index = 19 }, // Excadrill
+        new(60,10,5) { Species = 547, Ability = A4, Moves = new(538, 585, 073, 366), Index = 19 }, // Whimsicott
+        new(60,10,5) { Species = 887, Ability = A4, Moves = new(751, 566, 349, 211), Index = 19 }, // Dragapult
+        new(60,10,5) { Species = 468, Ability = A4, Moves = new(605, 219, 246, 053), Index = 19 }, // Togekiss
+        new(17,01,1,SW) { Species = 479, Ability = A4, Moves = new(104, 315, 084, 109), Index = 19, Form = 1 }, // Rotom-1
+        new(17,01,1,SW) { Species = 529, Ability = A4, Moves = new(189, 232, 010, 468), Index = 19 }, // Drilbur
+        new(30,03,2,SW) { Species = 479, Ability = A4, Moves = new(104, 315, 085, 109), Index = 19, Form = 1 }, // Rotom-1
+        new(40,05,3,SW) { Species = 479, Ability = A4, Moves = new(521, 315, 085, 506), Index = 19, Form = 1 }, // Rotom-1
+        new(50,08,4,SW) { Species = 479, Ability = A4, Moves = new(521, 315, 085, 261), Index = 19, Form = 1 }, // Rotom-1
+        new(60,10,5,SW) { Species = 479, Ability = A4, Moves = new(521, 315, 435, 261), Index = 19, Form = 1 }, // Rotom-1
+        new(17,01,1,SH) { Species = 479, Ability = A4, Moves = new(104, 435, 084, 109), Index = 19, Form = 2 }, // Rotom-2
+        //new(17,01,1,SH) { Species = 529, Ability = A4, Moves = new(189, 232, 056, 468), Index = 19 }, // Drilbur - From initial revision: treat this as illegal.
+        new(30,03,2,SH) { Species = 479, Ability = A4, Moves = new(104, 056, 085, 109), Index = 19, Form = 2 }, // Rotom-2
+        new(40,05,3,SH) { Species = 479, Ability = A4, Moves = new(521, 435, 085, 056), Index = 19, Form = 2 }, // Rotom-2
+        new(50,08,4,SH) { Species = 479, Ability = A4, Moves = new(521, 435, 247, 056), Index = 19, Form = 2 }, // Rotom-2
+        new(60,10,5,SH) { Species = 479, Ability = A4, Moves = new(521, 056, 247, 261), Index = 19, Form = 2 }, // Rotom-2
 
-        new(17,01,1) { Species = 878, Ability = A4, Moves = new[]{ 091, 249, 205, 523 }, Index = 17 }, // Cufant
-        new(17,01,1) { Species = 568, Ability = A4, Moves = new[]{ 001, 499, 491, 133 }, Index = 17 }, // Trubbish
-        new(17,01,1) { Species = 004, Ability = A4, Moves = new[]{ 424, 052, 108, 225 }, Index = 17 }, // Charmander
-        new(17,01,1) { Species = 884, Ability = A4, Moves = new[]{ 468, 249, 043, 232 }, Index = 17 }, // Duraludon
-        new(30,03,2) { Species = 878, Ability = A4, Moves = new[]{ 334, 091, 205, 523 }, Index = 17 }, // Cufant
-        new(30,03,2) { Species = 568, Ability = A4, Moves = new[]{ 036, 499, 124, 133 }, Index = 17 }, // Trubbish
-        new(30,03,2) { Species = 884, Ability = A4, Moves = new[]{ 468, 249, 784, 232 }, Index = 17 }, // Duraludon
-        new(30,03,2) { Species = 005, Ability = A4, Moves = new[]{ 053, 163, 108, 225 }, Index = 17 }, // Charmeleon
-        new(40,05,2) { Species = 848, Ability = A4, Moves = new[]{ 609, 051, 175, 715 }, Index = 17 }, // Toxel
-        new(40,05,2) { Species = 458, Ability = A4, Moves = new[]{ 403, 061, 469, 503 }, Index = 17 }, // Mantyke
-        new(40,05,3) { Species = 406, Ability = A4, Moves = new[]{ 071, 074, 078, 188 }, Index = 17 }, // Budew
-        new(40,05,3) { Species = 236, Ability = A4, Moves = new[]{ 280, 157, 252, 116 }, Index = 17 }, // Tyrogue
-        new(40,05,3) { Species = 438, Ability = A4, Moves = new[]{ 317, 389, 157, 313 }, Index = 17 }, // Bonsly
-        new(40,05,3) { Species = 447, Ability = A4, Moves = new[]{ 014, 009, 232, 249 }, Index = 17 }, // Riolu
-        new(40,05,3) { Species = 446, Ability = A4, Moves = new[]{ 034, 089, 044, 122 }, Index = 17 }, // Munchlax
-        new(40,05,3) { Species = 439, Ability = A4, Moves = new[]{ 389, 060, 182, 085 }, Index = 17 }, // Mime Jr.
-        new(50,08,4) { Species = 175, Ability = A4, Moves = new[]{ 605, 219, 246, 053 }, Index = 17 }, // Togepi
-        new(50,08,4) { Species = 360, Ability = A4, Moves = new[]{ 068, 243, 204, 133 }, Index = 17 }, // Wynaut
-        new(50,08,4) { Species = 173, Ability = A4, Moves = new[]{ 574, 005, 113, 034 }, Index = 17 }, // Cleffa
-        new(50,08,4) { Species = 006, Ability = A4, Moves = new[]{ 053, 403, 076, 257 }, Index = 17, CanGigantamax = true }, // Charizard
-        new(50,08,4) { Species = 172, Ability = A4, Moves = new[]{ 583, 417, 085, 186 }, Index = 17 }, // Pichu
-        new(50,08,4) { Species = 884, Ability = A4, Moves = new[]{ 337, 430, 784, 776 }, Index = 17, CanGigantamax = true }, // Duraludon
-        new(60,10,5) { Species = 132, Ability = A4, Moves = new[]{ 144, 000, 000, 000 }, Index = 17 }, // Ditto
-        new(60,10,5,SW) { Species = 879, Ability = A4, Moves = new[]{ 442, 583, 438, 089 }, Index = 17, CanGigantamax = true }, // Copperajah
-        new(60,10,5,SW) { Species = 884, Ability = A4, Moves = new[]{ 430, 406, 085, 334 }, Index = 17, CanGigantamax = true }, // Duraludon
-        new(60,10,5,SH) { Species = 569, Ability = A4, Moves = new[]{ 441, 499, 402, 707 }, Index = 17, CanGigantamax = true }, // Garbodor
-        new(60,10,5,SH) { Species = 006, Ability = A4, Moves = new[]{ 053, 403, 019, 411 }, Index = 17, CanGigantamax = true }, // Charizard
+        new(17,01,1) { Species = 878, Ability = A4, Moves = new(091, 249, 205, 523), Index = 17 }, // Cufant
+        new(17,01,1) { Species = 568, Ability = A4, Moves = new(001, 499, 491, 133), Index = 17 }, // Trubbish
+        new(17,01,1) { Species = 004, Ability = A4, Moves = new(424, 052, 108, 225), Index = 17 }, // Charmander
+        new(17,01,1) { Species = 884, Ability = A4, Moves = new(468, 249, 043, 232), Index = 17 }, // Duraludon
+        new(30,03,2) { Species = 878, Ability = A4, Moves = new(334, 091, 205, 523), Index = 17 }, // Cufant
+        new(30,03,2) { Species = 568, Ability = A4, Moves = new(036, 499, 124, 133), Index = 17 }, // Trubbish
+        new(30,03,2) { Species = 884, Ability = A4, Moves = new(468, 249, 784, 232), Index = 17 }, // Duraludon
+        new(30,03,2) { Species = 005, Ability = A4, Moves = new(053, 163, 108, 225), Index = 17 }, // Charmeleon
+        new(40,05,2) { Species = 848, Ability = A4, Moves = new(609, 051, 175, 715), Index = 17 }, // Toxel
+        new(40,05,2) { Species = 458, Ability = A4, Moves = new(403, 061, 469, 503), Index = 17 }, // Mantyke
+        new(40,05,3) { Species = 406, Ability = A4, Moves = new(071, 074, 078, 188), Index = 17 }, // Budew
+        new(40,05,3) { Species = 236, Ability = A4, Moves = new(280, 157, 252, 116), Index = 17 }, // Tyrogue
+        new(40,05,3) { Species = 438, Ability = A4, Moves = new(317, 389, 157, 313), Index = 17 }, // Bonsly
+        new(40,05,3) { Species = 447, Ability = A4, Moves = new(014, 009, 232, 249), Index = 17 }, // Riolu
+        new(40,05,3) { Species = 446, Ability = A4, Moves = new(034, 089, 044, 122), Index = 17 }, // Munchlax
+        new(40,05,3) { Species = 439, Ability = A4, Moves = new(389, 060, 182, 085), Index = 17 }, // Mime Jr.
+        new(50,08,4) { Species = 175, Ability = A4, Moves = new(605, 219, 246, 053), Index = 17 }, // Togepi
+        new(50,08,4) { Species = 360, Ability = A4, Moves = new(068, 243, 204, 133), Index = 17 }, // Wynaut
+        new(50,08,4) { Species = 173, Ability = A4, Moves = new(574, 005, 113, 034), Index = 17 }, // Cleffa
+        new(50,08,4) { Species = 006, Ability = A4, Moves = new(053, 403, 076, 257), Index = 17, CanGigantamax = true }, // Charizard
+        new(50,08,4) { Species = 172, Ability = A4, Moves = new(583, 417, 085, 186), Index = 17 }, // Pichu
+        new(50,08,4) { Species = 884, Ability = A4, Moves = new(337, 430, 784, 776), Index = 17, CanGigantamax = true }, // Duraludon
+        new(60,10,5) { Species = 132, Ability = A4, Moves = new(144, 000, 000, 000), Index = 17 }, // Ditto
+        new(60,10,5,SW) { Species = 879, Ability = A4, Moves = new(442, 583, 438, 089), Index = 17, CanGigantamax = true }, // Copperajah
+        new(60,10,5,SW) { Species = 884, Ability = A4, Moves = new(430, 406, 085, 334), Index = 17, CanGigantamax = true }, // Duraludon
+        new(60,10,5,SH) { Species = 569, Ability = A4, Moves = new(441, 499, 402, 707), Index = 17, CanGigantamax = true }, // Garbodor
+        new(60,10,5,SH) { Species = 006, Ability = A4, Moves = new(053, 403, 019, 411), Index = 17, CanGigantamax = true }, // Charizard
 
-        new(17,01,1) { Species = 878, Ability = A4, Moves = new[]{ 091, 249, 205, 523 }, Index = 16 }, // Cufant
-        new(17,01,1) { Species = 568, Ability = A4, Moves = new[]{ 001, 499, 491, 133 }, Index = 16 }, // Trubbish
-        new(17,01,1) { Species = 004, Ability = A4, Moves = new[]{ 424, 052, 108, 225 }, Index = 16 }, // Charmander
-        new(17,01,1) { Species = 884, Ability = A4, Moves = new[]{ 468, 249, 043, 232 }, Index = 16 }, // Duraludon
-        new(30,03,2) { Species = 878, Ability = A4, Moves = new[]{ 334, 091, 205, 523 }, Index = 16 }, // Cufant
-        new(30,03,2) { Species = 568, Ability = A4, Moves = new[]{ 036, 499, 124, 133 }, Index = 16 }, // Trubbish
-        new(30,03,2) { Species = 005, Ability = A4, Moves = new[]{ 053, 163, 108, 225 }, Index = 16 }, // Charmeleon
-        new(30,03,2) { Species = 884, Ability = A4, Moves = new[]{ 468, 249, 784, 232 }, Index = 16 }, // Duraludon
-        new(40,05,3) { Species = 879, Ability = A4, Moves = new[]{ 334, 070, 442, 523 }, Index = 16, CanGigantamax = true }, // Copperajah
-        new(40,05,3) { Species = 569, Ability = A4, Moves = new[]{ 188, 499, 034, 707 }, Index = 16, CanGigantamax = true }, // Garbodor
-        new(40,05,3) { Species = 006, Ability = A4, Moves = new[]{ 053, 403, 108, 225 }, Index = 16, CanGigantamax = true }, // Charizard
-        new(40,05,3) { Species = 884, Ability = A4, Moves = new[]{ 442, 555, 784, 334 }, Index = 16, CanGigantamax = true }, // Duraludon
-        new(50,08,4) { Species = 879, Ability = A4, Moves = new[]{ 667, 442, 438, 523 }, Index = 16, CanGigantamax = true }, // Copperajah
-        new(50,08,4) { Species = 569, Ability = A4, Moves = new[]{ 441, 499, 402, 707 }, Index = 16, CanGigantamax = true }, // Garbodor
-        new(50,08,4) { Species = 006, Ability = A4, Moves = new[]{ 053, 403, 076, 257 }, Index = 16, CanGigantamax = true }, // Charizard
-        new(50,08,4) { Species = 884, Ability = A4, Moves = new[]{ 337, 430, 784, 776 }, Index = 16, CanGigantamax = true }, // Duraludon
-        new(60,10,5,SW) { Species = 879, Ability = A4, Moves = new[]{ 442, 583, 438, 089 }, Index = 16, CanGigantamax = true }, // Copperajah
-        new(60,10,5,SW) { Species = 884, Ability = A4, Moves = new[]{ 430, 406, 085, 334 }, Index = 16, CanGigantamax = true }, // Duraludon
-        new(60,10,5,SH) { Species = 569, Ability = A4, Moves = new[]{ 441, 409, 402, 707 }, Index = 16, CanGigantamax = true }, // Garbodor
-        new(60,10,5,SH) { Species = 006, Ability = A4, Moves = new[]{ 257, 403, 406, 411 }, Index = 16, CanGigantamax = true, Shiny = Shiny.Never }, // Charizard
+        new(17,01,1) { Species = 878, Ability = A4, Moves = new(091, 249, 205, 523), Index = 16 }, // Cufant
+        new(17,01,1) { Species = 568, Ability = A4, Moves = new(001, 499, 491, 133), Index = 16 }, // Trubbish
+        new(17,01,1) { Species = 004, Ability = A4, Moves = new(424, 052, 108, 225), Index = 16 }, // Charmander
+        new(17,01,1) { Species = 884, Ability = A4, Moves = new(468, 249, 043, 232), Index = 16 }, // Duraludon
+        new(30,03,2) { Species = 878, Ability = A4, Moves = new(334, 091, 205, 523), Index = 16 }, // Cufant
+        new(30,03,2) { Species = 568, Ability = A4, Moves = new(036, 499, 124, 133), Index = 16 }, // Trubbish
+        new(30,03,2) { Species = 005, Ability = A4, Moves = new(053, 163, 108, 225), Index = 16 }, // Charmeleon
+        new(30,03,2) { Species = 884, Ability = A4, Moves = new(468, 249, 784, 232), Index = 16 }, // Duraludon
+        new(40,05,3) { Species = 879, Ability = A4, Moves = new(334, 070, 442, 523), Index = 16, CanGigantamax = true }, // Copperajah
+        new(40,05,3) { Species = 569, Ability = A4, Moves = new(188, 499, 034, 707), Index = 16, CanGigantamax = true }, // Garbodor
+        new(40,05,3) { Species = 006, Ability = A4, Moves = new(053, 403, 108, 225), Index = 16, CanGigantamax = true }, // Charizard
+        new(40,05,3) { Species = 884, Ability = A4, Moves = new(442, 555, 784, 334), Index = 16, CanGigantamax = true }, // Duraludon
+        new(50,08,4) { Species = 879, Ability = A4, Moves = new(667, 442, 438, 523), Index = 16, CanGigantamax = true }, // Copperajah
+        new(50,08,4) { Species = 569, Ability = A4, Moves = new(441, 499, 402, 707), Index = 16, CanGigantamax = true }, // Garbodor
+        new(50,08,4) { Species = 006, Ability = A4, Moves = new(053, 403, 076, 257), Index = 16, CanGigantamax = true }, // Charizard
+        new(50,08,4) { Species = 884, Ability = A4, Moves = new(337, 430, 784, 776), Index = 16, CanGigantamax = true }, // Duraludon
+        new(60,10,5,SW) { Species = 879, Ability = A4, Moves = new(442, 583, 438, 089), Index = 16, CanGigantamax = true }, // Copperajah
+        new(60,10,5,SW) { Species = 884, Ability = A4, Moves = new(430, 406, 085, 334), Index = 16, CanGigantamax = true }, // Duraludon
+        new(60,10,5,SH) { Species = 569, Ability = A4, Moves = new(441, 409, 402, 707), Index = 16, CanGigantamax = true }, // Garbodor
+        new(60,10,5,SH) { Species = 006, Ability = A4, Moves = new(257, 403, 406, 411), Index = 16, CanGigantamax = true, Shiny = Shiny.Never }, // Charizard
 
-        new(17,01,1) { Species = 588, Ability = A4, Moves = new[]{ 064, 043, 210, 491 }, Index = 15 }, // Karrablast
-        new(17,01,1) { Species = 616, Ability = A4, Moves = new[]{ 071, 051, 174, 522 }, Index = 15 }, // Shelmet
-        new(17,01,1) { Species = 092, Ability = A4, Moves = new[]{ 122, 109, 095, 371 }, Index = 15 }, // Gastly
-        new(17,01,1) { Species = 871, Ability = A4, Moves = new[]{ 084, 064, 055, 031 }, Index = 15 }, // Pincurchin
-        new(17,01,1) { Species = 066, Ability = A4, Moves = new[]{ 067, 043, 116, 279 }, Index = 15 }, // Machop
-        new(30,03,2) { Species = 143, Ability = A4, Moves = new[]{ 034, 242, 118, 111 }, Index = 15 }, // Snorlax
-        new(30,03,2) { Species = 093, Ability = A4, Moves = new[]{ 325, 095, 122, 101 }, Index = 15 }, // Haunter
-        new(30,03,2) { Species = 871, Ability = A4, Moves = new[]{ 209, 061, 086, 506 }, Index = 15 }, // Pincurchin
-        new(30,03,2) { Species = 067, Ability = A4, Moves = new[]{ 067, 490, 282, 233 }, Index = 15 }, // Machoke
-        new(40,05,3) { Species = 143, Ability = A4, Moves = new[]{ 034, 667, 242, 281 }, Index = 15, CanGigantamax = true }, // Snorlax
-        new(40,05,3) { Species = 094, Ability = A4, Moves = new[]{ 506, 188, 085, 261 }, Index = 15, CanGigantamax = true }, // Gengar
-        new(40,05,3) { Species = 871, Ability = A2, Moves = new[]{ 085, 503, 398, 716 }, Index = 15 }, // Pincurchin
-        new(40,05,3) { Species = 068, Ability = A4, Moves = new[]{ 279, 667, 008, 157 }, Index = 15, CanGigantamax = true }, // Machamp
-        new(50,08,4) { Species = 617, Ability = A2, Moves = new[]{ 405, 522, 188, 202 }, Index = 15 }, // Accelgor
-        new(50,08,4) { Species = 143, Ability = A4, Moves = new[]{ 034, 667, 280, 523 }, Index = 15, CanGigantamax = true }, // Snorlax
-        new(50,08,4) { Species = 589, Ability = A2, Moves = new[]{ 442, 224, 529, 398 }, Index = 15 }, // Escavalier
-        new(50,08,4) { Species = 094, Ability = A4, Moves = new[]{ 247, 482, 411, 605 }, Index = 15, CanGigantamax = true }, // Gengar
-        new(50,08,4) { Species = 871, Ability = A2, Moves = new[]{ 435, 330, 474, 367 }, Index = 15 }, // Pincurchin
-        new(50,08,4) { Species = 068, Ability = A4, Moves = new[]{ 280, 444, 371, 523 }, Index = 15, CanGigantamax = true }, // Machamp
-        new(60,10,5) { Species = 143, Ability = A4, Moves = new[]{ 034, 442, 242, 428 }, Index = 15, CanGigantamax = true }, // Snorlax
-        new(17,01,1,SW) { Species = 222, Ability = A4, Moves = new[]{ 033, 106, 310, 050 }, Index = 15, Form = 1 }, // Corsola-1
-        new(30,03,2,SW) { Species = 077, Ability = A4, Moves = new[]{ 093, 584, 060, 023 }, Index = 15, Form = 1 }, // Ponyta-1
-        new(30,03,2,SW) { Species = 222, Ability = A4, Moves = new[]{ 310, 050, 246, 506 }, Index = 15, Form = 1 }, // Corsola-1
-        new(40,05,3,SW) { Species = 077, Ability = A2, Moves = new[]{ 340, 023, 428, 583 }, Index = 15, Form = 1 }, // Ponyta-1
-        new(40,05,3,SW) { Species = 222, Ability = A2, Moves = new[]{ 506, 408, 503, 261 }, Index = 15, Form = 1 }, // Corsola-1
-        new(60,10,5,SW) { Species = 765, Ability = A2, Moves = new[]{ 492, 094, 085, 247 }, Index = 15 }, // Oranguru
-        new(60,10,5,SW) { Species = 876, Ability = A2, Moves = new[]{ 094, 595, 605, 304 }, Index = 15, Form = 1 }, // Indeedee-1
-        new(60,10,5,SW) { Species = 630, Ability = A2, Moves = new[]{ 403, 555, 492, 211 }, Index = 15 }, // Mandibuzz
-        new(60,10,5,SW) { Species = 078, Ability = A2, Moves = new[]{ 428, 583, 224, 340 }, Index = 15, Form = 1 }, // Rapidash-1
-        new(60,10,5,SW) { Species = 068, Ability = A4, Moves = new[]{ 238, 007, 008, 089 }, Index = 15, CanGigantamax = true }, // Machamp
-        new(17,01,1,SH) { Species = 554, Ability = A4, Moves = new[]{ 033, 181, 044, 419 }, Index = 15, Form = 1 }, // Darumaka-1
-        new(30,03,2,SH) { Species = 083, Ability = A4, Moves = new[]{ 064, 028, 249, 693 }, Index = 15, Form = 1 }, // Farfetch’d-1
-        new(30,03,2,SH) { Species = 554, Ability = A4, Moves = new[]{ 423, 029, 424, 280 }, Index = 15, Form = 1 }, // Darumaka-1
-        new(40,05,3,SH) { Species = 083, Ability = A2, Moves = new[]{ 280, 693, 348, 413 }, Index = 15, Form = 1 }, // Farfetch’d-1
-        new(40,05,3,SH) { Species = 554, Ability = A2, Moves = new[]{ 008, 007, 428, 276 }, Index = 15, Form = 1 }, // Darumaka-1
-        new(60,10,5,SH) { Species = 766, Ability = A2, Moves = new[]{ 370, 157, 523, 231 }, Index = 15 }, // Passimian
-        new(60,10,5,SH) { Species = 876, Ability = A2, Moves = new[]{ 094, 595, 605, 247 }, Index = 15 }, // Indeedee
-        new(60,10,5,SH) { Species = 628, Ability = A2, Moves = new[]{ 413, 276, 442, 157 }, Index = 15 }, // Braviary
-        new(60,10,5,SH) { Species = 865, Ability = A2, Moves = new[]{ 370, 413, 211, 675 }, Index = 15 }, // Sirfetch’d
-        new(60,10,5,SH) { Species = 094, Ability = A4, Moves = new[]{ 247, 482, 094, 196 }, Index = 15, CanGigantamax = true }, // Gengar
+        new(17,01,1) { Species = 588, Ability = A4, Moves = new(064, 043, 210, 491), Index = 15 }, // Karrablast
+        new(17,01,1) { Species = 616, Ability = A4, Moves = new(071, 051, 174, 522), Index = 15 }, // Shelmet
+        new(17,01,1) { Species = 092, Ability = A4, Moves = new(122, 109, 095, 371), Index = 15 }, // Gastly
+        new(17,01,1) { Species = 871, Ability = A4, Moves = new(084, 064, 055, 031), Index = 15 }, // Pincurchin
+        new(17,01,1) { Species = 066, Ability = A4, Moves = new(067, 043, 116, 279), Index = 15 }, // Machop
+        new(30,03,2) { Species = 143, Ability = A4, Moves = new(034, 242, 118, 111), Index = 15 }, // Snorlax
+        new(30,03,2) { Species = 093, Ability = A4, Moves = new(325, 095, 122, 101), Index = 15 }, // Haunter
+        new(30,03,2) { Species = 871, Ability = A4, Moves = new(209, 061, 086, 506), Index = 15 }, // Pincurchin
+        new(30,03,2) { Species = 067, Ability = A4, Moves = new(067, 490, 282, 233), Index = 15 }, // Machoke
+        new(40,05,3) { Species = 143, Ability = A4, Moves = new(034, 667, 242, 281), Index = 15, CanGigantamax = true }, // Snorlax
+        new(40,05,3) { Species = 094, Ability = A4, Moves = new(506, 188, 085, 261), Index = 15, CanGigantamax = true }, // Gengar
+        new(40,05,3) { Species = 871, Ability = A2, Moves = new(085, 503, 398, 716), Index = 15 }, // Pincurchin
+        new(40,05,3) { Species = 068, Ability = A4, Moves = new(279, 667, 008, 157), Index = 15, CanGigantamax = true }, // Machamp
+        new(50,08,4) { Species = 617, Ability = A2, Moves = new(405, 522, 188, 202), Index = 15 }, // Accelgor
+        new(50,08,4) { Species = 143, Ability = A4, Moves = new(034, 667, 280, 523), Index = 15, CanGigantamax = true }, // Snorlax
+        new(50,08,4) { Species = 589, Ability = A2, Moves = new(442, 224, 529, 398), Index = 15 }, // Escavalier
+        new(50,08,4) { Species = 094, Ability = A4, Moves = new(247, 482, 411, 605), Index = 15, CanGigantamax = true }, // Gengar
+        new(50,08,4) { Species = 871, Ability = A2, Moves = new(435, 330, 474, 367), Index = 15 }, // Pincurchin
+        new(50,08,4) { Species = 068, Ability = A4, Moves = new(280, 444, 371, 523), Index = 15, CanGigantamax = true }, // Machamp
+        new(60,10,5) { Species = 143, Ability = A4, Moves = new(034, 442, 242, 428), Index = 15, CanGigantamax = true }, // Snorlax
+        new(17,01,1,SW) { Species = 222, Ability = A4, Moves = new(033, 106, 310, 050), Index = 15, Form = 1 }, // Corsola-1
+        new(30,03,2,SW) { Species = 077, Ability = A4, Moves = new(093, 584, 060, 023), Index = 15, Form = 1 }, // Ponyta-1
+        new(30,03,2,SW) { Species = 222, Ability = A4, Moves = new(310, 050, 246, 506), Index = 15, Form = 1 }, // Corsola-1
+        new(40,05,3,SW) { Species = 077, Ability = A2, Moves = new(340, 023, 428, 583), Index = 15, Form = 1 }, // Ponyta-1
+        new(40,05,3,SW) { Species = 222, Ability = A2, Moves = new(506, 408, 503, 261), Index = 15, Form = 1 }, // Corsola-1
+        new(60,10,5,SW) { Species = 765, Ability = A2, Moves = new(492, 094, 085, 247), Index = 15 }, // Oranguru
+        new(60,10,5,SW) { Species = 876, Ability = A2, Moves = new(094, 595, 605, 304), Index = 15, Form = 1 }, // Indeedee-1
+        new(60,10,5,SW) { Species = 630, Ability = A2, Moves = new(403, 555, 492, 211), Index = 15 }, // Mandibuzz
+        new(60,10,5,SW) { Species = 078, Ability = A2, Moves = new(428, 583, 224, 340), Index = 15, Form = 1 }, // Rapidash-1
+        new(60,10,5,SW) { Species = 068, Ability = A4, Moves = new(238, 007, 008, 089), Index = 15, CanGigantamax = true }, // Machamp
+        new(17,01,1,SH) { Species = 554, Ability = A4, Moves = new(033, 181, 044, 419), Index = 15, Form = 1 }, // Darumaka-1
+        new(30,03,2,SH) { Species = 083, Ability = A4, Moves = new(064, 028, 249, 693), Index = 15, Form = 1 }, // Farfetch’d-1
+        new(30,03,2,SH) { Species = 554, Ability = A4, Moves = new(423, 029, 424, 280), Index = 15, Form = 1 }, // Darumaka-1
+        new(40,05,3,SH) { Species = 083, Ability = A2, Moves = new(280, 693, 348, 413), Index = 15, Form = 1 }, // Farfetch’d-1
+        new(40,05,3,SH) { Species = 554, Ability = A2, Moves = new(008, 007, 428, 276), Index = 15, Form = 1 }, // Darumaka-1
+        new(60,10,5,SH) { Species = 766, Ability = A2, Moves = new(370, 157, 523, 231), Index = 15 }, // Passimian
+        new(60,10,5,SH) { Species = 876, Ability = A2, Moves = new(094, 595, 605, 247), Index = 15 }, // Indeedee
+        new(60,10,5,SH) { Species = 628, Ability = A2, Moves = new(413, 276, 442, 157), Index = 15 }, // Braviary
+        new(60,10,5,SH) { Species = 865, Ability = A2, Moves = new(370, 413, 211, 675), Index = 15 }, // Sirfetch’d
+        new(60,10,5,SH) { Species = 094, Ability = A4, Moves = new(247, 482, 094, 196), Index = 15, CanGigantamax = true }, // Gengar
 
-        new(17,01,1) { Species = 446, Ability = A4, Moves = new[]{ 033, 044, 122, 111 }, Index = 14 }, // Munchlax
-        new(17,01,1) { Species = 092, Ability = A4, Moves = new[]{ 122, 109, 095, 371 }, Index = 14 }, // Gastly
-        new(17,01,1) { Species = 066, Ability = A4, Moves = new[]{ 067, 043, 116, 279 }, Index = 14 }, // Machop
-        new(30,03,2) { Species = 143, Ability = A4, Moves = new[]{ 034, 242, 118, 111 }, Index = 14 }, // Snorlax
-        new(30,03,2) { Species = 093, Ability = A4, Moves = new[]{ 325, 095, 122, 101 }, Index = 14 }, // Haunter
-        new(30,03,2) { Species = 067, Ability = A4, Moves = new[]{ 067, 490, 282, 233 }, Index = 14 }, // Machoke
-        new(40,05,3) { Species = 143, Ability = A4, Moves = new[]{ 034, 667, 242, 281 }, Index = 14 }, // Snorlax
-        new(40,05,3) { Species = 143, Ability = A4, Moves = new[]{ 034, 667, 242, 281 }, Index = 14, CanGigantamax = true }, // Snorlax
-        new(40,05,3) { Species = 094, Ability = A4, Moves = new[]{ 506, 188, 085, 261 }, Index = 14 }, // Gengar
-        new(40,05,3) { Species = 094, Ability = A4, Moves = new[]{ 506, 188, 085, 261 }, Index = 14, CanGigantamax = true }, // Gengar
-        new(40,05,3) { Species = 068, Ability = A4, Moves = new[]{ 279, 667, 008, 157 }, Index = 14 }, // Machamp
-        new(40,05,3) { Species = 068, Ability = A4, Moves = new[]{ 279, 667, 008, 157 }, Index = 14, CanGigantamax = true }, // Machamp
-        new(50,08,4) { Species = 143, Ability = A4, Moves = new[]{ 034, 667, 280, 523 }, Index = 14 }, // Snorlax
-        new(50,08,4) { Species = 143, Ability = A4, Moves = new[]{ 034, 667, 280, 523 }, Index = 14, CanGigantamax = true }, // Snorlax
-        new(50,08,4) { Species = 094, Ability = A4, Moves = new[]{ 247, 482, 411, 605 }, Index = 14 }, // Gengar
-        new(50,08,4) { Species = 094, Ability = A4, Moves = new[]{ 247, 482, 411, 605 }, Index = 14, CanGigantamax = true }, // Gengar
-        new(50,08,4) { Species = 068, Ability = A4, Moves = new[]{ 280, 444, 371, 523 }, Index = 14 }, // Machamp
-        new(50,08,4) { Species = 068, Ability = A4, Moves = new[]{ 280, 444, 371, 523 }, Index = 14, CanGigantamax = true }, // Machamp
-        new(60,10,5) { Species = 143, Ability = A4, Moves = new[]{ 034, 442, 242, 428 }, Index = 14 }, // Snorlax
-        new(60,10,5) { Species = 143, Ability = A4, Moves = new[]{ 034, 442, 242, 428 }, Index = 14, CanGigantamax = true }, // Snorlax
-        new(60,10,5,SW) { Species = 068, Ability = A4, Moves = new[]{ 238, 007, 008, 089 }, Index = 14 }, // Machamp
-        new(60,10,5,SW) { Species = 068, Ability = A4, Moves = new[]{ 238, 007, 008, 089 }, Index = 14, CanGigantamax = true }, // Machamp
-        new(60,10,5,SH) { Species = 094, Ability = A4, Moves = new[]{ 247, 482, 094, 196 }, Index = 14 }, // Gengar
-        new(60,10,5,SH) { Species = 094, Ability = A4, Moves = new[]{ 247, 482, 094, 196 }, Index = 14, CanGigantamax = true }, // Gengar
+        new(17,01,1) { Species = 446, Ability = A4, Moves = new(033, 044, 122, 111), Index = 14 }, // Munchlax
+        new(17,01,1) { Species = 092, Ability = A4, Moves = new(122, 109, 095, 371), Index = 14 }, // Gastly
+        new(17,01,1) { Species = 066, Ability = A4, Moves = new(067, 043, 116, 279), Index = 14 }, // Machop
+        new(30,03,2) { Species = 143, Ability = A4, Moves = new(034, 242, 118, 111), Index = 14 }, // Snorlax
+        new(30,03,2) { Species = 093, Ability = A4, Moves = new(325, 095, 122, 101), Index = 14 }, // Haunter
+        new(30,03,2) { Species = 067, Ability = A4, Moves = new(067, 490, 282, 233), Index = 14 }, // Machoke
+        new(40,05,3) { Species = 143, Ability = A4, Moves = new(034, 667, 242, 281), Index = 14 }, // Snorlax
+        new(40,05,3) { Species = 143, Ability = A4, Moves = new(034, 667, 242, 281), Index = 14, CanGigantamax = true }, // Snorlax
+        new(40,05,3) { Species = 094, Ability = A4, Moves = new(506, 188, 085, 261), Index = 14 }, // Gengar
+        new(40,05,3) { Species = 094, Ability = A4, Moves = new(506, 188, 085, 261), Index = 14, CanGigantamax = true }, // Gengar
+        new(40,05,3) { Species = 068, Ability = A4, Moves = new(279, 667, 008, 157), Index = 14 }, // Machamp
+        new(40,05,3) { Species = 068, Ability = A4, Moves = new(279, 667, 008, 157), Index = 14, CanGigantamax = true }, // Machamp
+        new(50,08,4) { Species = 143, Ability = A4, Moves = new(034, 667, 280, 523), Index = 14 }, // Snorlax
+        new(50,08,4) { Species = 143, Ability = A4, Moves = new(034, 667, 280, 523), Index = 14, CanGigantamax = true }, // Snorlax
+        new(50,08,4) { Species = 094, Ability = A4, Moves = new(247, 482, 411, 605), Index = 14 }, // Gengar
+        new(50,08,4) { Species = 094, Ability = A4, Moves = new(247, 482, 411, 605), Index = 14, CanGigantamax = true }, // Gengar
+        new(50,08,4) { Species = 068, Ability = A4, Moves = new(280, 444, 371, 523), Index = 14 }, // Machamp
+        new(50,08,4) { Species = 068, Ability = A4, Moves = new(280, 444, 371, 523), Index = 14, CanGigantamax = true }, // Machamp
+        new(60,10,5) { Species = 143, Ability = A4, Moves = new(034, 442, 242, 428), Index = 14 }, // Snorlax
+        new(60,10,5) { Species = 143, Ability = A4, Moves = new(034, 442, 242, 428), Index = 14, CanGigantamax = true }, // Snorlax
+        new(60,10,5,SW) { Species = 068, Ability = A4, Moves = new(238, 007, 008, 089), Index = 14 }, // Machamp
+        new(60,10,5,SW) { Species = 068, Ability = A4, Moves = new(238, 007, 008, 089), Index = 14, CanGigantamax = true }, // Machamp
+        new(60,10,5,SH) { Species = 094, Ability = A4, Moves = new(247, 482, 094, 196), Index = 14 }, // Gengar
+        new(60,10,5,SH) { Species = 094, Ability = A4, Moves = new(247, 482, 094, 196), Index = 14, CanGigantamax = true }, // Gengar
 
-        new(17,01,1) { Species = 001, Ability = A4, Moves = new[]{ 033, 045, 022, 074 }, Index = 12 }, // Bulbasaur
-        new(17,01,1) { Species = 004, Ability = A4, Moves = new[]{ 010, 045, 052, 108 }, Index = 12 }, // Charmander
-        new(17,01,1) { Species = 007, Ability = A4, Moves = new[]{ 033, 039, 055, 110 }, Index = 12 }, // Squirtle
-        new(17,01,1) { Species = 848, Ability = A4, Moves = new[]{ 609, 051, 496, 715 }, Index = 12 }, // Toxel
-        new(30,03,2) { Species = 001, Ability = A4, Moves = new[]{ 033, 022, 073, 075 }, Index = 12 }, // Bulbasaur
-        new(30,03,2) { Species = 004, Ability = A4, Moves = new[]{ 010, 052, 225, 424 }, Index = 12 }, // Charmander
-        new(30,03,2) { Species = 007, Ability = A4, Moves = new[]{ 033, 055, 044, 352 }, Index = 12 }, // Squirtle
-        new(40,05,3) { Species = 001, Ability = A4, Moves = new[]{ 073, 075, 077, 402 }, Index = 12 }, // Bulbasaur
-        new(40,05,3) { Species = 004, Ability = A4, Moves = new[]{ 424, 225, 163, 108 }, Index = 12 }, // Charmander
-        new(40,05,3) { Species = 007, Ability = A4, Moves = new[]{ 055, 229, 044, 352 }, Index = 12 }, // Squirtle
-        new(50,08,4) { Species = 002, Ability = A4, Moves = new[]{ 188, 412, 075, 034 }, Index = 12 }, // Ivysaur
-        new(50,08,4) { Species = 005, Ability = A4, Moves = new[]{ 257, 242, 009, 053 }, Index = 12 }, // Charmeleon
-        new(50,08,4) { Species = 008, Ability = A4, Moves = new[]{ 330, 396, 503, 428 }, Index = 12 }, // Wartortle
-        //new(100,10,6) { Species = 150, Ability = A0, Moves = new[]{ 540, 053, 396, 059 }, Index = 12, Shiny = Shiny.Never }, // Mewtwo
-        //new(100,10,6) { Species = 150, Ability = A0, Moves = new[]{ 428, 007, 089, 280 }, Index = 12, Shiny = Shiny.Never }, // Mewtwo
-        //new(100,10,6) { Species = 150, Ability = A0, Moves = new[]{ 540, 126, 411, 059 }, Index = 12, Shiny = Shiny.Never }, // Mewtwo
-        new(17,01,1,SW) { Species = 098, Ability = A4, Moves = new[]{ 055, 043, 106, 232 }, Index = 12 }, // Krabby
-        new(17,01,1,SW) { Species = 859, Ability = A4, Moves = new[]{ 044, 260, 590, 372 }, Index = 12 }, // Impidimp
-        new(30,03,2,SW) { Species = 099, Ability = A4, Moves = new[]{ 232, 341, 061, 023 }, Index = 12, CanGigantamax = true }, // Kingler
-        new(30,03,2,SW) { Species = 859, Ability = A4, Moves = new[]{ 389, 577, 260, 279 }, Index = 12 }, // Impidimp
-        new(30,03,2,SW) { Species = 849, Ability = A4, Moves = new[]{ 084, 209, 268, 175 }, Index = 12 }, // Toxtricity
-        new(40,05,3,SW) { Species = 099, Ability = A4, Moves = new[]{ 534, 232, 023, 106 }, Index = 12, CanGigantamax = true }, // Kingler
-        new(40,05,3,SW) { Species = 860, Ability = A4, Moves = new[]{ 492, 577, 421, 141 }, Index = 12 }, // Morgrem
-        new(40,05,3,SW) { Species = 849, Ability = A4, Moves = new[]{ 085, 474, 496, 103 }, Index = 12, CanGigantamax = true }, // Toxtricity
-        new(50,08,4,SW) { Species = 099, Ability = A4, Moves = new[]{ 359, 667, 157, 534 }, Index = 12, CanGigantamax = true }, // Kingler
-        new(50,08,4,SW) { Species = 861, Ability = A4, Moves = new[]{ 789, 793, 280, 409 }, Index = 12, CanGigantamax = true }, // Grimmsnarl
-        new(50,08,4,SW) { Species = 849, Ability = A4, Moves = new[]{ 786, 506, 474, 409 }, Index = 12, CanGigantamax = true }, // Toxtricity
-        new(60,10,5,SW) { Species = 099, Ability = A4, Moves = new[]{ 152, 667, 157, 404 }, Index = 12, CanGigantamax = true }, // Kingler
-        new(60,10,5,SW) { Species = 861, Ability = A4, Moves = new[]{ 789, 793, 409, 007 }, Index = 12, CanGigantamax = true }, // Grimmsnarl
-        new(60,10,5,SW) { Species = 849, Ability = A4, Moves = new[]{ 786, 586, 188, 506 }, Index = 12, CanGigantamax = true }, // Toxtricity
-        new(17,01,1,SH) { Species = 825, Ability = A4, Moves = new[]{ 093, 522, 113, 115 }, Index = 12 }, // Dottler
-        new(17,01,1,SH) { Species = 856, Ability = A4, Moves = new[]{ 093, 589, 791, 574 }, Index = 12 }, // Hatenna
-        new(30,03,2,SH) { Species = 826, Ability = A4, Moves = new[]{ 405, 060, 496, 095 }, Index = 12, CanGigantamax = true }, // Orbeetle
-        new(30,03,2,SH) { Species = 856, Ability = A4, Moves = new[]{ 605, 060, 345, 347 }, Index = 12 }, // Hatenna
-        new(30,03,2,SH) { Species = 849, Ability = A4, Moves = new[]{ 599, 209, 268, 175 }, Index = 12, Form = 1 }, // Toxtricity-1
-        new(40,05,3,SH) { Species = 826, Ability = A4, Moves = new[]{ 405, 060, 202, 109 }, Index = 12, CanGigantamax = true }, // Orbeetle
-        new(40,05,3,SH) { Species = 857, Ability = A4, Moves = new[]{ 605, 345, 399, 500 }, Index = 12 }, // Hattrem
-        new(40,05,3,SH) { Species = 849, Ability = A4, Moves = new[]{ 085, 599, 496, 103 }, Index = 12, Form = 1, CanGigantamax = true }, // Toxtricity-1
-        new(50,08,4,SH) { Species = 826, Ability = A4, Moves = new[]{ 405, 094, 202, 247 }, Index = 12, CanGigantamax = true }, // Orbeetle
-        new(50,08,4,SH) { Species = 858, Ability = A4, Moves = new[]{ 605, 094, 595, 247 }, Index = 12, CanGigantamax = true }, // Hatterene
-        new(50,08,4,SH) { Species = 849, Ability = A4, Moves = new[]{ 786, 506, 599, 409 }, Index = 12, Form = 1, CanGigantamax = true }, // Toxtricity-1
-        new(60,10,5,SH) { Species = 826, Ability = A4, Moves = new[]{ 405, 094, 247, 347 }, Index = 12, CanGigantamax = true }, // Orbeetle
-        new(60,10,5,SH) { Species = 858, Ability = A4, Moves = new[]{ 605, 094, 595, 500 }, Index = 12, CanGigantamax = true }, // Hatterene
-        new(60,10,5,SH) { Species = 849, Ability = A4, Moves = new[]{ 786, 586, 188, 506 }, Index = 12, Form = 1, CanGigantamax = true }, // Toxtricity-1
+        new(17,01,1) { Species = 001, Ability = A4, Moves = new(033, 045, 022, 074), Index = 12 }, // Bulbasaur
+        new(17,01,1) { Species = 004, Ability = A4, Moves = new(010, 045, 052, 108), Index = 12 }, // Charmander
+        new(17,01,1) { Species = 007, Ability = A4, Moves = new(033, 039, 055, 110), Index = 12 }, // Squirtle
+        new(17,01,1) { Species = 848, Ability = A4, Moves = new(609, 051, 496, 715), Index = 12 }, // Toxel
+        new(30,03,2) { Species = 001, Ability = A4, Moves = new(033, 022, 073, 075), Index = 12 }, // Bulbasaur
+        new(30,03,2) { Species = 004, Ability = A4, Moves = new(010, 052, 225, 424), Index = 12 }, // Charmander
+        new(30,03,2) { Species = 007, Ability = A4, Moves = new(033, 055, 044, 352), Index = 12 }, // Squirtle
+        new(40,05,3) { Species = 001, Ability = A4, Moves = new(073, 075, 077, 402), Index = 12 }, // Bulbasaur
+        new(40,05,3) { Species = 004, Ability = A4, Moves = new(424, 225, 163, 108), Index = 12 }, // Charmander
+        new(40,05,3) { Species = 007, Ability = A4, Moves = new(055, 229, 044, 352), Index = 12 }, // Squirtle
+        new(50,08,4) { Species = 002, Ability = A4, Moves = new(188, 412, 075, 034), Index = 12 }, // Ivysaur
+        new(50,08,4) { Species = 005, Ability = A4, Moves = new(257, 242, 009, 053), Index = 12 }, // Charmeleon
+        new(50,08,4) { Species = 008, Ability = A4, Moves = new(330, 396, 503, 428), Index = 12 }, // Wartortle
+        //new(100,10,6) { Species = 150, Ability = A0, Moves = new(540, 053, 396, 059), Index = 12, Shiny = Shiny.Never }, // Mewtwo
+        //new(100,10,6) { Species = 150, Ability = A0, Moves = new(428, 007, 089, 280), Index = 12, Shiny = Shiny.Never }, // Mewtwo
+        //new(100,10,6) { Species = 150, Ability = A0, Moves = new(540, 126, 411, 059), Index = 12, Shiny = Shiny.Never }, // Mewtwo
+        new(17,01,1,SW) { Species = 098, Ability = A4, Moves = new(055, 043, 106, 232), Index = 12 }, // Krabby
+        new(17,01,1,SW) { Species = 859, Ability = A4, Moves = new(044, 260, 590, 372), Index = 12 }, // Impidimp
+        new(30,03,2,SW) { Species = 099, Ability = A4, Moves = new(232, 341, 061, 023), Index = 12, CanGigantamax = true }, // Kingler
+        new(30,03,2,SW) { Species = 859, Ability = A4, Moves = new(389, 577, 260, 279), Index = 12 }, // Impidimp
+        new(30,03,2,SW) { Species = 849, Ability = A4, Moves = new(084, 209, 268, 175), Index = 12 }, // Toxtricity
+        new(40,05,3,SW) { Species = 099, Ability = A4, Moves = new(534, 232, 023, 106), Index = 12, CanGigantamax = true }, // Kingler
+        new(40,05,3,SW) { Species = 860, Ability = A4, Moves = new(492, 577, 421, 141), Index = 12 }, // Morgrem
+        new(40,05,3,SW) { Species = 849, Ability = A4, Moves = new(085, 474, 496, 103), Index = 12, CanGigantamax = true }, // Toxtricity
+        new(50,08,4,SW) { Species = 099, Ability = A4, Moves = new(359, 667, 157, 534), Index = 12, CanGigantamax = true }, // Kingler
+        new(50,08,4,SW) { Species = 861, Ability = A4, Moves = new(789, 793, 280, 409), Index = 12, CanGigantamax = true }, // Grimmsnarl
+        new(50,08,4,SW) { Species = 849, Ability = A4, Moves = new(786, 506, 474, 409), Index = 12, CanGigantamax = true }, // Toxtricity
+        new(60,10,5,SW) { Species = 099, Ability = A4, Moves = new(152, 667, 157, 404), Index = 12, CanGigantamax = true }, // Kingler
+        new(60,10,5,SW) { Species = 861, Ability = A4, Moves = new(789, 793, 409, 007), Index = 12, CanGigantamax = true }, // Grimmsnarl
+        new(60,10,5,SW) { Species = 849, Ability = A4, Moves = new(786, 586, 188, 506), Index = 12, CanGigantamax = true }, // Toxtricity
+        new(17,01,1,SH) { Species = 825, Ability = A4, Moves = new(093, 522, 113, 115), Index = 12 }, // Dottler
+        new(17,01,1,SH) { Species = 856, Ability = A4, Moves = new(093, 589, 791, 574), Index = 12 }, // Hatenna
+        new(30,03,2,SH) { Species = 826, Ability = A4, Moves = new(405, 060, 496, 095), Index = 12, CanGigantamax = true }, // Orbeetle
+        new(30,03,2,SH) { Species = 856, Ability = A4, Moves = new(605, 060, 345, 347), Index = 12 }, // Hatenna
+        new(30,03,2,SH) { Species = 849, Ability = A4, Moves = new(599, 209, 268, 175), Index = 12, Form = 1 }, // Toxtricity-1
+        new(40,05,3,SH) { Species = 826, Ability = A4, Moves = new(405, 060, 202, 109), Index = 12, CanGigantamax = true }, // Orbeetle
+        new(40,05,3,SH) { Species = 857, Ability = A4, Moves = new(605, 345, 399, 500), Index = 12 }, // Hattrem
+        new(40,05,3,SH) { Species = 849, Ability = A4, Moves = new(085, 599, 496, 103), Index = 12, Form = 1, CanGigantamax = true }, // Toxtricity-1
+        new(50,08,4,SH) { Species = 826, Ability = A4, Moves = new(405, 094, 202, 247), Index = 12, CanGigantamax = true }, // Orbeetle
+        new(50,08,4,SH) { Species = 858, Ability = A4, Moves = new(605, 094, 595, 247), Index = 12, CanGigantamax = true }, // Hatterene
+        new(50,08,4,SH) { Species = 849, Ability = A4, Moves = new(786, 506, 599, 409), Index = 12, Form = 1, CanGigantamax = true }, // Toxtricity-1
+        new(60,10,5,SH) { Species = 826, Ability = A4, Moves = new(405, 094, 247, 347), Index = 12, CanGigantamax = true }, // Orbeetle
+        new(60,10,5,SH) { Species = 858, Ability = A4, Moves = new(605, 094, 595, 500), Index = 12, CanGigantamax = true }, // Hatterene
+        new(60,10,5,SH) { Species = 849, Ability = A4, Moves = new(786, 586, 188, 506), Index = 12, Form = 1, CanGigantamax = true }, // Toxtricity-1
 
-        new(17,01,1) { Species = 848, Ability = A4, Moves = new[]{ 609, 051, 496, 715 }, Index = 11 }, // Toxel
-        new(17,01,1,SW) { Species = 098, Ability = A4, Moves = new[]{ 055, 043, 106, 232 }, Index = 11 }, // Krabby
-        new(17,01,1,SW) { Species = 859, Ability = A4, Moves = new[]{ 044, 260, 590, 372 }, Index = 11 }, // Impidimp
-        new(30,03,2,SW) { Species = 099, Ability = A4, Moves = new[]{ 232, 341, 061, 023 }, Index = 11 }, // Kingler
-        new(30,03,2,SW) { Species = 099, Ability = A4, Moves = new[]{ 232, 341, 061, 023 }, Index = 11, CanGigantamax = true }, // Kingler
-        new(30,03,2,SW) { Species = 859, Ability = A4, Moves = new[]{ 389, 577, 260, 279 }, Index = 11 }, // Impidimp
-        new(30,03,2,SW) { Species = 849, Ability = A4, Moves = new[]{ 474, 209, 268, 175 }, Index = 11 }, // Toxtricity
-        new(40,05,3,SW) { Species = 099, Ability = A4, Moves = new[]{ 534, 232, 023, 106 }, Index = 11 }, // Kingler
-        new(40,05,3,SW) { Species = 099, Ability = A4, Moves = new[]{ 534, 232, 023, 106 }, Index = 11, CanGigantamax = true }, // Kingler
-        new(40,05,3,SW) { Species = 860, Ability = A4, Moves = new[]{ 492, 577, 421, 141 }, Index = 11 }, // Morgrem
-        new(40,05,3,SW) { Species = 849, Ability = A4, Moves = new[]{ 085, 474, 496, 103 }, Index = 11 }, // Toxtricity
-        new(40,05,3,SW) { Species = 849, Ability = A4, Moves = new[]{ 085, 474, 496, 103 }, Index = 11, CanGigantamax = true }, // Toxtricity
-        new(50,08,4,SW) { Species = 099, Ability = A4, Moves = new[]{ 359, 667, 157, 534 }, Index = 11 }, // Kingler
-        new(50,08,4,SW) { Species = 099, Ability = A4, Moves = new[]{ 359, 667, 157, 534 }, Index = 11, CanGigantamax = true }, // Kingler
-        new(50,08,4,SW) { Species = 861, Ability = A4, Moves = new[]{ 789, 793, 280, 409 }, Index = 11 }, // Grimmsnarl
-        new(50,08,4,SW) { Species = 861, Ability = A4, Moves = new[]{ 789, 793, 280, 409 }, Index = 11, CanGigantamax = true }, // Grimmsnarl
-        new(50,08,4,SW) { Species = 849, Ability = A4, Moves = new[]{ 786, 506, 474, 409 }, Index = 11 }, // Toxtricity
-        new(50,08,4,SW) { Species = 849, Ability = A4, Moves = new[]{ 786, 506, 474, 409 }, Index = 11, CanGigantamax = true }, // Toxtricity
-        new(60,10,5,SW) { Species = 099, Ability = A4, Moves = new[]{ 152, 667, 157, 404 }, Index = 11 }, // Kingler
-        new(60,10,5,SW) { Species = 099, Ability = A4, Moves = new[]{ 152, 667, 157, 404 }, Index = 11, CanGigantamax = true }, // Kingler
-        new(60,10,5,SW) { Species = 861, Ability = A4, Moves = new[]{ 789, 793, 409, 007 }, Index = 11 }, // Grimmsnarl
-        new(60,10,5,SW) { Species = 861, Ability = A4, Moves = new[]{ 789, 793, 409, 007 }, Index = 11, CanGigantamax = true }, // Grimmsnarl
-        new(60,10,5,SW) { Species = 849, Ability = A4, Moves = new[]{ 786, 586, 188, 506 }, Index = 11 }, // Toxtricity
-        new(60,10,5,SW) { Species = 849, Ability = A4, Moves = new[]{ 786, 586, 188, 506 }, Index = 11, CanGigantamax = true }, // Toxtricity
-        new(17,01,1,SH) { Species = 825, Ability = A4, Moves = new[]{ 093, 522, 113, 115 }, Index = 11 }, // Dottler
-        new(17,01,1,SH) { Species = 856, Ability = A4, Moves = new[]{ 093, 589, 791, 574 }, Index = 11 }, // Hatenna
-        new(30,03,2,SH) { Species = 826, Ability = A4, Moves = new[]{ 405, 060, 496, 095 }, Index = 11 }, // Orbeetle
-        new(30,03,2,SH) { Species = 826, Ability = A4, Moves = new[]{ 405, 060, 496, 095 }, Index = 11, CanGigantamax = true }, // Orbeetle
-        new(30,03,2,SH) { Species = 856, Ability = A4, Moves = new[]{ 605, 060, 345, 347 }, Index = 11 }, // Hatenna
-        new(30,03,2,SH) { Species = 849, Ability = A4, Moves = new[]{ 599, 209, 268, 175 }, Index = 11, Form = 1 }, // Toxtricity-1
-        new(40,05,3,SH) { Species = 826, Ability = A4, Moves = new[]{ 405, 060, 202, 109 }, Index = 11 }, // Orbeetle
-        new(40,05,3,SH) { Species = 826, Ability = A4, Moves = new[]{ 405, 060, 202, 109 }, Index = 11, CanGigantamax = true }, // Orbeetle
-        new(40,05,3,SH) { Species = 857, Ability = A4, Moves = new[]{ 605, 345, 399, 500 }, Index = 11 }, // Hattrem
-        new(40,05,3,SH) { Species = 849, Ability = A4, Moves = new[]{ 085, 599, 496, 103 }, Index = 11, Form = 1 }, // Toxtricity-1
-        new(40,05,3,SH) { Species = 849, Ability = A4, Moves = new[]{ 085, 599, 496, 103 }, Index = 11, Form = 1, CanGigantamax = true }, // Toxtricity-1
-        new(50,08,4,SH) { Species = 826, Ability = A4, Moves = new[]{ 405, 094, 202, 247 }, Index = 11 }, // Orbeetle
-        new(50,08,4,SH) { Species = 826, Ability = A4, Moves = new[]{ 405, 094, 202, 247 }, Index = 11, CanGigantamax = true }, // Orbeetle
-        new(50,08,4,SH) { Species = 858, Ability = A4, Moves = new[]{ 605, 094, 595, 247 }, Index = 11 }, // Hatterene
-        new(50,08,4,SH) { Species = 858, Ability = A4, Moves = new[]{ 605, 094, 595, 247 }, Index = 11, CanGigantamax = true }, // Hatterene
-        new(50,08,4,SH) { Species = 849, Ability = A4, Moves = new[]{ 786, 506, 599, 409 }, Index = 11, Form = 1 }, // Toxtricity-1
-        new(50,08,4,SH) { Species = 849, Ability = A4, Moves = new[]{ 786, 506, 599, 409 }, Index = 11, Form = 1, CanGigantamax = true }, // Toxtricity-1
-        new(60,10,5,SH) { Species = 826, Ability = A4, Moves = new[]{ 405, 094, 247, 347 }, Index = 11 }, // Orbeetle
-        new(60,10,5,SH) { Species = 826, Ability = A4, Moves = new[]{ 405, 094, 247, 347 }, Index = 11, CanGigantamax = true }, // Orbeetle
-        new(60,10,5,SH) { Species = 858, Ability = A4, Moves = new[]{ 605, 094, 595, 500 }, Index = 11 }, // Hatterene
-        new(60,10,5,SH) { Species = 858, Ability = A4, Moves = new[]{ 605, 094, 595, 500 }, Index = 11, CanGigantamax = true }, // Hatterene
-        new(60,10,5,SH) { Species = 849, Ability = A4, Moves = new[]{ 786, 586, 188, 506 }, Index = 11, Form = 1 }, // Toxtricity-1
-        new(60,10,5,SH) { Species = 849, Ability = A4, Moves = new[]{ 786, 586, 188, 506 }, Index = 11, Form = 1, CanGigantamax = true }, // Toxtricity-1
+        new(17,01,1) { Species = 848, Ability = A4, Moves = new(609, 051, 496, 715), Index = 11 }, // Toxel
+        new(17,01,1,SW) { Species = 098, Ability = A4, Moves = new(055, 043, 106, 232), Index = 11 }, // Krabby
+        new(17,01,1,SW) { Species = 859, Ability = A4, Moves = new(044, 260, 590, 372), Index = 11 }, // Impidimp
+        new(30,03,2,SW) { Species = 099, Ability = A4, Moves = new(232, 341, 061, 023), Index = 11 }, // Kingler
+        new(30,03,2,SW) { Species = 099, Ability = A4, Moves = new(232, 341, 061, 023), Index = 11, CanGigantamax = true }, // Kingler
+        new(30,03,2,SW) { Species = 859, Ability = A4, Moves = new(389, 577, 260, 279), Index = 11 }, // Impidimp
+        new(30,03,2,SW) { Species = 849, Ability = A4, Moves = new(474, 209, 268, 175), Index = 11 }, // Toxtricity
+        new(40,05,3,SW) { Species = 099, Ability = A4, Moves = new(534, 232, 023, 106), Index = 11 }, // Kingler
+        new(40,05,3,SW) { Species = 099, Ability = A4, Moves = new(534, 232, 023, 106), Index = 11, CanGigantamax = true }, // Kingler
+        new(40,05,3,SW) { Species = 860, Ability = A4, Moves = new(492, 577, 421, 141), Index = 11 }, // Morgrem
+        new(40,05,3,SW) { Species = 849, Ability = A4, Moves = new(085, 474, 496, 103), Index = 11 }, // Toxtricity
+        new(40,05,3,SW) { Species = 849, Ability = A4, Moves = new(085, 474, 496, 103), Index = 11, CanGigantamax = true }, // Toxtricity
+        new(50,08,4,SW) { Species = 099, Ability = A4, Moves = new(359, 667, 157, 534), Index = 11 }, // Kingler
+        new(50,08,4,SW) { Species = 099, Ability = A4, Moves = new(359, 667, 157, 534), Index = 11, CanGigantamax = true }, // Kingler
+        new(50,08,4,SW) { Species = 861, Ability = A4, Moves = new(789, 793, 280, 409), Index = 11 }, // Grimmsnarl
+        new(50,08,4,SW) { Species = 861, Ability = A4, Moves = new(789, 793, 280, 409), Index = 11, CanGigantamax = true }, // Grimmsnarl
+        new(50,08,4,SW) { Species = 849, Ability = A4, Moves = new(786, 506, 474, 409), Index = 11 }, // Toxtricity
+        new(50,08,4,SW) { Species = 849, Ability = A4, Moves = new(786, 506, 474, 409), Index = 11, CanGigantamax = true }, // Toxtricity
+        new(60,10,5,SW) { Species = 099, Ability = A4, Moves = new(152, 667, 157, 404), Index = 11 }, // Kingler
+        new(60,10,5,SW) { Species = 099, Ability = A4, Moves = new(152, 667, 157, 404), Index = 11, CanGigantamax = true }, // Kingler
+        new(60,10,5,SW) { Species = 861, Ability = A4, Moves = new(789, 793, 409, 007), Index = 11 }, // Grimmsnarl
+        new(60,10,5,SW) { Species = 861, Ability = A4, Moves = new(789, 793, 409, 007), Index = 11, CanGigantamax = true }, // Grimmsnarl
+        new(60,10,5,SW) { Species = 849, Ability = A4, Moves = new(786, 586, 188, 506), Index = 11 }, // Toxtricity
+        new(60,10,5,SW) { Species = 849, Ability = A4, Moves = new(786, 586, 188, 506), Index = 11, CanGigantamax = true }, // Toxtricity
+        new(17,01,1,SH) { Species = 825, Ability = A4, Moves = new(093, 522, 113, 115), Index = 11 }, // Dottler
+        new(17,01,1,SH) { Species = 856, Ability = A4, Moves = new(093, 589, 791, 574), Index = 11 }, // Hatenna
+        new(30,03,2,SH) { Species = 826, Ability = A4, Moves = new(405, 060, 496, 095), Index = 11 }, // Orbeetle
+        new(30,03,2,SH) { Species = 826, Ability = A4, Moves = new(405, 060, 496, 095), Index = 11, CanGigantamax = true }, // Orbeetle
+        new(30,03,2,SH) { Species = 856, Ability = A4, Moves = new(605, 060, 345, 347), Index = 11 }, // Hatenna
+        new(30,03,2,SH) { Species = 849, Ability = A4, Moves = new(599, 209, 268, 175), Index = 11, Form = 1 }, // Toxtricity-1
+        new(40,05,3,SH) { Species = 826, Ability = A4, Moves = new(405, 060, 202, 109), Index = 11 }, // Orbeetle
+        new(40,05,3,SH) { Species = 826, Ability = A4, Moves = new(405, 060, 202, 109), Index = 11, CanGigantamax = true }, // Orbeetle
+        new(40,05,3,SH) { Species = 857, Ability = A4, Moves = new(605, 345, 399, 500), Index = 11 }, // Hattrem
+        new(40,05,3,SH) { Species = 849, Ability = A4, Moves = new(085, 599, 496, 103), Index = 11, Form = 1 }, // Toxtricity-1
+        new(40,05,3,SH) { Species = 849, Ability = A4, Moves = new(085, 599, 496, 103), Index = 11, Form = 1, CanGigantamax = true }, // Toxtricity-1
+        new(50,08,4,SH) { Species = 826, Ability = A4, Moves = new(405, 094, 202, 247), Index = 11 }, // Orbeetle
+        new(50,08,4,SH) { Species = 826, Ability = A4, Moves = new(405, 094, 202, 247), Index = 11, CanGigantamax = true }, // Orbeetle
+        new(50,08,4,SH) { Species = 858, Ability = A4, Moves = new(605, 094, 595, 247), Index = 11 }, // Hatterene
+        new(50,08,4,SH) { Species = 858, Ability = A4, Moves = new(605, 094, 595, 247), Index = 11, CanGigantamax = true }, // Hatterene
+        new(50,08,4,SH) { Species = 849, Ability = A4, Moves = new(786, 506, 599, 409), Index = 11, Form = 1 }, // Toxtricity-1
+        new(50,08,4,SH) { Species = 849, Ability = A4, Moves = new(786, 506, 599, 409), Index = 11, Form = 1, CanGigantamax = true }, // Toxtricity-1
+        new(60,10,5,SH) { Species = 826, Ability = A4, Moves = new(405, 094, 247, 347), Index = 11 }, // Orbeetle
+        new(60,10,5,SH) { Species = 826, Ability = A4, Moves = new(405, 094, 247, 347), Index = 11, CanGigantamax = true }, // Orbeetle
+        new(60,10,5,SH) { Species = 858, Ability = A4, Moves = new(605, 094, 595, 500), Index = 11 }, // Hatterene
+        new(60,10,5,SH) { Species = 858, Ability = A4, Moves = new(605, 094, 595, 500), Index = 11, CanGigantamax = true }, // Hatterene
+        new(60,10,5,SH) { Species = 849, Ability = A4, Moves = new(786, 586, 188, 506), Index = 11, Form = 1 }, // Toxtricity-1
+        new(60,10,5,SH) { Species = 849, Ability = A4, Moves = new(786, 586, 188, 506), Index = 11, Form = 1, CanGigantamax = true }, // Toxtricity-1
 
-        new(17,01,1) { Species = 868, Ability = A4, Moves = new[]{ 033, 186, 577, 496 }, Index = 10, CanGigantamax = true }, // Milcery
-        new(30,03,2) { Species = 868, Ability = A4, Moves = new[]{ 577, 186, 263, 500 }, Index = 10, CanGigantamax = true }, // Milcery
-        new(40,05,3) { Species = 868, Ability = A4, Moves = new[]{ 577, 605, 496, 213 }, Index = 10, CanGigantamax = true }, // Milcery
-        new(50,08,4) { Species = 868, Ability = A4, Moves = new[]{ 577, 605, 496, 500 }, Index = 10, CanGigantamax = true }, // Milcery
-        new(60,10,5) { Species = 868, Ability = A4, Moves = new[]{ 577, 605, 496, 500 }, Index = 10, CanGigantamax = true }, // Milcery
-        new(40,05,3,SW) { Species = 099, Ability = A4, Moves = new[]{ 534, 232, 023, 106 }, Index = 10, CanGigantamax = true }, // Kingler
-        new(40,05,3,SW) { Species = 860, Ability = A4, Moves = new[]{ 492, 577, 421, 141 }, Index = 10 }, // Morgrem
-        new(40,05,3,SW) { Species = 849, Ability = A4, Moves = new[]{ 085, 474, 496, 103 }, Index = 10, CanGigantamax = true }, // Toxtricity
-        new(50,08,4,SW) { Species = 099, Ability = A4, Moves = new[]{ 359, 667, 157, 534 }, Index = 10, CanGigantamax = true }, // Kingler
-        new(50,08,4,SW) { Species = 861, Ability = A4, Moves = new[]{ 789, 793, 280, 409 }, Index = 10, CanGigantamax = true }, // Grimmsnarl
-        new(50,08,4,SW) { Species = 849, Ability = A4, Moves = new[]{ 786, 506, 474, 409 }, Index = 10, CanGigantamax = true }, // Toxtricity
-        new(60,10,5,SW) { Species = 099, Ability = A4, Moves = new[]{ 152, 667, 157, 404 }, Index = 10, CanGigantamax = true }, // Kingler
-        new(60,10,5,SW) { Species = 861, Ability = A4, Moves = new[]{ 789, 793, 409, 007 }, Index = 10, CanGigantamax = true }, // Grimmsnarl
-        new(60,10,5,SW) { Species = 849, Ability = A4, Moves = new[]{ 786, 586, 482, 506 }, Index = 10, CanGigantamax = true }, // Toxtricity
-        new(40,05,3,SH) { Species = 826, Ability = A4, Moves = new[]{ 522, 060, 109, 202 }, Index = 10, CanGigantamax = true }, // Orbeetle
-        new(40,05,3,SH) { Species = 857, Ability = A4, Moves = new[]{ 605, 345, 399, 500 }, Index = 10 }, // Hattrem
-        new(40,05,3,SH) { Species = 849, Ability = A4, Moves = new[]{ 085, 599, 496, 103 }, Index = 10, Form = 1, CanGigantamax = true }, // Toxtricity-1
-        new(50,08,4,SH) { Species = 826, Ability = A4, Moves = new[]{ 405, 094, 202, 247 }, Index = 10, CanGigantamax = true }, // Orbeetle
-        new(50,08,4,SH) { Species = 858, Ability = A4, Moves = new[]{ 605, 094, 595, 247 }, Index = 10, CanGigantamax = true }, // Hatterene
-        new(50,08,4,SH) { Species = 849, Ability = A4, Moves = new[]{ 786, 506, 599, 409 }, Index = 10, Form = 1, CanGigantamax = true }, // Toxtricity-1
-        new(60,10,5,SH) { Species = 826, Ability = A4, Moves = new[]{ 405, 094, 247, 347 }, Index = 10, CanGigantamax = true }, // Orbeetle
-        new(60,10,5,SH) { Species = 858, Ability = A4, Moves = new[]{ 605, 094, 595, 500 }, Index = 10, CanGigantamax = true }, // Hatterene
-        new(60,10,5,SH) { Species = 849, Ability = A4, Moves = new[]{ 786, 586, 482, 506 }, Index = 10, Form = 1, CanGigantamax = true }, // Toxtricity-1
+        new(17,01,1) { Species = 868, Ability = A4, Moves = new(033, 186, 577, 496), Index = 10, CanGigantamax = true }, // Milcery
+        new(30,03,2) { Species = 868, Ability = A4, Moves = new(577, 186, 263, 500), Index = 10, CanGigantamax = true }, // Milcery
+        new(40,05,3) { Species = 868, Ability = A4, Moves = new(577, 605, 496, 213), Index = 10, CanGigantamax = true }, // Milcery
+        new(50,08,4) { Species = 868, Ability = A4, Moves = new(577, 605, 496, 500), Index = 10, CanGigantamax = true }, // Milcery
+        new(60,10,5) { Species = 868, Ability = A4, Moves = new(577, 605, 496, 500), Index = 10, CanGigantamax = true }, // Milcery
+        new(40,05,3,SW) { Species = 099, Ability = A4, Moves = new(534, 232, 023, 106), Index = 10, CanGigantamax = true }, // Kingler
+        new(40,05,3,SW) { Species = 860, Ability = A4, Moves = new(492, 577, 421, 141), Index = 10 }, // Morgrem
+        new(40,05,3,SW) { Species = 849, Ability = A4, Moves = new(085, 474, 496, 103), Index = 10, CanGigantamax = true }, // Toxtricity
+        new(50,08,4,SW) { Species = 099, Ability = A4, Moves = new(359, 667, 157, 534), Index = 10, CanGigantamax = true }, // Kingler
+        new(50,08,4,SW) { Species = 861, Ability = A4, Moves = new(789, 793, 280, 409), Index = 10, CanGigantamax = true }, // Grimmsnarl
+        new(50,08,4,SW) { Species = 849, Ability = A4, Moves = new(786, 506, 474, 409), Index = 10, CanGigantamax = true }, // Toxtricity
+        new(60,10,5,SW) { Species = 099, Ability = A4, Moves = new(152, 667, 157, 404), Index = 10, CanGigantamax = true }, // Kingler
+        new(60,10,5,SW) { Species = 861, Ability = A4, Moves = new(789, 793, 409, 007), Index = 10, CanGigantamax = true }, // Grimmsnarl
+        new(60,10,5,SW) { Species = 849, Ability = A4, Moves = new(786, 586, 482, 506), Index = 10, CanGigantamax = true }, // Toxtricity
+        new(40,05,3,SH) { Species = 826, Ability = A4, Moves = new(522, 060, 109, 202), Index = 10, CanGigantamax = true }, // Orbeetle
+        new(40,05,3,SH) { Species = 857, Ability = A4, Moves = new(605, 345, 399, 500), Index = 10 }, // Hattrem
+        new(40,05,3,SH) { Species = 849, Ability = A4, Moves = new(085, 599, 496, 103), Index = 10, Form = 1, CanGigantamax = true }, // Toxtricity-1
+        new(50,08,4,SH) { Species = 826, Ability = A4, Moves = new(405, 094, 202, 247), Index = 10, CanGigantamax = true }, // Orbeetle
+        new(50,08,4,SH) { Species = 858, Ability = A4, Moves = new(605, 094, 595, 247), Index = 10, CanGigantamax = true }, // Hatterene
+        new(50,08,4,SH) { Species = 849, Ability = A4, Moves = new(786, 506, 599, 409), Index = 10, Form = 1, CanGigantamax = true }, // Toxtricity-1
+        new(60,10,5,SH) { Species = 826, Ability = A4, Moves = new(405, 094, 247, 347), Index = 10, CanGigantamax = true }, // Orbeetle
+        new(60,10,5,SH) { Species = 858, Ability = A4, Moves = new(605, 094, 595, 500), Index = 10, CanGigantamax = true }, // Hatterene
+        new(60,10,5,SH) { Species = 849, Ability = A4, Moves = new(786, 586, 482, 506), Index = 10, Form = 1, CanGigantamax = true }, // Toxtricity-1
 
-        new(17,01,1) { Species = 868, Ability = A4, Moves = new[]{ 033, 186, 577, 496 }, Index = 9, CanGigantamax = true }, // Milcery
-        new(30,03,2) { Species = 868, Ability = A4, Moves = new[]{ 577, 186, 263, 500 }, Index = 9, CanGigantamax = true }, // Milcery
-        new(40,05,3) { Species = 868, Ability = A4, Moves = new[]{ 577, 605, 496, 213 }, Index = 9, CanGigantamax = true }, // Milcery
-        new(50,08,4) { Species = 868, Ability = A4, Moves = new[]{ 577, 605, 496, 500 }, Index = 9, CanGigantamax = true }, // Milcery
-        new(60,10,5) { Species = 868, Ability = A4, Moves = new[]{ 577, 605, 496, 500 }, Index = 9, CanGigantamax = true }, // Milcery
-        new(40,05,3,SW) { Species = 841, Ability = A4, Moves = new[]{ 788, 406, 512, 491 }, Index = 9, CanGigantamax = true }, // Flapple
-        new(40,05,3,SW) { Species = 839, Ability = A4, Moves = new[]{ 246, 510, 479, 488 }, Index = 9, CanGigantamax = true }, // Coalossal
-        new(50,08,4,SW) { Species = 841, Ability = A4, Moves = new[]{ 788, 407, 491, 334 }, Index = 9, CanGigantamax = true }, // Flapple
-        new(50,08,4,SW) { Species = 839, Ability = A4, Moves = new[]{ 246, 053, 157, 261 }, Index = 9, CanGigantamax = true }, // Coalossal
-        new(60,10,5,SW) { Species = 841, Ability = A4, Moves = new[]{ 407, 788, 512, 349 }, Index = 9, CanGigantamax = true }, // Flapple
-        new(60,10,5,SW) { Species = 839, Ability = A4, Moves = new[]{ 246, 053, 157, 523 }, Index = 9, CanGigantamax = true }, // Coalossal
-        new(40,05,3,SH) { Species = 842, Ability = A4, Moves = new[]{ 787, 496, 406, 523 }, Index = 9, CanGigantamax = true }, // Appletun
-        new(40,05,3,SH) { Species = 131, Ability = A4, Moves = new[]{ 352, 420, 109, 034 }, Index = 9, CanGigantamax = true }, // Lapras
-        new(50,08,4,SH) { Species = 842, Ability = A4, Moves = new[]{ 787, 202, 406, 089 }, Index = 9, CanGigantamax = true }, // Appletun
-        new(50,08,4,SH) { Species = 131, Ability = A4, Moves = new[]{ 057, 058, 246, 523 }, Index = 9, CanGigantamax = true }, // Lapras
-        new(60,10,5,SH) { Species = 842, Ability = A4, Moves = new[]{ 787, 406, 412, 089 }, Index = 9, CanGigantamax = true }, // Appletun
-        new(60,10,5,SH) { Species = 131, Ability = A4, Moves = new[]{ 057, 196, 573, 329 }, Index = 9, CanGigantamax = true }, // Lapras
+        new(17,01,1) { Species = 868, Ability = A4, Moves = new(033, 186, 577, 496), Index = 9, CanGigantamax = true }, // Milcery
+        new(30,03,2) { Species = 868, Ability = A4, Moves = new(577, 186, 263, 500), Index = 9, CanGigantamax = true }, // Milcery
+        new(40,05,3) { Species = 868, Ability = A4, Moves = new(577, 605, 496, 213), Index = 9, CanGigantamax = true }, // Milcery
+        new(50,08,4) { Species = 868, Ability = A4, Moves = new(577, 605, 496, 500), Index = 9, CanGigantamax = true }, // Milcery
+        new(60,10,5) { Species = 868, Ability = A4, Moves = new(577, 605, 496, 500), Index = 9, CanGigantamax = true }, // Milcery
+        new(40,05,3,SW) { Species = 841, Ability = A4, Moves = new(788, 406, 512, 491), Index = 9, CanGigantamax = true }, // Flapple
+        new(40,05,3,SW) { Species = 839, Ability = A4, Moves = new(246, 510, 479, 488), Index = 9, CanGigantamax = true }, // Coalossal
+        new(50,08,4,SW) { Species = 841, Ability = A4, Moves = new(788, 407, 491, 334), Index = 9, CanGigantamax = true }, // Flapple
+        new(50,08,4,SW) { Species = 839, Ability = A4, Moves = new(246, 053, 157, 261), Index = 9, CanGigantamax = true }, // Coalossal
+        new(60,10,5,SW) { Species = 841, Ability = A4, Moves = new(407, 788, 512, 349), Index = 9, CanGigantamax = true }, // Flapple
+        new(60,10,5,SW) { Species = 839, Ability = A4, Moves = new(246, 053, 157, 523), Index = 9, CanGigantamax = true }, // Coalossal
+        new(40,05,3,SH) { Species = 842, Ability = A4, Moves = new(787, 496, 406, 523), Index = 9, CanGigantamax = true }, // Appletun
+        new(40,05,3,SH) { Species = 131, Ability = A4, Moves = new(352, 420, 109, 034), Index = 9, CanGigantamax = true }, // Lapras
+        new(50,08,4,SH) { Species = 842, Ability = A4, Moves = new(787, 202, 406, 089), Index = 9, CanGigantamax = true }, // Appletun
+        new(50,08,4,SH) { Species = 131, Ability = A4, Moves = new(057, 058, 246, 523), Index = 9, CanGigantamax = true }, // Lapras
+        new(60,10,5,SH) { Species = 842, Ability = A4, Moves = new(787, 406, 412, 089), Index = 9, CanGigantamax = true }, // Appletun
+        new(60,10,5,SH) { Species = 131, Ability = A4, Moves = new(057, 196, 573, 329), Index = 9, CanGigantamax = true }, // Lapras
 
-        new(17,01,1) { Species = 840, Ability = A4, Moves = new[]{ 110, 310, 389, 213 }, Index = 8 }, // Applin
-        new(17,01,1) { Species = 840, Ability = A2, Moves = new[]{ 110, 310, 389, 213 }, Index = 8 }, // Applin
-        new(17,01,1) { Species = 868, Ability = A4, Moves = new[]{ 577, 033, 186, 263 }, Index = 8 }, // Milcery
-        new(17,01,1) { Species = 868, Ability = A2, Moves = new[]{ 577, 033, 186, 263 }, Index = 8 }, // Milcery
-        new(30,03,2) { Species = 869, Ability = A4, Moves = new[]{ 577, 213, 033, 186 }, Index = 8, CanGigantamax = true }, // Alcremie
-        new(17,01,1,SW) { Species = 837, Ability = A4, Moves = new[]{ 479, 033, 108, 189 }, Index = 8 }, // Rolycoly
-        new(17,01,1,SW) { Species = 837, Ability = A2, Moves = new[]{ 479, 033, 108, 189 }, Index = 8 }, // Rolycoly
-        new(30,03,2,SW) { Species = 841, Ability = A4, Moves = new[]{ 406, 491, 017, 225 }, Index = 8 }, // Flapple
-        new(30,03,2,SW) { Species = 841, Ability = A2, Moves = new[]{ 406, 491, 017, 225 }, Index = 8 }, // Flapple
-        new(30,03,2,SW) { Species = 838, Ability = A4, Moves = new[]{ 246, 510, 479, 189 }, Index = 8 }, // Carkol
-        new(30,03,2,SW) { Species = 838, Ability = A2, Moves = new[]{ 246, 510, 479, 189 }, Index = 8 }, // Carkol
-        new(40,05,3,SW) { Species = 841, Ability = A4, Moves = new[]{ 788, 406, 512, 491 }, Index = 8 }, // Flapple
-        new(40,05,3,SW) { Species = 841, Ability = A4, Moves = new[]{ 788, 406, 512, 491 }, Index = 8, CanGigantamax = true }, // Flapple
-        new(40,05,3,SW) { Species = 869, Ability = A4, Moves = new[]{ 577, 605, 202, 186 }, Index = 8, Form = 3, CanGigantamax = true }, // Alcremie-3
-        new(40,05,3,SW) { Species = 869, Ability = A4, Moves = new[]{ 577, 605, 202, 186 }, Index = 8, Form = 4, CanGigantamax = true }, // Alcremie-4
-        new(40,05,3,SW) { Species = 839, Ability = A4, Moves = new[]{ 246, 510, 479, 488 }, Index = 8 }, // Coalossal
-        new(40,05,3,SW) { Species = 839, Ability = A4, Moves = new[]{ 246, 510, 479, 488 }, Index = 8, CanGigantamax = true }, // Coalossal
-        new(50,08,4,SW) { Species = 841, Ability = A4, Moves = new[]{ 407, 788, 491, 334 }, Index = 8 }, // Flapple
-        new(50,08,4,SW) { Species = 841, Ability = A4, Moves = new[]{ 407, 788, 491, 334 }, Index = 8, CanGigantamax = true }, // Flapple
-        new(50,08,4,SW) { Species = 869, Ability = A4, Moves = new[]{ 605, 202, 094, 151 }, Index = 8, Form = 1, CanGigantamax = true }, // Alcremie-1
-        new(50,08,4,SW) { Species = 869, Ability = A4, Moves = new[]{ 605, 202, 094, 151 }, Index = 8, Form = 2, CanGigantamax = true }, // Alcremie-2
-        new(50,08,4,SW) { Species = 839, Ability = A4, Moves = new[]{ 246, 053, 157, 261 }, Index = 8 }, // Coalossal
-        new(50,08,4,SW) { Species = 839, Ability = A4, Moves = new[]{ 246, 053, 157, 261 }, Index = 8, CanGigantamax = true }, // Coalossal
-        new(60,10,5,SW) { Species = 841, Ability = A4, Moves = new[]{ 407, 788, 512, 349 }, Index = 8 }, // Flapple
-        new(60,10,5,SW) { Species = 841, Ability = A4, Moves = new[]{ 407, 788, 512, 349 }, Index = 8, CanGigantamax = true }, // Flapple
-        new(60,10,5,SW) { Species = 869, Ability = A4, Moves = new[]{ 605, 202, 595, 500 }, Index = 8, Form = 5, CanGigantamax = true }, // Alcremie-5
-        new(60,10,5,SW) { Species = 869, Ability = A4, Moves = new[]{ 605, 202, 595, 500 }, Index = 8, Form = 6, CanGigantamax = true }, // Alcremie-6
-        new(60,10,5,SW) { Species = 839, Ability = A4, Moves = new[]{ 246, 053, 157, 523 }, Index = 8 }, // Coalossal
-        new(60,10,5,SW) { Species = 839, Ability = A4, Moves = new[]{ 246, 053, 157, 523 }, Index = 8, CanGigantamax = true }, // Coalossal
-        new(17,01,1,SH) { Species = 131, Ability = A4, Moves = new[]{ 055, 496, 045, 047 }, Index = 8 }, // Lapras
-        new(17,01,1,SH) { Species = 131, Ability = A2, Moves = new[]{ 055, 496, 045, 047 }, Index = 8 }, // Lapras
-        new(30,03,2,SH) { Species = 842, Ability = A4, Moves = new[]{ 787, 029, 389, 073 }, Index = 8 }, // Appletun
-        new(30,03,2,SH) { Species = 842, Ability = A2, Moves = new[]{ 787, 029, 389, 073 }, Index = 8 }, // Appletun
-        new(30,03,2,SH) { Species = 131, Ability = A4, Moves = new[]{ 352, 420, 109, 047 }, Index = 8 }, // Lapras
-        new(30,03,2,SH) { Species = 131, Ability = A2, Moves = new[]{ 352, 420, 109, 047 }, Index = 8 }, // Lapras
-        new(40,05,3,SH) { Species = 842, Ability = A4, Moves = new[]{ 787, 496, 406, 523 }, Index = 8 }, // Appletun
-        new(40,05,3,SH) { Species = 842, Ability = A4, Moves = new[]{ 787, 496, 406, 523 }, Index = 8, CanGigantamax = true }, // Appletun
-        new(40,05,3,SH) { Species = 869, Ability = A4, Moves = new[]{ 577, 605, 202, 186 }, Index = 8, Form = 1, CanGigantamax = true }, // Alcremie-1
-        new(40,05,3,SH) { Species = 869, Ability = A4, Moves = new[]{ 577, 605, 202, 186 }, Index = 8, Form = 2, CanGigantamax = true }, // Alcremie-2
-        new(40,05,3,SH) { Species = 131, Ability = A4, Moves = new[]{ 352, 420, 109, 034 }, Index = 8 }, // Lapras
-        new(40,05,3,SH) { Species = 131, Ability = A4, Moves = new[]{ 352, 420, 109, 034 }, Index = 8, CanGigantamax = true }, // Lapras
-        new(50,08,4,SH) { Species = 842, Ability = A4, Moves = new[]{ 787, 202, 406, 089 }, Index = 8 }, // Appletun
-        new(50,08,4,SH) { Species = 842, Ability = A4, Moves = new[]{ 787, 202, 406, 089 }, Index = 8, CanGigantamax = true }, // Appletun
-        new(50,08,4,SH) { Species = 869, Ability = A4, Moves = new[]{ 605, 202, 094, 151 }, Index = 8, Form = 7, CanGigantamax = true }, // Alcremie-7
-        new(50,08,4,SH) { Species = 869, Ability = A4, Moves = new[]{ 605, 202, 094, 151 }, Index = 8, Form = 8, CanGigantamax = true }, // Alcremie-8
-        new(50,08,4,SH) { Species = 131, Ability = A4, Moves = new[]{ 057, 058, 246, 523 }, Index = 8 }, // Lapras
-        new(50,08,4,SH) { Species = 131, Ability = A4, Moves = new[]{ 057, 058, 246, 523 }, Index = 8, CanGigantamax = true }, // Lapras
-        new(60,10,5,SH) { Species = 842, Ability = A4, Moves = new[]{ 787, 406, 412, 089 }, Index = 8 }, // Appletun
-        new(60,10,5,SH) { Species = 842, Ability = A4, Moves = new[]{ 787, 406, 412, 089 }, Index = 8, CanGigantamax = true }, // Appletun
-        new(60,10,5,SH) { Species = 869, Ability = A4, Moves = new[]{ 605, 202, 595, 500 }, Index = 8, Form = 3, CanGigantamax = true }, // Alcremie-3
-        new(60,10,5,SH) { Species = 869, Ability = A4, Moves = new[]{ 605, 202, 595, 500 }, Index = 8, Form = 4, CanGigantamax = true }, // Alcremie-4
-        new(60,10,5,SH) { Species = 131, Ability = A4, Moves = new[]{ 057, 196, 573, 329 }, Index = 8 }, // Lapras
-        new(60,10,5,SH) { Species = 131, Ability = A4, Moves = new[]{ 057, 196, 573, 329 }, Index = 8, CanGigantamax = true }, // Lapras
+        new(17,01,1) { Species = 840, Ability = A4, Moves = new(110, 310, 389, 213), Index = 8 }, // Applin
+        new(17,01,1) { Species = 840, Ability = A2, Moves = new(110, 310, 389, 213), Index = 8 }, // Applin
+        new(17,01,1) { Species = 868, Ability = A4, Moves = new(577, 033, 186, 263), Index = 8 }, // Milcery
+        new(17,01,1) { Species = 868, Ability = A2, Moves = new(577, 033, 186, 263), Index = 8 }, // Milcery
+        new(30,03,2) { Species = 869, Ability = A4, Moves = new(577, 213, 033, 186), Index = 8, CanGigantamax = true }, // Alcremie
+        new(17,01,1,SW) { Species = 837, Ability = A4, Moves = new(479, 033, 108, 189), Index = 8 }, // Rolycoly
+        new(17,01,1,SW) { Species = 837, Ability = A2, Moves = new(479, 033, 108, 189), Index = 8 }, // Rolycoly
+        new(30,03,2,SW) { Species = 841, Ability = A4, Moves = new(406, 491, 017, 225), Index = 8 }, // Flapple
+        new(30,03,2,SW) { Species = 841, Ability = A2, Moves = new(406, 491, 017, 225), Index = 8 }, // Flapple
+        new(30,03,2,SW) { Species = 838, Ability = A4, Moves = new(246, 510, 479, 189), Index = 8 }, // Carkol
+        new(30,03,2,SW) { Species = 838, Ability = A2, Moves = new(246, 510, 479, 189), Index = 8 }, // Carkol
+        new(40,05,3,SW) { Species = 841, Ability = A4, Moves = new(788, 406, 512, 491), Index = 8 }, // Flapple
+        new(40,05,3,SW) { Species = 841, Ability = A4, Moves = new(788, 406, 512, 491), Index = 8, CanGigantamax = true }, // Flapple
+        new(40,05,3,SW) { Species = 869, Ability = A4, Moves = new(577, 605, 202, 186), Index = 8, Form = 3, CanGigantamax = true }, // Alcremie-3
+        new(40,05,3,SW) { Species = 869, Ability = A4, Moves = new(577, 605, 202, 186), Index = 8, Form = 4, CanGigantamax = true }, // Alcremie-4
+        new(40,05,3,SW) { Species = 839, Ability = A4, Moves = new(246, 510, 479, 488), Index = 8 }, // Coalossal
+        new(40,05,3,SW) { Species = 839, Ability = A4, Moves = new(246, 510, 479, 488), Index = 8, CanGigantamax = true }, // Coalossal
+        new(50,08,4,SW) { Species = 841, Ability = A4, Moves = new(407, 788, 491, 334), Index = 8 }, // Flapple
+        new(50,08,4,SW) { Species = 841, Ability = A4, Moves = new(407, 788, 491, 334), Index = 8, CanGigantamax = true }, // Flapple
+        new(50,08,4,SW) { Species = 869, Ability = A4, Moves = new(605, 202, 094, 151), Index = 8, Form = 1, CanGigantamax = true }, // Alcremie-1
+        new(50,08,4,SW) { Species = 869, Ability = A4, Moves = new(605, 202, 094, 151), Index = 8, Form = 2, CanGigantamax = true }, // Alcremie-2
+        new(50,08,4,SW) { Species = 839, Ability = A4, Moves = new(246, 053, 157, 261), Index = 8 }, // Coalossal
+        new(50,08,4,SW) { Species = 839, Ability = A4, Moves = new(246, 053, 157, 261), Index = 8, CanGigantamax = true }, // Coalossal
+        new(60,10,5,SW) { Species = 841, Ability = A4, Moves = new(407, 788, 512, 349), Index = 8 }, // Flapple
+        new(60,10,5,SW) { Species = 841, Ability = A4, Moves = new(407, 788, 512, 349), Index = 8, CanGigantamax = true }, // Flapple
+        new(60,10,5,SW) { Species = 869, Ability = A4, Moves = new(605, 202, 595, 500), Index = 8, Form = 5, CanGigantamax = true }, // Alcremie-5
+        new(60,10,5,SW) { Species = 869, Ability = A4, Moves = new(605, 202, 595, 500), Index = 8, Form = 6, CanGigantamax = true }, // Alcremie-6
+        new(60,10,5,SW) { Species = 839, Ability = A4, Moves = new(246, 053, 157, 523), Index = 8 }, // Coalossal
+        new(60,10,5,SW) { Species = 839, Ability = A4, Moves = new(246, 053, 157, 523), Index = 8, CanGigantamax = true }, // Coalossal
+        new(17,01,1,SH) { Species = 131, Ability = A4, Moves = new(055, 496, 045, 047), Index = 8 }, // Lapras
+        new(17,01,1,SH) { Species = 131, Ability = A2, Moves = new(055, 496, 045, 047), Index = 8 }, // Lapras
+        new(30,03,2,SH) { Species = 842, Ability = A4, Moves = new(787, 029, 389, 073), Index = 8 }, // Appletun
+        new(30,03,2,SH) { Species = 842, Ability = A2, Moves = new(787, 029, 389, 073), Index = 8 }, // Appletun
+        new(30,03,2,SH) { Species = 131, Ability = A4, Moves = new(352, 420, 109, 047), Index = 8 }, // Lapras
+        new(30,03,2,SH) { Species = 131, Ability = A2, Moves = new(352, 420, 109, 047), Index = 8 }, // Lapras
+        new(40,05,3,SH) { Species = 842, Ability = A4, Moves = new(787, 496, 406, 523), Index = 8 }, // Appletun
+        new(40,05,3,SH) { Species = 842, Ability = A4, Moves = new(787, 496, 406, 523), Index = 8, CanGigantamax = true }, // Appletun
+        new(40,05,3,SH) { Species = 869, Ability = A4, Moves = new(577, 605, 202, 186), Index = 8, Form = 1, CanGigantamax = true }, // Alcremie-1
+        new(40,05,3,SH) { Species = 869, Ability = A4, Moves = new(577, 605, 202, 186), Index = 8, Form = 2, CanGigantamax = true }, // Alcremie-2
+        new(40,05,3,SH) { Species = 131, Ability = A4, Moves = new(352, 420, 109, 034), Index = 8 }, // Lapras
+        new(40,05,3,SH) { Species = 131, Ability = A4, Moves = new(352, 420, 109, 034), Index = 8, CanGigantamax = true }, // Lapras
+        new(50,08,4,SH) { Species = 842, Ability = A4, Moves = new(787, 202, 406, 089), Index = 8 }, // Appletun
+        new(50,08,4,SH) { Species = 842, Ability = A4, Moves = new(787, 202, 406, 089), Index = 8, CanGigantamax = true }, // Appletun
+        new(50,08,4,SH) { Species = 869, Ability = A4, Moves = new(605, 202, 094, 151), Index = 8, Form = 7, CanGigantamax = true }, // Alcremie-7
+        new(50,08,4,SH) { Species = 869, Ability = A4, Moves = new(605, 202, 094, 151), Index = 8, Form = 8, CanGigantamax = true }, // Alcremie-8
+        new(50,08,4,SH) { Species = 131, Ability = A4, Moves = new(057, 058, 246, 523), Index = 8 }, // Lapras
+        new(50,08,4,SH) { Species = 131, Ability = A4, Moves = new(057, 058, 246, 523), Index = 8, CanGigantamax = true }, // Lapras
+        new(60,10,5,SH) { Species = 842, Ability = A4, Moves = new(787, 406, 412, 089), Index = 8 }, // Appletun
+        new(60,10,5,SH) { Species = 842, Ability = A4, Moves = new(787, 406, 412, 089), Index = 8, CanGigantamax = true }, // Appletun
+        new(60,10,5,SH) { Species = 869, Ability = A4, Moves = new(605, 202, 595, 500), Index = 8, Form = 3, CanGigantamax = true }, // Alcremie-3
+        new(60,10,5,SH) { Species = 869, Ability = A4, Moves = new(605, 202, 595, 500), Index = 8, Form = 4, CanGigantamax = true }, // Alcremie-4
+        new(60,10,5,SH) { Species = 131, Ability = A4, Moves = new(057, 196, 573, 329), Index = 8 }, // Lapras
+        new(60,10,5,SH) { Species = 131, Ability = A4, Moves = new(057, 196, 573, 329), Index = 8, CanGigantamax = true }, // Lapras
 
-        new(17,01,1) { Species = 129, Ability = A4, Moves = new[]{ 150, 033, 000, 000 }, Index = 6, Shiny = Shiny.Always }, // Magikarp
-        new(17,01,1) { Species = 446, Ability = A4, Moves = new[]{ 033, 044, 122, 111 }, Index = 6 }, // Munchlax
-        new(17,01,1) { Species = 129, Ability = A4, Moves = new[]{ 150, 033, 000, 000 }, Index = 6 }, // Magikarp
-        new(30,03,2) { Species = 129, Ability = A4, Moves = new[]{ 150, 033, 175, 000 }, Index = 6, Shiny = Shiny.Always }, // Magikarp
-        new(30,03,2) { Species = 143, Ability = A4, Moves = new[]{ 034, 242, 118, 111 }, Index = 6 }, // Snorlax
-        new(30,03,2) { Species = 129, Ability = A4, Moves = new[]{ 150, 033, 175, 000 }, Index = 6 }, // Magikarp
-        new(40,05,3) { Species = 012, Ability = A4, Moves = new[]{ 676, 403, 202, 527 }, Index = 6, CanGigantamax = true }, // Butterfree
-        new(40,05,3) { Species = 129, Ability = A4, Moves = new[]{ 150, 033, 175, 000 }, Index = 6, Shiny = Shiny.Always }, // Magikarp
-        new(40,05,3) { Species = 129, Ability = A4, Moves = new[]{ 150, 033, 175, 000 }, Index = 6 }, // Magikarp
-        new(40,05,3) { Species = 143, Ability = A4, Moves = new[]{ 034, 667, 242, 281 }, Index = 6, CanGigantamax = true }, // Snorlax
-        new(50,08,4) { Species = 012, Ability = A4, Moves = new[]{ 405, 403, 527, 078 }, Index = 6, CanGigantamax = true }, // Butterfree
-        new(50,08,4) { Species = 129, Ability = A4, Moves = new[]{ 150, 033, 175, 000 }, Index = 6, Shiny = Shiny.Always }, // Magikarp
-        new(50,08,4) { Species = 129, Ability = A4, Moves = new[]{ 150, 033, 175, 000 }, Index = 6 }, // Magikarp
-        new(50,08,4) { Species = 143, Ability = A4, Moves = new[]{ 034, 667, 280, 523 }, Index = 6, CanGigantamax = true }, // Snorlax
-        new(60,10,5) { Species = 129, Ability = A4, Moves = new[]{ 150, 033, 175, 340 }, Index = 6, Shiny = Shiny.Always }, // Magikarp
-        new(70,10,5) { Species = 129, Ability = A4, Moves = new[]{ 150, 033, 175, 340 }, Index = 6 }, // Magikarp
-        new(70,10,5) { Species = 143, Ability = A4, Moves = new[]{ 034, 442, 242, 428 }, Index = 6, CanGigantamax = true }, // Snorlax
-        new(17,01,1,SW) { Species = 012, Ability = A4, Moves = new[]{ 405, 060, 016, 078 }, Index = 6, CanGigantamax = true }, // Butterfree
-        new(17,01,1,SW) { Species = 843, Ability = A4, Moves = new[]{ 693, 523, 189, 103 }, Index = 6 }, // Silicobra
-        new(17,01,1,SW) { Species = 833, Ability = A4, Moves = new[]{ 055, 044, 033, 213 }, Index = 6 }, // Chewtle
-        new(30,03,2,SW) { Species = 012, Ability = A4, Moves = new[]{ 405, 403, 081, 079 }, Index = 6, CanGigantamax = true }, // Butterfree
-        new(30,03,2,SW) { Species = 843, Ability = A4, Moves = new[]{ 693, 523, 029, 137 }, Index = 6 }, // Silicobra
-        new(30,03,2,SW) { Species = 834, Ability = A4, Moves = new[]{ 317, 242, 055, 334 }, Index = 6 }, // Drednaw
-        new(40,05,3,SW) { Species = 844, Ability = A4, Moves = new[]{ 693, 529, 407, 424 }, Index = 6, CanGigantamax = true }, // Sandaconda
-        new(40,05,3,SW) { Species = 834, Ability = A4, Moves = new[]{ 157, 534, 034, 317 }, Index = 6, CanGigantamax = true }, // Drednaw
-        new(50,08,4,SW) { Species = 844, Ability = A4, Moves = new[]{ 693, 529, 342, 328 }, Index = 6, CanGigantamax = true }, // Sandaconda
-        new(50,08,4,SW) { Species = 834, Ability = A4, Moves = new[]{ 157, 710, 350, 523 }, Index = 6, CanGigantamax = true }, // Drednaw
-        new(60,10,5,SW) { Species = 012, Ability = A4, Moves = new[]{ 405, 094, 542, 202 }, Index = 6, CanGigantamax = true }, // Butterfree
-        new(70,10,5,SW) { Species = 844, Ability = A4, Moves = new[]{ 693, 529, 342, 328 }, Index = 6, CanGigantamax = true }, // Sandaconda
-        new(70,10,5,SW) { Species = 834, Ability = A4, Moves = new[]{ 157, 710, 317, 334 }, Index = 6, CanGigantamax = true }, // Drednaw
-        new(17,01,1,SH) { Species = 012, Ability = A4, Moves = new[]{ 405, 060, 016, 079 }, Index = 6, CanGigantamax = true }, // Butterfree
-        new(17,01,1,SH) { Species = 821, Ability = A4, Moves = new[]{ 403, 031, 116, 064 }, Index = 6 }, // Rookidee
-        new(17,01,1,SH) { Species = 850, Ability = A4, Moves = new[]{ 044, 172, 141, 693 }, Index = 6 }, // Sizzlipede
-        new(30,03,2,SH) { Species = 012, Ability = A4, Moves = new[]{ 405, 403, 081, 077 }, Index = 6, CanGigantamax = true }, // Butterfree
-        new(30,03,2,SH) { Species = 822, Ability = A4, Moves = new[]{ 403, 263, 179, 468 }, Index = 6 }, // Corvisquire
-        new(30,03,2,SH) { Species = 851, Ability = A4, Moves = new[]{ 172, 242, 404, 257 }, Index = 6 }, // Centiskorch
-        new(40,05,3,SH) { Species = 823, Ability = A4, Moves = new[]{ 065, 211, 034, 103 }, Index = 6, CanGigantamax = true }, // Corviknight
-        new(40,05,3,SH) { Species = 851, Ability = A4, Moves = new[]{ 141, 438, 053, 489 }, Index = 6, CanGigantamax = true }, // Centiskorch
-        new(50,08,4,SH) { Species = 823, Ability = A4, Moves = new[]{ 065, 442, 034, 334 }, Index = 6, CanGigantamax = true }, // Corviknight
-        new(50,08,4,SH) { Species = 851, Ability = A4, Moves = new[]{ 141, 424, 422, 242 }, Index = 6, CanGigantamax = true }, // Centiskorch
-        new(60,10,5,SH) { Species = 012, Ability = A4, Moves = new[]{ 405, 094, 403, 079 }, Index = 6, CanGigantamax = true }, // Butterfree
-        new(70,10,5,SH) { Species = 823, Ability = A4, Moves = new[]{ 413, 442, 249, 103 }, Index = 6, CanGigantamax = true }, // Corviknight
-        new(70,10,5,SH) { Species = 851, Ability = A4, Moves = new[]{ 679, 257, 083, 438 }, Index = 6, CanGigantamax = true }, // Centiskorch
+        new(17,01,1) { Species = 129, Ability = A4, Moves = new(150, 033, 000, 000), Index = 6, Shiny = Shiny.Always }, // Magikarp
+        new(17,01,1) { Species = 446, Ability = A4, Moves = new(033, 044, 122, 111), Index = 6 }, // Munchlax
+        new(17,01,1) { Species = 129, Ability = A4, Moves = new(150, 033, 000, 000), Index = 6 }, // Magikarp
+        new(30,03,2) { Species = 129, Ability = A4, Moves = new(150, 033, 175, 000), Index = 6, Shiny = Shiny.Always }, // Magikarp
+        new(30,03,2) { Species = 143, Ability = A4, Moves = new(034, 242, 118, 111), Index = 6 }, // Snorlax
+        new(30,03,2) { Species = 129, Ability = A4, Moves = new(150, 033, 175, 000), Index = 6 }, // Magikarp
+        new(40,05,3) { Species = 012, Ability = A4, Moves = new(676, 403, 202, 527), Index = 6, CanGigantamax = true }, // Butterfree
+        new(40,05,3) { Species = 129, Ability = A4, Moves = new(150, 033, 175, 000), Index = 6, Shiny = Shiny.Always }, // Magikarp
+        new(40,05,3) { Species = 129, Ability = A4, Moves = new(150, 033, 175, 000), Index = 6 }, // Magikarp
+        new(40,05,3) { Species = 143, Ability = A4, Moves = new(034, 667, 242, 281), Index = 6, CanGigantamax = true }, // Snorlax
+        new(50,08,4) { Species = 012, Ability = A4, Moves = new(405, 403, 527, 078), Index = 6, CanGigantamax = true }, // Butterfree
+        new(50,08,4) { Species = 129, Ability = A4, Moves = new(150, 033, 175, 000), Index = 6, Shiny = Shiny.Always }, // Magikarp
+        new(50,08,4) { Species = 129, Ability = A4, Moves = new(150, 033, 175, 000), Index = 6 }, // Magikarp
+        new(50,08,4) { Species = 143, Ability = A4, Moves = new(034, 667, 280, 523), Index = 6, CanGigantamax = true }, // Snorlax
+        new(60,10,5) { Species = 129, Ability = A4, Moves = new(150, 033, 175, 340), Index = 6, Shiny = Shiny.Always }, // Magikarp
+        new(70,10,5) { Species = 129, Ability = A4, Moves = new(150, 033, 175, 340), Index = 6 }, // Magikarp
+        new(70,10,5) { Species = 143, Ability = A4, Moves = new(034, 442, 242, 428), Index = 6, CanGigantamax = true }, // Snorlax
+        new(17,01,1,SW) { Species = 012, Ability = A4, Moves = new(405, 060, 016, 078), Index = 6, CanGigantamax = true }, // Butterfree
+        new(17,01,1,SW) { Species = 843, Ability = A4, Moves = new(693, 523, 189, 103), Index = 6 }, // Silicobra
+        new(17,01,1,SW) { Species = 833, Ability = A4, Moves = new(055, 044, 033, 213), Index = 6 }, // Chewtle
+        new(30,03,2,SW) { Species = 012, Ability = A4, Moves = new(405, 403, 081, 079), Index = 6, CanGigantamax = true }, // Butterfree
+        new(30,03,2,SW) { Species = 843, Ability = A4, Moves = new(693, 523, 029, 137), Index = 6 }, // Silicobra
+        new(30,03,2,SW) { Species = 834, Ability = A4, Moves = new(317, 242, 055, 334), Index = 6 }, // Drednaw
+        new(40,05,3,SW) { Species = 844, Ability = A4, Moves = new(693, 529, 407, 424), Index = 6, CanGigantamax = true }, // Sandaconda
+        new(40,05,3,SW) { Species = 834, Ability = A4, Moves = new(157, 534, 034, 317), Index = 6, CanGigantamax = true }, // Drednaw
+        new(50,08,4,SW) { Species = 844, Ability = A4, Moves = new(693, 529, 342, 328), Index = 6, CanGigantamax = true }, // Sandaconda
+        new(50,08,4,SW) { Species = 834, Ability = A4, Moves = new(157, 710, 350, 523), Index = 6, CanGigantamax = true }, // Drednaw
+        new(60,10,5,SW) { Species = 012, Ability = A4, Moves = new(405, 094, 542, 202), Index = 6, CanGigantamax = true }, // Butterfree
+        new(70,10,5,SW) { Species = 844, Ability = A4, Moves = new(693, 529, 342, 328), Index = 6, CanGigantamax = true }, // Sandaconda
+        new(70,10,5,SW) { Species = 834, Ability = A4, Moves = new(157, 710, 317, 334), Index = 6, CanGigantamax = true }, // Drednaw
+        new(17,01,1,SH) { Species = 012, Ability = A4, Moves = new(405, 060, 016, 079), Index = 6, CanGigantamax = true }, // Butterfree
+        new(17,01,1,SH) { Species = 821, Ability = A4, Moves = new(403, 031, 116, 064), Index = 6 }, // Rookidee
+        new(17,01,1,SH) { Species = 850, Ability = A4, Moves = new(044, 172, 141, 693), Index = 6 }, // Sizzlipede
+        new(30,03,2,SH) { Species = 012, Ability = A4, Moves = new(405, 403, 081, 077), Index = 6, CanGigantamax = true }, // Butterfree
+        new(30,03,2,SH) { Species = 822, Ability = A4, Moves = new(403, 263, 179, 468), Index = 6 }, // Corvisquire
+        new(30,03,2,SH) { Species = 851, Ability = A4, Moves = new(172, 242, 404, 257), Index = 6 }, // Centiskorch
+        new(40,05,3,SH) { Species = 823, Ability = A4, Moves = new(065, 211, 034, 103), Index = 6, CanGigantamax = true }, // Corviknight
+        new(40,05,3,SH) { Species = 851, Ability = A4, Moves = new(141, 438, 053, 489), Index = 6, CanGigantamax = true }, // Centiskorch
+        new(50,08,4,SH) { Species = 823, Ability = A4, Moves = new(065, 442, 034, 334), Index = 6, CanGigantamax = true }, // Corviknight
+        new(50,08,4,SH) { Species = 851, Ability = A4, Moves = new(141, 424, 422, 242), Index = 6, CanGigantamax = true }, // Centiskorch
+        new(60,10,5,SH) { Species = 012, Ability = A4, Moves = new(405, 094, 403, 079), Index = 6, CanGigantamax = true }, // Butterfree
+        new(70,10,5,SH) { Species = 823, Ability = A4, Moves = new(413, 442, 249, 103), Index = 6, CanGigantamax = true }, // Corviknight
+        new(70,10,5,SH) { Species = 851, Ability = A4, Moves = new(679, 257, 083, 438), Index = 6, CanGigantamax = true }, // Centiskorch
 
-        new(17,01,1) { Species = 446, Ability = A4, Moves = new[]{ 033, 044, 122, 111 }, Index = 5 }, // Munchlax
-        new(17,01,1) { Species = 446, Ability = A2, Moves = new[]{ 033, 044, 122, 111 }, Index = 5 }, // Munchlax
-        new(30,03,2) { Species = 143, Ability = A4, Moves = new[]{ 034, 242, 118, 111 }, Index = 5 }, // Snorlax
-        new(30,03,2) { Species = 143, Ability = A2, Moves = new[]{ 034, 242, 118, 111 }, Index = 5 }, // Snorlax
-        new(40,05,3) { Species = 012, Ability = A4, Moves = new[]{ 676, 403, 202, 527 }, Index = 5, CanGigantamax = true }, // Butterfree
-        new(40,05,3) { Species = 143, Ability = A4, Moves = new[]{ 034, 667, 242, 281 }, Index = 5 }, // Snorlax
-        new(40,05,3) { Species = 143, Ability = A4, Moves = new[]{ 034, 667, 242, 281 }, Index = 5, CanGigantamax = true }, // Snorlax
-        new(50,08,4) { Species = 012, Ability = A4, Moves = new[]{ 405, 403, 527, 078 }, Index = 5, CanGigantamax = true }, // Butterfree
-        new(50,08,4) { Species = 143, Ability = A4, Moves = new[]{ 034, 667, 280, 523 }, Index = 5 }, // Snorlax
-        new(50,08,4) { Species = 143, Ability = A4, Moves = new[]{ 034, 667, 280, 523 }, Index = 5, CanGigantamax = true }, // Snorlax
-        new(60,10,5) { Species = 143, Ability = A4, Moves = new[]{ 034, 442, 242, 428 }, Index = 5 }, // Snorlax
-        new(70,10,5) { Species = 143, Ability = A4, Moves = new[]{ 034, 442, 242, 428 }, Index = 5, CanGigantamax = true }, // Snorlax
-        new(17,01,1,SW) { Species = 012, Ability = A4, Moves = new[]{ 405, 060, 016, 078 }, Index = 5 }, // Butterfree
-        new(17,01,1,SW) { Species = 012, Ability = A4, Moves = new[]{ 405, 060, 016, 078 }, Index = 5, CanGigantamax = true }, // Butterfree
-        new(17,01,1,SW) { Species = 843, Ability = A4, Moves = new[]{ 693, 523, 189, 103 }, Index = 5 }, // Silicobra
-        new(17,01,1,SW) { Species = 833, Ability = A4, Moves = new[]{ 055, 044, 033, 213 }, Index = 5 }, // Chewtle
-        new(30,03,2,SW) { Species = 012, Ability = A4, Moves = new[]{ 405, 403, 081, 079 }, Index = 5, CanGigantamax = true }, // Butterfree
-        new(30,03,2,SW) { Species = 843, Ability = A4, Moves = new[]{ 693, 523, 029, 137 }, Index = 5 }, // Silicobra
-        new(30,03,2,SW) { Species = 834, Ability = A4, Moves = new[]{ 317, 242, 055, 334 }, Index = 5 }, // Drednaw
-        new(30,03,2,SW) { Species = 834, Ability = A2, Moves = new[]{ 317, 242, 055, 334 }, Index = 5 }, // Drednaw
-        new(40,05,3,SW) { Species = 844, Ability = A4, Moves = new[]{ 693, 529, 407, 424 }, Index = 5, CanGigantamax = true }, // Sandaconda
-        new(40,05,3,SW) { Species = 834, Ability = A4, Moves = new[]{ 157, 534, 034, 317 }, Index = 5 }, // Drednaw
-        new(40,05,3,SW) { Species = 834, Ability = A4, Moves = new[]{ 157, 534, 034, 317 }, Index = 5, CanGigantamax = true }, // Drednaw
-        new(50,08,4,SW) { Species = 844, Ability = A4, Moves = new[]{ 693, 529, 342, 328 }, Index = 5, CanGigantamax = true }, // Sandaconda
-        new(50,08,4,SW) { Species = 834, Ability = A4, Moves = new[]{ 157, 710, 350, 523 }, Index = 5 }, // Drednaw
-        new(50,08,4,SW) { Species = 834, Ability = A4, Moves = new[]{ 157, 710, 350, 523 }, Index = 5, CanGigantamax = true }, // Drednaw
-        new(60,10,5,SW) { Species = 012, Ability = A4, Moves = new[]{ 405, 094, 542, 202 }, Index = 5, CanGigantamax = true }, // Butterfree
-        new(70,10,5,SW) { Species = 844, Ability = A4, Moves = new[]{ 693, 529, 342, 328 }, Index = 5, CanGigantamax = true }, // Sandaconda
-        new(60,10,5,SW) { Species = 834, Ability = A4, Moves = new[]{ 157, 710, 317, 334 }, Index = 5 }, // Drednaw
-        new(70,10,5,SW) { Species = 834, Ability = A4, Moves = new[]{ 157, 710, 317, 334 }, Index = 5, CanGigantamax = true }, // Drednaw
-        new(17,01,1,SH) { Species = 012, Ability = A4, Moves = new[]{ 405, 060, 016, 079 }, Index = 5 }, // Butterfree
-        new(17,01,1,SH) { Species = 012, Ability = A4, Moves = new[]{ 405, 060, 016, 079 }, Index = 5, CanGigantamax = true }, // Butterfree
-        new(17,01,1,SH) { Species = 821, Ability = A4, Moves = new[]{ 403, 031, 116, 064 }, Index = 5 }, // Rookidee
-        new(17,01,1,SH) { Species = 850, Ability = A4, Moves = new[]{ 044, 172, 141, 693 }, Index = 5 }, // Sizzlipede
-        new(30,03,2,SH) { Species = 012, Ability = A4, Moves = new[]{ 405, 403, 081, 077 }, Index = 5, CanGigantamax = true }, // Butterfree
-        new(30,03,2,SH) { Species = 822, Ability = A4, Moves = new[]{ 403, 263, 179, 468 }, Index = 5 }, // Corvisquire
-        new(30,03,2,SH) { Species = 851, Ability = A4, Moves = new[]{ 172, 242, 404, 257 }, Index = 5 }, // Centiskorch
-        new(30,03,2,SH) { Species = 851, Ability = A2, Moves = new[]{ 172, 242, 404, 257 }, Index = 5 }, // Centiskorch
-        new(40,05,3,SH) { Species = 823, Ability = A4, Moves = new[]{ 065, 211, 034, 103 }, Index = 5, CanGigantamax = true }, // Corviknight
-        new(40,05,3,SH) { Species = 851, Ability = A4, Moves = new[]{ 141, 438, 053, 489 }, Index = 5 }, // Centiskorch
-        new(40,05,3,SH) { Species = 851, Ability = A4, Moves = new[]{ 141, 438, 053, 489 }, Index = 5, CanGigantamax = true }, // Centiskorch
-        new(50,08,4,SH) { Species = 823, Ability = A4, Moves = new[]{ 065, 442, 034, 334 }, Index = 5, CanGigantamax = true }, // Corviknight
-        new(50,08,4,SH) { Species = 851, Ability = A4, Moves = new[]{ 141, 424, 422, 242 }, Index = 5 }, // Centiskorch
-        new(50,08,4,SH) { Species = 851, Ability = A4, Moves = new[]{ 141, 424, 422, 242 }, Index = 5, CanGigantamax = true }, // Centiskorch
-        new(60,10,5,SH) { Species = 012, Ability = A4, Moves = new[]{ 405, 094, 403, 079 }, Index = 5, CanGigantamax = true }, // Butterfree
-        new(70,10,5,SH) { Species = 823, Ability = A4, Moves = new[]{ 413, 442, 249, 103 }, Index = 5, CanGigantamax = true }, // Corviknight
-        new(60,10,5,SH) { Species = 851, Ability = A4, Moves = new[]{ 679, 257, 083, 438 }, Index = 5 }, // Centiskorch
-        new(70,10,5,SH) { Species = 851, Ability = A4, Moves = new[]{ 679, 257, 083, 438 }, Index = 5, CanGigantamax = true }, // Centiskorch
+        new(17,01,1) { Species = 446, Ability = A4, Moves = new(033, 044, 122, 111), Index = 5 }, // Munchlax
+        new(17,01,1) { Species = 446, Ability = A2, Moves = new(033, 044, 122, 111), Index = 5 }, // Munchlax
+        new(30,03,2) { Species = 143, Ability = A4, Moves = new(034, 242, 118, 111), Index = 5 }, // Snorlax
+        new(30,03,2) { Species = 143, Ability = A2, Moves = new(034, 242, 118, 111), Index = 5 }, // Snorlax
+        new(40,05,3) { Species = 012, Ability = A4, Moves = new(676, 403, 202, 527), Index = 5, CanGigantamax = true }, // Butterfree
+        new(40,05,3) { Species = 143, Ability = A4, Moves = new(034, 667, 242, 281), Index = 5 }, // Snorlax
+        new(40,05,3) { Species = 143, Ability = A4, Moves = new(034, 667, 242, 281), Index = 5, CanGigantamax = true }, // Snorlax
+        new(50,08,4) { Species = 012, Ability = A4, Moves = new(405, 403, 527, 078), Index = 5, CanGigantamax = true }, // Butterfree
+        new(50,08,4) { Species = 143, Ability = A4, Moves = new(034, 667, 280, 523), Index = 5 }, // Snorlax
+        new(50,08,4) { Species = 143, Ability = A4, Moves = new(034, 667, 280, 523), Index = 5, CanGigantamax = true }, // Snorlax
+        new(60,10,5) { Species = 143, Ability = A4, Moves = new(034, 442, 242, 428), Index = 5 }, // Snorlax
+        new(70,10,5) { Species = 143, Ability = A4, Moves = new(034, 442, 242, 428), Index = 5, CanGigantamax = true }, // Snorlax
+        new(17,01,1,SW) { Species = 012, Ability = A4, Moves = new(405, 060, 016, 078), Index = 5 }, // Butterfree
+        new(17,01,1,SW) { Species = 012, Ability = A4, Moves = new(405, 060, 016, 078), Index = 5, CanGigantamax = true }, // Butterfree
+        new(17,01,1,SW) { Species = 843, Ability = A4, Moves = new(693, 523, 189, 103), Index = 5 }, // Silicobra
+        new(17,01,1,SW) { Species = 833, Ability = A4, Moves = new(055, 044, 033, 213), Index = 5 }, // Chewtle
+        new(30,03,2,SW) { Species = 012, Ability = A4, Moves = new(405, 403, 081, 079), Index = 5, CanGigantamax = true }, // Butterfree
+        new(30,03,2,SW) { Species = 843, Ability = A4, Moves = new(693, 523, 029, 137), Index = 5 }, // Silicobra
+        new(30,03,2,SW) { Species = 834, Ability = A4, Moves = new(317, 242, 055, 334), Index = 5 }, // Drednaw
+        new(30,03,2,SW) { Species = 834, Ability = A2, Moves = new(317, 242, 055, 334), Index = 5 }, // Drednaw
+        new(40,05,3,SW) { Species = 844, Ability = A4, Moves = new(693, 529, 407, 424), Index = 5, CanGigantamax = true }, // Sandaconda
+        new(40,05,3,SW) { Species = 834, Ability = A4, Moves = new(157, 534, 034, 317), Index = 5 }, // Drednaw
+        new(40,05,3,SW) { Species = 834, Ability = A4, Moves = new(157, 534, 034, 317), Index = 5, CanGigantamax = true }, // Drednaw
+        new(50,08,4,SW) { Species = 844, Ability = A4, Moves = new(693, 529, 342, 328), Index = 5, CanGigantamax = true }, // Sandaconda
+        new(50,08,4,SW) { Species = 834, Ability = A4, Moves = new(157, 710, 350, 523), Index = 5 }, // Drednaw
+        new(50,08,4,SW) { Species = 834, Ability = A4, Moves = new(157, 710, 350, 523), Index = 5, CanGigantamax = true }, // Drednaw
+        new(60,10,5,SW) { Species = 012, Ability = A4, Moves = new(405, 094, 542, 202), Index = 5, CanGigantamax = true }, // Butterfree
+        new(70,10,5,SW) { Species = 844, Ability = A4, Moves = new(693, 529, 342, 328), Index = 5, CanGigantamax = true }, // Sandaconda
+        new(60,10,5,SW) { Species = 834, Ability = A4, Moves = new(157, 710, 317, 334), Index = 5 }, // Drednaw
+        new(70,10,5,SW) { Species = 834, Ability = A4, Moves = new(157, 710, 317, 334), Index = 5, CanGigantamax = true }, // Drednaw
+        new(17,01,1,SH) { Species = 012, Ability = A4, Moves = new(405, 060, 016, 079), Index = 5 }, // Butterfree
+        new(17,01,1,SH) { Species = 012, Ability = A4, Moves = new(405, 060, 016, 079), Index = 5, CanGigantamax = true }, // Butterfree
+        new(17,01,1,SH) { Species = 821, Ability = A4, Moves = new(403, 031, 116, 064), Index = 5 }, // Rookidee
+        new(17,01,1,SH) { Species = 850, Ability = A4, Moves = new(044, 172, 141, 693), Index = 5 }, // Sizzlipede
+        new(30,03,2,SH) { Species = 012, Ability = A4, Moves = new(405, 403, 081, 077), Index = 5, CanGigantamax = true }, // Butterfree
+        new(30,03,2,SH) { Species = 822, Ability = A4, Moves = new(403, 263, 179, 468), Index = 5 }, // Corvisquire
+        new(30,03,2,SH) { Species = 851, Ability = A4, Moves = new(172, 242, 404, 257), Index = 5 }, // Centiskorch
+        new(30,03,2,SH) { Species = 851, Ability = A2, Moves = new(172, 242, 404, 257), Index = 5 }, // Centiskorch
+        new(40,05,3,SH) { Species = 823, Ability = A4, Moves = new(065, 211, 034, 103), Index = 5, CanGigantamax = true }, // Corviknight
+        new(40,05,3,SH) { Species = 851, Ability = A4, Moves = new(141, 438, 053, 489), Index = 5 }, // Centiskorch
+        new(40,05,3,SH) { Species = 851, Ability = A4, Moves = new(141, 438, 053, 489), Index = 5, CanGigantamax = true }, // Centiskorch
+        new(50,08,4,SH) { Species = 823, Ability = A4, Moves = new(065, 442, 034, 334), Index = 5, CanGigantamax = true }, // Corviknight
+        new(50,08,4,SH) { Species = 851, Ability = A4, Moves = new(141, 424, 422, 242), Index = 5 }, // Centiskorch
+        new(50,08,4,SH) { Species = 851, Ability = A4, Moves = new(141, 424, 422, 242), Index = 5, CanGigantamax = true }, // Centiskorch
+        new(60,10,5,SH) { Species = 012, Ability = A4, Moves = new(405, 094, 403, 079), Index = 5, CanGigantamax = true }, // Butterfree
+        new(70,10,5,SH) { Species = 823, Ability = A4, Moves = new(413, 442, 249, 103), Index = 5, CanGigantamax = true }, // Corviknight
+        new(60,10,5,SH) { Species = 851, Ability = A4, Moves = new(679, 257, 083, 438), Index = 5 }, // Centiskorch
+        new(70,10,5,SH) { Species = 851, Ability = A4, Moves = new(679, 257, 083, 438), Index = 5, CanGigantamax = true }, // Centiskorch
 
-        new(17,01,1) { Species = 446, Ability = A4, Moves = new[]{ 033, 044, 122, 111 }, Index = 3 }, // Munchlax
-        new(17,01,1) { Species = 225, Ability = A4, Moves = new[]{ 217, 229, 098, 420 }, Index = 3 }, // Delibird
-        new(30,03,2) { Species = 143, Ability = A4, Moves = new[]{ 034, 242, 118, 111 }, Index = 3 }, // Snorlax
-        new(30,03,2) { Species = 225, Ability = A4, Moves = new[]{ 217, 065, 034, 693 }, Index = 3 }, // Delibird
-        new(40,05,3) { Species = 012, Ability = A4, Moves = new[]{ 676, 403, 202, 527 }, Index = 3, CanGigantamax = true }, // Butterfree
-        new(40,05,3) { Species = 225, Ability = A4, Moves = new[]{ 217, 065, 280, 196 }, Index = 3 }, // Delibird
-        new(40,05,3) { Species = 143, Ability = A4, Moves = new[]{ 034, 667, 242, 281 }, Index = 3, CanGigantamax = true }, // Snorlax
-        new(50,08,4) { Species = 012, Ability = A4, Moves = new[]{ 405, 403, 527, 078 }, Index = 3, CanGigantamax = true }, // Butterfree
-        new(50,08,4) { Species = 225, Ability = A4, Moves = new[]{ 217, 059, 034, 280 }, Index = 3 }, // Delibird
-        new(50,08,4) { Species = 143, Ability = A4, Moves = new[]{ 034, 667, 280, 523 }, Index = 3, CanGigantamax = true }, // Snorlax
-        new(70,10,5) { Species = 225, Ability = A4, Moves = new[]{ 217, 059, 065, 280 }, Index = 3 }, // Delibird
-        new(70,10,5) { Species = 143, Ability = A4, Moves = new[]{ 034, 442, 242, 428 }, Index = 3, CanGigantamax = true }, // Snorlax
-        new(17,01,1,SW) { Species = 012, Ability = A4, Moves = new[]{ 405, 060, 016, 078 }, Index = 3 }, // Butterfree
-        new(17,01,1,SW) { Species = 012, Ability = A4, Moves = new[]{ 405, 060, 016, 078 }, Index = 3, CanGigantamax = true }, // Butterfree
-        new(17,01,1,SW) { Species = 843, Ability = A4, Moves = new[]{ 693, 523, 189, 103 }, Index = 3 }, // Silicobra
-        new(17,01,1,SW) { Species = 833, Ability = A4, Moves = new[]{ 055, 044, 033, 213 }, Index = 3 }, // Chewtle
-        new(30,03,2,SW) { Species = 012, Ability = A4, Moves = new[]{ 405, 403, 081, 079 }, Index = 3, CanGigantamax = true }, // Butterfree
-        new(30,03,2,SW) { Species = 843, Ability = A4, Moves = new[]{ 693, 523, 029, 137 }, Index = 3 }, // Silicobra
-        new(30,03,2,SW) { Species = 834, Ability = A4, Moves = new[]{ 317, 242, 055, 334 }, Index = 3 }, // Drednaw
-        new(40,05,3,SW) { Species = 844, Ability = A4, Moves = new[]{ 693, 529, 407, 424 }, Index = 3, CanGigantamax = true }, // Sandaconda
-        new(40,05,3,SW) { Species = 834, Ability = A4, Moves = new[]{ 157, 534, 034, 317 }, Index = 3 }, // Drednaw
-        new(40,05,3,SW) { Species = 834, Ability = A4, Moves = new[]{ 157, 534, 034, 317 }, Index = 3, CanGigantamax = true }, // Drednaw
-        new(50,08,3,SW) { Species = 844, Ability = A4, Moves = new[]{ 693, 529, 407, 424 }, Index = 3, CanGigantamax = true }, // Sandaconda
-        new(50,08,4,SW) { Species = 834, Ability = A4, Moves = new[]{ 157, 710, 350, 523 }, Index = 3 }, // Drednaw
-        new(50,08,4,SW) { Species = 834, Ability = A4, Moves = new[]{ 157, 710, 350, 523 }, Index = 3, CanGigantamax = true }, // Drednaw
-        new(60,10,5,SW) { Species = 012, Ability = A4, Moves = new[]{ 405, 094, 542, 202 }, Index = 3, CanGigantamax = true }, // Butterfree
-        new(70,10,5,SW) { Species = 844, Ability = A4, Moves = new[]{ 693, 529, 342, 328 }, Index = 3, CanGigantamax = true }, // Sandaconda
-        new(60,10,5,SW) { Species = 834, Ability = A4, Moves = new[]{ 157, 710, 317, 334 }, Index = 3 }, // Drednaw
-        new(70,10,5,SW) { Species = 834, Ability = A4, Moves = new[]{ 157, 710, 317, 334 }, Index = 3, CanGigantamax = true }, // Drednaw
-        new(17,01,1,SH) { Species = 012, Ability = A4, Moves = new[]{ 405, 060, 016, 079 }, Index = 3 }, // Butterfree
-        new(17,01,1,SH) { Species = 012, Ability = A4, Moves = new[]{ 405, 060, 016, 079 }, Index = 3, CanGigantamax = true }, // Butterfree
-        new(17,01,1,SH) { Species = 821, Ability = A4, Moves = new[]{ 403, 031, 116, 064 }, Index = 3 }, // Rookidee
-        new(17,01,1,SH) { Species = 850, Ability = A4, Moves = new[]{ 044, 172, 141, 693 }, Index = 3 }, // Sizzlipede
-        new(30,03,2,SH) { Species = 012, Ability = A4, Moves = new[]{ 405, 403, 081, 077 }, Index = 3, CanGigantamax = true }, // Butterfree
-        new(30,03,2,SH) { Species = 822, Ability = A4, Moves = new[]{ 403, 263, 179, 468 }, Index = 3 }, // Corvisquire
-        new(30,03,2,SH) { Species = 851, Ability = A4, Moves = new[]{ 172, 242, 404, 257 }, Index = 3 }, // Centiskorch
-        new(40,05,3,SH) { Species = 823, Ability = A4, Moves = new[]{ 065, 211, 034, 103 }, Index = 3, CanGigantamax = true }, // Corviknight
-        new(40,05,3,SH) { Species = 851, Ability = A4, Moves = new[]{ 141, 438, 053, 489 }, Index = 3 }, // Centiskorch
-        new(40,05,3,SH) { Species = 851, Ability = A4, Moves = new[]{ 141, 438, 053, 489 }, Index = 3, CanGigantamax = true }, // Centiskorch
-        new(50,08,4,SH) { Species = 823, Ability = A4, Moves = new[]{ 065, 442, 034, 334 }, Index = 3, CanGigantamax = true }, // Corviknight
-        new(50,08,4,SH) { Species = 851, Ability = A4, Moves = new[]{ 141, 424, 422, 242 }, Index = 3 }, // Centiskorch
-        new(50,08,4,SH) { Species = 851, Ability = A4, Moves = new[]{ 141, 424, 422, 242 }, Index = 3, CanGigantamax = true }, // Centiskorch
-        new(60,10,5,SH) { Species = 012, Ability = A4, Moves = new[]{ 405, 094, 403, 079 }, Index = 3, CanGigantamax = true }, // Butterfree
-        new(70,10,5,SH) { Species = 823, Ability = A4, Moves = new[]{ 413, 442, 249, 103 }, Index = 3, CanGigantamax = true }, // Corviknight
-        new(60,10,5,SH) { Species = 851, Ability = A4, Moves = new[]{ 679, 257, 083, 438 }, Index = 3 }, // Centiskorch
-        new(70,10,5,SH) { Species = 851, Ability = A4, Moves = new[]{ 679, 257, 083, 438 }, Index = 3, CanGigantamax = true }, // Centiskorch
+        new(17,01,1) { Species = 446, Ability = A4, Moves = new(033, 044, 122, 111), Index = 3 }, // Munchlax
+        new(17,01,1) { Species = 225, Ability = A4, Moves = new(217, 229, 098, 420), Index = 3 }, // Delibird
+        new(30,03,2) { Species = 143, Ability = A4, Moves = new(034, 242, 118, 111), Index = 3 }, // Snorlax
+        new(30,03,2) { Species = 225, Ability = A4, Moves = new(217, 065, 034, 693), Index = 3 }, // Delibird
+        new(40,05,3) { Species = 012, Ability = A4, Moves = new(676, 403, 202, 527), Index = 3, CanGigantamax = true }, // Butterfree
+        new(40,05,3) { Species = 225, Ability = A4, Moves = new(217, 065, 280, 196), Index = 3 }, // Delibird
+        new(40,05,3) { Species = 143, Ability = A4, Moves = new(034, 667, 242, 281), Index = 3, CanGigantamax = true }, // Snorlax
+        new(50,08,4) { Species = 012, Ability = A4, Moves = new(405, 403, 527, 078), Index = 3, CanGigantamax = true }, // Butterfree
+        new(50,08,4) { Species = 225, Ability = A4, Moves = new(217, 059, 034, 280), Index = 3 }, // Delibird
+        new(50,08,4) { Species = 143, Ability = A4, Moves = new(034, 667, 280, 523), Index = 3, CanGigantamax = true }, // Snorlax
+        new(70,10,5) { Species = 225, Ability = A4, Moves = new(217, 059, 065, 280), Index = 3 }, // Delibird
+        new(70,10,5) { Species = 143, Ability = A4, Moves = new(034, 442, 242, 428), Index = 3, CanGigantamax = true }, // Snorlax
+        new(17,01,1,SW) { Species = 012, Ability = A4, Moves = new(405, 060, 016, 078), Index = 3 }, // Butterfree
+        new(17,01,1,SW) { Species = 012, Ability = A4, Moves = new(405, 060, 016, 078), Index = 3, CanGigantamax = true }, // Butterfree
+        new(17,01,1,SW) { Species = 843, Ability = A4, Moves = new(693, 523, 189, 103), Index = 3 }, // Silicobra
+        new(17,01,1,SW) { Species = 833, Ability = A4, Moves = new(055, 044, 033, 213), Index = 3 }, // Chewtle
+        new(30,03,2,SW) { Species = 012, Ability = A4, Moves = new(405, 403, 081, 079), Index = 3, CanGigantamax = true }, // Butterfree
+        new(30,03,2,SW) { Species = 843, Ability = A4, Moves = new(693, 523, 029, 137), Index = 3 }, // Silicobra
+        new(30,03,2,SW) { Species = 834, Ability = A4, Moves = new(317, 242, 055, 334), Index = 3 }, // Drednaw
+        new(40,05,3,SW) { Species = 844, Ability = A4, Moves = new(693, 529, 407, 424), Index = 3, CanGigantamax = true }, // Sandaconda
+        new(40,05,3,SW) { Species = 834, Ability = A4, Moves = new(157, 534, 034, 317), Index = 3 }, // Drednaw
+        new(40,05,3,SW) { Species = 834, Ability = A4, Moves = new(157, 534, 034, 317), Index = 3, CanGigantamax = true }, // Drednaw
+        new(50,08,3,SW) { Species = 844, Ability = A4, Moves = new(693, 529, 407, 424), Index = 3, CanGigantamax = true }, // Sandaconda
+        new(50,08,4,SW) { Species = 834, Ability = A4, Moves = new(157, 710, 350, 523), Index = 3 }, // Drednaw
+        new(50,08,4,SW) { Species = 834, Ability = A4, Moves = new(157, 710, 350, 523), Index = 3, CanGigantamax = true }, // Drednaw
+        new(60,10,5,SW) { Species = 012, Ability = A4, Moves = new(405, 094, 542, 202), Index = 3, CanGigantamax = true }, // Butterfree
+        new(70,10,5,SW) { Species = 844, Ability = A4, Moves = new(693, 529, 342, 328), Index = 3, CanGigantamax = true }, // Sandaconda
+        new(60,10,5,SW) { Species = 834, Ability = A4, Moves = new(157, 710, 317, 334), Index = 3 }, // Drednaw
+        new(70,10,5,SW) { Species = 834, Ability = A4, Moves = new(157, 710, 317, 334), Index = 3, CanGigantamax = true }, // Drednaw
+        new(17,01,1,SH) { Species = 012, Ability = A4, Moves = new(405, 060, 016, 079), Index = 3 }, // Butterfree
+        new(17,01,1,SH) { Species = 012, Ability = A4, Moves = new(405, 060, 016, 079), Index = 3, CanGigantamax = true }, // Butterfree
+        new(17,01,1,SH) { Species = 821, Ability = A4, Moves = new(403, 031, 116, 064), Index = 3 }, // Rookidee
+        new(17,01,1,SH) { Species = 850, Ability = A4, Moves = new(044, 172, 141, 693), Index = 3 }, // Sizzlipede
+        new(30,03,2,SH) { Species = 012, Ability = A4, Moves = new(405, 403, 081, 077), Index = 3, CanGigantamax = true }, // Butterfree
+        new(30,03,2,SH) { Species = 822, Ability = A4, Moves = new(403, 263, 179, 468), Index = 3 }, // Corvisquire
+        new(30,03,2,SH) { Species = 851, Ability = A4, Moves = new(172, 242, 404, 257), Index = 3 }, // Centiskorch
+        new(40,05,3,SH) { Species = 823, Ability = A4, Moves = new(065, 211, 034, 103), Index = 3, CanGigantamax = true }, // Corviknight
+        new(40,05,3,SH) { Species = 851, Ability = A4, Moves = new(141, 438, 053, 489), Index = 3 }, // Centiskorch
+        new(40,05,3,SH) { Species = 851, Ability = A4, Moves = new(141, 438, 053, 489), Index = 3, CanGigantamax = true }, // Centiskorch
+        new(50,08,4,SH) { Species = 823, Ability = A4, Moves = new(065, 442, 034, 334), Index = 3, CanGigantamax = true }, // Corviknight
+        new(50,08,4,SH) { Species = 851, Ability = A4, Moves = new(141, 424, 422, 242), Index = 3 }, // Centiskorch
+        new(50,08,4,SH) { Species = 851, Ability = A4, Moves = new(141, 424, 422, 242), Index = 3, CanGigantamax = true }, // Centiskorch
+        new(60,10,5,SH) { Species = 012, Ability = A4, Moves = new(405, 094, 403, 079), Index = 3, CanGigantamax = true }, // Butterfree
+        new(70,10,5,SH) { Species = 823, Ability = A4, Moves = new(413, 442, 249, 103), Index = 3, CanGigantamax = true }, // Corviknight
+        new(60,10,5,SH) { Species = 851, Ability = A4, Moves = new(679, 257, 083, 438), Index = 3 }, // Centiskorch
+        new(70,10,5,SH) { Species = 851, Ability = A4, Moves = new(679, 257, 083, 438), Index = 3, CanGigantamax = true }, // Centiskorch
 
-        new(17,01,1) { Species = 446, Ability = A4, Moves = new[]{ 033, 044, 122, 111 }, Index = 2 }, // Munchlax
-        new(17,01,1) { Species = 446, Ability = A2, Moves = new[]{ 033, 044, 122, 111 }, Index = 2 }, // Munchlax
-        new(30,03,2) { Species = 143, Ability = A4, Moves = new[]{ 034, 242, 118, 111 }, Index = 2 }, // Snorlax
-        new(30,03,2) { Species = 143, Ability = A2, Moves = new[]{ 034, 242, 118, 111 }, Index = 2 }, // Snorlax
-        new(40,05,3) { Species = 012, Ability = A4, Moves = new[]{ 676, 403, 202, 527 }, Index = 2, CanGigantamax = true }, // Butterfree
-        new(40,05,3) { Species = 143, Ability = A4, Moves = new[]{ 034, 667, 242, 281 }, Index = 2 }, // Snorlax
-        new(40,05,3) { Species = 143, Ability = A4, Moves = new[]{ 034, 667, 242, 281 }, Index = 2, CanGigantamax = true }, // Snorlax
-        new(50,08,4) { Species = 012, Ability = A4, Moves = new[]{ 405, 403, 527, 078 }, Index = 2, CanGigantamax = true }, // Butterfree
-        new(50,08,4) { Species = 143, Ability = A4, Moves = new[]{ 034, 667, 280, 523 }, Index = 2 }, // Snorlax
-        new(50,08,4) { Species = 143, Ability = A4, Moves = new[]{ 034, 667, 280, 523 }, Index = 2, CanGigantamax = true }, // Snorlax
-        new(60,10,5) { Species = 143, Ability = A4, Moves = new[]{ 034, 442, 242, 428 }, Index = 2 }, // Snorlax
-        new(70,10,5) { Species = 143, Ability = A4, Moves = new[]{ 034, 442, 242, 428 }, Index = 2, CanGigantamax = true }, // Snorlax
-        new(17,01,1,SW) { Species = 012, Ability = A4, Moves = new[]{ 405, 060, 016, 078 }, Index = 2 }, // Butterfree
-        new(17,01,1,SW) { Species = 012, Ability = A4, Moves = new[]{ 405, 060, 016, 078 }, Index = 2, CanGigantamax = true }, // Butterfree
-        new(17,01,1,SW) { Species = 843, Ability = A4, Moves = new[]{ 693, 523, 189, 103 }, Index = 2 }, // Silicobra
-        new(17,01,1,SW) { Species = 833, Ability = A4, Moves = new[]{ 055, 044, 033, 213 }, Index = 2 }, // Chewtle
-        new(30,03,2,SW) { Species = 012, Ability = A4, Moves = new[]{ 405, 403, 081, 079 }, Index = 2, CanGigantamax = true }, // Butterfree
-        new(30,03,2,SW) { Species = 843, Ability = A4, Moves = new[]{ 693, 523, 029, 137 }, Index = 2 }, // Silicobra
-        new(30,03,2,SW) { Species = 834, Ability = A4, Moves = new[]{ 317, 242, 055, 334 }, Index = 2 }, // Drednaw
-        new(30,03,2,SW) { Species = 834, Ability = A2, Moves = new[]{ 317, 242, 055, 334 }, Index = 2 }, // Drednaw
-        new(40,05,3,SW) { Species = 844, Ability = A4, Moves = new[]{ 693, 529, 407, 424 }, Index = 2, CanGigantamax = true }, // Sandaconda
-        new(40,05,3,SW) { Species = 834, Ability = A4, Moves = new[]{ 157, 534, 034, 317 }, Index = 2 }, // Drednaw
-        new(40,05,3,SW) { Species = 834, Ability = A4, Moves = new[]{ 157, 534, 034, 317 }, Index = 2, CanGigantamax = true }, // Drednaw
-        new(50,08,4,SW) { Species = 844, Ability = A4, Moves = new[]{ 693, 529, 342, 328 }, Index = 2, CanGigantamax = true }, // Sandaconda
-        new(50,08,4,SW) { Species = 834, Ability = A4, Moves = new[]{ 157, 710, 350, 523 }, Index = 2 }, // Drednaw
-        new(50,08,4,SW) { Species = 834, Ability = A4, Moves = new[]{ 157, 710, 350, 523 }, Index = 2, CanGigantamax = true }, // Drednaw
-        new(60,10,5,SW) { Species = 012, Ability = A4, Moves = new[]{ 405, 094, 542, 202 }, Index = 2, CanGigantamax = true }, // Butterfree
-        new(70,10,5,SW) { Species = 844, Ability = A4, Moves = new[]{ 693, 529, 342, 328 }, Index = 2, CanGigantamax = true }, // Sandaconda
-        new(60,10,5,SW) { Species = 834, Ability = A4, Moves = new[]{ 157, 710, 317, 334 }, Index = 2 }, // Drednaw
-        new(70,10,5,SW) { Species = 834, Ability = A4, Moves = new[]{ 157, 710, 317, 334 }, Index = 2, CanGigantamax = true }, // Drednaw
-        new(17,01,1,SH) { Species = 012, Ability = A4, Moves = new[]{ 405, 060, 016, 079 }, Index = 2 }, // Butterfree
-        new(17,01,1,SH) { Species = 012, Ability = A4, Moves = new[]{ 405, 060, 016, 079 }, Index = 2, CanGigantamax = true }, // Butterfree
-        new(17,01,1,SH) { Species = 821, Ability = A4, Moves = new[]{ 403, 031, 116, 064 }, Index = 2 }, // Rookidee
-        new(17,01,1,SH) { Species = 850, Ability = A4, Moves = new[]{ 044, 172, 404, 693 }, Index = 2 }, // Sizzlipede
-        new(30,03,2,SH) { Species = 012, Ability = A4, Moves = new[]{ 405, 403, 081, 077 }, Index = 2, CanGigantamax = true }, // Butterfree
-        new(30,03,2,SH) { Species = 822, Ability = A4, Moves = new[]{ 403, 263, 179, 468 }, Index = 2 }, // Corvisquire
-        new(30,03,2,SH) { Species = 851, Ability = A4, Moves = new[]{ 172, 242, 404, 257 }, Index = 2 }, // Centiskorch
-        new(30,03,2,SH) { Species = 851, Ability = A2, Moves = new[]{ 172, 242, 404, 257 }, Index = 2 }, // Centiskorch
-        new(40,05,3,SH) { Species = 823, Ability = A4, Moves = new[]{ 065, 211, 034, 103 }, Index = 2, CanGigantamax = true }, // Corviknight
-        new(40,05,3,SH) { Species = 851, Ability = A4, Moves = new[]{ 141, 438, 053, 489 }, Index = 2 }, // Centiskorch
-        new(40,05,3,SH) { Species = 851, Ability = A4, Moves = new[]{ 141, 438, 053, 489 }, Index = 2, CanGigantamax = true }, // Centiskorch
-        new(50,08,4,SH) { Species = 823, Ability = A4, Moves = new[]{ 065, 442, 034, 334 }, Index = 2, CanGigantamax = true }, // Corviknight
-        new(50,08,4,SH) { Species = 851, Ability = A4, Moves = new[]{ 141, 424, 422, 242 }, Index = 2 }, // Centiskorch
-        new(50,08,4,SH) { Species = 851, Ability = A4, Moves = new[]{ 141, 424, 422, 242 }, Index = 2, CanGigantamax = true }, // Centiskorch
-        new(60,10,5,SH) { Species = 012, Ability = A4, Moves = new[]{ 405, 094, 403, 079 }, Index = 2, CanGigantamax = true }, // Butterfree
-        new(70,10,5,SH) { Species = 823, Ability = A4, Moves = new[]{ 413, 442, 249, 103 }, Index = 2, CanGigantamax = true }, // Corviknight
-        new(60,10,5,SH) { Species = 851, Ability = A4, Moves = new[]{ 679, 257, 083, 438 }, Index = 2 }, // Centiskorch
-        new(70,10,5,SH) { Species = 851, Ability = A4, Moves = new[]{ 679, 257, 083, 438 }, Index = 2, CanGigantamax = true }, // Centiskorch
+        new(17,01,1) { Species = 446, Ability = A4, Moves = new(033, 044, 122, 111), Index = 2 }, // Munchlax
+        new(17,01,1) { Species = 446, Ability = A2, Moves = new(033, 044, 122, 111), Index = 2 }, // Munchlax
+        new(30,03,2) { Species = 143, Ability = A4, Moves = new(034, 242, 118, 111), Index = 2 }, // Snorlax
+        new(30,03,2) { Species = 143, Ability = A2, Moves = new(034, 242, 118, 111), Index = 2 }, // Snorlax
+        new(40,05,3) { Species = 012, Ability = A4, Moves = new(676, 403, 202, 527), Index = 2, CanGigantamax = true }, // Butterfree
+        new(40,05,3) { Species = 143, Ability = A4, Moves = new(034, 667, 242, 281), Index = 2 }, // Snorlax
+        new(40,05,3) { Species = 143, Ability = A4, Moves = new(034, 667, 242, 281), Index = 2, CanGigantamax = true }, // Snorlax
+        new(50,08,4) { Species = 012, Ability = A4, Moves = new(405, 403, 527, 078), Index = 2, CanGigantamax = true }, // Butterfree
+        new(50,08,4) { Species = 143, Ability = A4, Moves = new(034, 667, 280, 523), Index = 2 }, // Snorlax
+        new(50,08,4) { Species = 143, Ability = A4, Moves = new(034, 667, 280, 523), Index = 2, CanGigantamax = true }, // Snorlax
+        new(60,10,5) { Species = 143, Ability = A4, Moves = new(034, 442, 242, 428), Index = 2 }, // Snorlax
+        new(70,10,5) { Species = 143, Ability = A4, Moves = new(034, 442, 242, 428), Index = 2, CanGigantamax = true }, // Snorlax
+        new(17,01,1,SW) { Species = 012, Ability = A4, Moves = new(405, 060, 016, 078), Index = 2 }, // Butterfree
+        new(17,01,1,SW) { Species = 012, Ability = A4, Moves = new(405, 060, 016, 078), Index = 2, CanGigantamax = true }, // Butterfree
+        new(17,01,1,SW) { Species = 843, Ability = A4, Moves = new(693, 523, 189, 103), Index = 2 }, // Silicobra
+        new(17,01,1,SW) { Species = 833, Ability = A4, Moves = new(055, 044, 033, 213), Index = 2 }, // Chewtle
+        new(30,03,2,SW) { Species = 012, Ability = A4, Moves = new(405, 403, 081, 079), Index = 2, CanGigantamax = true }, // Butterfree
+        new(30,03,2,SW) { Species = 843, Ability = A4, Moves = new(693, 523, 029, 137), Index = 2 }, // Silicobra
+        new(30,03,2,SW) { Species = 834, Ability = A4, Moves = new(317, 242, 055, 334), Index = 2 }, // Drednaw
+        new(30,03,2,SW) { Species = 834, Ability = A2, Moves = new(317, 242, 055, 334), Index = 2 }, // Drednaw
+        new(40,05,3,SW) { Species = 844, Ability = A4, Moves = new(693, 529, 407, 424), Index = 2, CanGigantamax = true }, // Sandaconda
+        new(40,05,3,SW) { Species = 834, Ability = A4, Moves = new(157, 534, 034, 317), Index = 2 }, // Drednaw
+        new(40,05,3,SW) { Species = 834, Ability = A4, Moves = new(157, 534, 034, 317), Index = 2, CanGigantamax = true }, // Drednaw
+        new(50,08,4,SW) { Species = 844, Ability = A4, Moves = new(693, 529, 342, 328), Index = 2, CanGigantamax = true }, // Sandaconda
+        new(50,08,4,SW) { Species = 834, Ability = A4, Moves = new(157, 710, 350, 523), Index = 2 }, // Drednaw
+        new(50,08,4,SW) { Species = 834, Ability = A4, Moves = new(157, 710, 350, 523), Index = 2, CanGigantamax = true }, // Drednaw
+        new(60,10,5,SW) { Species = 012, Ability = A4, Moves = new(405, 094, 542, 202), Index = 2, CanGigantamax = true }, // Butterfree
+        new(70,10,5,SW) { Species = 844, Ability = A4, Moves = new(693, 529, 342, 328), Index = 2, CanGigantamax = true }, // Sandaconda
+        new(60,10,5,SW) { Species = 834, Ability = A4, Moves = new(157, 710, 317, 334), Index = 2 }, // Drednaw
+        new(70,10,5,SW) { Species = 834, Ability = A4, Moves = new(157, 710, 317, 334), Index = 2, CanGigantamax = true }, // Drednaw
+        new(17,01,1,SH) { Species = 012, Ability = A4, Moves = new(405, 060, 016, 079), Index = 2 }, // Butterfree
+        new(17,01,1,SH) { Species = 012, Ability = A4, Moves = new(405, 060, 016, 079), Index = 2, CanGigantamax = true }, // Butterfree
+        new(17,01,1,SH) { Species = 821, Ability = A4, Moves = new(403, 031, 116, 064), Index = 2 }, // Rookidee
+        new(17,01,1,SH) { Species = 850, Ability = A4, Moves = new(044, 172, 404, 693), Index = 2 }, // Sizzlipede
+        new(30,03,2,SH) { Species = 012, Ability = A4, Moves = new(405, 403, 081, 077), Index = 2, CanGigantamax = true }, // Butterfree
+        new(30,03,2,SH) { Species = 822, Ability = A4, Moves = new(403, 263, 179, 468), Index = 2 }, // Corvisquire
+        new(30,03,2,SH) { Species = 851, Ability = A4, Moves = new(172, 242, 404, 257), Index = 2 }, // Centiskorch
+        new(30,03,2,SH) { Species = 851, Ability = A2, Moves = new(172, 242, 404, 257), Index = 2 }, // Centiskorch
+        new(40,05,3,SH) { Species = 823, Ability = A4, Moves = new(065, 211, 034, 103), Index = 2, CanGigantamax = true }, // Corviknight
+        new(40,05,3,SH) { Species = 851, Ability = A4, Moves = new(141, 438, 053, 489), Index = 2 }, // Centiskorch
+        new(40,05,3,SH) { Species = 851, Ability = A4, Moves = new(141, 438, 053, 489), Index = 2, CanGigantamax = true }, // Centiskorch
+        new(50,08,4,SH) { Species = 823, Ability = A4, Moves = new(065, 442, 034, 334), Index = 2, CanGigantamax = true }, // Corviknight
+        new(50,08,4,SH) { Species = 851, Ability = A4, Moves = new(141, 424, 422, 242), Index = 2 }, // Centiskorch
+        new(50,08,4,SH) { Species = 851, Ability = A4, Moves = new(141, 424, 422, 242), Index = 2, CanGigantamax = true }, // Centiskorch
+        new(60,10,5,SH) { Species = 012, Ability = A4, Moves = new(405, 094, 403, 079), Index = 2, CanGigantamax = true }, // Butterfree
+        new(70,10,5,SH) { Species = 823, Ability = A4, Moves = new(413, 442, 249, 103), Index = 2, CanGigantamax = true }, // Corviknight
+        new(60,10,5,SH) { Species = 851, Ability = A4, Moves = new(679, 257, 083, 438), Index = 2 }, // Centiskorch
+        new(70,10,5,SH) { Species = 851, Ability = A4, Moves = new(679, 257, 083, 438), Index = 2, CanGigantamax = true }, // Centiskorch
 
-        new(40,05,3) { Species = 012, Ability = A4, Moves = new[]{ 676, 403, 202, 527 }, Index = 1 }, // Butterfree
-        new(40,05,3) { Species = 012, Ability = A4, Moves = new[]{ 676, 403, 202, 527 }, Index = 1, CanGigantamax = true }, // Butterfree
-        new(50,08,4) { Species = 012, Ability = A4, Moves = new[]{ 405, 403, 527, 078 }, Index = 1 }, // Butterfree
-        new(50,08,4) { Species = 012, Ability = A4, Moves = new[]{ 405, 403, 527, 078 }, Index = 1, CanGigantamax = true }, // Butterfree
-        new(17,01,1,SW) { Species = 012, Ability = A4, Moves = new[]{ 405, 060, 016, 078 }, Index = 1 }, // Butterfree
-        new(17,01,1,SW) { Species = 012, Ability = A4, Moves = new[]{ 405, 060, 016, 078 }, Index = 1, CanGigantamax = true }, // Butterfree
-        new(17,01,1,SW) { Species = 843, Ability = A2, Moves = new[]{ 693, 523, 189, 103 }, Index = 1 }, // Silicobra
-        new(17,01,1,SW) { Species = 843, Ability = A4, Moves = new[]{ 693, 523, 189, 103 }, Index = 1 }, // Silicobra
-        new(17,01,1,SW) { Species = 833, Ability = A2, Moves = new[]{ 055, 044, 033, 213 }, Index = 1 }, // Chewtle
-        new(17,01,1,SW) { Species = 833, Ability = A4, Moves = new[]{ 055, 044, 033, 213 }, Index = 1 }, // Chewtle
-        new(30,03,2,SW) { Species = 012, Ability = A4, Moves = new[]{ 405, 403, 081, 079 }, Index = 1 }, // Butterfree
-        new(30,03,2,SW) { Species = 012, Ability = A4, Moves = new[]{ 405, 403, 081, 079 }, Index = 1, CanGigantamax = true }, // Butterfree
-        new(30,03,2,SW) { Species = 843, Ability = A2, Moves = new[]{ 693, 523, 029, 137 }, Index = 1 }, // Silicobra
-        new(30,03,2,SW) { Species = 843, Ability = A4, Moves = new[]{ 693, 523, 029, 137 }, Index = 1 }, // Silicobra
-        new(30,03,2,SW) { Species = 834, Ability = A2, Moves = new[]{ 317, 242, 055, 334 }, Index = 1 }, // Drednaw
-        new(30,03,2,SW) { Species = 834, Ability = A4, Moves = new[]{ 317, 242, 055, 334 }, Index = 1 }, // Drednaw
-        new(40,05,3,SW) { Species = 844, Ability = A4, Moves = new[]{ 693, 529, 407, 424 }, Index = 1 }, // Sandaconda
-        new(40,05,3,SW) { Species = 844, Ability = A4, Moves = new[]{ 693, 529, 407, 424 }, Index = 1, CanGigantamax = true }, // Sandaconda
-        new(40,05,3,SW) { Species = 834, Ability = A4, Moves = new[]{ 157, 534, 034, 317 }, Index = 1 }, // Drednaw
-        new(40,05,3,SW) { Species = 834, Ability = A4, Moves = new[]{ 157, 534, 034, 317 }, Index = 1, CanGigantamax = true }, // Drednaw
-        new(50,08,4,SW) { Species = 844, Ability = A4, Moves = new[]{ 693, 529, 342, 328 }, Index = 1 }, // Sandaconda
-        new(50,08,4,SW) { Species = 844, Ability = A4, Moves = new[]{ 693, 529, 342, 328 }, Index = 1, CanGigantamax = true }, // Sandaconda
-        new(50,08,4,SW) { Species = 834, Ability = A4, Moves = new[]{ 157, 710, 350, 523 }, Index = 1 }, // Drednaw
-        new(50,08,4,SW) { Species = 834, Ability = A4, Moves = new[]{ 157, 710, 350, 523 }, Index = 1, CanGigantamax = true }, // Drednaw
-        new(60,10,5,SW) { Species = 012, Ability = A4, Moves = new[]{ 405, 094, 542, 202 }, Index = 1 }, // Butterfree
-        new(70,10,5,SW) { Species = 012, Ability = A4, Moves = new[]{ 405, 094, 542, 202 }, Index = 1, CanGigantamax = true }, // Butterfree
-        new(60,10,5,SW) { Species = 844, Ability = A4, Moves = new[]{ 693, 529, 342, 328 }, Index = 1 }, // Sandaconda
-        new(70,10,5,SW) { Species = 844, Ability = A4, Moves = new[]{ 693, 529, 342, 328 }, Index = 1, CanGigantamax = true }, // Sandaconda
-        new(60,10,5,SW) { Species = 834, Ability = A4, Moves = new[]{ 157, 710, 317, 334 }, Index = 1 }, // Drednaw
-        new(70,10,5,SW) { Species = 834, Ability = A4, Moves = new[]{ 157, 710, 317, 334 }, Index = 1, CanGigantamax = true }, // Drednaw
-        new(17,01,1,SH) { Species = 012, Ability = A4, Moves = new[]{ 405, 060, 016, 079 }, Index = 1 }, // Butterfree
-        new(17,01,1,SH) { Species = 012, Ability = A4, Moves = new[]{ 405, 060, 016, 079 }, Index = 1, CanGigantamax = true }, // Butterfree
-        new(17,01,1,SH) { Species = 821, Ability = A2, Moves = new[]{ 365, 031, 526, 064 }, Index = 1 }, // Rookidee
-        new(17,01,1,SH) { Species = 821, Ability = A4, Moves = new[]{ 365, 031, 526, 064 }, Index = 1 }, // Rookidee
-        new(17,01,1,SH) { Species = 850, Ability = A2, Moves = new[]{ 044, 172, 450, 693 }, Index = 1 }, // Sizzlipede
-        new(17,01,1,SH) { Species = 850, Ability = A4, Moves = new[]{ 044, 172, 450, 693 }, Index = 1 }, // Sizzlipede
-        new(30,03,2,SH) { Species = 012, Ability = A4, Moves = new[]{ 405, 403, 081, 077 }, Index = 1 }, // Butterfree
-        new(30,03,2,SH) { Species = 012, Ability = A4, Moves = new[]{ 405, 403, 081, 077 }, Index = 1, CanGigantamax = true }, // Butterfree
-        new(30,03,2,SH) { Species = 822, Ability = A2, Moves = new[]{ 365, 263, 179, 468 }, Index = 1 }, // Corvisquire
-        new(30,03,2,SH) { Species = 822, Ability = A4, Moves = new[]{ 365, 263, 179, 468 }, Index = 1 }, // Corvisquire
-        new(30,03,2,SH) { Species = 851, Ability = A2, Moves = new[]{ 172, 242, 450, 257 }, Index = 1 }, // Centiskorch
-        new(30,03,2,SH) { Species = 851, Ability = A4, Moves = new[]{ 172, 242, 450, 257 }, Index = 1 }, // Centiskorch
-        new(40,05,3,SH) { Species = 823, Ability = A4, Moves = new[]{ 065, 211, 034, 103 }, Index = 1 }, // Corviknight
-        new(40,05,3,SH) { Species = 823, Ability = A4, Moves = new[]{ 065, 211, 034, 103 }, Index = 1, CanGigantamax = true }, // Corviknight
-        new(40,05,3,SH) { Species = 851, Ability = A4, Moves = new[]{ 141, 438, 053, 489 }, Index = 1 }, // Centiskorch
-        new(40,05,3,SH) { Species = 851, Ability = A4, Moves = new[]{ 141, 438, 053, 489 }, Index = 1, CanGigantamax = true }, // Centiskorch
-        new(50,08,4,SH) { Species = 823, Ability = A4, Moves = new[]{ 065, 442, 034, 334 }, Index = 1 }, // Corviknight
-        new(50,08,4,SH) { Species = 823, Ability = A4, Moves = new[]{ 065, 442, 034, 334 }, Index = 1, CanGigantamax = true }, // Corviknight
-        new(50,08,4,SH) { Species = 851, Ability = A4, Moves = new[]{ 141, 424, 422, 242 }, Index = 1 }, // Centiskorch
-        new(50,08,4,SH) { Species = 851, Ability = A4, Moves = new[]{ 141, 424, 422, 242 }, Index = 1, CanGigantamax = true }, // Centiskorch
-        new(60,10,5,SH) { Species = 012, Ability = A4, Moves = new[]{ 405, 094, 403, 079 }, Index = 1 }, // Butterfree
-        new(70,10,5,SH) { Species = 012, Ability = A4, Moves = new[]{ 405, 094, 403, 079 }, Index = 1, CanGigantamax = true }, // Butterfree
-        new(60,10,5,SH) { Species = 823, Ability = A4, Moves = new[]{ 413, 442, 249, 103 }, Index = 1 }, // Corviknight
-        new(70,10,5,SH) { Species = 823, Ability = A4, Moves = new[]{ 413, 442, 249, 103 }, Index = 1, CanGigantamax = true }, // Corviknight
-        new(60,10,5,SH) { Species = 851, Ability = A4, Moves = new[]{ 679, 257, 083, 438 }, Index = 1 }, // Centiskorch
-        new(70,10,5,SH) { Species = 851, Ability = A4, Moves = new[]{ 679, 257, 083, 438 }, Index = 1, CanGigantamax = true }, // Centiskorch
+        new(40,05,3) { Species = 012, Ability = A4, Moves = new(676, 403, 202, 527), Index = 1 }, // Butterfree
+        new(40,05,3) { Species = 012, Ability = A4, Moves = new(676, 403, 202, 527), Index = 1, CanGigantamax = true }, // Butterfree
+        new(50,08,4) { Species = 012, Ability = A4, Moves = new(405, 403, 527, 078), Index = 1 }, // Butterfree
+        new(50,08,4) { Species = 012, Ability = A4, Moves = new(405, 403, 527, 078), Index = 1, CanGigantamax = true }, // Butterfree
+        new(17,01,1,SW) { Species = 012, Ability = A4, Moves = new(405, 060, 016, 078), Index = 1 }, // Butterfree
+        new(17,01,1,SW) { Species = 012, Ability = A4, Moves = new(405, 060, 016, 078), Index = 1, CanGigantamax = true }, // Butterfree
+        new(17,01,1,SW) { Species = 843, Ability = A2, Moves = new(693, 523, 189, 103), Index = 1 }, // Silicobra
+        new(17,01,1,SW) { Species = 843, Ability = A4, Moves = new(693, 523, 189, 103), Index = 1 }, // Silicobra
+        new(17,01,1,SW) { Species = 833, Ability = A2, Moves = new(055, 044, 033, 213), Index = 1 }, // Chewtle
+        new(17,01,1,SW) { Species = 833, Ability = A4, Moves = new(055, 044, 033, 213), Index = 1 }, // Chewtle
+        new(30,03,2,SW) { Species = 012, Ability = A4, Moves = new(405, 403, 081, 079), Index = 1 }, // Butterfree
+        new(30,03,2,SW) { Species = 012, Ability = A4, Moves = new(405, 403, 081, 079), Index = 1, CanGigantamax = true }, // Butterfree
+        new(30,03,2,SW) { Species = 843, Ability = A2, Moves = new(693, 523, 029, 137), Index = 1 }, // Silicobra
+        new(30,03,2,SW) { Species = 843, Ability = A4, Moves = new(693, 523, 029, 137), Index = 1 }, // Silicobra
+        new(30,03,2,SW) { Species = 834, Ability = A2, Moves = new(317, 242, 055, 334), Index = 1 }, // Drednaw
+        new(30,03,2,SW) { Species = 834, Ability = A4, Moves = new(317, 242, 055, 334), Index = 1 }, // Drednaw
+        new(40,05,3,SW) { Species = 844, Ability = A4, Moves = new(693, 529, 407, 424), Index = 1 }, // Sandaconda
+        new(40,05,3,SW) { Species = 844, Ability = A4, Moves = new(693, 529, 407, 424), Index = 1, CanGigantamax = true }, // Sandaconda
+        new(40,05,3,SW) { Species = 834, Ability = A4, Moves = new(157, 534, 034, 317), Index = 1 }, // Drednaw
+        new(40,05,3,SW) { Species = 834, Ability = A4, Moves = new(157, 534, 034, 317), Index = 1, CanGigantamax = true }, // Drednaw
+        new(50,08,4,SW) { Species = 844, Ability = A4, Moves = new(693, 529, 342, 328), Index = 1 }, // Sandaconda
+        new(50,08,4,SW) { Species = 844, Ability = A4, Moves = new(693, 529, 342, 328), Index = 1, CanGigantamax = true }, // Sandaconda
+        new(50,08,4,SW) { Species = 834, Ability = A4, Moves = new(157, 710, 350, 523), Index = 1 }, // Drednaw
+        new(50,08,4,SW) { Species = 834, Ability = A4, Moves = new(157, 710, 350, 523), Index = 1, CanGigantamax = true }, // Drednaw
+        new(60,10,5,SW) { Species = 012, Ability = A4, Moves = new(405, 094, 542, 202), Index = 1 }, // Butterfree
+        new(70,10,5,SW) { Species = 012, Ability = A4, Moves = new(405, 094, 542, 202), Index = 1, CanGigantamax = true }, // Butterfree
+        new(60,10,5,SW) { Species = 844, Ability = A4, Moves = new(693, 529, 342, 328), Index = 1 }, // Sandaconda
+        new(70,10,5,SW) { Species = 844, Ability = A4, Moves = new(693, 529, 342, 328), Index = 1, CanGigantamax = true }, // Sandaconda
+        new(60,10,5,SW) { Species = 834, Ability = A4, Moves = new(157, 710, 317, 334), Index = 1 }, // Drednaw
+        new(70,10,5,SW) { Species = 834, Ability = A4, Moves = new(157, 710, 317, 334), Index = 1, CanGigantamax = true }, // Drednaw
+        new(17,01,1,SH) { Species = 012, Ability = A4, Moves = new(405, 060, 016, 079), Index = 1 }, // Butterfree
+        new(17,01,1,SH) { Species = 012, Ability = A4, Moves = new(405, 060, 016, 079), Index = 1, CanGigantamax = true }, // Butterfree
+        new(17,01,1,SH) { Species = 821, Ability = A2, Moves = new(365, 031, 526, 064), Index = 1 }, // Rookidee
+        new(17,01,1,SH) { Species = 821, Ability = A4, Moves = new(365, 031, 526, 064), Index = 1 }, // Rookidee
+        new(17,01,1,SH) { Species = 850, Ability = A2, Moves = new(044, 172, 450, 693), Index = 1 }, // Sizzlipede
+        new(17,01,1,SH) { Species = 850, Ability = A4, Moves = new(044, 172, 450, 693), Index = 1 }, // Sizzlipede
+        new(30,03,2,SH) { Species = 012, Ability = A4, Moves = new(405, 403, 081, 077), Index = 1 }, // Butterfree
+        new(30,03,2,SH) { Species = 012, Ability = A4, Moves = new(405, 403, 081, 077), Index = 1, CanGigantamax = true }, // Butterfree
+        new(30,03,2,SH) { Species = 822, Ability = A2, Moves = new(365, 263, 179, 468), Index = 1 }, // Corvisquire
+        new(30,03,2,SH) { Species = 822, Ability = A4, Moves = new(365, 263, 179, 468), Index = 1 }, // Corvisquire
+        new(30,03,2,SH) { Species = 851, Ability = A2, Moves = new(172, 242, 450, 257), Index = 1 }, // Centiskorch
+        new(30,03,2,SH) { Species = 851, Ability = A4, Moves = new(172, 242, 450, 257), Index = 1 }, // Centiskorch
+        new(40,05,3,SH) { Species = 823, Ability = A4, Moves = new(065, 211, 034, 103), Index = 1 }, // Corviknight
+        new(40,05,3,SH) { Species = 823, Ability = A4, Moves = new(065, 211, 034, 103), Index = 1, CanGigantamax = true }, // Corviknight
+        new(40,05,3,SH) { Species = 851, Ability = A4, Moves = new(141, 438, 053, 489), Index = 1 }, // Centiskorch
+        new(40,05,3,SH) { Species = 851, Ability = A4, Moves = new(141, 438, 053, 489), Index = 1, CanGigantamax = true }, // Centiskorch
+        new(50,08,4,SH) { Species = 823, Ability = A4, Moves = new(065, 442, 034, 334), Index = 1 }, // Corviknight
+        new(50,08,4,SH) { Species = 823, Ability = A4, Moves = new(065, 442, 034, 334), Index = 1, CanGigantamax = true }, // Corviknight
+        new(50,08,4,SH) { Species = 851, Ability = A4, Moves = new(141, 424, 422, 242), Index = 1 }, // Centiskorch
+        new(50,08,4,SH) { Species = 851, Ability = A4, Moves = new(141, 424, 422, 242), Index = 1, CanGigantamax = true }, // Centiskorch
+        new(60,10,5,SH) { Species = 012, Ability = A4, Moves = new(405, 094, 403, 079), Index = 1 }, // Butterfree
+        new(70,10,5,SH) { Species = 012, Ability = A4, Moves = new(405, 094, 403, 079), Index = 1, CanGigantamax = true }, // Butterfree
+        new(60,10,5,SH) { Species = 823, Ability = A4, Moves = new(413, 442, 249, 103), Index = 1 }, // Corviknight
+        new(70,10,5,SH) { Species = 823, Ability = A4, Moves = new(413, 442, 249, 103), Index = 1, CanGigantamax = true }, // Corviknight
+        new(60,10,5,SH) { Species = 851, Ability = A4, Moves = new(679, 257, 083, 438), Index = 1 }, // Centiskorch
+        new(70,10,5,SH) { Species = 851, Ability = A4, Moves = new(679, 257, 083, 438), Index = 1, CanGigantamax = true }, // Centiskorch
     };
 }

--- a/PKHeX.Core/Legality/Encounters/Data/Encounters8NestDistDLC1.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Encounters8NestDistDLC1.cs
@@ -1,4 +1,4 @@
-﻿using static PKHeX.Core.GameVersion;
+using static PKHeX.Core.GameVersion;
 
 namespace PKHeX.Core;
 
@@ -10,287 +10,287 @@ internal static partial class Encounters8Nest
     /// </summary>
     internal static readonly EncounterStatic8ND[] Dist_DLC1 =
     {
-        new(17,01,1) { Species = 093, Ability = A4, Moves = new[]{ 371, 122, 095, 325 }, Index = 39 }, // Haunter
-        new(17,01,1) { Species = 425, Ability = A4, Moves = new[]{ 016, 506, 310, 371 }, Index = 39 }, // Drifloon
-        new(17,01,1) { Species = 355, Ability = A4, Moves = new[]{ 310, 425, 043, 506 }, Index = 39 }, // Duskull
-        new(17,01,1) { Species = 859, Ability = A4, Moves = new[]{ 372, 313, 260, 044 }, Index = 39 }, // Impidimp
-        new(17,01,1) { Species = 633, Ability = A4, Moves = new[]{ 225, 033, 399, 044 }, Index = 39 }, // Deino
-        new(17,01,1) { Species = 877, Ability = A4, Moves = new[]{ 084, 098, 681, 043 }, Index = 39 }, // Morpeko
-        new(30,03,2) { Species = 094, Ability = A4, Moves = new[]{ 371, 389, 095, 325 }, Index = 39, CanGigantamax = true }, // Gengar
-        new(30,03,2) { Species = 426, Ability = A4, Moves = new[]{ 016, 247, 310, 371 }, Index = 39 }, // Drifblim
-        new(30,03,2) { Species = 355, Ability = A4, Moves = new[]{ 310, 425, 371, 506 }, Index = 39 }, // Duskull
-        new(30,03,2) { Species = 859, Ability = A4, Moves = new[]{ 259, 389, 207, 044 }, Index = 39 }, // Impidimp
-        new(30,03,2) { Species = 633, Ability = A4, Moves = new[]{ 225, 021, 399, 029 }, Index = 39 }, // Deino
-        new(30,03,2) { Species = 877, Ability = A4, Moves = new[]{ 209, 098, 044, 043 }, Index = 39 }, // Morpeko
-        new(40,05,3) { Species = 094, Ability = A4, Moves = new[]{ 506, 389, 095, 325 }, Index = 39, CanGigantamax = true }, // Gengar
-        new(40,05,3) { Species = 426, Ability = A4, Moves = new[]{ 016, 247, 360, 371 }, Index = 39 }, // Drifblim
-        new(40,05,3) { Species = 477, Ability = A4, Moves = new[]{ 247, 009, 371, 157 }, Index = 39 }, // Dusknoir
-        new(40,05,3) { Species = 860, Ability = A4, Moves = new[]{ 417, 793, 421, 399 }, Index = 39 }, // Morgrem
-        new(40,05,3) { Species = 633, Ability = A4, Moves = new[]{ 406, 021, 399, 423 }, Index = 39 }, // Deino
-        new(40,05,3) { Species = 877, Ability = A4, Moves = new[]{ 209, 098, 044, 402 }, Index = 39 }, // Morpeko
-        new(50,08,4) { Species = 094, Ability = A4, Moves = new[]{ 247, 399, 094, 085 }, Index = 39, CanGigantamax = true }, // Gengar
-        new(50,08,4) { Species = 426, Ability = A4, Moves = new[]{ 366, 247, 360, 371 }, Index = 39 }, // Drifblim
-        new(50,08,4) { Species = 477, Ability = A4, Moves = new[]{ 247, 009, 280, 157 }, Index = 39 }, // Dusknoir
-        new(50,08,4) { Species = 861, Ability = A4, Moves = new[]{ 789, 492, 421, 399 }, Index = 39, CanGigantamax = true }, // Grimmsnarl
-        new(50,08,4) { Species = 634, Ability = A4, Moves = new[]{ 406, 304, 399, 423 }, Index = 39 }, // Zweilous
-        new(50,08,4) { Species = 877, Ability = A4, Moves = new[]{ 783, 098, 242, 402 }, Index = 39 }, // Morpeko
-        new(60,10,5) { Species = 094, Ability = A4, Moves = new[]{ 247, 399, 605, 085 }, Index = 39, CanGigantamax = true }, // Gengar
-        new(60,10,5) { Species = 426, Ability = A4, Moves = new[]{ 366, 247, 360, 693 }, Index = 39 }, // Drifblim
-        new(60,10,5) { Species = 477, Ability = A4, Moves = new[]{ 247, 009, 280, 089 }, Index = 39 }, // Dusknoir
-        new(60,10,5) { Species = 861, Ability = A4, Moves = new[]{ 789, 492, 421, 417 }, Index = 39, CanGigantamax = true }, // Grimmsnarl
-        new(60,10,5) { Species = 635, Ability = A4, Moves = new[]{ 406, 304, 399, 056 }, Index = 39 }, // Hydreigon
-        new(60,10,5) { Species = 877, Ability = A4, Moves = new[]{ 783, 037, 242, 402 }, Index = 39 }, // Morpeko
+        new(17,01,1) { Species = 093, Ability = A4, Moves = new(371, 122, 095, 325), Index = 39}, // Haunter
+        new(17,01,1) { Species = 425, Ability = A4, Moves = new(016, 506, 310, 371), Index = 39}, // Drifloon
+        new(17,01,1) { Species = 355, Ability = A4, Moves = new(310, 425, 043, 506), Index = 39}, // Duskull
+        new(17,01,1) { Species = 859, Ability = A4, Moves = new(372, 313, 260, 044), Index = 39}, // Impidimp
+        new(17,01,1) { Species = 633, Ability = A4, Moves = new(225, 033, 399, 044), Index = 39}, // Deino
+        new(17,01,1) { Species = 877, Ability = A4, Moves = new(084, 098, 681, 043), Index = 39}, // Morpeko
+        new(30,03,2) { Species = 094, Ability = A4, Moves = new(371, 389, 095, 325), Index = 39, CanGigantamax = true}, // Gengar
+        new(30,03,2) { Species = 426, Ability = A4, Moves = new(016, 247, 310, 371), Index = 39}, // Drifblim
+        new(30,03,2) { Species = 355, Ability = A4, Moves = new(310, 425, 371, 506), Index = 39}, // Duskull
+        new(30,03,2) { Species = 859, Ability = A4, Moves = new(259, 389, 207, 044), Index = 39}, // Impidimp
+        new(30,03,2) { Species = 633, Ability = A4, Moves = new(225, 021, 399, 029), Index = 39}, // Deino
+        new(30,03,2) { Species = 877, Ability = A4, Moves = new(209, 098, 044, 043), Index = 39}, // Morpeko
+        new(40,05,3) { Species = 094, Ability = A4, Moves = new(506, 389, 095, 325), Index = 39, CanGigantamax = true}, // Gengar
+        new(40,05,3) { Species = 426, Ability = A4, Moves = new(016, 247, 360, 371), Index = 39}, // Drifblim
+        new(40,05,3) { Species = 477, Ability = A4, Moves = new(247, 009, 371, 157), Index = 39}, // Dusknoir
+        new(40,05,3) { Species = 860, Ability = A4, Moves = new(417, 793, 421, 399), Index = 39}, // Morgrem
+        new(40,05,3) { Species = 633, Ability = A4, Moves = new(406, 021, 399, 423), Index = 39}, // Deino
+        new(40,05,3) { Species = 877, Ability = A4, Moves = new(209, 098, 044, 402), Index = 39}, // Morpeko
+        new(50,08,4) { Species = 094, Ability = A4, Moves = new(247, 399, 094, 085), Index = 39, CanGigantamax = true}, // Gengar
+        new(50,08,4) { Species = 426, Ability = A4, Moves = new(366, 247, 360, 371), Index = 39}, // Drifblim
+        new(50,08,4) { Species = 477, Ability = A4, Moves = new(247, 009, 280, 157), Index = 39}, // Dusknoir
+        new(50,08,4) { Species = 861, Ability = A4, Moves = new(789, 492, 421, 399), Index = 39, CanGigantamax = true}, // Grimmsnarl
+        new(50,08,4) { Species = 634, Ability = A4, Moves = new(406, 304, 399, 423), Index = 39}, // Zweilous
+        new(50,08,4) { Species = 877, Ability = A4, Moves = new(783, 098, 242, 402), Index = 39}, // Morpeko
+        new(60,10,5) { Species = 094, Ability = A4, Moves = new(247, 399, 605, 085), Index = 39, CanGigantamax = true}, // Gengar
+        new(60,10,5) { Species = 426, Ability = A4, Moves = new(366, 247, 360, 693), Index = 39}, // Drifblim
+        new(60,10,5) { Species = 477, Ability = A4, Moves = new(247, 009, 280, 089), Index = 39}, // Dusknoir
+        new(60,10,5) { Species = 861, Ability = A4, Moves = new(789, 492, 421, 417), Index = 39, CanGigantamax = true}, // Grimmsnarl
+        new(60,10,5) { Species = 635, Ability = A4, Moves = new(406, 304, 399, 056), Index = 39}, // Hydreigon
+        new(60,10,5) { Species = 877, Ability = A4, Moves = new(783, 037, 242, 402), Index = 39}, // Morpeko
 
-        new(17,01,1) { Species = 036, Ability = A4, Moves = new[]{ 574, 001, 204, 045 }, Index = 37 }, // Clefable
-        new(17,01,1) { Species = 040, Ability = A4, Moves = new[]{ 497, 574, 001, 111 }, Index = 37 }, // Wigglytuff
-        new(17,01,1) { Species = 044, Ability = A4, Moves = new[]{ 078, 079, 230, 051 }, Index = 37 }, // Gloom
-        new(17,01,1) { Species = 518, Ability = A4, Moves = new[]{ 060, 236, 111, 000 }, Index = 37 }, // Musharna
-        new(17,01,1) { Species = 547, Ability = A4, Moves = new[]{ 412, 585, 073, 178 }, Index = 37 }, // Whimsicott
-        new(17,01,1) { Species = 549, Ability = A4, Moves = new[]{ 412, 241, 437, 263 }, Index = 37 }, // Lilligant
-        new(30,03,2) { Species = 036, Ability = A4, Moves = new[]{ 574, 001, 236, 045 }, Index = 37 }, // Clefable
-        new(30,03,2) { Species = 040, Ability = A4, Moves = new[]{ 497, 574, 001, 034 }, Index = 37 }, // Wigglytuff
-        new(30,03,2) { Species = 182, Ability = A4, Moves = new[]{ 585, 572, 236, 051 }, Index = 37 }, // Bellossom
-        new(30,03,2) { Species = 518, Ability = A4, Moves = new[]{ 428, 060, 236, 111 }, Index = 37 }, // Musharna
-        new(30,03,2) { Species = 547, Ability = A4, Moves = new[]{ 412, 585, 073, 178 }, Index = 37 }, // Whimsicott
-        new(30,03,2) { Species = 549, Ability = A4, Moves = new[]{ 412, 241, 437, 263 }, Index = 37 }, // Lilligant
-        new(40,05,3) { Species = 036, Ability = A4, Moves = new[]{ 585, 309, 236, 345 }, Index = 37 }, // Clefable
-        new(40,05,3) { Species = 040, Ability = A4, Moves = new[]{ 304, 583, 360, 034 }, Index = 37 }, // Wigglytuff
-        new(40,05,3) { Species = 182, Ability = A4, Moves = new[]{ 585, 572, 236, 051 }, Index = 37 }, // Bellossom
-        new(40,05,3) { Species = 518, Ability = A4, Moves = new[]{ 585, 094, 236, 360 }, Index = 37 }, // Musharna
-        new(40,05,3) { Species = 547, Ability = A4, Moves = new[]{ 412, 585, 073, 366 }, Index = 37 }, // Whimsicott
-        new(40,05,3) { Species = 549, Ability = A4, Moves = new[]{ 412, 241, 437, 263 }, Index = 37 }, // Lilligant
-        new(50,08,4) { Species = 036, Ability = A4, Moves = new[]{ 585, 309, 236, 345 }, Index = 37 }, // Clefable
-        new(50,08,4) { Species = 040, Ability = A4, Moves = new[]{ 304, 583, 360, 034 }, Index = 37 }, // Wigglytuff
-        new(50,08,4) { Species = 182, Ability = A4, Moves = new[]{ 585, 572, 236, 051 }, Index = 37 }, // Bellossom
-        new(50,08,4) { Species = 518, Ability = A4, Moves = new[]{ 585, 094, 236, 360 }, Index = 37 }, // Musharna
-        new(50,08,4) { Species = 547, Ability = A4, Moves = new[]{ 538, 585, 073, 366 }, Index = 37 }, // Whimsicott
-        new(50,08,4) { Species = 549, Ability = A4, Moves = new[]{ 412, 241, 437, 263 }, Index = 37 }, // Lilligant
-        new(60,10,5) { Species = 036, Ability = A4, Moves = new[]{ 585, 309, 236, 345 }, Index = 37 }, // Clefable
-        new(60,10,5) { Species = 040, Ability = A4, Moves = new[]{ 304, 583, 360, 034 }, Index = 37 }, // Wigglytuff
-        new(60,10,5) { Species = 182, Ability = A4, Moves = new[]{ 585, 572, 236, 051 }, Index = 37 }, // Bellossom
-        new(60,10,5) { Species = 518, Ability = A4, Moves = new[]{ 585, 094, 236, 360 }, Index = 37 }, // Musharna
-        new(60,10,5) { Species = 036, Ability = A4, Moves = new[]{ 585, 309, 236, 345 }, Index = 37, Shiny = Shiny.Always }, // Clefable
-        new(60,10,5) { Species = 549, Ability = A4, Moves = new[]{ 412, 241, 437, 263 }, Index = 37 }, // Lilligant
+        new(17,01,1) { Species = 036, Ability = A4, Moves = new(574, 001, 204, 045), Index = 37}, // Clefable
+        new(17,01,1) { Species = 040, Ability = A4, Moves = new(497, 574, 001, 111), Index = 37}, // Wigglytuff
+        new(17,01,1) { Species = 044, Ability = A4, Moves = new(078, 079, 230, 051), Index = 37}, // Gloom
+        new(17,01,1) { Species = 518, Ability = A4, Moves = new(060, 236, 111, 000), Index = 37}, // Musharna
+        new(17,01,1) { Species = 547, Ability = A4, Moves = new(412, 585, 073, 178), Index = 37}, // Whimsicott
+        new(17,01,1) { Species = 549, Ability = A4, Moves = new(412, 241, 437, 263), Index = 37}, // Lilligant
+        new(30,03,2) { Species = 036, Ability = A4, Moves = new(574, 001, 236, 045), Index = 37}, // Clefable
+        new(30,03,2) { Species = 040, Ability = A4, Moves = new(497, 574, 001, 034), Index = 37}, // Wigglytuff
+        new(30,03,2) { Species = 182, Ability = A4, Moves = new(585, 572, 236, 051), Index = 37}, // Bellossom
+        new(30,03,2) { Species = 518, Ability = A4, Moves = new(428, 060, 236, 111), Index = 37}, // Musharna
+        new(30,03,2) { Species = 547, Ability = A4, Moves = new(412, 585, 073, 178), Index = 37}, // Whimsicott
+        new(30,03,2) { Species = 549, Ability = A4, Moves = new(412, 241, 437, 263), Index = 37}, // Lilligant
+        new(40,05,3) { Species = 036, Ability = A4, Moves = new(585, 309, 236, 345), Index = 37}, // Clefable
+        new(40,05,3) { Species = 040, Ability = A4, Moves = new(304, 583, 360, 034), Index = 37}, // Wigglytuff
+        new(40,05,3) { Species = 182, Ability = A4, Moves = new(585, 572, 236, 051), Index = 37}, // Bellossom
+        new(40,05,3) { Species = 518, Ability = A4, Moves = new(585, 094, 236, 360), Index = 37}, // Musharna
+        new(40,05,3) { Species = 547, Ability = A4, Moves = new(412, 585, 073, 366), Index = 37}, // Whimsicott
+        new(40,05,3) { Species = 549, Ability = A4, Moves = new(412, 241, 437, 263), Index = 37}, // Lilligant
+        new(50,08,4) { Species = 036, Ability = A4, Moves = new(585, 309, 236, 345), Index = 37}, // Clefable
+        new(50,08,4) { Species = 040, Ability = A4, Moves = new(304, 583, 360, 034), Index = 37}, // Wigglytuff
+        new(50,08,4) { Species = 182, Ability = A4, Moves = new(585, 572, 236, 051), Index = 37}, // Bellossom
+        new(50,08,4) { Species = 518, Ability = A4, Moves = new(585, 094, 236, 360), Index = 37}, // Musharna
+        new(50,08,4) { Species = 547, Ability = A4, Moves = new(538, 585, 073, 366), Index = 37}, // Whimsicott
+        new(50,08,4) { Species = 549, Ability = A4, Moves = new(412, 241, 437, 263), Index = 37}, // Lilligant
+        new(60,10,5) { Species = 036, Ability = A4, Moves = new(585, 309, 236, 345), Index = 37}, // Clefable
+        new(60,10,5) { Species = 040, Ability = A4, Moves = new(304, 583, 360, 034), Index = 37}, // Wigglytuff
+        new(60,10,5) { Species = 182, Ability = A4, Moves = new(585, 572, 236, 051), Index = 37}, // Bellossom
+        new(60,10,5) { Species = 518, Ability = A4, Moves = new(585, 094, 236, 360), Index = 37}, // Musharna
+        new(60,10,5) { Species = 036, Ability = A4, Moves = new(585, 309, 236, 345), Index = 37, Shiny = Shiny.Always}, // Clefable
+        new(60,10,5) { Species = 549, Ability = A4, Moves = new(412, 241, 437, 263), Index = 37}, // Lilligant
 
-        new(17,01,1) { Species = 848, Ability = A4, Moves = new[]{ 609, 051, 496, 715 }, Index = 36 }, // Toxel
-        new(17,01,1) { Species = 835, Ability = A4, Moves = new[]{ 609, 033, 044, 046 }, Index = 36 }, // Yamper
-        new(17,01,1) { Species = 695, Ability = A4, Moves = new[]{ 085, 098, 001, 189 }, Index = 36 }, // Heliolisk
-        new(17,01,1) { Species = 840, Ability = A4, Moves = new[]{ 110, 310, 000, 000 }, Index = 36 }, // Applin
-        new(17,01,1) { Species = 597, Ability = A4, Moves = new[]{ 033, 042, 232, 106 }, Index = 36 }, // Ferroseed
-        new(17,01,1) { Species = 829, Ability = A4, Moves = new[]{ 075, 496, 229, 670 }, Index = 36 }, // Gossifleur
-        new(30,03,2) { Species = 836, Ability = A4, Moves = new[]{ 609, 209, 204, 706 }, Index = 36 }, // Boltund
-        new(30,03,2) { Species = 695, Ability = A4, Moves = new[]{ 085, 098, 001, 189 }, Index = 36 }, // Heliolisk
-        new(30,03,2) { Species = 597, Ability = A4, Moves = new[]{ 442, 042, 232, 106 }, Index = 36 }, // Ferroseed
-        new(30,03,2) { Species = 830, Ability = A4, Moves = new[]{ 536, 496, 229, 670 }, Index = 36 }, // Eldegoss
-        new(40,05,3) { Species = 836, Ability = A4, Moves = new[]{ 609, 209, 424, 706 }, Index = 36 }, // Boltund
-        new(40,05,3) { Species = 695, Ability = A4, Moves = new[]{ 085, 098, 447, 189 }, Index = 36 }, // Heliolisk
-        new(40,05,3) { Species = 598, Ability = A4, Moves = new[]{ 442, 438, 398, 106 }, Index = 36 }, // Ferrothorn
-        new(40,05,3) { Species = 830, Ability = A4, Moves = new[]{ 536, 304, 229, 670 }, Index = 36 }, // Eldegoss
-        new(50,08,4) { Species = 836, Ability = A4, Moves = new[]{ 609, 528, 424, 706 }, Index = 36 }, // Boltund
-        new(50,08,4) { Species = 695, Ability = A4, Moves = new[]{ 085, 304, 447, 523 }, Index = 36 }, // Heliolisk
-        new(50,08,4) { Species = 598, Ability = A4, Moves = new[]{ 360, 438, 398, 014 }, Index = 36 }, // Ferrothorn
-        new(50,08,4) { Species = 830, Ability = A4, Moves = new[]{ 536, 304, 229, 437 }, Index = 36 }, // Eldegoss
-        new(60,10,5) { Species = 836, Ability = A4, Moves = new[]{ 609, 528, 424, 706 }, Index = 36 }, // Boltund
-        new(60,10,5) { Species = 695, Ability = A4, Moves = new[]{ 085, 304, 447, 523 }, Index = 36 }, // Heliolisk
-        new(60,10,5) { Species = 598, Ability = A4, Moves = new[]{ 360, 438, 398, 014 }, Index = 36 }, // Ferrothorn
-        new(60,10,5) { Species = 830, Ability = A4, Moves = new[]{ 536, 304, 063, 437 }, Index = 36 }, // Eldegoss
-        new(30,03,2,SW) { Species = 849, Ability = A4, Moves = new[]{ 351, 506, 491, 103 }, Index = 36, Form = 1, CanGigantamax = true }, // Toxtricity-1
-        new(30,03,2,SW) { Species = 842, Ability = A4, Moves = new[]{ 787, 496, 310, 029 }, Index = 36, CanGigantamax = true }, // Appletun
-        new(40,05,3,SW) { Species = 849, Ability = A4, Moves = new[]{ 435, 506, 398, 103 }, Index = 36, Form = 1, CanGigantamax = true }, // Toxtricity-1
-        new(40,05,3,SW) { Species = 842, Ability = A4, Moves = new[]{ 787, 496, 406, 029 }, Index = 36, CanGigantamax = true }, // Appletun
-        new(50,08,4,SW) { Species = 849, Ability = A4, Moves = new[]{ 786, 506, 398, 586 }, Index = 36, Form = 1, CanGigantamax = true }, // Toxtricity-1
-        new(50,08,4,SW) { Species = 842, Ability = A4, Moves = new[]{ 787, 496, 406, 523 }, Index = 36, CanGigantamax = true }, // Appletun
-        new(60,10,5,SW) { Species = 849, Ability = A4, Moves = new[]{ 786, 506, 599, 586 }, Index = 36, Form = 1, CanGigantamax = true }, // Toxtricity-1
-        new(60,10,5,SW) { Species = 842, Ability = A4, Moves = new[]{ 787, 034, 406, 523 }, Index = 36, CanGigantamax = true }, // Appletun
-        new(30,03,2,SH) { Species = 849, Ability = A4, Moves = new[]{ 351, 506, 491, 103 }, Index = 36, CanGigantamax = true }, // Toxtricity
-        new(30,03,2,SH) { Species = 841, Ability = A4, Moves = new[]{ 406, 073, 491, 184 }, Index = 36, CanGigantamax = true }, // Flapple
-        new(40,05,3,SH) { Species = 849, Ability = A4, Moves = new[]{ 435, 506, 474, 103 }, Index = 36, CanGigantamax = true }, // Toxtricity
-        new(40,05,3,SH) { Species = 841, Ability = A4, Moves = new[]{ 406, 788, 491, 184 }, Index = 36, CanGigantamax = true }, // Flapple
-        new(50,08,4,SH) { Species = 849, Ability = A4, Moves = new[]{ 786, 506, 474, 586 }, Index = 36, CanGigantamax = true }, // Toxtricity
-        new(50,08,4,SH) { Species = 841, Ability = A4, Moves = new[]{ 406, 788, 491, 263 }, Index = 36, CanGigantamax = true }, // Flapple
-        new(60,10,5,SH) { Species = 849, Ability = A4, Moves = new[]{ 786, 506, 474, 586 }, Index = 36, CanGigantamax = true }, // Toxtricity
-        new(60,10,5,SH) { Species = 841, Ability = A4, Moves = new[]{ 406, 788, 491, 263 }, Index = 36, CanGigantamax = true }, // Flapple
+        new(17,01,1) { Species = 848, Ability = A4, Moves = new(609, 051, 496, 715), Index = 36}, // Toxel
+        new(17,01,1) { Species = 835, Ability = A4, Moves = new(609, 033, 044, 046), Index = 36}, // Yamper
+        new(17,01,1) { Species = 695, Ability = A4, Moves = new(085, 098, 001, 189), Index = 36}, // Heliolisk
+        new(17,01,1) { Species = 840, Ability = A4, Moves = new(110, 310, 000, 000), Index = 36}, // Applin
+        new(17,01,1) { Species = 597, Ability = A4, Moves = new(033, 042, 232, 106), Index = 36}, // Ferroseed
+        new(17,01,1) { Species = 829, Ability = A4, Moves = new(075, 496, 229, 670), Index = 36}, // Gossifleur
+        new(30,03,2) { Species = 836, Ability = A4, Moves = new(609, 209, 204, 706), Index = 36}, // Boltund
+        new(30,03,2) { Species = 695, Ability = A4, Moves = new(085, 098, 001, 189), Index = 36}, // Heliolisk
+        new(30,03,2) { Species = 597, Ability = A4, Moves = new(442, 042, 232, 106), Index = 36}, // Ferroseed
+        new(30,03,2) { Species = 830, Ability = A4, Moves = new(536, 496, 229, 670), Index = 36}, // Eldegoss
+        new(40,05,3) { Species = 836, Ability = A4, Moves = new(609, 209, 424, 706), Index = 36}, // Boltund
+        new(40,05,3) { Species = 695, Ability = A4, Moves = new(085, 098, 447, 189), Index = 36}, // Heliolisk
+        new(40,05,3) { Species = 598, Ability = A4, Moves = new(442, 438, 398, 106), Index = 36}, // Ferrothorn
+        new(40,05,3) { Species = 830, Ability = A4, Moves = new(536, 304, 229, 670), Index = 36}, // Eldegoss
+        new(50,08,4) { Species = 836, Ability = A4, Moves = new(609, 528, 424, 706), Index = 36}, // Boltund
+        new(50,08,4) { Species = 695, Ability = A4, Moves = new(085, 304, 447, 523), Index = 36}, // Heliolisk
+        new(50,08,4) { Species = 598, Ability = A4, Moves = new(360, 438, 398, 014), Index = 36}, // Ferrothorn
+        new(50,08,4) { Species = 830, Ability = A4, Moves = new(536, 304, 229, 437), Index = 36}, // Eldegoss
+        new(60,10,5) { Species = 836, Ability = A4, Moves = new(609, 528, 424, 706), Index = 36}, // Boltund
+        new(60,10,5) { Species = 695, Ability = A4, Moves = new(085, 304, 447, 523), Index = 36}, // Heliolisk
+        new(60,10,5) { Species = 598, Ability = A4, Moves = new(360, 438, 398, 014), Index = 36}, // Ferrothorn
+        new(60,10,5) { Species = 830, Ability = A4, Moves = new(536, 304, 063, 437), Index = 36}, // Eldegoss
+        new(30,03,2,SW) { Species = 849, Ability = A4, Moves = new(351, 506, 491, 103), Index = 36, Form = 1, CanGigantamax = true}, // Toxtricity-1
+        new(30,03,2,SW) { Species = 842, Ability = A4, Moves = new(787, 496, 310, 029), Index = 36, CanGigantamax = true}, // Appletun
+        new(40,05,3,SW) { Species = 849, Ability = A4, Moves = new(435, 506, 398, 103), Index = 36, Form = 1, CanGigantamax = true}, // Toxtricity-1
+        new(40,05,3,SW) { Species = 842, Ability = A4, Moves = new(787, 496, 406, 029), Index = 36, CanGigantamax = true}, // Appletun
+        new(50,08,4,SW) { Species = 849, Ability = A4, Moves = new(786, 506, 398, 586), Index = 36, Form = 1, CanGigantamax = true}, // Toxtricity-1
+        new(50,08,4,SW) { Species = 842, Ability = A4, Moves = new(787, 496, 406, 523), Index = 36, CanGigantamax = true}, // Appletun
+        new(60,10,5,SW) { Species = 849, Ability = A4, Moves = new(786, 506, 599, 586), Index = 36, Form = 1, CanGigantamax = true}, // Toxtricity-1
+        new(60,10,5,SW) { Species = 842, Ability = A4, Moves = new(787, 034, 406, 523), Index = 36, CanGigantamax = true}, // Appletun
+        new(30,03,2,SH) { Species = 849, Ability = A4, Moves = new(351, 506, 491, 103), Index = 36, CanGigantamax = true}, // Toxtricity
+        new(30,03,2,SH) { Species = 841, Ability = A4, Moves = new(406, 073, 491, 184), Index = 36, CanGigantamax = true}, // Flapple
+        new(40,05,3,SH) { Species = 849, Ability = A4, Moves = new(435, 506, 474, 103), Index = 36, CanGigantamax = true}, // Toxtricity
+        new(40,05,3,SH) { Species = 841, Ability = A4, Moves = new(406, 788, 491, 184), Index = 36, CanGigantamax = true}, // Flapple
+        new(50,08,4,SH) { Species = 849, Ability = A4, Moves = new(786, 506, 474, 586), Index = 36, CanGigantamax = true}, // Toxtricity
+        new(50,08,4,SH) { Species = 841, Ability = A4, Moves = new(406, 788, 491, 263), Index = 36, CanGigantamax = true}, // Flapple
+        new(60,10,5,SH) { Species = 849, Ability = A4, Moves = new(786, 506, 474, 586), Index = 36, CanGigantamax = true}, // Toxtricity
+        new(60,10,5,SH) { Species = 841, Ability = A4, Moves = new(406, 788, 491, 263), Index = 36, CanGigantamax = true}, // Flapple
 
-        new(17,01,1) { Species = 025, Ability = A4, Moves = new[]{ 084, 098, 204, 086 }, Index = 34 }, // Pikachu
-        new(17,01,1) { Species = 026, Ability = A4, Moves = new[]{ 009, 129, 280, 204 }, Index = 34 }, // Raichu
-        new(17,01,1) { Species = 026, Ability = A4, Moves = new[]{ 009, 129, 280, 204 }, Index = 34, Form = 1 }, // Raichu-1
-        new(17,01,1) { Species = 172, Ability = A4, Moves = new[]{ 589, 609, 085, 186 }, Index = 34 }, // Pichu
-        new(17,01,1) { Species = 778, Ability = A4, Moves = new[]{ 086, 452, 425, 010 }, Index = 34 }, // Mimikyu
-        new(30,03,2) { Species = 025, Ability = A4, Moves = new[]{ 209, 097, 204, 086 }, Index = 34 }, // Pikachu
-        new(30,03,2) { Species = 026, Ability = A4, Moves = new[]{ 009, 129, 280, 204 }, Index = 34 }, // Raichu
-        new(30,03,2) { Species = 026, Ability = A4, Moves = new[]{ 009, 129, 280, 204 }, Index = 34, Form = 1 }, // Raichu-1
-        new(30,03,2) { Species = 172, Ability = A4, Moves = new[]{ 204, 609, 085, 186 }, Index = 34 }, // Pichu
-        new(30,03,2) { Species = 778, Ability = A4, Moves = new[]{ 086, 452, 425, 608 }, Index = 34 }, // Mimikyu
-        new(40,05,3) { Species = 025, Ability = A4, Moves = new[]{ 085, 231, 583, 086 }, Index = 34 }, // Pikachu
-        new(40,05,3) { Species = 026, Ability = A4, Moves = new[]{ 085, 034, 411, 583 }, Index = 34 }, // Raichu
-        new(40,05,3) { Species = 026, Ability = A4, Moves = new[]{ 085, 034, 057, 583 }, Index = 34, Form = 1 }, // Raichu-1
-        new(40,05,3) { Species = 172, Ability = A4, Moves = new[]{ 204, 609, 085, 583 }, Index = 34 }, // Pichu
-        new(40,05,3) { Species = 778, Ability = A4, Moves = new[]{ 085, 452, 421, 608 }, Index = 34 }, // Mimikyu
-        new(50,08,4) { Species = 025, Ability = A4, Moves = new[]{ 087, 231, 583, 086 }, Index = 34 }, // Pikachu
-        new(50,08,4) { Species = 026, Ability = A4, Moves = new[]{ 087, 034, 411, 583 }, Index = 34 }, // Raichu
-        new(50,08,4) { Species = 026, Ability = A4, Moves = new[]{ 087, 034, 057, 583 }, Index = 34, Form = 1 }, // Raichu-1
-        new(50,08,4) { Species = 172, Ability = A4, Moves = new[]{ 253, 609, 085, 583 }, Index = 34 }, // Pichu
-        new(50,08,4) { Species = 778, Ability = A4, Moves = new[]{ 085, 452, 261, 204 }, Index = 34 }, // Mimikyu
-        new(60,10,5) { Species = 025, Ability = A4, Moves = new[]{ 344, 231, 583, 086 }, Index = 34 }, // Pikachu
-        new(60,10,5) { Species = 025, Ability = A4, Moves = new[]{ 344, 231, 583, 086 }, Index = 34, Shiny = Shiny.Always }, // Pikachu
-        new(60,10,5) { Species = 026, Ability = A4, Moves = new[]{ 087, 034, 411, 583 }, Index = 34 }, // Raichu
-        new(60,10,5) { Species = 026, Ability = A4, Moves = new[]{ 087, 034, 057, 583 }, Index = 34, Form = 1 }, // Raichu-1
-        new(60,10,5) { Species = 172, Ability = A4, Moves = new[]{ 253, 609, 085, 583 }, Index = 34 }, // Pichu
-        new(60,10,5) { Species = 778, Ability = A4, Moves = new[]{ 087, 452, 261, 583 }, Index = 34 }, // Mimikyu
+        new(17,01,1) { Species = 025, Ability = A4, Moves = new(084, 098, 204, 086), Index = 34}, // Pikachu
+        new(17,01,1) { Species = 026, Ability = A4, Moves = new(009, 129, 280, 204), Index = 34}, // Raichu
+        new(17,01,1) { Species = 026, Ability = A4, Moves = new(009, 129, 280, 204), Index = 34, Form = 1}, // Raichu-1
+        new(17,01,1) { Species = 172, Ability = A4, Moves = new(589, 609, 085, 186), Index = 34}, // Pichu
+        new(17,01,1) { Species = 778, Ability = A4, Moves = new(086, 452, 425, 010), Index = 34}, // Mimikyu
+        new(30,03,2) { Species = 025, Ability = A4, Moves = new(209, 097, 204, 086), Index = 34}, // Pikachu
+        new(30,03,2) { Species = 026, Ability = A4, Moves = new(009, 129, 280, 204), Index = 34}, // Raichu
+        new(30,03,2) { Species = 026, Ability = A4, Moves = new(009, 129, 280, 204), Index = 34, Form = 1}, // Raichu-1
+        new(30,03,2) { Species = 172, Ability = A4, Moves = new(204, 609, 085, 186), Index = 34}, // Pichu
+        new(30,03,2) { Species = 778, Ability = A4, Moves = new(086, 452, 425, 608), Index = 34}, // Mimikyu
+        new(40,05,3) { Species = 025, Ability = A4, Moves = new(085, 231, 583, 086), Index = 34}, // Pikachu
+        new(40,05,3) { Species = 026, Ability = A4, Moves = new(085, 034, 411, 583), Index = 34}, // Raichu
+        new(40,05,3) { Species = 026, Ability = A4, Moves = new(085, 034, 057, 583), Index = 34, Form = 1}, // Raichu-1
+        new(40,05,3) { Species = 172, Ability = A4, Moves = new(204, 609, 085, 583), Index = 34}, // Pichu
+        new(40,05,3) { Species = 778, Ability = A4, Moves = new(085, 452, 421, 608), Index = 34}, // Mimikyu
+        new(50,08,4) { Species = 025, Ability = A4, Moves = new(087, 231, 583, 086), Index = 34}, // Pikachu
+        new(50,08,4) { Species = 026, Ability = A4, Moves = new(087, 034, 411, 583), Index = 34}, // Raichu
+        new(50,08,4) { Species = 026, Ability = A4, Moves = new(087, 034, 057, 583), Index = 34, Form = 1}, // Raichu-1
+        new(50,08,4) { Species = 172, Ability = A4, Moves = new(253, 609, 085, 583), Index = 34}, // Pichu
+        new(50,08,4) { Species = 778, Ability = A4, Moves = new(085, 452, 261, 204), Index = 34}, // Mimikyu
+        new(60,10,5) { Species = 025, Ability = A4, Moves = new(344, 231, 583, 086), Index = 34}, // Pikachu
+        new(60,10,5) { Species = 025, Ability = A4, Moves = new(344, 231, 583, 086), Index = 34, Shiny = Shiny.Always}, // Pikachu
+        new(60,10,5) { Species = 026, Ability = A4, Moves = new(087, 034, 411, 583), Index = 34}, // Raichu
+        new(60,10,5) { Species = 026, Ability = A4, Moves = new(087, 034, 057, 583), Index = 34, Form = 1}, // Raichu-1
+        new(60,10,5) { Species = 172, Ability = A4, Moves = new(253, 609, 085, 583), Index = 34}, // Pichu
+        new(60,10,5) { Species = 778, Ability = A4, Moves = new(087, 452, 261, 583), Index = 34}, // Mimikyu
 
-        new(17,01,1) { Species = 833, Ability = A4, Moves = new[]{ 055, 033, 044, 240 }, Index = 33 }, // Chewtle
-        new(17,01,1) { Species = 349, Ability = A4, Moves = new[]{ 150, 033, 175, 057 }, Index = 33 }, // Feebas
-        new(17,01,1) { Species = 194, Ability = A4, Moves = new[]{ 341, 021, 039, 055 }, Index = 33 }, // Wooper
-        new(17,01,1) { Species = 843, Ability = A4, Moves = new[]{ 028, 035, 523, 693 }, Index = 33 }, // Silicobra
-        new(17,01,1) { Species = 449, Ability = A4, Moves = new[]{ 341, 328, 044, 033 }, Index = 33 }, // Hippopotas
-        new(17,01,1) { Species = 422, Ability = A4, Moves = new[]{ 352, 106, 189, 055 }, Index = 33, Form = 1 }, // Shellos-1
-        new(30,03,2) { Species = 834, Ability = A4, Moves = new[]{ 157, 534, 317, 055 }, Index = 33, CanGigantamax = true }, // Drednaw
-        new(30,03,2) { Species = 349, Ability = A4, Moves = new[]{ 057, 033, 175, 150 }, Index = 33 }, // Feebas
-        new(30,03,2) { Species = 195, Ability = A4, Moves = new[]{ 341, 021, 401, 055 }, Index = 33 }, // Quagsire
-        new(30,03,2) { Species = 843, Ability = A4, Moves = new[]{ 091, 029, 523, 693 }, Index = 33 }, // Silicobra
-        new(30,03,2) { Species = 449, Ability = A4, Moves = new[]{ 341, 036, 044, 242 }, Index = 33 }, // Hippopotas
-        new(30,03,2) { Species = 423, Ability = A4, Moves = new[]{ 189, 352, 246, 106 }, Index = 33, Form = 1 }, // Gastrodon-1
-        new(40,05,3) { Species = 834, Ability = A4, Moves = new[]{ 157, 534, 317, 055 }, Index = 33, CanGigantamax = true }, // Drednaw
-        new(40,05,3) { Species = 350, Ability = A4, Moves = new[]{ 057, 239, 034, 574 }, Index = 33 }, // Milotic
-        new(40,05,3) { Species = 195, Ability = A4, Moves = new[]{ 341, 021, 401, 005 }, Index = 33 }, // Quagsire
-        new(40,05,3) { Species = 844, Ability = A4, Moves = new[]{ 693, 523, 201, 091 }, Index = 33, CanGigantamax = true }, // Sandaconda
-        new(40,05,3) { Species = 450, Ability = A4, Moves = new[]{ 341, 422, 036, 242 }, Index = 33 }, // Hippowdon
-        new(40,05,3) { Species = 423, Ability = A4, Moves = new[]{ 414, 352, 246, 106 }, Index = 33, Form = 1 }, // Gastrodon-1
-        new(50,08,4) { Species = 834, Ability = A4, Moves = new[]{ 157, 710, 317, 334 }, Index = 33, CanGigantamax = true }, // Drednaw
-        new(50,08,4) { Species = 350, Ability = A4, Moves = new[]{ 057, 231, 034, 574 }, Index = 33 }, // Milotic
-        new(50,08,4) { Species = 195, Ability = A4, Moves = new[]{ 341, 280, 401, 005 }, Index = 33 }, // Quagsire
-        new(50,08,4) { Species = 844, Ability = A4, Moves = new[]{ 693, 529, 201, 091 }, Index = 33, CanGigantamax = true }, // Sandaconda
-        new(50,08,4) { Species = 450, Ability = A4, Moves = new[]{ 089, 422, 036, 242 }, Index = 33 }, // Hippowdon
-        new(50,08,4) { Species = 423, Ability = A4, Moves = new[]{ 414, 503, 311, 106 }, Index = 33, Form = 1 }, // Gastrodon-1
-        new(60,10,5) { Species = 834, Ability = A4, Moves = new[]{ 157, 710, 317, 334 }, Index = 33, CanGigantamax = true }, // Drednaw
-        new(60,10,5) { Species = 350, Ability = A4, Moves = new[]{ 503, 231, 034, 574 }, Index = 33 }, // Milotic
-        new(60,10,5) { Species = 195, Ability = A4, Moves = new[]{ 089, 280, 401, 005 }, Index = 33 }, // Quagsire
-        new(60,10,5) { Species = 844, Ability = A4, Moves = new[]{ 693, 529, 201, 091 }, Index = 33, CanGigantamax = true }, // Sandaconda
-        new(60,10,5) { Species = 450, Ability = A4, Moves = new[]{ 089, 422, 231, 242 }, Index = 33 }, // Hippowdon
-        new(60,10,5) { Species = 423, Ability = A4, Moves = new[]{ 414, 503, 311, 352 }, Index = 33, Form = 1 }, // Gastrodon-1
+        new(17,01,1) { Species = 833, Ability = A4, Moves = new(055, 033, 044, 240), Index = 33}, // Chewtle
+        new(17,01,1) { Species = 349, Ability = A4, Moves = new(150, 033, 175, 057), Index = 33}, // Feebas
+        new(17,01,1) { Species = 194, Ability = A4, Moves = new(341, 021, 039, 055), Index = 33}, // Wooper
+        new(17,01,1) { Species = 843, Ability = A4, Moves = new(028, 035, 523, 693), Index = 33}, // Silicobra
+        new(17,01,1) { Species = 449, Ability = A4, Moves = new(341, 328, 044, 033), Index = 33}, // Hippopotas
+        new(17,01,1) { Species = 422, Ability = A4, Moves = new(352, 106, 189, 055), Index = 33, Form = 1}, // Shellos-1
+        new(30,03,2) { Species = 834, Ability = A4, Moves = new(157, 534, 317, 055), Index = 33, CanGigantamax = true}, // Drednaw
+        new(30,03,2) { Species = 349, Ability = A4, Moves = new(057, 033, 175, 150), Index = 33}, // Feebas
+        new(30,03,2) { Species = 195, Ability = A4, Moves = new(341, 021, 401, 055), Index = 33}, // Quagsire
+        new(30,03,2) { Species = 843, Ability = A4, Moves = new(091, 029, 523, 693), Index = 33}, // Silicobra
+        new(30,03,2) { Species = 449, Ability = A4, Moves = new(341, 036, 044, 242), Index = 33}, // Hippopotas
+        new(30,03,2) { Species = 423, Ability = A4, Moves = new(189, 352, 246, 106), Index = 33, Form = 1}, // Gastrodon-1
+        new(40,05,3) { Species = 834, Ability = A4, Moves = new(157, 534, 317, 055), Index = 33, CanGigantamax = true}, // Drednaw
+        new(40,05,3) { Species = 350, Ability = A4, Moves = new(057, 239, 034, 574), Index = 33}, // Milotic
+        new(40,05,3) { Species = 195, Ability = A4, Moves = new(341, 021, 401, 005), Index = 33}, // Quagsire
+        new(40,05,3) { Species = 844, Ability = A4, Moves = new(693, 523, 201, 091), Index = 33, CanGigantamax = true}, // Sandaconda
+        new(40,05,3) { Species = 450, Ability = A4, Moves = new(341, 422, 036, 242), Index = 33}, // Hippowdon
+        new(40,05,3) { Species = 423, Ability = A4, Moves = new(414, 352, 246, 106), Index = 33, Form = 1}, // Gastrodon-1
+        new(50,08,4) { Species = 834, Ability = A4, Moves = new(157, 710, 317, 334), Index = 33, CanGigantamax = true}, // Drednaw
+        new(50,08,4) { Species = 350, Ability = A4, Moves = new(057, 231, 034, 574), Index = 33}, // Milotic
+        new(50,08,4) { Species = 195, Ability = A4, Moves = new(341, 280, 401, 005), Index = 33}, // Quagsire
+        new(50,08,4) { Species = 844, Ability = A4, Moves = new(693, 529, 201, 091), Index = 33, CanGigantamax = true}, // Sandaconda
+        new(50,08,4) { Species = 450, Ability = A4, Moves = new(089, 422, 036, 242), Index = 33}, // Hippowdon
+        new(50,08,4) { Species = 423, Ability = A4, Moves = new(414, 503, 311, 106), Index = 33, Form = 1}, // Gastrodon-1
+        new(60,10,5) { Species = 834, Ability = A4, Moves = new(157, 710, 317, 334), Index = 33, CanGigantamax = true}, // Drednaw
+        new(60,10,5) { Species = 350, Ability = A4, Moves = new(503, 231, 034, 574), Index = 33}, // Milotic
+        new(60,10,5) { Species = 195, Ability = A4, Moves = new(089, 280, 401, 005), Index = 33}, // Quagsire
+        new(60,10,5) { Species = 844, Ability = A4, Moves = new(693, 529, 201, 091), Index = 33, CanGigantamax = true}, // Sandaconda
+        new(60,10,5) { Species = 450, Ability = A4, Moves = new(089, 422, 231, 242), Index = 33}, // Hippowdon
+        new(60,10,5) { Species = 423, Ability = A4, Moves = new(414, 503, 311, 352), Index = 33, Form = 1}, // Gastrodon-1
 
-        new(17,01,1) { Species = 320, Ability = A4, Moves = new[]{ 362, 034, 310, 054 }, Index = 31 }, // Wailmer
-        new(17,01,1) { Species = 098, Ability = A4, Moves = new[]{ 055, 341, 043, 232 }, Index = 31 }, // Krabby
-        new(17,01,1) { Species = 771, Ability = A4, Moves = new[]{ 240, 219, 213, 269 }, Index = 31 }, // Pyukumuku
-        new(17,01,1) { Species = 592, Ability = A4, Moves = new[]{ 352, 101, 071, 240 }, Index = 31 }, // Frillish
-        new(17,01,1) { Species = 458, Ability = A4, Moves = new[]{ 033, 017, 352, 469 }, Index = 31 }, // Mantyke
-        new(17,01,1) { Species = 318, Ability = A4, Moves = new[]{ 453, 305, 116, 044 }, Index = 31 }, // Carvanha
-        new(30,03,2) { Species = 320, Ability = A4, Moves = new[]{ 362, 034, 310, 054 }, Index = 31 }, // Wailmer
-        new(30,03,2) { Species = 098, Ability = A4, Moves = new[]{ 061, 341, 023, 232 }, Index = 31 }, // Krabby
-        new(30,03,2) { Species = 771, Ability = A4, Moves = new[]{ 240, 219, 213, 174 }, Index = 31 }, // Pyukumuku
-        new(30,03,2) { Species = 592, Ability = A4, Moves = new[]{ 362, 101, 071, 240 }, Index = 31 }, // Frillish
-        new(30,03,2) { Species = 458, Ability = A4, Moves = new[]{ 029, 017, 061, 469 }, Index = 31 }, // Mantyke
-        new(30,03,2) { Species = 319, Ability = A4, Moves = new[]{ 453, 400, 423, 044 }, Index = 31 }, // Sharpedo
-        new(40,05,3) { Species = 321, Ability = A4, Moves = new[]{ 362, 034, 340, 568 }, Index = 31 }, // Wailord
-        new(40,05,3) { Species = 099, Ability = A4, Moves = new[]{ 534, 341, 021, 014 }, Index = 31 }, // Kingler
-        new(40,05,3) { Species = 771, Ability = A4, Moves = new[]{ 240, 219, 213, 174 }, Index = 31 }, // Pyukumuku
-        new(40,05,3) { Species = 593, Ability = A4, Moves = new[]{ 362, 247, 071, 151 }, Index = 31 }, // Jellicent
-        new(40,05,3) { Species = 226, Ability = A4, Moves = new[]{ 029, 403, 060, 331 }, Index = 31 }, // Mantine
-        new(40,05,3) { Species = 319, Ability = A4, Moves = new[]{ 453, 242, 423, 044 }, Index = 31 }, // Sharpedo
-        new(50,08,4) { Species = 321, Ability = A4, Moves = new[]{ 056, 034, 340, 133 }, Index = 31 }, // Wailord
-        new(50,08,4) { Species = 099, Ability = A4, Moves = new[]{ 534, 341, 359, 014 }, Index = 31, CanGigantamax = true }, // Kingler
-        new(50,08,4) { Species = 771, Ability = A4, Moves = new[]{ 240, 219, 213, 174 }, Index = 31 }, // Pyukumuku
-        new(50,08,4) { Species = 593, Ability = A4, Moves = new[]{ 056, 247, 071, 151 }, Index = 31 }, // Jellicent
-        new(50,08,4) { Species = 226, Ability = A4, Moves = new[]{ 036, 403, 060, 331 }, Index = 31 }, // Mantine
-        new(50,08,4) { Species = 319, Ability = A4, Moves = new[]{ 057, 242, 423, 044 }, Index = 31 }, // Sharpedo
-        new(60,10,5) { Species = 321, Ability = A4, Moves = new[]{ 503, 034, 340, 133 }, Index = 31, Shiny = Shiny.Always }, // Wailord
-        new(60,10,5) { Species = 321, Ability = A4, Moves = new[]{ 056, 034, 340, 133 }, Index = 31 }, // Wailord
-        new(60,10,5) { Species = 771, Ability = A4, Moves = new[]{ 092, 599, 213, 174 }, Index = 31 }, // Pyukumuku
-        new(60,10,5) { Species = 593, Ability = A4, Moves = new[]{ 056, 058, 605, 433 }, Index = 31 }, // Jellicent
-        new(60,10,5) { Species = 226, Ability = A4, Moves = new[]{ 036, 403, 060, 331 }, Index = 31 }, // Mantine
-        new(60,10,5) { Species = 319, Ability = A4, Moves = new[]{ 057, 242, 423, 305 }, Index = 31 }, // Sharpedo
+        new(17,01,1) { Species = 320, Ability = A4, Moves = new(362, 034, 310, 054), Index = 31}, // Wailmer
+        new(17,01,1) { Species = 098, Ability = A4, Moves = new(055, 341, 043, 232), Index = 31}, // Krabby
+        new(17,01,1) { Species = 771, Ability = A4, Moves = new(240, 219, 213, 269), Index = 31}, // Pyukumuku
+        new(17,01,1) { Species = 592, Ability = A4, Moves = new(352, 101, 071, 240), Index = 31}, // Frillish
+        new(17,01,1) { Species = 458, Ability = A4, Moves = new(033, 017, 352, 469), Index = 31}, // Mantyke
+        new(17,01,1) { Species = 318, Ability = A4, Moves = new(453, 305, 116, 044), Index = 31}, // Carvanha
+        new(30,03,2) { Species = 320, Ability = A4, Moves = new(362, 034, 310, 054), Index = 31}, // Wailmer
+        new(30,03,2) { Species = 098, Ability = A4, Moves = new(061, 341, 023, 232), Index = 31}, // Krabby
+        new(30,03,2) { Species = 771, Ability = A4, Moves = new(240, 219, 213, 174), Index = 31}, // Pyukumuku
+        new(30,03,2) { Species = 592, Ability = A4, Moves = new(362, 101, 071, 240), Index = 31}, // Frillish
+        new(30,03,2) { Species = 458, Ability = A4, Moves = new(029, 017, 061, 469), Index = 31}, // Mantyke
+        new(30,03,2) { Species = 319, Ability = A4, Moves = new(453, 400, 423, 044), Index = 31}, // Sharpedo
+        new(40,05,3) { Species = 321, Ability = A4, Moves = new(362, 034, 340, 568), Index = 31}, // Wailord
+        new(40,05,3) { Species = 099, Ability = A4, Moves = new(534, 341, 021, 014), Index = 31}, // Kingler
+        new(40,05,3) { Species = 771, Ability = A4, Moves = new(240, 219, 213, 174), Index = 31}, // Pyukumuku
+        new(40,05,3) { Species = 593, Ability = A4, Moves = new(362, 247, 071, 151), Index = 31}, // Jellicent
+        new(40,05,3) { Species = 226, Ability = A4, Moves = new(029, 403, 060, 331), Index = 31}, // Mantine
+        new(40,05,3) { Species = 319, Ability = A4, Moves = new(453, 242, 423, 044), Index = 31}, // Sharpedo
+        new(50,08,4) { Species = 321, Ability = A4, Moves = new(056, 034, 340, 133), Index = 31}, // Wailord
+        new(50,08,4) { Species = 099, Ability = A4, Moves = new(534, 341, 359, 014), Index = 31, CanGigantamax = true}, // Kingler
+        new(50,08,4) { Species = 771, Ability = A4, Moves = new(240, 219, 213, 174), Index = 31}, // Pyukumuku
+        new(50,08,4) { Species = 593, Ability = A4, Moves = new(056, 247, 071, 151), Index = 31}, // Jellicent
+        new(50,08,4) { Species = 226, Ability = A4, Moves = new(036, 403, 060, 331), Index = 31}, // Mantine
+        new(50,08,4) { Species = 319, Ability = A4, Moves = new(057, 242, 423, 044), Index = 31}, // Sharpedo
+        new(60,10,5) { Species = 321, Ability = A4, Moves = new(503, 034, 340, 133), Index = 31, Shiny = Shiny.Always}, // Wailord
+        new(60,10,5) { Species = 321, Ability = A4, Moves = new(056, 034, 340, 133), Index = 31}, // Wailord
+        new(60,10,5) { Species = 771, Ability = A4, Moves = new(092, 599, 213, 174), Index = 31}, // Pyukumuku
+        new(60,10,5) { Species = 593, Ability = A4, Moves = new(056, 058, 605, 433), Index = 31}, // Jellicent
+        new(60,10,5) { Species = 226, Ability = A4, Moves = new(036, 403, 060, 331), Index = 31}, // Mantine
+        new(60,10,5) { Species = 319, Ability = A4, Moves = new(057, 242, 423, 305), Index = 31}, // Sharpedo
 
-        new(17,01,1) { Species = 878, Ability = A4, Moves = new[]{ 523, 205, 045, 249 }, Index = 27 }, // Cufant
-        new(17,01,1) { Species = 208, Ability = A4, Moves = new[]{ 242, 442, 106, 422 }, Index = 27 }, // Steelix
-        new(17,01,1) { Species = 052, Ability = A4, Moves = new[]{ 232, 006, 242, 045 }, Index = 27, Form = 2 }, // Meowth-2
-        new(17,01,1) { Species = 837, Ability = A4, Moves = new[]{ 229, 261, 479, 108 }, Index = 27 }, // Rolycoly
-        new(17,01,1) { Species = 111, Ability = A4, Moves = new[]{ 479, 523, 196, 182 }, Index = 27 }, // Rhyhorn
-        new(17,01,1) { Species = 095, Ability = A4, Moves = new[]{ 174, 225, 034, 106 }, Index = 27 }, // Onix
-        new(30,03,2) { Species = 878, Ability = A4, Moves = new[]{ 523, 023, 334, 249 }, Index = 27 }, // Cufant
-        new(30,03,2) { Species = 208, Ability = A4, Moves = new[]{ 157, 442, 328, 422 }, Index = 27 }, // Steelix
-        new(30,03,2) { Species = 863, Ability = A4, Moves = new[]{ 442, 006, 242, 269 }, Index = 27 }, // Perrserker
-        new(30,03,2) { Species = 838, Ability = A4, Moves = new[]{ 229, 488, 157, 108 }, Index = 27 }, // Carkol
-        new(30,03,2) { Species = 111, Ability = A4, Moves = new[]{ 350, 523, 196, 182 }, Index = 27 }, // Rhyhorn
-        new(30,03,2) { Species = 095, Ability = A4, Moves = new[]{ 776, 225, 034, 106 }, Index = 27 }, // Onix
-        new(40,05,3) { Species = 879, Ability = A4, Moves = new[]{ 070, 523, 334, 442 }, Index = 27, CanGigantamax = true }, // Copperajah
-        new(40,05,3) { Species = 208, Ability = A4, Moves = new[]{ 157, 442, 328, 422 }, Index = 27 }, // Steelix
-        new(40,05,3) { Species = 863, Ability = A4, Moves = new[]{ 442, 006, 154, 269 }, Index = 27 }, // Perrserker
-        new(40,05,3) { Species = 839, Ability = A4, Moves = new[]{ 025, 488, 157, 108 }, Index = 27, CanGigantamax = true }, // Coalossal
-        new(40,05,3) { Species = 112, Ability = A4, Moves = new[]{ 036, 529, 008, 182 }, Index = 27 }, // Rhydon
-        new(40,05,3) { Species = 095, Ability = A4, Moves = new[]{ 776, 225, 021, 201 }, Index = 27 }, // Onix
-        new(50,08,4) { Species = 879, Ability = A4, Moves = new[]{ 070, 523, 334, 442 }, Index = 27, CanGigantamax = true }, // Copperajah
-        new(50,08,4) { Species = 208, Ability = A4, Moves = new[]{ 157, 231, 328, 422 }, Index = 27 }, // Steelix
-        new(50,08,4) { Species = 863, Ability = A4, Moves = new[]{ 442, 583, 154, 269 }, Index = 27 }, // Perrserker
-        new(50,08,4) { Species = 839, Ability = A4, Moves = new[]{ 025, 488, 157, 115 }, Index = 27, CanGigantamax = true }, // Coalossal
-        new(50,08,4) { Species = 464, Ability = A4, Moves = new[]{ 350, 089, 008, 182 }, Index = 27 }, // Rhyperior
-        new(50,08,4) { Species = 095, Ability = A4, Moves = new[]{ 776, 225, 784, 201 }, Index = 27 }, // Onix
-        new(60,10,5) { Species = 879, Ability = A4, Moves = new[]{ 276, 089, 583, 442 }, Index = 27, CanGigantamax = true }, // Copperajah
-        new(60,10,5) { Species = 208, Ability = A4, Moves = new[]{ 038, 231, 529, 422 }, Index = 27 }, // Steelix
-        new(60,10,5) { Species = 863, Ability = A4, Moves = new[]{ 442, 583, 370, 269 }, Index = 27 }, // Perrserker
-        new(60,10,5) { Species = 839, Ability = A4, Moves = new[]{ 076, 682, 157, 115 }, Index = 27, CanGigantamax = true }, // Coalossal
-        new(60,10,5) { Species = 464, Ability = A4, Moves = new[]{ 444, 089, 008, 224 }, Index = 27 }, // Rhyperior
-        new(60,10,5) { Species = 095, Ability = A4, Moves = new[]{ 776, 444, 784, 201 }, Index = 27 }, // Onix
+        new(17,01,1) { Species = 878, Ability = A4, Moves = new(523, 205, 045, 249), Index = 27}, // Cufant
+        new(17,01,1) { Species = 208, Ability = A4, Moves = new(242, 442, 106, 422), Index = 27}, // Steelix
+        new(17,01,1) { Species = 052, Ability = A4, Moves = new(232, 006, 242, 045), Index = 27, Form = 2}, // Meowth-2
+        new(17,01,1) { Species = 837, Ability = A4, Moves = new(229, 261, 479, 108), Index = 27}, // Rolycoly
+        new(17,01,1) { Species = 111, Ability = A4, Moves = new(479, 523, 196, 182), Index = 27}, // Rhyhorn
+        new(17,01,1) { Species = 095, Ability = A4, Moves = new(174, 225, 034, 106), Index = 27}, // Onix
+        new(30,03,2) { Species = 878, Ability = A4, Moves = new(523, 023, 334, 249), Index = 27}, // Cufant
+        new(30,03,2) { Species = 208, Ability = A4, Moves = new(157, 442, 328, 422), Index = 27}, // Steelix
+        new(30,03,2) { Species = 863, Ability = A4, Moves = new(442, 006, 242, 269), Index = 27}, // Perrserker
+        new(30,03,2) { Species = 838, Ability = A4, Moves = new(229, 488, 157, 108), Index = 27}, // Carkol
+        new(30,03,2) { Species = 111, Ability = A4, Moves = new(350, 523, 196, 182), Index = 27}, // Rhyhorn
+        new(30,03,2) { Species = 095, Ability = A4, Moves = new(776, 225, 034, 106), Index = 27}, // Onix
+        new(40,05,3) { Species = 879, Ability = A4, Moves = new(070, 523, 334, 442), Index = 27, CanGigantamax = true}, // Copperajah
+        new(40,05,3) { Species = 208, Ability = A4, Moves = new(157, 442, 328, 422), Index = 27}, // Steelix
+        new(40,05,3) { Species = 863, Ability = A4, Moves = new(442, 006, 154, 269), Index = 27}, // Perrserker
+        new(40,05,3) { Species = 839, Ability = A4, Moves = new(025, 488, 157, 108), Index = 27, CanGigantamax = true}, // Coalossal
+        new(40,05,3) { Species = 112, Ability = A4, Moves = new(036, 529, 008, 182), Index = 27}, // Rhydon
+        new(40,05,3) { Species = 095, Ability = A4, Moves = new(776, 225, 021, 201), Index = 27}, // Onix
+        new(50,08,4) { Species = 879, Ability = A4, Moves = new(070, 523, 334, 442), Index = 27, CanGigantamax = true}, // Copperajah
+        new(50,08,4) { Species = 208, Ability = A4, Moves = new(157, 231, 328, 422), Index = 27}, // Steelix
+        new(50,08,4) { Species = 863, Ability = A4, Moves = new(442, 583, 154, 269), Index = 27}, // Perrserker
+        new(50,08,4) { Species = 839, Ability = A4, Moves = new(025, 488, 157, 115), Index = 27, CanGigantamax = true}, // Coalossal
+        new(50,08,4) { Species = 464, Ability = A4, Moves = new(350, 089, 008, 182), Index = 27}, // Rhyperior
+        new(50,08,4) { Species = 095, Ability = A4, Moves = new(776, 225, 784, 201), Index = 27}, // Onix
+        new(60,10,5) { Species = 879, Ability = A4, Moves = new(276, 089, 583, 442), Index = 27, CanGigantamax = true}, // Copperajah
+        new(60,10,5) { Species = 208, Ability = A4, Moves = new(038, 231, 529, 422), Index = 27}, // Steelix
+        new(60,10,5) { Species = 863, Ability = A4, Moves = new(442, 583, 370, 269), Index = 27}, // Perrserker
+        new(60,10,5) { Species = 839, Ability = A4, Moves = new(076, 682, 157, 115), Index = 27, CanGigantamax = true}, // Coalossal
+        new(60,10,5) { Species = 464, Ability = A4, Moves = new(444, 089, 008, 224), Index = 27}, // Rhyperior
+        new(60,10,5) { Species = 095, Ability = A4, Moves = new(776, 444, 784, 201), Index = 27}, // Onix
 
-        new(30,03,2) { Species = 143, Ability = A4, Moves = new[]{ 034, 044, 280, 523 }, Index = 26, CanGigantamax = true }, // Snorlax
-        new(60,10,5) { Species = 143, Ability = A4, Moves = new[]{ 034, 442, 242, 428 }, Index = 26, CanGigantamax = true }, // Snorlax
-        new(17,01,1,SW) { Species = 869, Ability = A4, Moves = new[]{ 033, 186, 577, 230 }, Index = 26, CanGigantamax = true }, // Alcremie
-        new(30,03,2,SW) { Species = 851, Ability = A4, Moves = new[]{ 044, 172, 489, 693 }, Index = 26, CanGigantamax = true }, // Centiskorch
-        new(30,03,2,SW) { Species = 131, Ability = A4, Moves = new[]{ 352, 420, 109, 047 }, Index = 26, CanGigantamax = true }, // Lapras
-        new(40,05,3,SW) { Species = 099, Ability = A4, Moves = new[]{ 534, 232, 023, 106 }, Index = 26, CanGigantamax = true }, // Kingler
-        new(40,05,3,SW) { Species = 842, Ability = A4, Moves = new[]{ 787, 496, 406, 523 }, Index = 26, CanGigantamax = true }, // Appletun
-        new(40,05,3,SW) { Species = 851, Ability = A4, Moves = new[]{ 141, 424, 422, 044 }, Index = 26, CanGigantamax = true }, // Centiskorch
-        new(50,08,4,SW) { Species = 823, Ability = A4, Moves = new[]{ 413, 442, 269, 103 }, Index = 26, CanGigantamax = true }, // Corviknight
-        new(50,08,4,SW) { Species = 861, Ability = A4, Moves = new[]{ 789, 793, 280, 409 }, Index = 26, CanGigantamax = true }, // Grimmsnarl
-        new(50,08,4,SW) { Species = 569, Ability = A4, Moves = new[]{ 188, 499, 034, 707 }, Index = 26, CanGigantamax = true }, // Garbodor
-        new(50,08,4,SW) { Species = 869, Ability = A4, Moves = new[]{ 577, 605, 105, 500 }, Index = 26, CanGigantamax = true }, // Alcremie
-        new(60,10,5,SW) { Species = 131, Ability = A4, Moves = new[]{ 057, 196, 058, 329 }, Index = 26, CanGigantamax = true }, // Lapras
-        new(60,10,5,SW) { Species = 849, Ability = A4, Moves = new[]{ 786, 506, 474, 409 }, Index = 26, CanGigantamax = true }, // Toxtricity
-        new(60,10,5,SW) { Species = 094, Ability = A4, Moves = new[]{ 247, 482, 094, 196 }, Index = 26, CanGigantamax = true }, // Gengar
-        new(60,10,5,SW) { Species = 884, Ability = A4, Moves = new[]{ 430, 406, 085, 334 }, Index = 26, CanGigantamax = true }, // Duraludon
-        new(17,01,1,SH) { Species = 012, Ability = A4, Moves = new[]{ 405, 060, 016, 079 }, Index = 26, CanGigantamax = true }, // Butterfree
-        new(30,03,2,SH) { Species = 826, Ability = A4, Moves = new[]{ 405, 060, 496, 095 }, Index = 26, CanGigantamax = true }, // Orbeetle
-        new(30,03,2,SH) { Species = 068, Ability = A4, Moves = new[]{ 523, 490, 279, 233 }, Index = 26, CanGigantamax = true }, // Machamp
-        new(40,05,3,SH) { Species = 826, Ability = A4, Moves = new[]{ 405, 094, 202, 247 }, Index = 26, CanGigantamax = true }, // Orbeetle
-        new(40,05,3,SH) { Species = 841, Ability = A4, Moves = new[]{ 406, 788, 491, 334 }, Index = 26, CanGigantamax = true }, // Flapple
-        new(40,05,3,SH) { Species = 844, Ability = A4, Moves = new[]{ 693, 529, 201, 091 }, Index = 26, CanGigantamax = true }, // Sandaconda
-        new(50,08,4,SH) { Species = 834, Ability = A4, Moves = new[]{ 157, 710, 317, 334 }, Index = 26, CanGigantamax = true }, // Drednaw
-        new(50,08,4,SH) { Species = 858, Ability = A4, Moves = new[]{ 605, 094, 595, 247 }, Index = 26, CanGigantamax = true }, // Hatterene
-        new(50,08,4,SH) { Species = 006, Ability = A4, Moves = new[]{ 053, 403, 076, 257 }, Index = 26, CanGigantamax = true }, // Charizard
-        new(50,08,4,SH) { Species = 012, Ability = A4, Moves = new[]{ 405, 403, 527, 078 }, Index = 26, CanGigantamax = true }, // Butterfree
-        new(60,10,5,SH) { Species = 849, Ability = A4, Moves = new[]{ 786, 506, 599, 409 }, Index = 26, Form = 1, CanGigantamax = true }, // Toxtricity-1
-        new(60,10,5,SH) { Species = 839, Ability = A4, Moves = new[]{ 246, 053, 157, 523 }, Index = 26, CanGigantamax = true }, // Coalossal
-        new(60,10,5,SH) { Species = 068, Ability = A4, Moves = new[]{ 238, 007, 008, 089 }, Index = 26, CanGigantamax = true }, // Machamp
-        new(60,10,5,SH) { Species = 879, Ability = A4, Moves = new[]{ 442, 583, 438, 089 }, Index = 26, CanGigantamax = true }, // Copperajah
+        new(30,03,2) { Species = 143, Ability = A4, Moves = new(034, 044, 280, 523), Index = 26, CanGigantamax = true}, // Snorlax
+        new(60,10,5) { Species = 143, Ability = A4, Moves = new(034, 442, 242, 428), Index = 26, CanGigantamax = true}, // Snorlax
+        new(17,01,1,SW) { Species = 869, Ability = A4, Moves = new(033, 186, 577, 230), Index = 26, CanGigantamax = true}, // Alcremie
+        new(30,03,2,SW) { Species = 851, Ability = A4, Moves = new(044, 172, 489, 693), Index = 26, CanGigantamax = true}, // Centiskorch
+        new(30,03,2,SW) { Species = 131, Ability = A4, Moves = new(352, 420, 109, 047), Index = 26, CanGigantamax = true}, // Lapras
+        new(40,05,3,SW) { Species = 099, Ability = A4, Moves = new(534, 232, 023, 106), Index = 26, CanGigantamax = true}, // Kingler
+        new(40,05,3,SW) { Species = 842, Ability = A4, Moves = new(787, 496, 406, 523), Index = 26, CanGigantamax = true}, // Appletun
+        new(40,05,3,SW) { Species = 851, Ability = A4, Moves = new(141, 424, 422, 044), Index = 26, CanGigantamax = true}, // Centiskorch
+        new(50,08,4,SW) { Species = 823, Ability = A4, Moves = new(413, 442, 269, 103), Index = 26, CanGigantamax = true}, // Corviknight
+        new(50,08,4,SW) { Species = 861, Ability = A4, Moves = new(789, 793, 280, 409), Index = 26, CanGigantamax = true}, // Grimmsnarl
+        new(50,08,4,SW) { Species = 569, Ability = A4, Moves = new(188, 499, 034, 707), Index = 26, CanGigantamax = true}, // Garbodor
+        new(50,08,4,SW) { Species = 869, Ability = A4, Moves = new(577, 605, 105, 500), Index = 26, CanGigantamax = true}, // Alcremie
+        new(60,10,5,SW) { Species = 131, Ability = A4, Moves = new(057, 196, 058, 329), Index = 26, CanGigantamax = true}, // Lapras
+        new(60,10,5,SW) { Species = 849, Ability = A4, Moves = new(786, 506, 474, 409), Index = 26, CanGigantamax = true}, // Toxtricity
+        new(60,10,5,SW) { Species = 094, Ability = A4, Moves = new(247, 482, 094, 196), Index = 26, CanGigantamax = true}, // Gengar
+        new(60,10,5,SW) { Species = 884, Ability = A4, Moves = new(430, 406, 085, 334), Index = 26, CanGigantamax = true}, // Duraludon
+        new(17,01,1,SH) { Species = 012, Ability = A4, Moves = new(405, 060, 016, 079), Index = 26, CanGigantamax = true}, // Butterfree
+        new(30,03,2,SH) { Species = 826, Ability = A4, Moves = new(405, 060, 496, 095), Index = 26, CanGigantamax = true}, // Orbeetle
+        new(30,03,2,SH) { Species = 068, Ability = A4, Moves = new(523, 490, 279, 233), Index = 26, CanGigantamax = true}, // Machamp
+        new(40,05,3,SH) { Species = 826, Ability = A4, Moves = new(405, 094, 202, 247), Index = 26, CanGigantamax = true}, // Orbeetle
+        new(40,05,3,SH) { Species = 841, Ability = A4, Moves = new(406, 788, 491, 334), Index = 26, CanGigantamax = true}, // Flapple
+        new(40,05,3,SH) { Species = 844, Ability = A4, Moves = new(693, 529, 201, 091), Index = 26, CanGigantamax = true}, // Sandaconda
+        new(50,08,4,SH) { Species = 834, Ability = A4, Moves = new(157, 710, 317, 334), Index = 26, CanGigantamax = true}, // Drednaw
+        new(50,08,4,SH) { Species = 858, Ability = A4, Moves = new(605, 094, 595, 247), Index = 26, CanGigantamax = true}, // Hatterene
+        new(50,08,4,SH) { Species = 006, Ability = A4, Moves = new(053, 403, 076, 257), Index = 26, CanGigantamax = true}, // Charizard
+        new(50,08,4,SH) { Species = 012, Ability = A4, Moves = new(405, 403, 527, 078), Index = 26, CanGigantamax = true}, // Butterfree
+        new(60,10,5,SH) { Species = 849, Ability = A4, Moves = new(786, 506, 599, 409), Index = 26, Form = 1, CanGigantamax = true}, // Toxtricity-1
+        new(60,10,5,SH) { Species = 839, Ability = A4, Moves = new(246, 053, 157, 523), Index = 26, CanGigantamax = true}, // Coalossal
+        new(60,10,5,SH) { Species = 068, Ability = A4, Moves = new(238, 007, 008, 089), Index = 26, CanGigantamax = true}, // Machamp
+        new(60,10,5,SH) { Species = 879, Ability = A4, Moves = new(442, 583, 438, 089), Index = 26, CanGigantamax = true}, // Copperajah
 
-        new(17,01,1) { Species = 143, Ability = A4, Moves = new[]{ 033, 044, 122, 111 }, Index = 25, CanGigantamax = true }, // Snorlax
-        //new(40,05,3) { Species = 807, Ability = A0, Moves = new[]{ 085, 007, 512, 280 }, Index = 25, Shiny = Shiny.Never }, // Zeraora
-        //new(50,08,4) { Species = 807, Ability = A0, Moves = new[]{ 085, 007, 200, 370 }, Index = 25, Shiny = Shiny.Never }, // Zeraora
-        //new(60,10,5) { Species = 807, Ability = A0, Moves = new[]{ 009, 299, 200, 370 }, Index = 25, Shiny = Shiny.Never }, // Zeraora
-        //new(100,10,6) { Species = 807, Ability = A0, Moves = new[]{ 435, 299, 200, 370 }, Index = 25, Shiny = Shiny.Always }, // Zeraora
-        new(60,10,5) { Species = 143, Ability = A4, Moves = new[]{ 034, 442, 242, 428 }, Index = 25, CanGigantamax = true }, // Snorlax
-        new(30,03,2,SW) { Species = 131, Ability = A4, Moves = new[]{ 352, 420, 109, 047 }, Index = 25, CanGigantamax = true }, // Lapras
-        new(40,05,3,SW) { Species = 099, Ability = A4, Moves = new[]{ 534, 232, 023, 106 }, Index = 25, CanGigantamax = true }, // Kingler
-        new(40,05,3,SW) { Species = 842, Ability = A4, Moves = new[]{ 787, 496, 406, 523 }, Index = 25, CanGigantamax = true }, // Appletun
-        new(40,05,3,SW) { Species = 851, Ability = A4, Moves = new[]{ 141, 424, 422, 044 }, Index = 25, CanGigantamax = true }, // Centiskorch
-        new(50,08,4,SW) { Species = 823, Ability = A4, Moves = new[]{ 413, 442, 269, 103 }, Index = 25, CanGigantamax = true }, // Corviknight
-        new(50,08,4,SW) { Species = 861, Ability = A4, Moves = new[]{ 789, 793, 280, 409 }, Index = 25, CanGigantamax = true }, // Grimmsnarl
-        new(50,08,4,SW) { Species = 569, Ability = A4, Moves = new[]{ 188, 499, 034, 707 }, Index = 25, CanGigantamax = true }, // Garbodor
-        new(50,08,4,SW) { Species = 869, Ability = A4, Moves = new[]{ 577, 605, 105, 500 }, Index = 25, CanGigantamax = true }, // Alcremie
-        new(60,10,5,SW) { Species = 131, Ability = A4, Moves = new[]{ 057, 196, 058, 329 }, Index = 25, CanGigantamax = true }, // Lapras
-        new(60,10,5,SW) { Species = 849, Ability = A4, Moves = new[]{ 786, 506, 474, 409 }, Index = 25, CanGigantamax = true }, // Toxtricity
-        new(60,10,5,SW) { Species = 094, Ability = A4, Moves = new[]{ 247, 482, 094, 196 }, Index = 25, CanGigantamax = true }, // Gengar
-        new(60,10,5,SW) { Species = 884, Ability = A4, Moves = new[]{ 430, 406, 085, 334 }, Index = 25, CanGigantamax = true }, // Duraludon
-        new(30,03,2,SH) { Species = 068, Ability = A4, Moves = new[]{ 523, 490, 279, 233 }, Index = 25, CanGigantamax = true }, // Machamp
-        new(40,05,3,SH) { Species = 826, Ability = A4, Moves = new[]{ 405, 094, 202, 247 }, Index = 25, CanGigantamax = true }, // Orbeetle
-        new(40,05,3,SH) { Species = 841, Ability = A4, Moves = new[]{ 406, 788, 491, 334 }, Index = 25, CanGigantamax = true }, // Flapple
-        new(40,05,3,SH) { Species = 844, Ability = A4, Moves = new[]{ 693, 529, 201, 091 }, Index = 25, CanGigantamax = true }, // Sandaconda
-        new(50,08,4,SH) { Species = 834, Ability = A4, Moves = new[]{ 157, 710, 317, 334 }, Index = 25, CanGigantamax = true }, // Drednaw
-        new(50,08,4,SH) { Species = 858, Ability = A4, Moves = new[]{ 605, 094, 595, 247 }, Index = 25, CanGigantamax = true }, // Hatterene
-        new(50,08,4,SH) { Species = 006, Ability = A4, Moves = new[]{ 053, 403, 076, 257 }, Index = 25, CanGigantamax = true }, // Charizard
-        new(50,08,4,SH) { Species = 012, Ability = A4, Moves = new[]{ 405, 403, 527, 078 }, Index = 25, CanGigantamax = true }, // Butterfree
-        new(60,10,5,SH) { Species = 849, Ability = A4, Moves = new[]{ 786, 506, 599, 409 }, Index = 25, Form = 1, CanGigantamax = true }, // Toxtricity-1
-        new(60,10,5,SH) { Species = 839, Ability = A4, Moves = new[]{ 246, 053, 157, 523 }, Index = 25, CanGigantamax = true }, // Coalossal
-        new(60,10,5,SH) { Species = 068, Ability = A4, Moves = new[]{ 238, 007, 008, 089 }, Index = 25, CanGigantamax = true }, // Machamp
-        new(60,10,5,SH) { Species = 879, Ability = A4, Moves = new[]{ 442, 583, 438, 089 }, Index = 25, CanGigantamax = true }, // Copperajah
+        new(17,01,1) { Species = 143, Ability = A4, Moves = new(033, 044, 122, 111), Index = 25, CanGigantamax = true}, // Snorlax
+        //new(40,05,3) { Species = 807, Ability = A0, Moves = new(085, 007, 512, 280), Index = 25, Shiny = Shiny.Never}, // Zeraora
+        //new(50,08,4) { Species = 807, Ability = A0, Moves = new(085, 007, 200, 370), Index = 25, Shiny = Shiny.Never}, // Zeraora
+        //new(60,10,5) { Species = 807, Ability = A0, Moves = new(009, 299, 200, 370), Index = 25, Shiny = Shiny.Never}, // Zeraora
+        //new(100,10,6) { Species = 807, Ability = A0, Moves = new(435, 299, 200, 370), Index = 25, Shiny = Shiny.Always}, // Zeraora
+        new(60,10,5) { Species = 143, Ability = A4, Moves = new(034, 442, 242, 428), Index = 25, CanGigantamax = true}, // Snorlax
+        new(30,03,2,SW) { Species = 131, Ability = A4, Moves = new(352, 420, 109, 047), Index = 25, CanGigantamax = true}, // Lapras
+        new(40,05,3,SW) { Species = 099, Ability = A4, Moves = new(534, 232, 023, 106), Index = 25, CanGigantamax = true}, // Kingler
+        new(40,05,3,SW) { Species = 842, Ability = A4, Moves = new(787, 496, 406, 523), Index = 25, CanGigantamax = true}, // Appletun
+        new(40,05,3,SW) { Species = 851, Ability = A4, Moves = new(141, 424, 422, 044), Index = 25, CanGigantamax = true}, // Centiskorch
+        new(50,08,4,SW) { Species = 823, Ability = A4, Moves = new(413, 442, 269, 103), Index = 25, CanGigantamax = true}, // Corviknight
+        new(50,08,4,SW) { Species = 861, Ability = A4, Moves = new(789, 793, 280, 409), Index = 25, CanGigantamax = true}, // Grimmsnarl
+        new(50,08,4,SW) { Species = 569, Ability = A4, Moves = new(188, 499, 034, 707), Index = 25, CanGigantamax = true}, // Garbodor
+        new(50,08,4,SW) { Species = 869, Ability = A4, Moves = new(577, 605, 105, 500), Index = 25, CanGigantamax = true}, // Alcremie
+        new(60,10,5,SW) { Species = 131, Ability = A4, Moves = new(057, 196, 058, 329), Index = 25, CanGigantamax = true}, // Lapras
+        new(60,10,5,SW) { Species = 849, Ability = A4, Moves = new(786, 506, 474, 409), Index = 25, CanGigantamax = true}, // Toxtricity
+        new(60,10,5,SW) { Species = 094, Ability = A4, Moves = new(247, 482, 094, 196), Index = 25, CanGigantamax = true}, // Gengar
+        new(60,10,5,SW) { Species = 884, Ability = A4, Moves = new(430, 406, 085, 334), Index = 25, CanGigantamax = true}, // Duraludon
+        new(30,03,2,SH) { Species = 068, Ability = A4, Moves = new(523, 490, 279, 233), Index = 25, CanGigantamax = true}, // Machamp
+        new(40,05,3,SH) { Species = 826, Ability = A4, Moves = new(405, 094, 202, 247), Index = 25, CanGigantamax = true}, // Orbeetle
+        new(40,05,3,SH) { Species = 841, Ability = A4, Moves = new(406, 788, 491, 334), Index = 25, CanGigantamax = true}, // Flapple
+        new(40,05,3,SH) { Species = 844, Ability = A4, Moves = new(693, 529, 201, 091), Index = 25, CanGigantamax = true}, // Sandaconda
+        new(50,08,4,SH) { Species = 834, Ability = A4, Moves = new(157, 710, 317, 334), Index = 25, CanGigantamax = true}, // Drednaw
+        new(50,08,4,SH) { Species = 858, Ability = A4, Moves = new(605, 094, 595, 247), Index = 25, CanGigantamax = true}, // Hatterene
+        new(50,08,4,SH) { Species = 006, Ability = A4, Moves = new(053, 403, 076, 257), Index = 25, CanGigantamax = true}, // Charizard
+        new(50,08,4,SH) { Species = 012, Ability = A4, Moves = new(405, 403, 527, 078), Index = 25, CanGigantamax = true}, // Butterfree
+        new(60,10,5,SH) { Species = 849, Ability = A4, Moves = new(786, 506, 599, 409), Index = 25, Form = 1, CanGigantamax = true}, // Toxtricity-1
+        new(60,10,5,SH) { Species = 839, Ability = A4, Moves = new(246, 053, 157, 523), Index = 25, CanGigantamax = true}, // Coalossal
+        new(60,10,5,SH) { Species = 068, Ability = A4, Moves = new(238, 007, 008, 089), Index = 25, CanGigantamax = true}, // Machamp
+        new(60,10,5,SH) { Species = 879, Ability = A4, Moves = new(442, 583, 438, 089), Index = 25, CanGigantamax = true}, // Copperajah
     };
 }

--- a/PKHeX.Core/Legality/Encounters/Data/Encounters8NestDistDLC2.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Encounters8NestDistDLC2.cs
@@ -8,874 +8,874 @@ internal static partial class Encounters8Nest
     /// </summary>
     internal static readonly EncounterStatic8ND[] Dist_DLC2 =
     {
-        new(17,01,1) { Species = 859, Ability = A4, Moves = new[]{ 372, 044, 252, 590 }, Index = 111 }, // Impidimp
-        new(30,03,2) { Species = 859, Ability = A4, Moves = new[]{ 399, 583, 252, 005 }, Index = 111 }, // Impidimp
-        new(40,05,3) { Species = 860, Ability = A4, Moves = new[]{ 793, 583, 421, 025 }, Index = 111 }, // Morgrem
-        new(40,05,3) { Species = 859, Ability = A4, Moves = new[]{ 399, 583, 252, 005 }, Index = 111 }, // Impidimp
-        new(50,08,4) { Species = 861, Ability = A4, Moves = new[]{ 789, 492, 359, 025 }, Index = 111 }, // Grimmsnarl
-        new(50,08,4) { Species = 860, Ability = A4, Moves = new[]{ 793, 583, 421, 025 }, Index = 111 }, // Morgrem
-        new(50,08,4) { Species = 859, Ability = A4, Moves = new[]{ 399, 583, 252, 005 }, Index = 111 }, // Impidimp
-        new(60,10,5) { Species = 861, Ability = A4, Moves = new[]{ 789, 663, 359, 025 }, Index = 111, Shiny = Shiny.Always }, // Grimmsnarl
-        new(60,10,5) { Species = 861, Ability = A4, Moves = new[]{ 789, 663, 359, 025 }, Index = 111 }, // Grimmsnarl
+        new(17,01,1) { Species = 859, Ability = A4, Moves = new(372, 044, 252, 590), Index = 111 }, // Impidimp
+        new(30,03,2) { Species = 859, Ability = A4, Moves = new(399, 583, 252, 005), Index = 111 }, // Impidimp
+        new(40,05,3) { Species = 860, Ability = A4, Moves = new(793, 583, 421, 025), Index = 111 }, // Morgrem
+        new(40,05,3) { Species = 859, Ability = A4, Moves = new(399, 583, 252, 005), Index = 111 }, // Impidimp
+        new(50,08,4) { Species = 861, Ability = A4, Moves = new(789, 492, 359, 025), Index = 111 }, // Grimmsnarl
+        new(50,08,4) { Species = 860, Ability = A4, Moves = new(793, 583, 421, 025), Index = 111 }, // Morgrem
+        new(50,08,4) { Species = 859, Ability = A4, Moves = new(399, 583, 252, 005), Index = 111 }, // Impidimp
+        new(60,10,5) { Species = 861, Ability = A4, Moves = new(789, 663, 359, 025), Index = 111, Shiny = Shiny.Always }, // Grimmsnarl
+        new(60,10,5) { Species = 861, Ability = A4, Moves = new(789, 663, 359, 025), Index = 111 }, // Grimmsnarl
 
-        new(17,01,1) { Species = 183, Ability = A4, Moves = new[]{ 583, 392, 205, 021 }, Index = 109 }, // Marill
-        new(17,01,1) { Species = 060, Ability = A4, Moves = new[]{ 055, 001, 341, 061 }, Index = 109 }, // Poliwag
-        new(17,01,1) { Species = 363, Ability = A4, Moves = new[]{ 181, 055, 205, 111 }, Index = 109 }, // Spheal
-        new(30,03,2) { Species = 183, Ability = A4, Moves = new[]{ 583, 392, 231, 021 }, Index = 109 }, // Marill
-        new(30,03,2) { Species = 060, Ability = A4, Moves = new[]{ 061, 001, 341, 094 }, Index = 109 }, // Poliwag
-        new(30,03,2) { Species = 363, Ability = A4, Moves = new[]{ 062, 362, 205, 231 }, Index = 109 }, // Spheal
-        new(40,05,3) { Species = 183, Ability = A4, Moves = new[]{ 583, 056, 231, 021 }, Index = 109 }, // Marill
-        new(40,05,3) { Species = 060, Ability = A4, Moves = new[]{ 056, 058, 341, 094 }, Index = 109 }, // Poliwag
-        new(40,05,3) { Species = 363, Ability = A4, Moves = new[]{ 062, 057, 523, 231 }, Index = 109 }, // Spheal
-        new(50,08,4) { Species = 183, Ability = A4, Moves = new[]{ 583, 056, 276, 021 }, Index = 109 }, // Marill
-        new(50,08,4) { Species = 060, Ability = A4, Moves = new[]{ 056, 058, 414, 094 }, Index = 109 }, // Poliwag
-        new(50,08,4) { Species = 363, Ability = A4, Moves = new[]{ 058, 057, 523, 231 }, Index = 109 }, // Spheal
-        new(60,10,5) { Species = 183, Ability = A4, Moves = new[]{ 583, 056, 276, 059 }, Index = 109, Shiny = Shiny.Always }, // Marill
-        new(60,10,5) { Species = 183, Ability = A4, Moves = new[]{ 583, 056, 276, 059 }, Index = 109 }, // Marill
-        new(60,10,5) { Species = 060, Ability = A4, Moves = new[]{ 503, 058, 414, 094 }, Index = 109 }, // Poliwag
-        new(60,10,5) { Species = 363, Ability = A4, Moves = new[]{ 329, 057, 523, 231 }, Index = 109 }, // Spheal
+        new(17,01,1) { Species = 183, Ability = A4, Moves = new(583, 392, 205, 021), Index = 109 }, // Marill
+        new(17,01,1) { Species = 060, Ability = A4, Moves = new(055, 001, 341, 061), Index = 109 }, // Poliwag
+        new(17,01,1) { Species = 363, Ability = A4, Moves = new(181, 055, 205, 111), Index = 109 }, // Spheal
+        new(30,03,2) { Species = 183, Ability = A4, Moves = new(583, 392, 231, 021), Index = 109 }, // Marill
+        new(30,03,2) { Species = 060, Ability = A4, Moves = new(061, 001, 341, 094), Index = 109 }, // Poliwag
+        new(30,03,2) { Species = 363, Ability = A4, Moves = new(062, 362, 205, 231), Index = 109 }, // Spheal
+        new(40,05,3) { Species = 183, Ability = A4, Moves = new(583, 056, 231, 021), Index = 109 }, // Marill
+        new(40,05,3) { Species = 060, Ability = A4, Moves = new(056, 058, 341, 094), Index = 109 }, // Poliwag
+        new(40,05,3) { Species = 363, Ability = A4, Moves = new(062, 057, 523, 231), Index = 109 }, // Spheal
+        new(50,08,4) { Species = 183, Ability = A4, Moves = new(583, 056, 276, 021), Index = 109 }, // Marill
+        new(50,08,4) { Species = 060, Ability = A4, Moves = new(056, 058, 414, 094), Index = 109 }, // Poliwag
+        new(50,08,4) { Species = 363, Ability = A4, Moves = new(058, 057, 523, 231), Index = 109 }, // Spheal
+        new(60,10,5) { Species = 183, Ability = A4, Moves = new(583, 056, 276, 059), Index = 109, Shiny = Shiny.Always }, // Marill
+        new(60,10,5) { Species = 183, Ability = A4, Moves = new(583, 056, 276, 059), Index = 109 }, // Marill
+        new(60,10,5) { Species = 060, Ability = A4, Moves = new(503, 058, 414, 094), Index = 109 }, // Poliwag
+        new(60,10,5) { Species = 363, Ability = A4, Moves = new(329, 057, 523, 231), Index = 109 }, // Spheal
 
-        new(17,01,1) { Species = 824, Ability = A4, Moves = new[]{ 522, 000, 000, 000 }, Index = 106 }, // Blipbug
-        new(30,03,2) { Species = 833, Ability = A4, Moves = new[]{ 055, 033, 044, 029 }, Index = 106 }, // Chewtle
-        new(40,05,3) { Species = 832, Ability = A4, Moves = new[]{ 036, 024, 428, 086 }, Index = 106 }, // Dubwool
-        new(50,08,4) { Species = 823, Ability = A4, Moves = new[]{ 413, 442, 034, 681 }, Index = 106 }, // Corviknight
-        //new(60,10,5) { Species = 892, Ability = A0, Moves = new[]{ 555, 370, 389, 398 }, Index = 106, CanGigantamax = true }, // Urshifu
-        //new(60,10,5) { Species = 892, Ability = A0, Moves = new[]{ 710, 370, 009, 512 }, Index = 106, Form = 1, CanGigantamax = true }, // Urshifu-1
+        new(17,01,1) { Species = 824, Ability = A4, Moves = new(522, 000, 000, 000), Index = 106 }, // Blipbug
+        new(30,03,2) { Species = 833, Ability = A4, Moves = new(055, 033, 044, 029), Index = 106 }, // Chewtle
+        new(40,05,3) { Species = 832, Ability = A4, Moves = new(036, 024, 428, 086), Index = 106 }, // Dubwool
+        new(50,08,4) { Species = 823, Ability = A4, Moves = new(413, 442, 034, 681), Index = 106 }, // Corviknight
+        //new(60,10,5) { Species = 892, Ability = A0, Moves = new(555, 370, 389, 398), Index = 106, CanGigantamax = true }, // Urshifu
+        //new(60,10,5) { Species = 892, Ability = A0, Moves = new(710, 370, 009, 512), Index = 106, Form = 1, CanGigantamax = true }, // Urshifu-1
 
-        new(17,01,1) { Species = 090, Ability = A4, Moves = new[]{ 420, 056, 033, 250 }, Index = 104 }, // Shellder
-        new(17,01,1) { Species = 090, Ability = A4, Moves = new[]{ 420, 057, 033, 710 }, Index = 104 }, // Shellder
-        new(30,03,2) { Species = 090, Ability = A4, Moves = new[]{ 062, 056, 033, 250 }, Index = 104 }, // Shellder
-        new(30,03,2) { Species = 090, Ability = A4, Moves = new[]{ 062, 057, 033, 710 }, Index = 104 }, // Shellder
-        new(40,05,3) { Species = 090, Ability = A4, Moves = new[]{ 062, 056, 504, 534 }, Index = 104 }, // Shellder
-        new(40,05,3) { Species = 090, Ability = A4, Moves = new[]{ 062, 057, 161, 710 }, Index = 104 }, // Shellder
-        new(50,08,4) { Species = 090, Ability = A4, Moves = new[]{ 058, 057, 504, 534 }, Index = 104 }, // Shellder
-        new(50,08,4) { Species = 090, Ability = A4, Moves = new[]{ 058, 057, 161, 710 }, Index = 104 }, // Shellder
-        new(60,10,5) { Species = 090, Ability = A4, Moves = new[]{ 058, 057, 504, 534 }, Index = 104, Shiny = Shiny.Always }, // Shellder
-        new(60,10,5) { Species = 090, Ability = A4, Moves = new[]{ 058, 057, 161, 710 }, Index = 104 }, // Shellder
-        new(60,10,5) { Species = 090, Ability = A4, Moves = new[]{ 058, 057, 504, 534 }, Index = 104 }, // Shellder
+        new(17,01,1) { Species = 090, Ability = A4, Moves = new(420, 056, 033, 250), Index = 104 }, // Shellder
+        new(17,01,1) { Species = 090, Ability = A4, Moves = new(420, 057, 033, 710), Index = 104 }, // Shellder
+        new(30,03,2) { Species = 090, Ability = A4, Moves = new(062, 056, 033, 250), Index = 104 }, // Shellder
+        new(30,03,2) { Species = 090, Ability = A4, Moves = new(062, 057, 033, 710), Index = 104 }, // Shellder
+        new(40,05,3) { Species = 090, Ability = A4, Moves = new(062, 056, 504, 534), Index = 104 }, // Shellder
+        new(40,05,3) { Species = 090, Ability = A4, Moves = new(062, 057, 161, 710), Index = 104 }, // Shellder
+        new(50,08,4) { Species = 090, Ability = A4, Moves = new(058, 057, 504, 534), Index = 104 }, // Shellder
+        new(50,08,4) { Species = 090, Ability = A4, Moves = new(058, 057, 161, 710), Index = 104 }, // Shellder
+        new(60,10,5) { Species = 090, Ability = A4, Moves = new(058, 057, 504, 534), Index = 104, Shiny = Shiny.Always }, // Shellder
+        new(60,10,5) { Species = 090, Ability = A4, Moves = new(058, 057, 161, 710), Index = 104 }, // Shellder
+        new(60,10,5) { Species = 090, Ability = A4, Moves = new(058, 057, 504, 534), Index = 104 }, // Shellder
 
-        new(17,01,1) { Species = 438, Ability = A4, Moves = new[]{ 088, 383, 175, 313 }, Index = 102 }, // Bonsly
-        new(30,03,2) { Species = 438, Ability = A4, Moves = new[]{ 088, 317, 175, 313 }, Index = 102 }, // Bonsly
-        new(40,05,3) { Species = 438, Ability = A4, Moves = new[]{ 317, 389, 157, 313 }, Index = 102 }, // Bonsly
-        new(50,08,4) { Species = 185, Ability = A4, Moves = new[]{ 452, 359, 157, 389 }, Index = 102 }, // Sudowoodo
-        new(60,10,5) { Species = 185, Ability = A4, Moves = new[]{ 452, 444, 038, 389 }, Index = 102, Shiny = Shiny.Always }, // Sudowoodo
-        new(60,10,5) { Species = 185, Ability = A4, Moves = new[]{ 452, 444, 038, 389 }, Index = 102 }, // Sudowoodo
+        new(17,01,1) { Species = 438, Ability = A4, Moves = new(088, 383, 175, 313), Index = 102 }, // Bonsly
+        new(30,03,2) { Species = 438, Ability = A4, Moves = new(088, 317, 175, 313), Index = 102 }, // Bonsly
+        new(40,05,3) { Species = 438, Ability = A4, Moves = new(317, 389, 157, 313), Index = 102 }, // Bonsly
+        new(50,08,4) { Species = 185, Ability = A4, Moves = new(452, 359, 157, 389), Index = 102 }, // Sudowoodo
+        new(60,10,5) { Species = 185, Ability = A4, Moves = new(452, 444, 038, 389), Index = 102, Shiny = Shiny.Always }, // Sudowoodo
+        new(60,10,5) { Species = 185, Ability = A4, Moves = new(452, 444, 038, 389), Index = 102 }, // Sudowoodo
 
-        new(17,01,1) { Species = 696, Ability = A4, Moves = new[]{ 246, 033, 525, 046 }, Index = 100 }, // Tyrunt
-        new(17,01,1) { Species = 564, Ability = A4, Moves = new[]{ 453, 414, 246, 044 }, Index = 100 }, // Tirtouga
-        new(17,01,1) { Species = 566, Ability = A4, Moves = new[]{ 017, 246, 225, 414 }, Index = 100 }, // Archen
-        new(17,01,1) { Species = 698, Ability = A4, Moves = new[]{ 181, 086, 246, 196 }, Index = 100 }, // Amaura
-        new(30,03,2) { Species = 696, Ability = A4, Moves = new[]{ 246, 523, 525, 044 }, Index = 100 }, // Tyrunt
-        new(30,03,2) { Species = 564, Ability = A4, Moves = new[]{ 453, 414, 246, 242 }, Index = 100 }, // Tirtouga
-        new(30,03,2) { Species = 566, Ability = A4, Moves = new[]{ 017, 246, 225, 414 }, Index = 100 }, // Archen
-        new(30,03,2) { Species = 698, Ability = A4, Moves = new[]{ 062, 086, 246, 196 }, Index = 100 }, // Amaura
-        new(40,05,3) { Species = 697, Ability = A4, Moves = new[]{ 444, 523, 337, 231 }, Index = 100 }, // Tyrantrum
-        new(40,05,3) { Species = 565, Ability = A4, Moves = new[]{ 453, 414, 246, 231 }, Index = 100 }, // Carracosta
-        new(40,05,3) { Species = 567, Ability = A4, Moves = new[]{ 403, 157, 337, 414 }, Index = 100 }, // Archeops
-        new(40,05,3) { Species = 699, Ability = A4, Moves = new[]{ 059, 086, 444, 304 }, Index = 100 }, // Aurorus
-        new(50,08,4) { Species = 697, Ability = A4, Moves = new[]{ 444, 089, 337, 231 }, Index = 100 }, // Tyrantrum
-        new(50,08,4) { Species = 565, Ability = A4, Moves = new[]{ 056, 414, 246, 231 }, Index = 100 }, // Carracosta
-        new(50,08,4) { Species = 567, Ability = A4, Moves = new[]{ 403, 444, 337, 414 }, Index = 100 }, // Archeops
-        new(50,08,4) { Species = 699, Ability = A4, Moves = new[]{ 059, 094, 444, 304 }, Index = 100 }, // Aurorus
-        new(60,10,5) { Species = 697, Ability = A4, Moves = new[]{ 457, 089, 406, 231 }, Index = 100, Shiny = Shiny.Always }, // Tyrantrum
-        new(60,10,5) { Species = 697, Ability = A4, Moves = new[]{ 444, 089, 406, 231 }, Index = 100 }, // Tyrantrum
-        new(60,10,5) { Species = 565, Ability = A4, Moves = new[]{ 056, 444, 089, 231 }, Index = 100 }, // Carracosta
-        new(60,10,5) { Species = 567, Ability = A4, Moves = new[]{ 403, 444, 406, 414 }, Index = 100 }, // Archeops
-        new(60,10,5) { Species = 699, Ability = A4, Moves = new[]{ 059, 573, 444, 304 }, Index = 100 }, // Aurorus
+        new(17,01,1) { Species = 696, Ability = A4, Moves = new(246, 033, 525, 046), Index = 100 }, // Tyrunt
+        new(17,01,1) { Species = 564, Ability = A4, Moves = new(453, 414, 246, 044), Index = 100 }, // Tirtouga
+        new(17,01,1) { Species = 566, Ability = A4, Moves = new(017, 246, 225, 414), Index = 100 }, // Archen
+        new(17,01,1) { Species = 698, Ability = A4, Moves = new(181, 086, 246, 196), Index = 100 }, // Amaura
+        new(30,03,2) { Species = 696, Ability = A4, Moves = new(246, 523, 525, 044), Index = 100 }, // Tyrunt
+        new(30,03,2) { Species = 564, Ability = A4, Moves = new(453, 414, 246, 242), Index = 100 }, // Tirtouga
+        new(30,03,2) { Species = 566, Ability = A4, Moves = new(017, 246, 225, 414), Index = 100 }, // Archen
+        new(30,03,2) { Species = 698, Ability = A4, Moves = new(062, 086, 246, 196), Index = 100 }, // Amaura
+        new(40,05,3) { Species = 697, Ability = A4, Moves = new(444, 523, 337, 231), Index = 100 }, // Tyrantrum
+        new(40,05,3) { Species = 565, Ability = A4, Moves = new(453, 414, 246, 231), Index = 100 }, // Carracosta
+        new(40,05,3) { Species = 567, Ability = A4, Moves = new(403, 157, 337, 414), Index = 100 }, // Archeops
+        new(40,05,3) { Species = 699, Ability = A4, Moves = new(059, 086, 444, 304), Index = 100 }, // Aurorus
+        new(50,08,4) { Species = 697, Ability = A4, Moves = new(444, 089, 337, 231), Index = 100 }, // Tyrantrum
+        new(50,08,4) { Species = 565, Ability = A4, Moves = new(056, 414, 246, 231), Index = 100 }, // Carracosta
+        new(50,08,4) { Species = 567, Ability = A4, Moves = new(403, 444, 337, 414), Index = 100 }, // Archeops
+        new(50,08,4) { Species = 699, Ability = A4, Moves = new(059, 094, 444, 304), Index = 100 }, // Aurorus
+        new(60,10,5) { Species = 697, Ability = A4, Moves = new(457, 089, 406, 231), Index = 100, Shiny = Shiny.Always }, // Tyrantrum
+        new(60,10,5) { Species = 697, Ability = A4, Moves = new(444, 089, 406, 231), Index = 100 }, // Tyrantrum
+        new(60,10,5) { Species = 565, Ability = A4, Moves = new(056, 444, 089, 231), Index = 100 }, // Carracosta
+        new(60,10,5) { Species = 567, Ability = A4, Moves = new(403, 444, 406, 414), Index = 100 }, // Archeops
+        new(60,10,5) { Species = 699, Ability = A4, Moves = new(059, 573, 444, 304), Index = 100 }, // Aurorus
 
-        new(50,08,4) { Species = 003, Ability = A4, Moves = new[]{ 572, 188, 414, 200 }, Index = 98, CanGigantamax = true }, // Venusaur
-        new(50,08,4) { Species = 006, Ability = A4, Moves = new[]{ 257, 076, 542, 406 }, Index = 98, CanGigantamax = true }, // Charizard
-        new(50,08,4) { Species = 009, Ability = A4, Moves = new[]{ 057, 059, 430, 089 }, Index = 98, CanGigantamax = true }, // Blastoise
-        new(80,10,5) { Species = 003, Ability = A4, Moves = new[]{ 572, 188, 414, 200 }, Index = 98, CanGigantamax = true }, // Venusaur
-        new(80,10,5) { Species = 006, Ability = A4, Moves = new[]{ 257, 076, 542, 406 }, Index = 98, CanGigantamax = true }, // Charizard
-        new(80,10,5) { Species = 009, Ability = A4, Moves = new[]{ 057, 059, 430, 089 }, Index = 98, CanGigantamax = true }, // Blastoise
+        new(50,08,4) { Species = 003, Ability = A4, Moves = new(572, 188, 414, 200), Index = 98, CanGigantamax = true }, // Venusaur
+        new(50,08,4) { Species = 006, Ability = A4, Moves = new(257, 076, 542, 406), Index = 98, CanGigantamax = true }, // Charizard
+        new(50,08,4) { Species = 009, Ability = A4, Moves = new(057, 059, 430, 089), Index = 98, CanGigantamax = true }, // Blastoise
+        new(80,10,5) { Species = 003, Ability = A4, Moves = new(572, 188, 414, 200), Index = 98, CanGigantamax = true }, // Venusaur
+        new(80,10,5) { Species = 006, Ability = A4, Moves = new(257, 076, 542, 406), Index = 98, CanGigantamax = true }, // Charizard
+        new(80,10,5) { Species = 009, Ability = A4, Moves = new(057, 059, 430, 089), Index = 98, CanGigantamax = true }, // Blastoise
 
-        new(17,01,1) { Species = 129, Ability = A4, Moves = new[]{ 150, 033, 000, 000 }, Index = 95 }, // Magikarp
-        new(17,01,1) { Species = 052, Ability = A4, Moves = new[]{ 006, 492, 402, 247 }, Index = 95 }, // Meowth
-        new(17,01,1) { Species = 052, Ability = A4, Moves = new[]{ 006, 441, 087, 231 }, Index = 95 }, // Meowth
-        new(17,01,1) { Species = 438, Ability = A4, Moves = new[]{ 088, 383, 175, 313 }, Index = 95 }, // Bonsly
-        new(17,01,1) { Species = 554, Ability = A4, Moves = new[]{ 052, 044, 033, 526 }, Index = 95 }, // Darumaka
-        new(30,03,2) { Species = 129, Ability = A4, Moves = new[]{ 150, 033, 000, 000 }, Index = 95 }, // Magikarp
-        new(30,03,2) { Species = 052, Ability = A4, Moves = new[]{ 006, 492, 402, 247 }, Index = 95 }, // Meowth
-        new(30,03,2) { Species = 052, Ability = A4, Moves = new[]{ 006, 441, 087, 231 }, Index = 95 }, // Meowth
-        new(30,03,2) { Species = 438, Ability = A4, Moves = new[]{ 088, 317, 175, 313 }, Index = 95 }, // Bonsly
-        new(30,03,2) { Species = 554, Ability = A4, Moves = new[]{ 007, 044, 157, 029 }, Index = 95 }, // Darumaka
-        new(40,05,3) { Species = 129, Ability = A4, Moves = new[]{ 150, 033, 175, 000 }, Index = 95 }, // Magikarp
-        new(40,05,3) { Species = 052, Ability = A4, Moves = new[]{ 006, 492, 402, 247 }, Index = 95 }, // Meowth
-        new(40,05,3) { Species = 052, Ability = A4, Moves = new[]{ 006, 441, 087, 231 }, Index = 95 }, // Meowth
-        new(40,05,3) { Species = 438, Ability = A4, Moves = new[]{ 317, 389, 157, 313 }, Index = 95 }, // Bonsly
-        new(40,05,3) { Species = 555, Ability = A4, Moves = new[]{ 359, 276, 157, 442 }, Index = 95 }, // Darmanitan
-        new(50,08,4) { Species = 129, Ability = A4, Moves = new[]{ 150, 033, 175, 000 }, Index = 95 }, // Magikarp
-        new(50,08,4) { Species = 052, Ability = A4, Moves = new[]{ 006, 492, 402, 247 }, Index = 95 }, // Meowth
-        new(50,08,4) { Species = 052, Ability = A4, Moves = new[]{ 006, 441, 087, 231 }, Index = 95 }, // Meowth
-        new(50,08,4) { Species = 185, Ability = A4, Moves = new[]{ 452, 359, 157, 389 }, Index = 95 }, // Sudowoodo
-        new(50,08,4) { Species = 555, Ability = A4, Moves = new[]{ 394, 276, 157, 442 }, Index = 95 }, // Darmanitan
-        new(60,10,5) { Species = 129, Ability = A4, Moves = new[]{ 150, 033, 175, 340 }, Index = 95, Shiny = Shiny.Always }, // Magikarp
-        new(60,10,5) { Species = 129, Ability = A4, Moves = new[]{ 150, 033, 175, 340 }, Index = 95 }, // Magikarp
-        new(60,10,5) { Species = 052, Ability = A4, Moves = new[]{ 006, 492, 402, 247 }, Index = 95 }, // Meowth
-        new(60,10,5) { Species = 052, Ability = A4, Moves = new[]{ 006, 441, 087, 231 }, Index = 95 }, // Meowth
-        new(60,10,5) { Species = 185, Ability = A4, Moves = new[]{ 452, 444, 038, 389 }, Index = 95 }, // Sudowoodo
-        new(60,10,5) { Species = 555, Ability = A4, Moves = new[]{ 394, 276, 089, 442 }, Index = 95 }, // Darmanitan
+        new(17,01,1) { Species = 129, Ability = A4, Moves = new(150, 033, 000, 000), Index = 95 }, // Magikarp
+        new(17,01,1) { Species = 052, Ability = A4, Moves = new(006, 492, 402, 247), Index = 95 }, // Meowth
+        new(17,01,1) { Species = 052, Ability = A4, Moves = new(006, 441, 087, 231), Index = 95 }, // Meowth
+        new(17,01,1) { Species = 438, Ability = A4, Moves = new(088, 383, 175, 313), Index = 95 }, // Bonsly
+        new(17,01,1) { Species = 554, Ability = A4, Moves = new(052, 044, 033, 526), Index = 95 }, // Darumaka
+        new(30,03,2) { Species = 129, Ability = A4, Moves = new(150, 033, 000, 000), Index = 95 }, // Magikarp
+        new(30,03,2) { Species = 052, Ability = A4, Moves = new(006, 492, 402, 247), Index = 95 }, // Meowth
+        new(30,03,2) { Species = 052, Ability = A4, Moves = new(006, 441, 087, 231), Index = 95 }, // Meowth
+        new(30,03,2) { Species = 438, Ability = A4, Moves = new(088, 317, 175, 313), Index = 95 }, // Bonsly
+        new(30,03,2) { Species = 554, Ability = A4, Moves = new(007, 044, 157, 029), Index = 95 }, // Darumaka
+        new(40,05,3) { Species = 129, Ability = A4, Moves = new(150, 033, 175, 000), Index = 95 }, // Magikarp
+        new(40,05,3) { Species = 052, Ability = A4, Moves = new(006, 492, 402, 247), Index = 95 }, // Meowth
+        new(40,05,3) { Species = 052, Ability = A4, Moves = new(006, 441, 087, 231), Index = 95 }, // Meowth
+        new(40,05,3) { Species = 438, Ability = A4, Moves = new(317, 389, 157, 313), Index = 95 }, // Bonsly
+        new(40,05,3) { Species = 555, Ability = A4, Moves = new(359, 276, 157, 442), Index = 95 }, // Darmanitan
+        new(50,08,4) { Species = 129, Ability = A4, Moves = new(150, 033, 175, 000), Index = 95 }, // Magikarp
+        new(50,08,4) { Species = 052, Ability = A4, Moves = new(006, 492, 402, 247), Index = 95 }, // Meowth
+        new(50,08,4) { Species = 052, Ability = A4, Moves = new(006, 441, 087, 231), Index = 95 }, // Meowth
+        new(50,08,4) { Species = 185, Ability = A4, Moves = new(452, 359, 157, 389), Index = 95 }, // Sudowoodo
+        new(50,08,4) { Species = 555, Ability = A4, Moves = new(394, 276, 157, 442), Index = 95 }, // Darmanitan
+        new(60,10,5) { Species = 129, Ability = A4, Moves = new(150, 033, 175, 340), Index = 95, Shiny = Shiny.Always }, // Magikarp
+        new(60,10,5) { Species = 129, Ability = A4, Moves = new(150, 033, 175, 340), Index = 95 }, // Magikarp
+        new(60,10,5) { Species = 052, Ability = A4, Moves = new(006, 492, 402, 247), Index = 95 }, // Meowth
+        new(60,10,5) { Species = 052, Ability = A4, Moves = new(006, 441, 087, 231), Index = 95 }, // Meowth
+        new(60,10,5) { Species = 185, Ability = A4, Moves = new(452, 444, 038, 389), Index = 95 }, // Sudowoodo
+        new(60,10,5) { Species = 555, Ability = A4, Moves = new(394, 276, 089, 442), Index = 95 }, // Darmanitan
 
-        new(17,01,1) { Species = 225, Ability = A4, Moves = new[]{ 217, 065, 034, 372 }, Index = 93 }, // Delibird
-        new(17,01,1) { Species = 121, Ability = A4, Moves = new[]{ 057, 408, 055, 129 }, Index = 93 }, // Starmie
-        new(17,01,1) { Species = 615, Ability = A4, Moves = new[]{ 196, 020, 229, 420 }, Index = 93 }, // Cryogonal
-        new(30,03,2) { Species = 225, Ability = A4, Moves = new[]{ 217, 065, 034, 693 }, Index = 93 }, // Delibird
-        new(30,03,2) { Species = 121, Ability = A4, Moves = new[]{ 057, 408, 094, 129 }, Index = 93 }, // Starmie
-        new(30,03,2) { Species = 615, Ability = A4, Moves = new[]{ 400, 062, 229, 246 }, Index = 93 }, // Cryogonal
-        new(40,05,3) { Species = 225, Ability = A4, Moves = new[]{ 217, 065, 280, 196 }, Index = 93 }, // Delibird
-        new(40,05,3) { Species = 121, Ability = A4, Moves = new[]{ 056, 408, 094, 129 }, Index = 93 }, // Starmie
-        new(40,05,3) { Species = 615, Ability = A4, Moves = new[]{ 400, 062, 573, 246 }, Index = 93 }, // Cryogonal
-        new(50,08,4) { Species = 225, Ability = A4, Moves = new[]{ 217, 059, 034, 280 }, Index = 93 }, // Delibird
-        new(50,08,4) { Species = 121, Ability = A4, Moves = new[]{ 056, 408, 094, 605 }, Index = 93 }, // Starmie
-        new(50,08,4) { Species = 615, Ability = A4, Moves = new[]{ 400, 058, 573, 430 }, Index = 93 }, // Cryogonal
-        new(60,10,5) { Species = 225, Ability = A4, Moves = new[]{ 217, 059, 065, 280 }, Index = 93, Shiny = Shiny.Always }, // Delibird
-        new(60,10,5) { Species = 225, Ability = A4, Moves = new[]{ 217, 059, 065, 280 }, Index = 93 }, // Delibird
-        new(60,10,5) { Species = 121, Ability = A4, Moves = new[]{ 056, 800, 094, 605 }, Index = 93 }, // Starmie
-        new(60,10,5) { Species = 615, Ability = A4, Moves = new[]{ 400, 329, 573, 430 }, Index = 93 }, // Cryogonal
+        new(17,01,1) { Species = 225, Ability = A4, Moves = new(217, 065, 034, 372), Index = 93 }, // Delibird
+        new(17,01,1) { Species = 121, Ability = A4, Moves = new(057, 408, 055, 129), Index = 93 }, // Starmie
+        new(17,01,1) { Species = 615, Ability = A4, Moves = new(196, 020, 229, 420), Index = 93 }, // Cryogonal
+        new(30,03,2) { Species = 225, Ability = A4, Moves = new(217, 065, 034, 693), Index = 93 }, // Delibird
+        new(30,03,2) { Species = 121, Ability = A4, Moves = new(057, 408, 094, 129), Index = 93 }, // Starmie
+        new(30,03,2) { Species = 615, Ability = A4, Moves = new(400, 062, 229, 246), Index = 93 }, // Cryogonal
+        new(40,05,3) { Species = 225, Ability = A4, Moves = new(217, 065, 280, 196), Index = 93 }, // Delibird
+        new(40,05,3) { Species = 121, Ability = A4, Moves = new(056, 408, 094, 129), Index = 93 }, // Starmie
+        new(40,05,3) { Species = 615, Ability = A4, Moves = new(400, 062, 573, 246), Index = 93 }, // Cryogonal
+        new(50,08,4) { Species = 225, Ability = A4, Moves = new(217, 059, 034, 280), Index = 93 }, // Delibird
+        new(50,08,4) { Species = 121, Ability = A4, Moves = new(056, 408, 094, 605), Index = 93 }, // Starmie
+        new(50,08,4) { Species = 615, Ability = A4, Moves = new(400, 058, 573, 430), Index = 93 }, // Cryogonal
+        new(60,10,5) { Species = 225, Ability = A4, Moves = new(217, 059, 065, 280), Index = 93, Shiny = Shiny.Always }, // Delibird
+        new(60,10,5) { Species = 225, Ability = A4, Moves = new(217, 059, 065, 280), Index = 93 }, // Delibird
+        new(60,10,5) { Species = 121, Ability = A4, Moves = new(056, 800, 094, 605), Index = 93 }, // Starmie
+        new(60,10,5) { Species = 615, Ability = A4, Moves = new(400, 329, 573, 430), Index = 93 }, // Cryogonal
 
-        new(17,01,1) { Species = 133, Ability = A4, Moves = new[]{ 033, 098, 039, 608 }, Index = 91 }, // Eevee
-        new(30,03,2) { Species = 133, Ability = A4, Moves = new[]{ 129, 098, 039, 608 }, Index = 91 }, // Eevee
-        new(40,05,3) { Species = 133, Ability = A4, Moves = new[]{ 129, 098, 231, 608 }, Index = 91 }, // Eevee
-        new(40,05,3) { Species = 134, Ability = A4, Moves = new[]{ 352, 058, 330, 304 }, Index = 91 }, // Vaporeon
-        new(40,05,3) { Species = 135, Ability = A4, Moves = new[]{ 422, 086, 247, 129 }, Index = 91 }, // Jolteon
-        new(40,05,3) { Species = 136, Ability = A4, Moves = new[]{ 436, 098, 276, 044 }, Index = 91 }, // Flareon
-        new(40,05,3) { Species = 196, Ability = A4, Moves = new[]{ 060, 605, 231, 098 }, Index = 91 }, // Espeon
-        new(40,05,3) { Species = 197, Ability = A4, Moves = new[]{ 555, 044, 247, 098 }, Index = 91 }, // Umbreon
-        new(40,05,3) { Species = 470, Ability = A4, Moves = new[]{ 202, 098, 073, 231 }, Index = 91 }, // Leafeon
-        new(40,05,3) { Species = 471, Ability = A4, Moves = new[]{ 573, 059, 247, 129 }, Index = 91 }, // Glaceon
-        new(40,05,3) { Species = 700, Ability = A4, Moves = new[]{ 574, 595, 129, 605 }, Index = 91 }, // Sylveon
-        new(50,08,4) { Species = 133, Ability = A4, Moves = new[]{ 129, 500, 231, 204 }, Index = 91 }, // Eevee
-        new(50,08,4) { Species = 134, Ability = A4, Moves = new[]{ 056, 058, 330, 304 }, Index = 91 }, // Vaporeon
-        new(50,08,4) { Species = 135, Ability = A4, Moves = new[]{ 087, 086, 247, 129 }, Index = 91 }, // Jolteon
-        new(50,08,4) { Species = 136, Ability = A4, Moves = new[]{ 394, 098, 276, 044 }, Index = 91 }, // Flareon
-        new(50,08,4) { Species = 196, Ability = A4, Moves = new[]{ 094, 605, 231, 098 }, Index = 91 }, // Espeon
-        new(50,08,4) { Species = 197, Ability = A4, Moves = new[]{ 555, 492, 247, 098 }, Index = 91 }, // Umbreon
-        new(50,08,4) { Species = 470, Ability = A4, Moves = new[]{ 348, 098, 073, 231 }, Index = 91 }, // Leafeon
-        new(50,08,4) { Species = 471, Ability = A4, Moves = new[]{ 573, 059, 247, 311 }, Index = 91 }, // Glaceon
-        new(50,08,4) { Species = 700, Ability = A4, Moves = new[]{ 585, 595, 129, 605 }, Index = 91 }, // Sylveon
-        new(60,10,5) { Species = 133, Ability = A4, Moves = new[]{ 387, 500, 231, 204 }, Index = 91, Shiny = Shiny.Always }, // Eevee
-        new(60,10,5) { Species = 134, Ability = A4, Moves = new[]{ 056, 058, 503, 304 }, Index = 91 }, // Vaporeon
-        new(60,10,5) { Species = 135, Ability = A4, Moves = new[]{ 087, 085, 247, 129 }, Index = 91 }, // Jolteon
-        new(60,10,5) { Species = 136, Ability = A4, Moves = new[]{ 394, 231, 276, 044 }, Index = 91 }, // Flareon
-        new(60,10,5) { Species = 196, Ability = A4, Moves = new[]{ 094, 605, 231, 129 }, Index = 91 }, // Espeon
-        new(60,10,5) { Species = 197, Ability = A4, Moves = new[]{ 555, 492, 247, 304 }, Index = 91 }, // Umbreon
-        new(60,10,5) { Species = 470, Ability = A4, Moves = new[]{ 348, 311, 073, 231 }, Index = 91 }, // Leafeon
-        new(60,10,5) { Species = 471, Ability = A4, Moves = new[]{ 573, 059, 247, 304 }, Index = 91 }, // Glaceon
-        new(60,10,5) { Species = 700, Ability = A4, Moves = new[]{ 585, 595, 304, 605 }, Index = 91 }, // Sylveon
-        new(60,10,5) { Species = 133, Ability = A4, Moves = new[]{ 387, 500, 231, 204 }, Index = 91, CanGigantamax = true }, // Eevee
+        new(17,01,1) { Species = 133, Ability = A4, Moves = new(033, 098, 039, 608), Index = 91 }, // Eevee
+        new(30,03,2) { Species = 133, Ability = A4, Moves = new(129, 098, 039, 608), Index = 91 }, // Eevee
+        new(40,05,3) { Species = 133, Ability = A4, Moves = new(129, 098, 231, 608), Index = 91 }, // Eevee
+        new(40,05,3) { Species = 134, Ability = A4, Moves = new(352, 058, 330, 304), Index = 91 }, // Vaporeon
+        new(40,05,3) { Species = 135, Ability = A4, Moves = new(422, 086, 247, 129), Index = 91 }, // Jolteon
+        new(40,05,3) { Species = 136, Ability = A4, Moves = new(436, 098, 276, 044), Index = 91 }, // Flareon
+        new(40,05,3) { Species = 196, Ability = A4, Moves = new(060, 605, 231, 098), Index = 91 }, // Espeon
+        new(40,05,3) { Species = 197, Ability = A4, Moves = new(555, 044, 247, 098), Index = 91 }, // Umbreon
+        new(40,05,3) { Species = 470, Ability = A4, Moves = new(202, 098, 073, 231), Index = 91 }, // Leafeon
+        new(40,05,3) { Species = 471, Ability = A4, Moves = new(573, 059, 247, 129), Index = 91 }, // Glaceon
+        new(40,05,3) { Species = 700, Ability = A4, Moves = new(574, 595, 129, 605), Index = 91 }, // Sylveon
+        new(50,08,4) { Species = 133, Ability = A4, Moves = new(129, 500, 231, 204), Index = 91 }, // Eevee
+        new(50,08,4) { Species = 134, Ability = A4, Moves = new(056, 058, 330, 304), Index = 91 }, // Vaporeon
+        new(50,08,4) { Species = 135, Ability = A4, Moves = new(087, 086, 247, 129), Index = 91 }, // Jolteon
+        new(50,08,4) { Species = 136, Ability = A4, Moves = new(394, 098, 276, 044), Index = 91 }, // Flareon
+        new(50,08,4) { Species = 196, Ability = A4, Moves = new(094, 605, 231, 098), Index = 91 }, // Espeon
+        new(50,08,4) { Species = 197, Ability = A4, Moves = new(555, 492, 247, 098), Index = 91 }, // Umbreon
+        new(50,08,4) { Species = 470, Ability = A4, Moves = new(348, 098, 073, 231), Index = 91 }, // Leafeon
+        new(50,08,4) { Species = 471, Ability = A4, Moves = new(573, 059, 247, 311), Index = 91 }, // Glaceon
+        new(50,08,4) { Species = 700, Ability = A4, Moves = new(585, 595, 129, 605), Index = 91 }, // Sylveon
+        new(60,10,5) { Species = 133, Ability = A4, Moves = new(387, 500, 231, 204), Index = 91, Shiny = Shiny.Always }, // Eevee
+        new(60,10,5) { Species = 134, Ability = A4, Moves = new(056, 058, 503, 304), Index = 91 }, // Vaporeon
+        new(60,10,5) { Species = 135, Ability = A4, Moves = new(087, 085, 247, 129), Index = 91 }, // Jolteon
+        new(60,10,5) { Species = 136, Ability = A4, Moves = new(394, 231, 276, 044), Index = 91 }, // Flareon
+        new(60,10,5) { Species = 196, Ability = A4, Moves = new(094, 605, 231, 129), Index = 91 }, // Espeon
+        new(60,10,5) { Species = 197, Ability = A4, Moves = new(555, 492, 247, 304), Index = 91 }, // Umbreon
+        new(60,10,5) { Species = 470, Ability = A4, Moves = new(348, 311, 073, 231), Index = 91 }, // Leafeon
+        new(60,10,5) { Species = 471, Ability = A4, Moves = new(573, 059, 247, 304), Index = 91 }, // Glaceon
+        new(60,10,5) { Species = 700, Ability = A4, Moves = new(585, 595, 304, 605), Index = 91 }, // Sylveon
+        new(60,10,5) { Species = 133, Ability = A4, Moves = new(387, 500, 231, 204), Index = 91, CanGigantamax = true }, // Eevee
 
-        new(17,01,1) { Species = 570, Ability = A4, Moves = new[]{ 468, 247, 010, 043 }, Index = 89 }, // Zorua
-        new(17,01,1) { Species = 302, Ability = A4, Moves = new[]{ 252, 010, 425, 555 }, Index = 89 }, // Sableye
-        new(17,01,1) { Species = 355, Ability = A4, Moves = new[]{ 310, 425, 043, 506 }, Index = 89 }, // Duskull
-        new(17,01,1) { Species = 821, Ability = A4, Moves = new[]{ 403, 031, 043, 681 }, Index = 89 }, // Rookidee
-        new(17,01,1) { Species = 827, Ability = A4, Moves = new[]{ 555, 098, 251, 468 }, Index = 89 }, // Nickit
-        new(30,03,2) { Species = 571, Ability = A4, Moves = new[]{ 400, 247, 279, 304 }, Index = 89 }, // Zoroark
-        new(30,03,2) { Species = 302, Ability = A4, Moves = new[]{ 252, 094, 425, 555 }, Index = 89 }, // Sableye
-        new(30,03,2) { Species = 355, Ability = A4, Moves = new[]{ 310, 425, 371, 506 }, Index = 89 }, // Duskull
-        new(30,03,2) { Species = 822, Ability = A4, Moves = new[]{ 403, 263, 279, 681 }, Index = 89 }, // Corvisquire
-        new(30,03,2) { Species = 828, Ability = A4, Moves = new[]{ 555, 098, 251, 583 }, Index = 89 }, // Thievul
-        new(40,05,3) { Species = 571, Ability = A4, Moves = new[]{ 400, 247, 411, 304 }, Index = 89 }, // Zoroark
-        new(40,05,3) { Species = 302, Ability = A4, Moves = new[]{ 252, 261, 247, 555 }, Index = 89 }, // Sableye
-        new(40,05,3) { Species = 477, Ability = A4, Moves = new[]{ 247, 009, 371, 157 }, Index = 89 }, // Dusknoir
-        new(40,05,3) { Species = 823, Ability = A4, Moves = new[]{ 403, 442, 034, 681 }, Index = 89 }, // Corviknight
-        new(40,05,3) { Species = 828, Ability = A4, Moves = new[]{ 555, 098, 094, 583 }, Index = 89 }, // Thievul
-        new(50,08,4) { Species = 571, Ability = A4, Moves = new[]{ 539, 247, 411, 304 }, Index = 89 }, // Zoroark
-        new(50,08,4) { Species = 302, Ability = A4, Moves = new[]{ 605, 261, 247, 555 }, Index = 89 }, // Sableye
-        new(50,08,4) { Species = 477, Ability = A4, Moves = new[]{ 247, 009, 280, 157 }, Index = 89 }, // Dusknoir
-        new(50,08,4) { Species = 823, Ability = A4, Moves = new[]{ 413, 442, 034, 681 }, Index = 89 }, // Corviknight
-        new(50,08,4) { Species = 828, Ability = A4, Moves = new[]{ 555, 341, 094, 583 }, Index = 89 }, // Thievul
-        new(60,10,5) { Species = 571, Ability = A4, Moves = new[]{ 539, 247, 411, 492 }, Index = 89, Shiny = Shiny.Always }, // Zoroark
-        new(60,10,5) { Species = 571, Ability = A4, Moves = new[]{ 539, 247, 411, 492 }, Index = 89 }, // Zoroark
-        new(60,10,5) { Species = 302, Ability = A4, Moves = new[]{ 605, 261, 247, 492 }, Index = 89 }, // Sableye
-        new(60,10,5) { Species = 477, Ability = A4, Moves = new[]{ 247, 009, 280, 089 }, Index = 89 }, // Dusknoir
-        new(60,10,5) { Species = 823, Ability = A4, Moves = new[]{ 413, 442, 776, 372 }, Index = 89 }, // Corviknight
-        new(60,10,5) { Species = 828, Ability = A4, Moves = new[]{ 555, 492, 094, 583 }, Index = 89 }, // Thievul
+        new(17,01,1) { Species = 570, Ability = A4, Moves = new(468, 247, 010, 043), Index = 89 }, // Zorua
+        new(17,01,1) { Species = 302, Ability = A4, Moves = new(252, 010, 425, 555), Index = 89 }, // Sableye
+        new(17,01,1) { Species = 355, Ability = A4, Moves = new(310, 425, 043, 506), Index = 89 }, // Duskull
+        new(17,01,1) { Species = 821, Ability = A4, Moves = new(403, 031, 043, 681), Index = 89 }, // Rookidee
+        new(17,01,1) { Species = 827, Ability = A4, Moves = new(555, 098, 251, 468), Index = 89 }, // Nickit
+        new(30,03,2) { Species = 571, Ability = A4, Moves = new(400, 247, 279, 304), Index = 89 }, // Zoroark
+        new(30,03,2) { Species = 302, Ability = A4, Moves = new(252, 094, 425, 555), Index = 89 }, // Sableye
+        new(30,03,2) { Species = 355, Ability = A4, Moves = new(310, 425, 371, 506), Index = 89 }, // Duskull
+        new(30,03,2) { Species = 822, Ability = A4, Moves = new(403, 263, 279, 681), Index = 89 }, // Corvisquire
+        new(30,03,2) { Species = 828, Ability = A4, Moves = new(555, 098, 251, 583), Index = 89 }, // Thievul
+        new(40,05,3) { Species = 571, Ability = A4, Moves = new(400, 247, 411, 304), Index = 89 }, // Zoroark
+        new(40,05,3) { Species = 302, Ability = A4, Moves = new(252, 261, 247, 555), Index = 89 }, // Sableye
+        new(40,05,3) { Species = 477, Ability = A4, Moves = new(247, 009, 371, 157), Index = 89 }, // Dusknoir
+        new(40,05,3) { Species = 823, Ability = A4, Moves = new(403, 442, 034, 681), Index = 89 }, // Corviknight
+        new(40,05,3) { Species = 828, Ability = A4, Moves = new(555, 098, 094, 583), Index = 89 }, // Thievul
+        new(50,08,4) { Species = 571, Ability = A4, Moves = new(539, 247, 411, 304), Index = 89 }, // Zoroark
+        new(50,08,4) { Species = 302, Ability = A4, Moves = new(605, 261, 247, 555), Index = 89 }, // Sableye
+        new(50,08,4) { Species = 477, Ability = A4, Moves = new(247, 009, 280, 157), Index = 89 }, // Dusknoir
+        new(50,08,4) { Species = 823, Ability = A4, Moves = new(413, 442, 034, 681), Index = 89 }, // Corviknight
+        new(50,08,4) { Species = 828, Ability = A4, Moves = new(555, 341, 094, 583), Index = 89 }, // Thievul
+        new(60,10,5) { Species = 571, Ability = A4, Moves = new(539, 247, 411, 492), Index = 89, Shiny = Shiny.Always }, // Zoroark
+        new(60,10,5) { Species = 571, Ability = A4, Moves = new(539, 247, 411, 492), Index = 89 }, // Zoroark
+        new(60,10,5) { Species = 302, Ability = A4, Moves = new(605, 261, 247, 492), Index = 89 }, // Sableye
+        new(60,10,5) { Species = 477, Ability = A4, Moves = new(247, 009, 280, 089), Index = 89 }, // Dusknoir
+        new(60,10,5) { Species = 823, Ability = A4, Moves = new(413, 442, 776, 372), Index = 89 }, // Corviknight
+        new(60,10,5) { Species = 828, Ability = A4, Moves = new(555, 492, 094, 583), Index = 89 }, // Thievul
 
-        new(17,01,1) { Species = 722, Ability = A4, Moves = new[]{ 064, 075, 389, 129 }, Index = 87 }, // Rowlet
-        new(17,01,1) { Species = 725, Ability = A4, Moves = new[]{ 052, 006, 044, 421 }, Index = 87 }, // Litten
-        new(17,01,1) { Species = 728, Ability = A4, Moves = new[]{ 574, 001, 453, 196 }, Index = 87 }, // Popplio
-        new(30,03,2) { Species = 722, Ability = A4, Moves = new[]{ 064, 348, 389, 129 }, Index = 87 }, // Rowlet
-        new(30,03,2) { Species = 725, Ability = A4, Moves = new[]{ 053, 006, 044, 421 }, Index = 87 }, // Litten
-        new(30,03,2) { Species = 728, Ability = A4, Moves = new[]{ 574, 061, 453, 196 }, Index = 87 }, // Popplio
-        new(40,05,3) { Species = 722, Ability = A4, Moves = new[]{ 413, 348, 389, 129 }, Index = 87 }, // Rowlet
-        new(40,05,3) { Species = 725, Ability = A4, Moves = new[]{ 394, 006, 044, 421 }, Index = 87 }, // Litten
-        new(40,05,3) { Species = 728, Ability = A4, Moves = new[]{ 585, 056, 453, 196 }, Index = 87 }, // Popplio
-        new(50,08,4) { Species = 722, Ability = A4, Moves = new[]{ 413, 348, 389, 412 }, Index = 87 }, // Rowlet
-        new(50,08,4) { Species = 725, Ability = A4, Moves = new[]{ 394, 006, 279, 421 }, Index = 87 }, // Litten
-        new(50,08,4) { Species = 728, Ability = A4, Moves = new[]{ 585, 056, 453, 059 }, Index = 87 }, // Popplio
-        new(60,10,5) { Species = 722, Ability = A4, Moves = new[]{ 413, 348, 421, 412 }, Index = 87 }, // Rowlet
-        new(60,10,5) { Species = 725, Ability = A4, Moves = new[]{ 394, 006, 279, 242 }, Index = 87 }, // Litten
-        new(60,10,5) { Species = 728, Ability = A4, Moves = new[]{ 585, 056, 453, 058 }, Index = 87 }, // Popplio
+        new(17,01,1) { Species = 722, Ability = A4, Moves = new(064, 075, 389, 129), Index = 87 }, // Rowlet
+        new(17,01,1) { Species = 725, Ability = A4, Moves = new(052, 006, 044, 421), Index = 87 }, // Litten
+        new(17,01,1) { Species = 728, Ability = A4, Moves = new(574, 001, 453, 196), Index = 87 }, // Popplio
+        new(30,03,2) { Species = 722, Ability = A4, Moves = new(064, 348, 389, 129), Index = 87 }, // Rowlet
+        new(30,03,2) { Species = 725, Ability = A4, Moves = new(053, 006, 044, 421), Index = 87 }, // Litten
+        new(30,03,2) { Species = 728, Ability = A4, Moves = new(574, 061, 453, 196), Index = 87 }, // Popplio
+        new(40,05,3) { Species = 722, Ability = A4, Moves = new(413, 348, 389, 129), Index = 87 }, // Rowlet
+        new(40,05,3) { Species = 725, Ability = A4, Moves = new(394, 006, 044, 421), Index = 87 }, // Litten
+        new(40,05,3) { Species = 728, Ability = A4, Moves = new(585, 056, 453, 196), Index = 87 }, // Popplio
+        new(50,08,4) { Species = 722, Ability = A4, Moves = new(413, 348, 389, 412), Index = 87 }, // Rowlet
+        new(50,08,4) { Species = 725, Ability = A4, Moves = new(394, 006, 279, 421), Index = 87 }, // Litten
+        new(50,08,4) { Species = 728, Ability = A4, Moves = new(585, 056, 453, 059), Index = 87 }, // Popplio
+        new(60,10,5) { Species = 722, Ability = A4, Moves = new(413, 348, 421, 412), Index = 87 }, // Rowlet
+        new(60,10,5) { Species = 725, Ability = A4, Moves = new(394, 006, 279, 242), Index = 87 }, // Litten
+        new(60,10,5) { Species = 728, Ability = A4, Moves = new(585, 056, 453, 058), Index = 87 }, // Popplio
 
-        new(17,01,1) { Species = 337, Ability = A4, Moves = new[]{ 585, 033, 093, 088 }, Index = 85 }, // Lunatone
-        new(17,01,1) { Species = 338, Ability = A4, Moves = new[]{ 394, 033, 093, 088 }, Index = 85 }, // Solrock
-        new(30,03,2) { Species = 337, Ability = A4, Moves = new[]{ 585, 129, 094, 088 }, Index = 85 }, // Lunatone
-        new(30,03,2) { Species = 338, Ability = A4, Moves = new[]{ 394, 129, 094, 088 }, Index = 85 }, // Solrock
-        new(40,05,3) { Species = 337, Ability = A4, Moves = new[]{ 585, 129, 094, 157 }, Index = 85 }, // Lunatone
-        new(40,05,3) { Species = 338, Ability = A4, Moves = new[]{ 394, 129, 094, 157 }, Index = 85 }, // Solrock
-        new(50,08,4) { Species = 337, Ability = A4, Moves = new[]{ 585, 058, 094, 157 }, Index = 85 }, // Lunatone
-        new(50,08,4) { Species = 338, Ability = A4, Moves = new[]{ 394, 076, 094, 157 }, Index = 85 }, // Solrock
-        new(60,10,5) { Species = 337, Ability = A4, Moves = new[]{ 585, 058, 094, 444 }, Index = 85, Shiny = Shiny.Always }, // Lunatone
-        new(60,10,5) { Species = 337, Ability = A4, Moves = new[]{ 585, 058, 094, 444 }, Index = 85 }, // Lunatone
-        new(60,10,5) { Species = 338, Ability = A4, Moves = new[]{ 394, 076, 094, 444 }, Index = 85, Shiny = Shiny.Always }, // Solrock
-        new(60,10,5) { Species = 338, Ability = A4, Moves = new[]{ 394, 076, 094, 444 }, Index = 85 }, // Solrock
+        new(17,01,1) { Species = 337, Ability = A4, Moves = new(585, 033, 093, 088), Index = 85 }, // Lunatone
+        new(17,01,1) { Species = 338, Ability = A4, Moves = new(394, 033, 093, 088), Index = 85 }, // Solrock
+        new(30,03,2) { Species = 337, Ability = A4, Moves = new(585, 129, 094, 088), Index = 85 }, // Lunatone
+        new(30,03,2) { Species = 338, Ability = A4, Moves = new(394, 129, 094, 088), Index = 85 }, // Solrock
+        new(40,05,3) { Species = 337, Ability = A4, Moves = new(585, 129, 094, 157), Index = 85 }, // Lunatone
+        new(40,05,3) { Species = 338, Ability = A4, Moves = new(394, 129, 094, 157), Index = 85 }, // Solrock
+        new(50,08,4) { Species = 337, Ability = A4, Moves = new(585, 058, 094, 157), Index = 85 }, // Lunatone
+        new(50,08,4) { Species = 338, Ability = A4, Moves = new(394, 076, 094, 157), Index = 85 }, // Solrock
+        new(60,10,5) { Species = 337, Ability = A4, Moves = new(585, 058, 094, 444), Index = 85, Shiny = Shiny.Always }, // Lunatone
+        new(60,10,5) { Species = 337, Ability = A4, Moves = new(585, 058, 094, 444), Index = 85 }, // Lunatone
+        new(60,10,5) { Species = 338, Ability = A4, Moves = new(394, 076, 094, 444), Index = 85, Shiny = Shiny.Always }, // Solrock
+        new(60,10,5) { Species = 338, Ability = A4, Moves = new(394, 076, 094, 444), Index = 85 }, // Solrock
 
-        new(17,01,1) { Species = 573, Ability = A4, Moves = new[]{ 350, 541, 331, 001 }, Index = 83 }, // Cinccino
-        new(17,01,1) { Species = 333, Ability = A4, Moves = new[]{ 574, 064, 257, 031 }, Index = 83 }, // Swablu
-        new(17,01,1) { Species = 479, Ability = A4, Moves = new[]{ 437, 104, 310, 084 }, Index = 83, Form = 5 }, // Rotom-5
-        new(17,01,1) { Species = 767, Ability = A4, Moves = new[]{ 522, 057, 111, 028 }, Index = 83 }, // Wimpod
-        new(30,03,2) { Species = 573, Ability = A4, Moves = new[]{ 350, 541, 331, 583 }, Index = 83 }, // Cinccino
-        new(30,03,2) { Species = 333, Ability = A4, Moves = new[]{ 583, 225, 257, 058 }, Index = 83 }, // Swablu
-        new(30,03,2) { Species = 479, Ability = A4, Moves = new[]{ 437, 399, 310, 084 }, Index = 83, Form = 5 }, // Rotom-5
-        new(30,03,2) { Species = 767, Ability = A4, Moves = new[]{ 522, 057, 111, 028 }, Index = 83 }, // Wimpod
-        new(40,05,3) { Species = 573, Ability = A4, Moves = new[]{ 350, 541, 331, 441 }, Index = 83 }, // Cinccino
-        new(40,05,3) { Species = 334, Ability = A4, Moves = new[]{ 583, 784, 083, 058 }, Index = 83 }, // Altaria
-        new(40,05,3) { Species = 479, Ability = A4, Moves = new[]{ 437, 399, 506, 351 }, Index = 83, Form = 5 }, // Rotom-5
-        new(40,05,3) { Species = 767, Ability = A4, Moves = new[]{ 522, 057, 372, 028 }, Index = 83 }, // Wimpod
-        new(50,08,4) { Species = 573, Ability = A4, Moves = new[]{ 350, 541, 331, 086 }, Index = 83 }, // Cinccino
-        new(50,08,4) { Species = 334, Ability = A4, Moves = new[]{ 585, 784, 083, 058 }, Index = 83 }, // Altaria
-        new(50,08,4) { Species = 479, Ability = A4, Moves = new[]{ 437, 399, 247, 085 }, Index = 83, Form = 5 }, // Rotom-5
-        new(50,08,4) { Species = 767, Ability = A4, Moves = new[]{ 522, 057, 372, 341 }, Index = 83 }, // Wimpod
-        new(60,10,5) { Species = 573, Ability = A4, Moves = new[]{ 350, 541, 331, 813 }, Index = 83, Shiny = Shiny.Always }, // Cinccino
-        new(60,10,5) { Species = 573, Ability = A4, Moves = new[]{ 350, 541, 331, 813 }, Index = 83 }, // Cinccino
-        new(60,10,5) { Species = 334, Ability = A4, Moves = new[]{ 585, 784, 542, 058 }, Index = 83 }, // Altaria
-        new(60,10,5) { Species = 479, Ability = A4, Moves = new[]{ 437, 399, 261, 085 }, Index = 83, Form = 5 }, // Rotom-5
-        new(60,10,5) { Species = 767, Ability = A4, Moves = new[]{ 806, 057, 372, 341 }, Index = 83 }, // Wimpod
+        new(17,01,1) { Species = 573, Ability = A4, Moves = new(350, 541, 331, 001), Index = 83 }, // Cinccino
+        new(17,01,1) { Species = 333, Ability = A4, Moves = new(574, 064, 257, 031), Index = 83 }, // Swablu
+        new(17,01,1) { Species = 479, Ability = A4, Moves = new(437, 104, 310, 084), Index = 83, Form = 5 }, // Rotom-5
+        new(17,01,1) { Species = 767, Ability = A4, Moves = new(522, 057, 111, 028), Index = 83 }, // Wimpod
+        new(30,03,2) { Species = 573, Ability = A4, Moves = new(350, 541, 331, 583), Index = 83 }, // Cinccino
+        new(30,03,2) { Species = 333, Ability = A4, Moves = new(583, 225, 257, 058), Index = 83 }, // Swablu
+        new(30,03,2) { Species = 479, Ability = A4, Moves = new(437, 399, 310, 084), Index = 83, Form = 5 }, // Rotom-5
+        new(30,03,2) { Species = 767, Ability = A4, Moves = new(522, 057, 111, 028), Index = 83 }, // Wimpod
+        new(40,05,3) { Species = 573, Ability = A4, Moves = new(350, 541, 331, 441), Index = 83 }, // Cinccino
+        new(40,05,3) { Species = 334, Ability = A4, Moves = new(583, 784, 083, 058), Index = 83 }, // Altaria
+        new(40,05,3) { Species = 479, Ability = A4, Moves = new(437, 399, 506, 351), Index = 83, Form = 5 }, // Rotom-5
+        new(40,05,3) { Species = 767, Ability = A4, Moves = new(522, 057, 372, 028), Index = 83 }, // Wimpod
+        new(50,08,4) { Species = 573, Ability = A4, Moves = new(350, 541, 331, 086), Index = 83 }, // Cinccino
+        new(50,08,4) { Species = 334, Ability = A4, Moves = new(585, 784, 083, 058), Index = 83 }, // Altaria
+        new(50,08,4) { Species = 479, Ability = A4, Moves = new(437, 399, 247, 085), Index = 83, Form = 5 }, // Rotom-5
+        new(50,08,4) { Species = 767, Ability = A4, Moves = new(522, 057, 372, 341), Index = 83 }, // Wimpod
+        new(60,10,5) { Species = 573, Ability = A4, Moves = new(350, 541, 331, 813), Index = 83, Shiny = Shiny.Always }, // Cinccino
+        new(60,10,5) { Species = 573, Ability = A4, Moves = new(350, 541, 331, 813), Index = 83 }, // Cinccino
+        new(60,10,5) { Species = 334, Ability = A4, Moves = new(585, 784, 542, 058), Index = 83 }, // Altaria
+        new(60,10,5) { Species = 479, Ability = A4, Moves = new(437, 399, 261, 085), Index = 83, Form = 5 }, // Rotom-5
+        new(60,10,5) { Species = 767, Ability = A4, Moves = new(806, 057, 372, 341), Index = 83 }, // Wimpod
 
-        new(17,01,1) { Species = 092, Ability = A4, Moves = new[]{ 122, 605, 474, 009 }, Index = 81 }, // Gastly
-        new(17,01,1) { Species = 607, Ability = A4, Moves = new[]{ 052, 506, 123, 109 }, Index = 81 }, // Litwick
-        new(17,01,1) { Species = 425, Ability = A4, Moves = new[]{ 310, 016, 107, 506 }, Index = 81 }, // Drifloon
-        new(30,03,2) { Species = 093, Ability = A4, Moves = new[]{ 325, 605, 474, 009 }, Index = 81 }, // Haunter
-        new(30,03,2) { Species = 607, Ability = A4, Moves = new[]{ 083, 506, 123, 261 }, Index = 81 }, // Litwick
-        new(30,03,2) { Species = 426, Ability = A4, Moves = new[]{ 668, 016, 261, 506 }, Index = 81 }, // Drifblim
-        new(40,05,3) { Species = 094, Ability = A4, Moves = new[]{ 325, 605, 474, 087 }, Index = 81 }, // Gengar
-        new(40,05,3) { Species = 607, Ability = A4, Moves = new[]{ 517, 247, 123, 094 }, Index = 81 }, // Litwick
-        new(40,05,3) { Species = 426, Ability = A4, Moves = new[]{ 668, 086, 261, 506 }, Index = 81 }, // Drifblim
-        new(50,08,4) { Species = 094, Ability = A4, Moves = new[]{ 247, 605, 482, 087 }, Index = 81 }, // Gengar
-        new(50,08,4) { Species = 609, Ability = A4, Moves = new[]{ 315, 247, 123, 094 }, Index = 81 }, // Chandelure
-        new(50,08,4) { Species = 426, Ability = A4, Moves = new[]{ 668, 086, 261, 247 }, Index = 81 }, // Drifblim
-        new(60,10,5) { Species = 094, Ability = A4, Moves = new[]{ 247, 605, 482, 261 }, Index = 81, CanGigantamax = true }, // Gengar
-        new(60,10,5) { Species = 094, Ability = A4, Moves = new[]{ 247, 605, 482, 261 }, Index = 81 }, // Gengar
-        new(60,10,5) { Species = 609, Ability = A4, Moves = new[]{ 315, 247, 399, 094 }, Index = 81, Shiny = Shiny.Always }, // Chandelure
-        new(60,10,5) { Species = 609, Ability = A4, Moves = new[]{ 315, 247, 399, 094 }, Index = 81 }, // Chandelure
-        new(60,10,5) { Species = 426, Ability = A4, Moves = new[]{ 668, 371, 261, 247 }, Index = 81 }, // Drifblim
+        new(17,01,1) { Species = 092, Ability = A4, Moves = new(122, 605, 474, 009), Index = 81 }, // Gastly
+        new(17,01,1) { Species = 607, Ability = A4, Moves = new(052, 506, 123, 109), Index = 81 }, // Litwick
+        new(17,01,1) { Species = 425, Ability = A4, Moves = new(310, 016, 107, 506), Index = 81 }, // Drifloon
+        new(30,03,2) { Species = 093, Ability = A4, Moves = new(325, 605, 474, 009), Index = 81 }, // Haunter
+        new(30,03,2) { Species = 607, Ability = A4, Moves = new(083, 506, 123, 261), Index = 81 }, // Litwick
+        new(30,03,2) { Species = 426, Ability = A4, Moves = new(668, 016, 261, 506), Index = 81 }, // Drifblim
+        new(40,05,3) { Species = 094, Ability = A4, Moves = new(325, 605, 474, 087), Index = 81 }, // Gengar
+        new(40,05,3) { Species = 607, Ability = A4, Moves = new(517, 247, 123, 094), Index = 81 }, // Litwick
+        new(40,05,3) { Species = 426, Ability = A4, Moves = new(668, 086, 261, 506), Index = 81 }, // Drifblim
+        new(50,08,4) { Species = 094, Ability = A4, Moves = new(247, 605, 482, 087), Index = 81 }, // Gengar
+        new(50,08,4) { Species = 609, Ability = A4, Moves = new(315, 247, 123, 094), Index = 81 }, // Chandelure
+        new(50,08,4) { Species = 426, Ability = A4, Moves = new(668, 086, 261, 247), Index = 81 }, // Drifblim
+        new(60,10,5) { Species = 094, Ability = A4, Moves = new(247, 605, 482, 261), Index = 81, CanGigantamax = true }, // Gengar
+        new(60,10,5) { Species = 094, Ability = A4, Moves = new(247, 605, 482, 261), Index = 81 }, // Gengar
+        new(60,10,5) { Species = 609, Ability = A4, Moves = new(315, 247, 399, 094), Index = 81, Shiny = Shiny.Always }, // Chandelure
+        new(60,10,5) { Species = 609, Ability = A4, Moves = new(315, 247, 399, 094), Index = 81 }, // Chandelure
+        new(60,10,5) { Species = 426, Ability = A4, Moves = new(668, 371, 261, 247), Index = 81 }, // Drifblim
 
-        new(17,01,1) { Species = 582, Ability = A4, Moves = new[]{ 419, 106, 263, 310 }, Index = 79 }, // Vanillite
-        new(17,01,1) { Species = 118, Ability = A4, Moves = new[]{ 030, 039, 352, 064 }, Index = 79 }, // Goldeen
-        new(17,01,1) { Species = 127, Ability = A4, Moves = new[]{ 458, 693, 157, 069 }, Index = 79 }, // Pinsir
-        new(17,01,1) { Species = 214, Ability = A4, Moves = new[]{ 280, 031, 089, 332 }, Index = 79 }, // Heracross
-        new(17,01,1) { Species = 290, Ability = A4, Moves = new[]{ 189, 206, 028, 010 }, Index = 79 }, // Nincada
-        new(17,01,1) { Species = 479, Ability = A4, Moves = new[]{ 403, 084, 310, 104 }, Index = 79, Form = 4 }, // Rotom-4
-        new(30,03,2) { Species = 582, Ability = A4, Moves = new[]{ 419, 430, 263, 310 }, Index = 79 }, // Vanillite
-        new(30,03,2) { Species = 118, Ability = A4, Moves = new[]{ 030, 398, 352, 064 }, Index = 79 }, // Goldeen
-        new(30,03,2) { Species = 127, Ability = A4, Moves = new[]{ 458, 675, 157, 069 }, Index = 79 }, // Pinsir
-        new(30,03,2) { Species = 214, Ability = A4, Moves = new[]{ 280, 030, 089, 332 }, Index = 79 }, // Heracross
-        new(30,03,2) { Species = 291, Ability = A4, Moves = new[]{ 232, 210, 403, 010 }, Index = 79 }, // Ninjask
-        new(30,03,2) { Species = 479, Ability = A4, Moves = new[]{ 403, 351, 310, 104 }, Index = 79, Form = 4 }, // Rotom-4
-        new(40,05,3) { Species = 583, Ability = A4, Moves = new[]{ 419, 430, 304, 310 }, Index = 79 }, // Vanillish
-        new(40,05,3) { Species = 119, Ability = A4, Moves = new[]{ 030, 224, 352, 529 }, Index = 79 }, // Seaking
-        new(40,05,3) { Species = 127, Ability = A4, Moves = new[]{ 404, 675, 157, 280 }, Index = 79 }, // Pinsir
-        new(40,05,3) { Species = 214, Ability = A4, Moves = new[]{ 280, 042, 089, 157 }, Index = 79 }, // Heracross
-        new(40,05,3) { Species = 291, Ability = A4, Moves = new[]{ 232, 210, 403, 104 }, Index = 79 }, // Ninjask
-        new(40,05,3) { Species = 479, Ability = A4, Moves = new[]{ 403, 085, 310, 399 }, Index = 79, Form = 4 }, // Rotom-4
-        new(50,08,4) { Species = 584, Ability = A4, Moves = new[]{ 573, 430, 304, 058 }, Index = 79 }, // Vanilluxe
-        new(50,08,4) { Species = 119, Ability = A4, Moves = new[]{ 030, 224, 503, 529 }, Index = 79 }, // Seaking
-        new(50,08,4) { Species = 127, Ability = A4, Moves = new[]{ 404, 675, 157, 276 }, Index = 79 }, // Pinsir
-        new(50,08,4) { Species = 214, Ability = A4, Moves = new[]{ 280, 331, 089, 157 }, Index = 79 }, // Heracross
-        new(50,08,4) { Species = 291, Ability = A4, Moves = new[]{ 232, 210, 403, 163 }, Index = 79 }, // Ninjask
-        new(50,08,4) { Species = 479, Ability = A4, Moves = new[]{ 403, 085, 506, 399 }, Index = 79, Form = 4 }, // Rotom-4
-        new(60,10,5) { Species = 584, Ability = A4, Moves = new[]{ 573, 430, 304, 059 }, Index = 79, Shiny = Shiny.Always }, // Vanilluxe
-        new(60,10,5) { Species = 119, Ability = A4, Moves = new[]{ 032, 224, 503, 529 }, Index = 79 }, // Seaking
-        new(60,10,5) { Species = 127, Ability = A4, Moves = new[]{ 404, 675, 317, 276 }, Index = 79 }, // Pinsir
-        new(60,10,5) { Species = 214, Ability = A4, Moves = new[]{ 370, 331, 089, 157 }, Index = 79 }, // Heracross
-        new(60,10,5) { Species = 291, Ability = A4, Moves = new[]{ 232, 404, 403, 163 }, Index = 79 }, // Ninjask
-        new(60,10,5) { Species = 479, Ability = A4, Moves = new[]{ 403, 085, 247, 399 }, Index = 79, Form = 4 }, // Rotom-4
+        new(17,01,1) { Species = 582, Ability = A4, Moves = new(419, 106, 263, 310), Index = 79 }, // Vanillite
+        new(17,01,1) { Species = 118, Ability = A4, Moves = new(030, 039, 352, 064), Index = 79 }, // Goldeen
+        new(17,01,1) { Species = 127, Ability = A4, Moves = new(458, 693, 157, 069), Index = 79 }, // Pinsir
+        new(17,01,1) { Species = 214, Ability = A4, Moves = new(280, 031, 089, 332), Index = 79 }, // Heracross
+        new(17,01,1) { Species = 290, Ability = A4, Moves = new(189, 206, 028, 010), Index = 79 }, // Nincada
+        new(17,01,1) { Species = 479, Ability = A4, Moves = new(403, 084, 310, 104), Index = 79, Form = 4 }, // Rotom-4
+        new(30,03,2) { Species = 582, Ability = A4, Moves = new(419, 430, 263, 310), Index = 79 }, // Vanillite
+        new(30,03,2) { Species = 118, Ability = A4, Moves = new(030, 398, 352, 064), Index = 79 }, // Goldeen
+        new(30,03,2) { Species = 127, Ability = A4, Moves = new(458, 675, 157, 069), Index = 79 }, // Pinsir
+        new(30,03,2) { Species = 214, Ability = A4, Moves = new(280, 030, 089, 332), Index = 79 }, // Heracross
+        new(30,03,2) { Species = 291, Ability = A4, Moves = new(232, 210, 403, 010), Index = 79 }, // Ninjask
+        new(30,03,2) { Species = 479, Ability = A4, Moves = new(403, 351, 310, 104), Index = 79, Form = 4 }, // Rotom-4
+        new(40,05,3) { Species = 583, Ability = A4, Moves = new(419, 430, 304, 310), Index = 79 }, // Vanillish
+        new(40,05,3) { Species = 119, Ability = A4, Moves = new(030, 224, 352, 529), Index = 79 }, // Seaking
+        new(40,05,3) { Species = 127, Ability = A4, Moves = new(404, 675, 157, 280), Index = 79 }, // Pinsir
+        new(40,05,3) { Species = 214, Ability = A4, Moves = new(280, 042, 089, 157), Index = 79 }, // Heracross
+        new(40,05,3) { Species = 291, Ability = A4, Moves = new(232, 210, 403, 104), Index = 79 }, // Ninjask
+        new(40,05,3) { Species = 479, Ability = A4, Moves = new(403, 085, 310, 399), Index = 79, Form = 4 }, // Rotom-4
+        new(50,08,4) { Species = 584, Ability = A4, Moves = new(573, 430, 304, 058), Index = 79 }, // Vanilluxe
+        new(50,08,4) { Species = 119, Ability = A4, Moves = new(030, 224, 503, 529), Index = 79 }, // Seaking
+        new(50,08,4) { Species = 127, Ability = A4, Moves = new(404, 675, 157, 276), Index = 79 }, // Pinsir
+        new(50,08,4) { Species = 214, Ability = A4, Moves = new(280, 331, 089, 157), Index = 79 }, // Heracross
+        new(50,08,4) { Species = 291, Ability = A4, Moves = new(232, 210, 403, 163), Index = 79 }, // Ninjask
+        new(50,08,4) { Species = 479, Ability = A4, Moves = new(403, 085, 506, 399), Index = 79, Form = 4 }, // Rotom-4
+        new(60,10,5) { Species = 584, Ability = A4, Moves = new(573, 430, 304, 059), Index = 79, Shiny = Shiny.Always }, // Vanilluxe
+        new(60,10,5) { Species = 119, Ability = A4, Moves = new(032, 224, 503, 529), Index = 79 }, // Seaking
+        new(60,10,5) { Species = 127, Ability = A4, Moves = new(404, 675, 317, 276), Index = 79 }, // Pinsir
+        new(60,10,5) { Species = 214, Ability = A4, Moves = new(370, 331, 089, 157), Index = 79 }, // Heracross
+        new(60,10,5) { Species = 291, Ability = A4, Moves = new(232, 404, 403, 163), Index = 79 }, // Ninjask
+        new(60,10,5) { Species = 479, Ability = A4, Moves = new(403, 085, 247, 399), Index = 79, Form = 4 }, // Rotom-4
 
-        new(17,01,1) { Species = 138, Ability = A4, Moves = new[]{ 055, 028, 205, 020 }, Index = 77 }, // Omanyte
-        new(17,01,1) { Species = 140, Ability = A4, Moves = new[]{ 453, 028, 263, 010 }, Index = 77 }, // Kabuto
-        new(17,01,1) { Species = 142, Ability = A4, Moves = new[]{ 246, 414, 044, 017 }, Index = 77 }, // Aerodactyl
-        new(30,03,2) { Species = 138, Ability = A4, Moves = new[]{ 055, 341, 246, 020 }, Index = 77 }, // Omanyte
-        new(30,03,2) { Species = 140, Ability = A4, Moves = new[]{ 453, 246, 263, 058 }, Index = 77 }, // Kabuto
-        new(30,03,2) { Species = 142, Ability = A4, Moves = new[]{ 157, 414, 242, 017 }, Index = 77 }, // Aerodactyl
-        new(40,05,3) { Species = 138, Ability = A4, Moves = new[]{ 362, 414, 246, 196 }, Index = 77 }, // Omanyte
-        new(40,05,3) { Species = 140, Ability = A4, Moves = new[]{ 362, 246, 263, 059 }, Index = 77 }, // Kabuto
-        new(40,05,3) { Species = 142, Ability = A4, Moves = new[]{ 157, 414, 422, 017 }, Index = 77 }, // Aerodactyl
-        new(50,08,4) { Species = 138, Ability = A4, Moves = new[]{ 057, 414, 246, 058 }, Index = 77 }, // Omanyte
-        new(50,08,4) { Species = 140, Ability = A4, Moves = new[]{ 710, 246, 141, 059 }, Index = 77 }, // Kabuto
-        new(50,08,4) { Species = 142, Ability = A4, Moves = new[]{ 444, 414, 422, 542 }, Index = 77 }, // Aerodactyl
-        new(60,10,5) { Species = 138, Ability = A4, Moves = new[]{ 056, 414, 246, 058 }, Index = 77, Shiny = Shiny.Always }, // Omanyte
-        new(60,10,5) { Species = 138, Ability = A4, Moves = new[]{ 056, 414, 246, 058 }, Index = 77 }, // Omanyte
-        new(60,10,5) { Species = 140, Ability = A4, Moves = new[]{ 710, 444, 141, 059 }, Index = 77 }, // Kabuto
-        new(60,10,5) { Species = 142, Ability = A4, Moves = new[]{ 444, 089, 422, 542 }, Index = 77 }, // Aerodactyl
+        new(17,01,1) { Species = 138, Ability = A4, Moves = new(055, 028, 205, 020), Index = 77 }, // Omanyte
+        new(17,01,1) { Species = 140, Ability = A4, Moves = new(453, 028, 263, 010), Index = 77 }, // Kabuto
+        new(17,01,1) { Species = 142, Ability = A4, Moves = new(246, 414, 044, 017), Index = 77 }, // Aerodactyl
+        new(30,03,2) { Species = 138, Ability = A4, Moves = new(055, 341, 246, 020), Index = 77 }, // Omanyte
+        new(30,03,2) { Species = 140, Ability = A4, Moves = new(453, 246, 263, 058), Index = 77 }, // Kabuto
+        new(30,03,2) { Species = 142, Ability = A4, Moves = new(157, 414, 242, 017), Index = 77 }, // Aerodactyl
+        new(40,05,3) { Species = 138, Ability = A4, Moves = new(362, 414, 246, 196), Index = 77 }, // Omanyte
+        new(40,05,3) { Species = 140, Ability = A4, Moves = new(362, 246, 263, 059), Index = 77 }, // Kabuto
+        new(40,05,3) { Species = 142, Ability = A4, Moves = new(157, 414, 422, 017), Index = 77 }, // Aerodactyl
+        new(50,08,4) { Species = 138, Ability = A4, Moves = new(057, 414, 246, 058), Index = 77 }, // Omanyte
+        new(50,08,4) { Species = 140, Ability = A4, Moves = new(710, 246, 141, 059), Index = 77 }, // Kabuto
+        new(50,08,4) { Species = 142, Ability = A4, Moves = new(444, 414, 422, 542), Index = 77 }, // Aerodactyl
+        new(60,10,5) { Species = 138, Ability = A4, Moves = new(056, 414, 246, 058), Index = 77, Shiny = Shiny.Always }, // Omanyte
+        new(60,10,5) { Species = 138, Ability = A4, Moves = new(056, 414, 246, 058), Index = 77 }, // Omanyte
+        new(60,10,5) { Species = 140, Ability = A4, Moves = new(710, 444, 141, 059), Index = 77 }, // Kabuto
+        new(60,10,5) { Species = 142, Ability = A4, Moves = new(444, 089, 422, 542), Index = 77 }, // Aerodactyl
 
-        new(17,01,1) { Species = 878, Ability = A4, Moves = new[]{ 523, 249, 033, 045 }, Index = 75 }, // Cufant
-        new(17,01,1) { Species = 109, Ability = A4, Moves = new[]{ 188, 372, 139, 108 }, Index = 75 }, // Koffing
-        new(17,01,1) { Species = 202, Ability = A4, Moves = new[]{ 243, 227, 068, 204 }, Index = 75 }, // Wobbuffet
-        new(17,01,1) { Species = 868, Ability = A4, Moves = new[]{ 033, 186, 577, 496 }, Index = 75 }, // Milcery
-        new(17,01,1) { Species = 004, Ability = A4, Moves = new[]{ 052, 225, 010, 108 }, Index = 75 }, // Charmander
-        new(30,03,2) { Species = 878, Ability = A4, Moves = new[]{ 523, 249, 023, 045 }, Index = 75 }, // Cufant
-        new(30,03,2) { Species = 109, Ability = A4, Moves = new[]{ 188, 372, 123, 108 }, Index = 75 }, // Koffing
-        new(30,03,2) { Species = 202, Ability = A4, Moves = new[]{ 243, 227, 068, 204 }, Index = 75 }, // Wobbuffet
-        new(30,03,2) { Species = 868, Ability = A4, Moves = new[]{ 577, 186, 263, 500 }, Index = 75 }, // Milcery
-        new(30,03,2) { Species = 005, Ability = A4, Moves = new[]{ 225, 512, 242, 053 }, Index = 75 }, // Charmeleon
-        new(40,05,3) { Species = 879, Ability = A4, Moves = new[]{ 484, 583, 070, 249 }, Index = 75, CanGigantamax = true }, // Copperajah
-        new(40,05,3) { Species = 109, Ability = A4, Moves = new[]{ 482, 372, 053, 085 }, Index = 75 }, // Koffing
-        new(40,05,3) { Species = 202, Ability = A4, Moves = new[]{ 243, 227, 068, 204 }, Index = 75 }, // Wobbuffet
-        new(40,05,3) { Species = 868, Ability = A4, Moves = new[]{ 577, 605, 496, 213 }, Index = 75 }, // Milcery
-        new(40,05,3) { Species = 006, Ability = A4, Moves = new[]{ 337, 403, 280, 257 }, Index = 75, CanGigantamax = true }, // Charizard
-        new(50,08,4) { Species = 879, Ability = A4, Moves = new[]{ 484, 583, 070, 438 }, Index = 75, CanGigantamax = true }, // Copperajah
-        new(50,08,4) { Species = 109, Ability = A4, Moves = new[]{ 482, 399, 053, 085 }, Index = 75 }, // Koffing
-        new(50,08,4) { Species = 202, Ability = A4, Moves = new[]{ 243, 227, 068, 204 }, Index = 75 }, // Wobbuffet
-        new(50,08,4) { Species = 868, Ability = A4, Moves = new[]{ 577, 605, 496, 500 }, Index = 75 }, // Milcery
-        new(50,08,4) { Species = 006, Ability = A4, Moves = new[]{ 337, 403, 411, 257 }, Index = 75, CanGigantamax = true }, // Charizard
-        new(60,10,5) { Species = 879, Ability = A4, Moves = new[]{ 484, 583, 089, 438 }, Index = 75, CanGigantamax = true, Shiny = Shiny.Always }, // Copperajah
-        new(60,10,5) { Species = 879, Ability = A4, Moves = new[]{ 484, 583, 089, 438 }, Index = 75, CanGigantamax = true }, // Copperajah
-        new(60,10,5) { Species = 109, Ability = A4, Moves = new[]{ 482, 399, 053, 087 }, Index = 75 }, // Koffing
-        new(60,10,5) { Species = 202, Ability = A4, Moves = new[]{ 243, 227, 068, 204 }, Index = 75 }, // Wobbuffet
-        new(60,10,5) { Species = 868, Ability = A4, Moves = new[]{ 577, 605, 496, 500 }, Index = 75 }, // Milcery
-        new(60,10,5) { Species = 006, Ability = A4, Moves = new[]{ 406, 403, 411, 257 }, Index = 75, CanGigantamax = true }, // Charizard
+        new(17,01,1) { Species = 878, Ability = A4, Moves = new(523, 249, 033, 045), Index = 75 }, // Cufant
+        new(17,01,1) { Species = 109, Ability = A4, Moves = new(188, 372, 139, 108), Index = 75 }, // Koffing
+        new(17,01,1) { Species = 202, Ability = A4, Moves = new(243, 227, 068, 204), Index = 75 }, // Wobbuffet
+        new(17,01,1) { Species = 868, Ability = A4, Moves = new(033, 186, 577, 496), Index = 75 }, // Milcery
+        new(17,01,1) { Species = 004, Ability = A4, Moves = new(052, 225, 010, 108), Index = 75 }, // Charmander
+        new(30,03,2) { Species = 878, Ability = A4, Moves = new(523, 249, 023, 045), Index = 75 }, // Cufant
+        new(30,03,2) { Species = 109, Ability = A4, Moves = new(188, 372, 123, 108), Index = 75 }, // Koffing
+        new(30,03,2) { Species = 202, Ability = A4, Moves = new(243, 227, 068, 204), Index = 75 }, // Wobbuffet
+        new(30,03,2) { Species = 868, Ability = A4, Moves = new(577, 186, 263, 500), Index = 75 }, // Milcery
+        new(30,03,2) { Species = 005, Ability = A4, Moves = new(225, 512, 242, 053), Index = 75 }, // Charmeleon
+        new(40,05,3) { Species = 879, Ability = A4, Moves = new(484, 583, 070, 249), Index = 75, CanGigantamax = true }, // Copperajah
+        new(40,05,3) { Species = 109, Ability = A4, Moves = new(482, 372, 053, 085), Index = 75 }, // Koffing
+        new(40,05,3) { Species = 202, Ability = A4, Moves = new(243, 227, 068, 204), Index = 75 }, // Wobbuffet
+        new(40,05,3) { Species = 868, Ability = A4, Moves = new(577, 605, 496, 213), Index = 75 }, // Milcery
+        new(40,05,3) { Species = 006, Ability = A4, Moves = new(337, 403, 280, 257), Index = 75, CanGigantamax = true }, // Charizard
+        new(50,08,4) { Species = 879, Ability = A4, Moves = new(484, 583, 070, 438), Index = 75, CanGigantamax = true }, // Copperajah
+        new(50,08,4) { Species = 109, Ability = A4, Moves = new(482, 399, 053, 085), Index = 75 }, // Koffing
+        new(50,08,4) { Species = 202, Ability = A4, Moves = new(243, 227, 068, 204), Index = 75 }, // Wobbuffet
+        new(50,08,4) { Species = 868, Ability = A4, Moves = new(577, 605, 496, 500), Index = 75 }, // Milcery
+        new(50,08,4) { Species = 006, Ability = A4, Moves = new(337, 403, 411, 257), Index = 75, CanGigantamax = true }, // Charizard
+        new(60,10,5) { Species = 879, Ability = A4, Moves = new(484, 583, 089, 438), Index = 75, CanGigantamax = true, Shiny = Shiny.Always }, // Copperajah
+        new(60,10,5) { Species = 879, Ability = A4, Moves = new(484, 583, 089, 438), Index = 75, CanGigantamax = true }, // Copperajah
+        new(60,10,5) { Species = 109, Ability = A4, Moves = new(482, 399, 053, 087), Index = 75 }, // Koffing
+        new(60,10,5) { Species = 202, Ability = A4, Moves = new(243, 227, 068, 204), Index = 75 }, // Wobbuffet
+        new(60,10,5) { Species = 868, Ability = A4, Moves = new(577, 605, 496, 500), Index = 75 }, // Milcery
+        new(60,10,5) { Species = 006, Ability = A4, Moves = new(406, 403, 411, 257), Index = 75, CanGigantamax = true }, // Charizard
 
-        new(17,01,1) { Species = 852, Ability = A4, Moves = new[]{ 371, 249, 362, 364 }, Index = 73 }, // Clobbopus
-        new(17,01,1) { Species = 223, Ability = A4, Moves = new[]{ 055, 062, 060, 129 }, Index = 73 }, // Remoraid
-        new(17,01,1) { Species = 686, Ability = A4, Moves = new[]{ 371, 060, 035, 095 }, Index = 73 }, // Inkay
-        new(30,03,2) { Species = 852, Ability = A4, Moves = new[]{ 371, 066, 362, 364 }, Index = 73 }, // Clobbopus
-        new(30,03,2) { Species = 223, Ability = A4, Moves = new[]{ 061, 062, 060, 129 }, Index = 73 }, // Remoraid
-        new(30,03,2) { Species = 686, Ability = A4, Moves = new[]{ 400, 060, 035, 095 }, Index = 73 }, // Inkay
-        new(40,05,3) { Species = 853, Ability = A4, Moves = new[]{ 693, 276, 190, 034 }, Index = 73 }, // Grapploct
-        new(40,05,3) { Species = 224, Ability = A4, Moves = new[]{ 503, 058, 086, 129 }, Index = 73 }, // Octillery
-        new(40,05,3) { Species = 687, Ability = A4, Moves = new[]{ 492, 060, 035, 095 }, Index = 73 }, // Malamar
-        new(50,08,4) { Species = 853, Ability = A4, Moves = new[]{ 576, 276, 008, 034 }, Index = 73 }, // Grapploct
-        new(50,08,4) { Species = 224, Ability = A4, Moves = new[]{ 056, 058, 086, 129 }, Index = 73 }, // Octillery
-        new(50,08,4) { Species = 687, Ability = A4, Moves = new[]{ 492, 427, 163, 085 }, Index = 73 }, // Malamar
-        new(60,10,5) { Species = 853, Ability = A4, Moves = new[]{ 576, 276, 008, 707 }, Index = 73, Shiny = Shiny.Always }, // Grapploct
-        new(60,10,5) { Species = 853, Ability = A4, Moves = new[]{ 576, 276, 008, 707 }, Index = 73 }, // Grapploct
-        new(60,10,5) { Species = 224, Ability = A4, Moves = new[]{ 056, 058, 086, 053 }, Index = 73 }, // Octillery
-        new(60,10,5) { Species = 687, Ability = A4, Moves = new[]{ 492, 094, 157, 085 }, Index = 73 }, // Malamar
+        new(17,01,1) { Species = 852, Ability = A4, Moves = new(371, 249, 362, 364), Index = 73 }, // Clobbopus
+        new(17,01,1) { Species = 223, Ability = A4, Moves = new(055, 062, 060, 129), Index = 73 }, // Remoraid
+        new(17,01,1) { Species = 686, Ability = A4, Moves = new(371, 060, 035, 095), Index = 73 }, // Inkay
+        new(30,03,2) { Species = 852, Ability = A4, Moves = new(371, 066, 362, 364), Index = 73 }, // Clobbopus
+        new(30,03,2) { Species = 223, Ability = A4, Moves = new(061, 062, 060, 129), Index = 73 }, // Remoraid
+        new(30,03,2) { Species = 686, Ability = A4, Moves = new(400, 060, 035, 095), Index = 73 }, // Inkay
+        new(40,05,3) { Species = 853, Ability = A4, Moves = new(693, 276, 190, 034), Index = 73 }, // Grapploct
+        new(40,05,3) { Species = 224, Ability = A4, Moves = new(503, 058, 086, 129), Index = 73 }, // Octillery
+        new(40,05,3) { Species = 687, Ability = A4, Moves = new(492, 060, 035, 095), Index = 73 }, // Malamar
+        new(50,08,4) { Species = 853, Ability = A4, Moves = new(576, 276, 008, 034), Index = 73 }, // Grapploct
+        new(50,08,4) { Species = 224, Ability = A4, Moves = new(056, 058, 086, 129), Index = 73 }, // Octillery
+        new(50,08,4) { Species = 687, Ability = A4, Moves = new(492, 427, 163, 085), Index = 73 }, // Malamar
+        new(60,10,5) { Species = 853, Ability = A4, Moves = new(576, 276, 008, 707), Index = 73, Shiny = Shiny.Always }, // Grapploct
+        new(60,10,5) { Species = 853, Ability = A4, Moves = new(576, 276, 008, 707), Index = 73 }, // Grapploct
+        new(60,10,5) { Species = 224, Ability = A4, Moves = new(056, 058, 086, 053), Index = 73 }, // Octillery
+        new(60,10,5) { Species = 687, Ability = A4, Moves = new(492, 094, 157, 085), Index = 73 }, // Malamar
 
-        new(17,01,1) { Species = 002, Ability = A4, Moves = new[]{ 075, 077, 033, 079 }, Index = 71 }, // Ivysaur
-        new(17,01,1) { Species = 060, Ability = A4, Moves = new[]{ 055, 095, 001, 341 }, Index = 71 }, // Poliwag
-        new(17,01,1) { Species = 453, Ability = A4, Moves = new[]{ 040, 279, 189, 372 }, Index = 71 }, // Croagunk
-        new(17,01,1) { Species = 535, Ability = A4, Moves = new[]{ 497, 341, 045, 051 }, Index = 71 }, // Tympole
-        new(30,03,2) { Species = 002, Ability = A4, Moves = new[]{ 402, 077, 033, 036 }, Index = 71 }, // Ivysaur
-        new(30,03,2) { Species = 061, Ability = A4, Moves = new[]{ 061, 095, 001, 341 }, Index = 71 }, // Poliwhirl
-        new(30,03,2) { Species = 453, Ability = A4, Moves = new[]{ 474, 279, 189, 372 }, Index = 71 }, // Croagunk
-        new(30,03,2) { Species = 536, Ability = A4, Moves = new[]{ 061, 341, 175, 051 }, Index = 71 }, // Palpitoad
-        new(40,05,3) { Species = 003, Ability = A4, Moves = new[]{ 402, 188, 414, 036 }, Index = 71 }, // Venusaur
-        new(40,05,3) { Species = 186, Ability = A4, Moves = new[]{ 056, 411, 034, 341 }, Index = 71 }, // Politoed
-        new(40,05,3) { Species = 453, Ability = A4, Moves = new[]{ 092, 279, 404, 372 }, Index = 71 }, // Croagunk
-        new(40,05,3) { Species = 537, Ability = A4, Moves = new[]{ 503, 341, 438, 051 }, Index = 71 }, // Seismitoad
-        new(50,08,4) { Species = 003, Ability = A4, Moves = new[]{ 438, 188, 414, 036 }, Index = 71 }, // Venusaur
-        new(50,08,4) { Species = 186, Ability = A4, Moves = new[]{ 056, 411, 034, 414 }, Index = 71 }, // Politoed
-        new(50,08,4) { Species = 453, Ability = A4, Moves = new[]{ 188, 067, 404, 372 }, Index = 71 }, // Croagunk
-        new(50,08,4) { Species = 537, Ability = A4, Moves = new[]{ 503, 341, 438, 398 }, Index = 71 }, // Seismitoad
-        new(60,10,5) { Species = 003, Ability = A4, Moves = new[]{ 438, 188, 414, 034 }, Index = 71, CanGigantamax = true }, // Venusaur
-        new(60,10,5) { Species = 003, Ability = A4, Moves = new[]{ 438, 188, 414, 034 }, Index = 71 }, // Venusaur
-        new(60,10,5) { Species = 186, Ability = A4, Moves = new[]{ 056, 311, 034, 414 }, Index = 71, Shiny = Shiny.Always }, // Politoed
-        new(60,10,5) { Species = 186, Ability = A4, Moves = new[]{ 056, 311, 034, 414 }, Index = 71 }, // Politoed
-        new(60,10,5) { Species = 453, Ability = A4, Moves = new[]{ 188, 067, 404, 247 }, Index = 71 }, // Croagunk
-        new(60,10,5) { Species = 537, Ability = A4, Moves = new[]{ 503, 089, 438, 398 }, Index = 71 }, // Seismitoad
+        new(17,01,1) { Species = 002, Ability = A4, Moves = new(075, 077, 033, 079), Index = 71 }, // Ivysaur
+        new(17,01,1) { Species = 060, Ability = A4, Moves = new(055, 095, 001, 341), Index = 71 }, // Poliwag
+        new(17,01,1) { Species = 453, Ability = A4, Moves = new(040, 279, 189, 372), Index = 71 }, // Croagunk
+        new(17,01,1) { Species = 535, Ability = A4, Moves = new(497, 341, 045, 051), Index = 71 }, // Tympole
+        new(30,03,2) { Species = 002, Ability = A4, Moves = new(402, 077, 033, 036), Index = 71 }, // Ivysaur
+        new(30,03,2) { Species = 061, Ability = A4, Moves = new(061, 095, 001, 341), Index = 71 }, // Poliwhirl
+        new(30,03,2) { Species = 453, Ability = A4, Moves = new(474, 279, 189, 372), Index = 71 }, // Croagunk
+        new(30,03,2) { Species = 536, Ability = A4, Moves = new(061, 341, 175, 051), Index = 71 }, // Palpitoad
+        new(40,05,3) { Species = 003, Ability = A4, Moves = new(402, 188, 414, 036), Index = 71 }, // Venusaur
+        new(40,05,3) { Species = 186, Ability = A4, Moves = new(056, 411, 034, 341), Index = 71 }, // Politoed
+        new(40,05,3) { Species = 453, Ability = A4, Moves = new(092, 279, 404, 372), Index = 71 }, // Croagunk
+        new(40,05,3) { Species = 537, Ability = A4, Moves = new(503, 341, 438, 051), Index = 71 }, // Seismitoad
+        new(50,08,4) { Species = 003, Ability = A4, Moves = new(438, 188, 414, 036), Index = 71 }, // Venusaur
+        new(50,08,4) { Species = 186, Ability = A4, Moves = new(056, 411, 034, 414), Index = 71 }, // Politoed
+        new(50,08,4) { Species = 453, Ability = A4, Moves = new(188, 067, 404, 372), Index = 71 }, // Croagunk
+        new(50,08,4) { Species = 537, Ability = A4, Moves = new(503, 341, 438, 398), Index = 71 }, // Seismitoad
+        new(60,10,5) { Species = 003, Ability = A4, Moves = new(438, 188, 414, 034), Index = 71, CanGigantamax = true }, // Venusaur
+        new(60,10,5) { Species = 003, Ability = A4, Moves = new(438, 188, 414, 034), Index = 71 }, // Venusaur
+        new(60,10,5) { Species = 186, Ability = A4, Moves = new(056, 311, 034, 414), Index = 71, Shiny = Shiny.Always }, // Politoed
+        new(60,10,5) { Species = 186, Ability = A4, Moves = new(056, 311, 034, 414), Index = 71 }, // Politoed
+        new(60,10,5) { Species = 453, Ability = A4, Moves = new(188, 067, 404, 247), Index = 71 }, // Croagunk
+        new(60,10,5) { Species = 537, Ability = A4, Moves = new(503, 089, 438, 398), Index = 71 }, // Seismitoad
 
-        new(17,01,1) { Species = 831, Ability = A4, Moves = new[]{ 029, 024, 045, 033 }, Index = 69 }, // Wooloo
-        new(30,03,2) { Species = 831, Ability = A4, Moves = new[]{ 029, 024, 528, 033 }, Index = 69 }, // Wooloo
-        new(30,03,2) { Species = 832, Ability = A4, Moves = new[]{ 036, 024, 528, 371 }, Index = 69 }, // Dubwool
-        new(40,05,3) { Species = 831, Ability = A4, Moves = new[]{ 029, 179, 528, 024 }, Index = 69 }, // Wooloo
-        new(40,05,3) { Species = 832, Ability = A4, Moves = new[]{ 036, 179, 528, 371 }, Index = 69 }, // Dubwool
-        new(50,08,4) { Species = 831, Ability = A4, Moves = new[]{ 029, 179, 528, 371 }, Index = 69 }, // Wooloo
-        new(50,08,4) { Species = 832, Ability = A4, Moves = new[]{ 036, 179, 528, 024 }, Index = 69 }, // Dubwool
-        new(60,10,5) { Species = 831, Ability = A4, Moves = new[]{ 038, 179, 086, 371 }, Index = 69, Shiny = Shiny.Always }, // Wooloo
-        new(60,10,5) { Species = 831, Ability = A4, Moves = new[]{ 038, 179, 086, 371 }, Index = 69 }, // Wooloo
-        new(60,10,5) { Species = 832, Ability = A4, Moves = new[]{ 776, 038, 086, 371 }, Index = 69 }, // Dubwool
+        new(17,01,1) { Species = 831, Ability = A4, Moves = new(029, 024, 045, 033), Index = 69 }, // Wooloo
+        new(30,03,2) { Species = 831, Ability = A4, Moves = new(029, 024, 528, 033), Index = 69 }, // Wooloo
+        new(30,03,2) { Species = 832, Ability = A4, Moves = new(036, 024, 528, 371), Index = 69 }, // Dubwool
+        new(40,05,3) { Species = 831, Ability = A4, Moves = new(029, 179, 528, 024), Index = 69 }, // Wooloo
+        new(40,05,3) { Species = 832, Ability = A4, Moves = new(036, 179, 528, 371), Index = 69 }, // Dubwool
+        new(50,08,4) { Species = 831, Ability = A4, Moves = new(029, 179, 528, 371), Index = 69 }, // Wooloo
+        new(50,08,4) { Species = 832, Ability = A4, Moves = new(036, 179, 528, 024), Index = 69 }, // Dubwool
+        new(60,10,5) { Species = 831, Ability = A4, Moves = new(038, 179, 086, 371), Index = 69, Shiny = Shiny.Always }, // Wooloo
+        new(60,10,5) { Species = 831, Ability = A4, Moves = new(038, 179, 086, 371), Index = 69 }, // Wooloo
+        new(60,10,5) { Species = 832, Ability = A4, Moves = new(776, 038, 086, 371), Index = 69 }, // Dubwool
 
-        new(17,01,1) { Species = 052, Ability = A4, Moves = new[]{ 006, 232, 442, 583 }, Index = 67, Form = 2 }, // Meowth-2
-        new(17,01,1) { Species = 052, Ability = A4, Moves = new[]{ 006, 583, 196, 675 }, Index = 67, Form = 1 }, // Meowth-1
-        new(17,01,1) { Species = 052, Ability = A4, Moves = new[]{ 006, 492, 402, 247 }, Index = 67 }, // Meowth
-        new(17,01,1) { Species = 052, Ability = A4, Moves = new[]{ 006, 441, 087, 231 }, Index = 67 }, // Meowth
-        new(30,03,2) { Species = 052, Ability = A4, Moves = new[]{ 006, 232, 442, 583 }, Index = 67, Form = 2 }, // Meowth-2
-        new(30,03,2) { Species = 052, Ability = A4, Moves = new[]{ 006, 583, 196, 675 }, Index = 67, Form = 1 }, // Meowth-1
-        new(30,03,2) { Species = 052, Ability = A4, Moves = new[]{ 006, 492, 402, 247 }, Index = 67 }, // Meowth
-        new(30,03,2) { Species = 052, Ability = A4, Moves = new[]{ 006, 441, 087, 231 }, Index = 67 }, // Meowth
-        new(40,05,3) { Species = 052, Ability = A4, Moves = new[]{ 006, 232, 442, 583 }, Index = 67, Form = 2 }, // Meowth-2
-        new(40,05,3) { Species = 052, Ability = A4, Moves = new[]{ 006, 583, 196, 675 }, Index = 67, Form = 1 }, // Meowth-1
-        new(40,05,3) { Species = 052, Ability = A4, Moves = new[]{ 006, 492, 402, 247 }, Index = 67 }, // Meowth
-        new(40,05,3) { Species = 052, Ability = A4, Moves = new[]{ 006, 441, 087, 231 }, Index = 67 }, // Meowth
-        new(50,08,4) { Species = 052, Ability = A4, Moves = new[]{ 006, 232, 442, 583 }, Index = 67, Form = 2 }, // Meowth-2
-        new(50,08,4) { Species = 052, Ability = A4, Moves = new[]{ 006, 583, 196, 675 }, Index = 67, Form = 1 }, // Meowth-1
-        new(50,08,4) { Species = 052, Ability = A4, Moves = new[]{ 006, 492, 402, 247 }, Index = 67 }, // Meowth
-        new(50,08,4) { Species = 052, Ability = A4, Moves = new[]{ 006, 441, 087, 231 }, Index = 67 }, // Meowth
-        new(60,10,5) { Species = 052, Ability = A4, Moves = new[]{ 006, 232, 442, 583 }, Index = 67, Form = 2, Shiny = Shiny.Always }, // Meowth-2
-        new(60,10,5) { Species = 052, Ability = A4, Moves = new[]{ 006, 232, 442, 583 }, Index = 67, Form = 2 }, // Meowth-2
-        new(60,10,5) { Species = 052, Ability = A4, Moves = new[]{ 006, 583, 196, 675 }, Index = 67, Form = 1 }, // Meowth-1
-        new(60,10,5) { Species = 052, Ability = A4, Moves = new[]{ 006, 492, 402, 247 }, Index = 67 }, // Meowth
-        new(60,10,5) { Species = 052, Ability = A4, Moves = new[]{ 006, 441, 087, 231 }, Index = 67 }, // Meowth
-        new(60,10,5) { Species = 052, Ability = A4, Moves = new[]{ 006, 583, 421, 034 }, Index = 67, CanGigantamax = true }, // Meowth
+        new(17,01,1) { Species = 052, Ability = A4, Moves = new(006, 232, 442, 583), Index = 67, Form = 2 }, // Meowth-2
+        new(17,01,1) { Species = 052, Ability = A4, Moves = new(006, 583, 196, 675), Index = 67, Form = 1 }, // Meowth-1
+        new(17,01,1) { Species = 052, Ability = A4, Moves = new(006, 492, 402, 247), Index = 67 }, // Meowth
+        new(17,01,1) { Species = 052, Ability = A4, Moves = new(006, 441, 087, 231), Index = 67 }, // Meowth
+        new(30,03,2) { Species = 052, Ability = A4, Moves = new(006, 232, 442, 583), Index = 67, Form = 2 }, // Meowth-2
+        new(30,03,2) { Species = 052, Ability = A4, Moves = new(006, 583, 196, 675), Index = 67, Form = 1 }, // Meowth-1
+        new(30,03,2) { Species = 052, Ability = A4, Moves = new(006, 492, 402, 247), Index = 67 }, // Meowth
+        new(30,03,2) { Species = 052, Ability = A4, Moves = new(006, 441, 087, 231), Index = 67 }, // Meowth
+        new(40,05,3) { Species = 052, Ability = A4, Moves = new(006, 232, 442, 583), Index = 67, Form = 2 }, // Meowth-2
+        new(40,05,3) { Species = 052, Ability = A4, Moves = new(006, 583, 196, 675), Index = 67, Form = 1 }, // Meowth-1
+        new(40,05,3) { Species = 052, Ability = A4, Moves = new(006, 492, 402, 247), Index = 67 }, // Meowth
+        new(40,05,3) { Species = 052, Ability = A4, Moves = new(006, 441, 087, 231), Index = 67 }, // Meowth
+        new(50,08,4) { Species = 052, Ability = A4, Moves = new(006, 232, 442, 583), Index = 67, Form = 2 }, // Meowth-2
+        new(50,08,4) { Species = 052, Ability = A4, Moves = new(006, 583, 196, 675), Index = 67, Form = 1 }, // Meowth-1
+        new(50,08,4) { Species = 052, Ability = A4, Moves = new(006, 492, 402, 247), Index = 67 }, // Meowth
+        new(50,08,4) { Species = 052, Ability = A4, Moves = new(006, 441, 087, 231), Index = 67 }, // Meowth
+        new(60,10,5) { Species = 052, Ability = A4, Moves = new(006, 232, 442, 583), Index = 67, Form = 2, Shiny = Shiny.Always }, // Meowth-2
+        new(60,10,5) { Species = 052, Ability = A4, Moves = new(006, 232, 442, 583), Index = 67, Form = 2 }, // Meowth-2
+        new(60,10,5) { Species = 052, Ability = A4, Moves = new(006, 583, 196, 675), Index = 67, Form = 1 }, // Meowth-1
+        new(60,10,5) { Species = 052, Ability = A4, Moves = new(006, 492, 402, 247), Index = 67 }, // Meowth
+        new(60,10,5) { Species = 052, Ability = A4, Moves = new(006, 441, 087, 231), Index = 67 }, // Meowth
+        new(60,10,5) { Species = 052, Ability = A4, Moves = new(006, 583, 421, 034), Index = 67, CanGigantamax = true }, // Meowth
 
-        new(17,01,1) { Species = 875, Ability = A4, Moves = new[]{ 181, 362, 033, 311 }, Index = 65 }, // Eiscue
-        new(30,03,2) { Species = 875, Ability = A4, Moves = new[]{ 196, 362, 033, 029 }, Index = 65 }, // Eiscue
-        new(40,05,3) { Species = 875, Ability = A4, Moves = new[]{ 008, 057, 263, 029 }, Index = 65 }, // Eiscue
-        new(50,08,4) { Species = 875, Ability = A4, Moves = new[]{ 333, 057, 428, 029 }, Index = 65 }, // Eiscue
-        new(60,10,5) { Species = 875, Ability = A4, Moves = new[]{ 333, 710, 442, 029 }, Index = 65, Shiny = Shiny.Always }, // Eiscue
-        new(60,10,5) { Species = 875, Ability = A4, Moves = new[]{ 333, 710, 442, 029 }, Index = 65 }, // Eiscue
+        new(17,01,1) { Species = 875, Ability = A4, Moves = new(181, 362, 033, 311), Index = 65 }, // Eiscue
+        new(30,03,2) { Species = 875, Ability = A4, Moves = new(196, 362, 033, 029), Index = 65 }, // Eiscue
+        new(40,05,3) { Species = 875, Ability = A4, Moves = new(008, 057, 263, 029), Index = 65 }, // Eiscue
+        new(50,08,4) { Species = 875, Ability = A4, Moves = new(333, 057, 428, 029), Index = 65 }, // Eiscue
+        new(60,10,5) { Species = 875, Ability = A4, Moves = new(333, 710, 442, 029), Index = 65, Shiny = Shiny.Always }, // Eiscue
+        new(60,10,5) { Species = 875, Ability = A4, Moves = new(333, 710, 442, 029), Index = 65 }, // Eiscue
 
-        new(17,01,1) { Species = 132, Ability = A4, Moves = new[]{ 144, 000, 000, 000 }, Index = 64 }, // Ditto
-        new(17,01,1) { Species = 821, Ability = A4, Moves = new[]{ 403, 031, 043, 681 }, Index = 64 }, // Rookidee
-        new(17,01,1) { Species = 833, Ability = A4, Moves = new[]{ 055, 033, 044, 240 }, Index = 64 }, // Chewtle
-        new(17,01,1) { Species = 824, Ability = A4, Moves = new[]{ 522, 000, 000, 000 }, Index = 64 }, // Blipbug
-        new(17,01,1) { Species = 850, Ability = A4, Moves = new[]{ 172, 044, 035, 052 }, Index = 64 }, // Sizzlipede
-        new(17,01,1) { Species = 831, Ability = A4, Moves = new[]{ 033, 024, 029, 045 }, Index = 64 }, // Wooloo
-        new(30,03,2) { Species = 132, Ability = A4, Moves = new[]{ 144, 000, 000, 000 }, Index = 64 }, // Ditto
-        new(30,03,2) { Species = 822, Ability = A4, Moves = new[]{ 403, 263, 279, 681 }, Index = 64 }, // Corvisquire
-        new(30,03,2) { Species = 833, Ability = A4, Moves = new[]{ 055, 033, 044, 029 }, Index = 64 }, // Chewtle
-        new(30,03,2) { Species = 825, Ability = A4, Moves = new[]{ 522, 263, 371, 247 }, Index = 64 }, // Dottler
-        new(30,03,2) { Species = 850, Ability = A4, Moves = new[]{ 172, 044, 035, 052 }, Index = 64 }, // Sizzlipede
-        new(30,03,2) { Species = 831, Ability = A4, Moves = new[]{ 036, 024, 029, 086 }, Index = 64 }, // Wooloo
-        new(40,05,3) { Species = 132, Ability = A4, Moves = new[]{ 144, 000, 000, 000 }, Index = 64 }, // Ditto
-        new(40,05,3) { Species = 823, Ability = A4, Moves = new[]{ 403, 442, 034, 681 }, Index = 64 }, // Corviknight
-        new(40,05,3) { Species = 834, Ability = A4, Moves = new[]{ 157, 534, 317, 055 }, Index = 64 }, // Drednaw
-        new(40,05,3) { Species = 826, Ability = A4, Moves = new[]{ 405, 277, 371, 247 }, Index = 64 }, // Orbeetle
-        new(40,05,3) { Species = 851, Ability = A4, Moves = new[]{ 424, 404, 422, 044 }, Index = 64 }, // Centiskorch
-        new(40,05,3) { Species = 832, Ability = A4, Moves = new[]{ 036, 024, 428, 086 }, Index = 64 }, // Dubwool
-        new(50,08,4) { Species = 132, Ability = A4, Moves = new[]{ 144, 000, 000, 000 }, Index = 64 }, // Ditto
-        new(50,08,4) { Species = 823, Ability = A4, Moves = new[]{ 413, 442, 034, 681 }, Index = 64 }, // Corviknight
-        new(50,08,4) { Species = 834, Ability = A4, Moves = new[]{ 157, 710, 317, 334 }, Index = 64 }, // Drednaw
-        new(50,08,4) { Species = 826, Ability = A4, Moves = new[]{ 405, 277, 776, 247 }, Index = 64 }, // Orbeetle
-        new(50,08,4) { Species = 851, Ability = A4, Moves = new[]{ 680, 404, 422, 044 }, Index = 64 }, // Centiskorch
-        new(50,08,4) { Species = 832, Ability = A4, Moves = new[]{ 038, 024, 428, 086 }, Index = 64 }, // Dubwool
-        new(60,10,5) { Species = 132, Ability = A4, Moves = new[]{ 144, 000, 000, 000 }, Index = 64 }, // Ditto
-        new(60,10,5) { Species = 823, Ability = A4, Moves = new[]{ 413, 442, 776, 372 }, Index = 64 }, // Corviknight
-        new(60,10,5) { Species = 834, Ability = A4, Moves = new[]{ 157, 710, 317, 334 }, Index = 64 }, // Drednaw
-        new(60,10,5) { Species = 826, Ability = A4, Moves = new[]{ 405, 277, 776, 412 }, Index = 64 }, // Orbeetle
-        new(60,10,5) { Species = 851, Ability = A4, Moves = new[]{ 680, 679, 422, 044 }, Index = 64 }, // Centiskorch
-        new(60,10,5) { Species = 832, Ability = A4, Moves = new[]{ 038, 776, 428, 086 }, Index = 64 }, // Dubwool
+        new(17,01,1) { Species = 132, Ability = A4, Moves = new(144, 000, 000, 000), Index = 64 }, // Ditto
+        new(17,01,1) { Species = 821, Ability = A4, Moves = new(403, 031, 043, 681), Index = 64 }, // Rookidee
+        new(17,01,1) { Species = 833, Ability = A4, Moves = new(055, 033, 044, 240), Index = 64 }, // Chewtle
+        new(17,01,1) { Species = 824, Ability = A4, Moves = new(522, 000, 000, 000), Index = 64 }, // Blipbug
+        new(17,01,1) { Species = 850, Ability = A4, Moves = new(172, 044, 035, 052), Index = 64 }, // Sizzlipede
+        new(17,01,1) { Species = 831, Ability = A4, Moves = new(033, 024, 029, 045), Index = 64 }, // Wooloo
+        new(30,03,2) { Species = 132, Ability = A4, Moves = new(144, 000, 000, 000), Index = 64 }, // Ditto
+        new(30,03,2) { Species = 822, Ability = A4, Moves = new(403, 263, 279, 681), Index = 64 }, // Corvisquire
+        new(30,03,2) { Species = 833, Ability = A4, Moves = new(055, 033, 044, 029), Index = 64 }, // Chewtle
+        new(30,03,2) { Species = 825, Ability = A4, Moves = new(522, 263, 371, 247), Index = 64 }, // Dottler
+        new(30,03,2) { Species = 850, Ability = A4, Moves = new(172, 044, 035, 052), Index = 64 }, // Sizzlipede
+        new(30,03,2) { Species = 831, Ability = A4, Moves = new(036, 024, 029, 086), Index = 64 }, // Wooloo
+        new(40,05,3) { Species = 132, Ability = A4, Moves = new(144, 000, 000, 000), Index = 64 }, // Ditto
+        new(40,05,3) { Species = 823, Ability = A4, Moves = new(403, 442, 034, 681), Index = 64 }, // Corviknight
+        new(40,05,3) { Species = 834, Ability = A4, Moves = new(157, 534, 317, 055), Index = 64 }, // Drednaw
+        new(40,05,3) { Species = 826, Ability = A4, Moves = new(405, 277, 371, 247), Index = 64 }, // Orbeetle
+        new(40,05,3) { Species = 851, Ability = A4, Moves = new(424, 404, 422, 044), Index = 64 }, // Centiskorch
+        new(40,05,3) { Species = 832, Ability = A4, Moves = new(036, 024, 428, 086), Index = 64 }, // Dubwool
+        new(50,08,4) { Species = 132, Ability = A4, Moves = new(144, 000, 000, 000), Index = 64 }, // Ditto
+        new(50,08,4) { Species = 823, Ability = A4, Moves = new(413, 442, 034, 681), Index = 64 }, // Corviknight
+        new(50,08,4) { Species = 834, Ability = A4, Moves = new(157, 710, 317, 334), Index = 64 }, // Drednaw
+        new(50,08,4) { Species = 826, Ability = A4, Moves = new(405, 277, 776, 247), Index = 64 }, // Orbeetle
+        new(50,08,4) { Species = 851, Ability = A4, Moves = new(680, 404, 422, 044), Index = 64 }, // Centiskorch
+        new(50,08,4) { Species = 832, Ability = A4, Moves = new(038, 024, 428, 086), Index = 64 }, // Dubwool
+        new(60,10,5) { Species = 132, Ability = A4, Moves = new(144, 000, 000, 000), Index = 64 }, // Ditto
+        new(60,10,5) { Species = 823, Ability = A4, Moves = new(413, 442, 776, 372), Index = 64 }, // Corviknight
+        new(60,10,5) { Species = 834, Ability = A4, Moves = new(157, 710, 317, 334), Index = 64 }, // Drednaw
+        new(60,10,5) { Species = 826, Ability = A4, Moves = new(405, 277, 776, 412), Index = 64 }, // Orbeetle
+        new(60,10,5) { Species = 851, Ability = A4, Moves = new(680, 679, 422, 044), Index = 64 }, // Centiskorch
+        new(60,10,5) { Species = 832, Ability = A4, Moves = new(038, 776, 428, 086), Index = 64 }, // Dubwool
 
-        new(17,01,1) { Species = 183, Ability = A4, Moves = new[]{ 061, 204, 111, 205 }, Index = 63 }, // Marill
-        new(17,01,1) { Species = 427, Ability = A4, Moves = new[]{ 098, 608, 150, 111 }, Index = 63 }, // Buneary
-        new(17,01,1) { Species = 659, Ability = A4, Moves = new[]{ 098, 189, 280, 341 }, Index = 63 }, // Bunnelby
-        new(30,03,2) { Species = 184, Ability = A4, Moves = new[]{ 401, 583, 280, 205 }, Index = 63 }, // Azumarill
-        new(30,03,2) { Species = 428, Ability = A4, Moves = new[]{ 024, 204, 029, 111 }, Index = 63 }, // Lopunny
-        new(30,03,2) { Species = 660, Ability = A4, Moves = new[]{ 098, 523, 280, 341 }, Index = 63 }, // Diggersby
-        new(40,05,3) { Species = 184, Ability = A4, Moves = new[]{ 056, 583, 280, 205 }, Index = 63 }, // Azumarill
-        new(40,05,3) { Species = 428, Ability = A4, Moves = new[]{ 024, 204, 029, 129 }, Index = 63 }, // Lopunny
-        new(40,05,3) { Species = 660, Ability = A4, Moves = new[]{ 005, 523, 280, 036 }, Index = 63 }, // Diggersby
-        new(50,08,4) { Species = 184, Ability = A4, Moves = new[]{ 710, 583, 276, 205 }, Index = 63 }, // Azumarill
-        new(50,08,4) { Species = 428, Ability = A4, Moves = new[]{ 024, 583, 025, 129 }, Index = 63 }, // Lopunny
-        new(50,08,4) { Species = 660, Ability = A4, Moves = new[]{ 005, 089, 280, 162 }, Index = 63 }, // Diggersby
-        new(60,10,5) { Species = 184, Ability = A4, Moves = new[]{ 710, 583, 276, 523 }, Index = 63 }, // Azumarill
-        new(60,10,5) { Species = 184, Ability = A4, Moves = new[]{ 710, 583, 276, 523 }, Index = 63, Shiny = Shiny.Always }, // Azumarill
-        new(60,10,5) { Species = 428, Ability = A4, Moves = new[]{ 136, 583, 025, 693 }, Index = 63 }, // Lopunny
-        new(60,10,5) { Species = 660, Ability = A4, Moves = new[]{ 416, 089, 359, 162 }, Index = 63 }, // Diggersby
-        //new(60,10,5) { Species = 815, Ability = A2, Moves = new[]{ 780, 442, 279, 555 }, Index = 63, CanGigantamax = true }, // Cinderace
+        new(17,01,1) { Species = 183, Ability = A4, Moves = new(061, 204, 111, 205), Index = 63 }, // Marill
+        new(17,01,1) { Species = 427, Ability = A4, Moves = new(098, 608, 150, 111), Index = 63 }, // Buneary
+        new(17,01,1) { Species = 659, Ability = A4, Moves = new(098, 189, 280, 341), Index = 63 }, // Bunnelby
+        new(30,03,2) { Species = 184, Ability = A4, Moves = new(401, 583, 280, 205), Index = 63 }, // Azumarill
+        new(30,03,2) { Species = 428, Ability = A4, Moves = new(024, 204, 029, 111), Index = 63 }, // Lopunny
+        new(30,03,2) { Species = 660, Ability = A4, Moves = new(098, 523, 280, 341), Index = 63 }, // Diggersby
+        new(40,05,3) { Species = 184, Ability = A4, Moves = new(056, 583, 280, 205), Index = 63 }, // Azumarill
+        new(40,05,3) { Species = 428, Ability = A4, Moves = new(024, 204, 029, 129), Index = 63 }, // Lopunny
+        new(40,05,3) { Species = 660, Ability = A4, Moves = new(005, 523, 280, 036), Index = 63 }, // Diggersby
+        new(50,08,4) { Species = 184, Ability = A4, Moves = new(710, 583, 276, 205), Index = 63 }, // Azumarill
+        new(50,08,4) { Species = 428, Ability = A4, Moves = new(024, 583, 025, 129), Index = 63 }, // Lopunny
+        new(50,08,4) { Species = 660, Ability = A4, Moves = new(005, 089, 280, 162), Index = 63 }, // Diggersby
+        new(60,10,5) { Species = 184, Ability = A4, Moves = new(710, 583, 276, 523), Index = 63 }, // Azumarill
+        new(60,10,5) { Species = 184, Ability = A4, Moves = new(710, 583, 276, 523), Index = 63, Shiny = Shiny.Always }, // Azumarill
+        new(60,10,5) { Species = 428, Ability = A4, Moves = new(136, 583, 025, 693), Index = 63 }, // Lopunny
+        new(60,10,5) { Species = 660, Ability = A4, Moves = new(416, 089, 359, 162), Index = 63 }, // Diggersby
+        //new(60,10,5) { Species = 815, Ability = A2, Moves = new(780, 442, 279, 555), Index = 63, CanGigantamax = true }, // Cinderace
 
-        //new(17,01,1) { Species = 129, Ability = A4, Moves = new[]{ 150, 000, 000, 000 }, Index = 62 }, // Magikarp
-        //new(30,03,2) { Species = 129, Ability = A4, Moves = new[]{ 150, 000, 000, 000 }, Index = 62 }, // Magikarp
-        //new(40,05,3) { Species = 129, Ability = A4, Moves = new[]{ 150, 000, 000, 000 }, Index = 62 }, // Magikarp
-        //new(50,08,4) { Species = 129, Ability = A4, Moves = new[]{ 150, 000, 000, 000 }, Index = 62 }, // Magikarp
-        //new(60,10,5) { Species = 129, Ability = A4, Moves = new[]{ 150, 000, 000, 000 }, Index = 62 }, // Magikarp
+        //new(17,01,1) { Species = 129, Ability = A4, Moves = new(150, 000, 000, 000), Index = 62 }, // Magikarp
+        //new(30,03,2) { Species = 129, Ability = A4, Moves = new(150, 000, 000, 000), Index = 62 }, // Magikarp
+        //new(40,05,3) { Species = 129, Ability = A4, Moves = new(150, 000, 000, 000), Index = 62 }, // Magikarp
+        //new(50,08,4) { Species = 129, Ability = A4, Moves = new(150, 000, 000, 000), Index = 62 }, // Magikarp
+        //new(60,10,5) { Species = 129, Ability = A4, Moves = new(150, 000, 000, 000), Index = 62 }, // Magikarp
 
-        new(17,01,1) { Species = 043, Ability = A4, Moves = new[]{ 331, 236, 051, 074 }, Index = 60 }, // Oddish
-        new(17,01,1) { Species = 420, Ability = A4, Moves = new[]{ 234, 572, 670, 033 }, Index = 60 }, // Cherubi
-        new(17,01,1) { Species = 549, Ability = A4, Moves = new[]{ 412, 298, 345, 263 }, Index = 60 }, // Lilligant
-        new(17,01,1) { Species = 753, Ability = A4, Moves = new[]{ 210, 074, 075, 275 }, Index = 60 }, // Fomantis
-        new(17,01,1) { Species = 764, Ability = A4, Moves = new[]{ 345, 579, 035, 074 }, Index = 60 }, // Comfey
-        new(30,03,2) { Species = 045, Ability = A4, Moves = new[]{ 572, 236, 051, 496 }, Index = 60 }, // Vileplume
-        new(30,03,2) { Species = 182, Ability = A4, Moves = new[]{ 572, 483, 074, 605 }, Index = 60 }, // Bellossom
-        new(30,03,2) { Species = 421, Ability = A4, Moves = new[]{ 579, 345, 670, 033 }, Index = 60 }, // Cherrim
-        new(30,03,2) { Species = 549, Ability = A4, Moves = new[]{ 412, 298, 345, 263 }, Index = 60 }, // Lilligant
-        new(30,03,2) { Species = 753, Ability = A4, Moves = new[]{ 210, 163, 075, 230 }, Index = 60 }, // Fomantis
-        new(30,03,2) { Species = 764, Ability = A4, Moves = new[]{ 345, 579, 035, 583 }, Index = 60 }, // Comfey
-        new(40,05,3) { Species = 045, Ability = A4, Moves = new[]{ 572, 585, 051, 496 }, Index = 60 }, // Vileplume
-        new(40,05,3) { Species = 182, Ability = A4, Moves = new[]{ 572, 483, 077, 605 }, Index = 60 }, // Bellossom
-        new(40,05,3) { Species = 421, Ability = A4, Moves = new[]{ 579, 345, 583, 036 }, Index = 60 }, // Cherrim
-        new(40,05,3) { Species = 549, Ability = A4, Moves = new[]{ 572, 298, 345, 483 }, Index = 60 }, // Lilligant
-        new(40,05,3) { Species = 754, Ability = A4, Moves = new[]{ 210, 572, 400, 530 }, Index = 60 }, // Lurantis
-        new(40,05,3) { Species = 764, Ability = A4, Moves = new[]{ 572, 579, 035, 583 }, Index = 60 }, // Comfey
-        new(50,08,4) { Species = 045, Ability = A4, Moves = new[]{ 572, 585, 092, 496 }, Index = 60 }, // Vileplume
-        new(50,08,4) { Species = 182, Ability = A4, Moves = new[]{ 080, 483, 051, 605 }, Index = 60 }, // Bellossom
-        new(50,08,4) { Species = 421, Ability = A4, Moves = new[]{ 579, 572, 583, 676 }, Index = 60 }, // Cherrim
-        new(50,08,4) { Species = 549, Ability = A4, Moves = new[]{ 572, 298, 241, 676 }, Index = 60 }, // Lilligant
-        new(50,08,4) { Species = 754, Ability = A4, Moves = new[]{ 404, 572, 400, 530 }, Index = 60 }, // Lurantis
-        new(50,08,4) { Species = 764, Ability = A4, Moves = new[]{ 572, 579, 035, 583 }, Index = 60 }, // Comfey
-        new(60,10,5) { Species = 045, Ability = A4, Moves = new[]{ 572, 585, 092, 034 }, Index = 60 }, // Vileplume
-        new(60,10,5) { Species = 549, Ability = A4, Moves = new[]{ 080, 298, 241, 676 }, Index = 60, Shiny = Shiny.Always }, // Lilligant
-        new(60,10,5) { Species = 421, Ability = A4, Moves = new[]{ 579, 572, 605, 676 }, Index = 60 }, // Cherrim
-        new(60,10,5) { Species = 549, Ability = A4, Moves = new[]{ 080, 298, 241, 676 }, Index = 60 }, // Lilligant
-        new(60,10,5) { Species = 754, Ability = A4, Moves = new[]{ 404, 572, 398, 530 }, Index = 60 }, // Lurantis
-        new(60,10,5) { Species = 764, Ability = A4, Moves = new[]{ 572, 579, 447, 583 }, Index = 60 }, // Comfey
+        new(17,01,1) { Species = 043, Ability = A4, Moves = new(331, 236, 051, 074), Index = 60 }, // Oddish
+        new(17,01,1) { Species = 420, Ability = A4, Moves = new(234, 572, 670, 033), Index = 60 }, // Cherubi
+        new(17,01,1) { Species = 549, Ability = A4, Moves = new(412, 298, 345, 263), Index = 60 }, // Lilligant
+        new(17,01,1) { Species = 753, Ability = A4, Moves = new(210, 074, 075, 275), Index = 60 }, // Fomantis
+        new(17,01,1) { Species = 764, Ability = A4, Moves = new(345, 579, 035, 074), Index = 60 }, // Comfey
+        new(30,03,2) { Species = 045, Ability = A4, Moves = new(572, 236, 051, 496), Index = 60 }, // Vileplume
+        new(30,03,2) { Species = 182, Ability = A4, Moves = new(572, 483, 074, 605), Index = 60 }, // Bellossom
+        new(30,03,2) { Species = 421, Ability = A4, Moves = new(579, 345, 670, 033), Index = 60 }, // Cherrim
+        new(30,03,2) { Species = 549, Ability = A4, Moves = new(412, 298, 345, 263), Index = 60 }, // Lilligant
+        new(30,03,2) { Species = 753, Ability = A4, Moves = new(210, 163, 075, 230), Index = 60 }, // Fomantis
+        new(30,03,2) { Species = 764, Ability = A4, Moves = new(345, 579, 035, 583), Index = 60 }, // Comfey
+        new(40,05,3) { Species = 045, Ability = A4, Moves = new(572, 585, 051, 496), Index = 60 }, // Vileplume
+        new(40,05,3) { Species = 182, Ability = A4, Moves = new(572, 483, 077, 605), Index = 60 }, // Bellossom
+        new(40,05,3) { Species = 421, Ability = A4, Moves = new(579, 345, 583, 036), Index = 60 }, // Cherrim
+        new(40,05,3) { Species = 549, Ability = A4, Moves = new(572, 298, 345, 483), Index = 60 }, // Lilligant
+        new(40,05,3) { Species = 754, Ability = A4, Moves = new(210, 572, 400, 530), Index = 60 }, // Lurantis
+        new(40,05,3) { Species = 764, Ability = A4, Moves = new(572, 579, 035, 583), Index = 60 }, // Comfey
+        new(50,08,4) { Species = 045, Ability = A4, Moves = new(572, 585, 092, 496), Index = 60 }, // Vileplume
+        new(50,08,4) { Species = 182, Ability = A4, Moves = new(080, 483, 051, 605), Index = 60 }, // Bellossom
+        new(50,08,4) { Species = 421, Ability = A4, Moves = new(579, 572, 583, 676), Index = 60 }, // Cherrim
+        new(50,08,4) { Species = 549, Ability = A4, Moves = new(572, 298, 241, 676), Index = 60 }, // Lilligant
+        new(50,08,4) { Species = 754, Ability = A4, Moves = new(404, 572, 400, 530), Index = 60 }, // Lurantis
+        new(50,08,4) { Species = 764, Ability = A4, Moves = new(572, 579, 035, 583), Index = 60 }, // Comfey
+        new(60,10,5) { Species = 045, Ability = A4, Moves = new(572, 585, 092, 034), Index = 60 }, // Vileplume
+        new(60,10,5) { Species = 549, Ability = A4, Moves = new(080, 298, 241, 676), Index = 60, Shiny = Shiny.Always }, // Lilligant
+        new(60,10,5) { Species = 421, Ability = A4, Moves = new(579, 572, 605, 676), Index = 60 }, // Cherrim
+        new(60,10,5) { Species = 549, Ability = A4, Moves = new(080, 298, 241, 676), Index = 60 }, // Lilligant
+        new(60,10,5) { Species = 754, Ability = A4, Moves = new(404, 572, 398, 530), Index = 60 }, // Lurantis
+        new(60,10,5) { Species = 764, Ability = A4, Moves = new(572, 579, 447, 583), Index = 60 }, // Comfey
 
-        new(17,01,1) { Species = 856, Ability = A4, Moves = new[]{ 312, 093, 574, 595 }, Index = 59 }, // Hatenna
-        new(17,01,1) { Species = 280, Ability = A4, Moves = new[]{ 574, 093, 104, 045 }, Index = 59 }, // Ralts
-        new(17,01,1) { Species = 109, Ability = A4, Moves = new[]{ 499, 053, 124, 372 }, Index = 59 }, // Koffing
-        new(17,01,1) { Species = 821, Ability = A4, Moves = new[]{ 403, 031, 043, 681 }, Index = 59 }, // Rookidee
-        new(17,01,1) { Species = 627, Ability = A4, Moves = new[]{ 043, 276, 017, 064 }, Index = 59 }, // Rufflet
-        new(17,01,1) { Species = 845, Ability = A4, Moves = new[]{ 055, 254, 064, 562 }, Index = 59 }, // Cramorant
-        new(30,03,2) { Species = 856, Ability = A4, Moves = new[]{ 605, 060, 574, 595 }, Index = 59 }, // Hatenna
-        new(30,03,2) { Species = 281, Ability = A4, Moves = new[]{ 574, 060, 104, 085 }, Index = 59 }, // Kirlia
-        new(30,03,2) { Species = 109, Ability = A4, Moves = new[]{ 499, 053, 482, 372 }, Index = 59 }, // Koffing
-        new(30,03,2) { Species = 822, Ability = A4, Moves = new[]{ 403, 263, 279, 681 }, Index = 59 }, // Corvisquire
-        new(30,03,2) { Species = 627, Ability = A4, Moves = new[]{ 184, 276, 017, 157 }, Index = 59 }, // Rufflet
-        new(30,03,2) { Species = 845, Ability = A4, Moves = new[]{ 055, 058, 064, 562 }, Index = 59 }, // Cramorant
-        new(40,05,3) { Species = 857, Ability = A4, Moves = new[]{ 605, 060, 595, 574 }, Index = 59, CanGigantamax = true }, // Hattrem
-        new(40,05,3) { Species = 282, Ability = A4, Moves = new[]{ 585, 060, 595, 085 }, Index = 59 }, // Gardevoir
-        new(40,05,3) { Species = 110, Ability = A4, Moves = new[]{ 790, 053, 482, 372 }, Index = 59, Form = 1 }, // Weezing-1
-        new(40,05,3) { Species = 823, Ability = A4, Moves = new[]{ 403, 442, 034, 681 }, Index = 59, CanGigantamax = true }, // Corviknight
-        new(40,05,3) { Species = 628, Ability = A4, Moves = new[]{ 403, 276, 163, 157 }, Index = 59 }, // Braviary
-        new(40,05,3) { Species = 845, Ability = A4, Moves = new[]{ 503, 058, 403, 065 }, Index = 59 }, // Cramorant
-        new(50,08,4) { Species = 858, Ability = A4, Moves = new[]{ 605, 094, 595, 247 }, Index = 59, CanGigantamax = true }, // Hatterene
-        new(50,08,4) { Species = 282, Ability = A4, Moves = new[]{ 585, 094, 595, 085 }, Index = 59 }, // Gardevoir
-        new(50,08,4) { Species = 110, Ability = A4, Moves = new[]{ 790, 126, 482, 372 }, Index = 59, Form = 1 }, // Weezing-1
-        new(50,08,4) { Species = 823, Ability = A4, Moves = new[]{ 413, 442, 034, 681 }, Index = 59, CanGigantamax = true }, // Corviknight
-        new(50,08,4) { Species = 628, Ability = A4, Moves = new[]{ 403, 276, 442, 157 }, Index = 59 }, // Braviary
-        new(50,08,4) { Species = 845, Ability = A4, Moves = new[]{ 056, 058, 403, 065 }, Index = 59 }, // Cramorant
-        new(60,10,5) { Species = 858, Ability = A4, Moves = new[]{ 605, 094, 438, 247 }, Index = 59, CanGigantamax = true }, // Hatterene
-        new(60,10,5) { Species = 282, Ability = A4, Moves = new[]{ 585, 094, 261, 085 }, Index = 59 }, // Gardevoir
-        new(60,10,5) { Species = 110, Ability = A4, Moves = new[]{ 790, 126, 482, 399 }, Index = 59, Form = 1 }, // Weezing-1
-        new(60,10,5) { Species = 823, Ability = A4, Moves = new[]{ 413, 442, 776, 372 }, Index = 59, CanGigantamax = true }, // Corviknight
-        new(60,10,5) { Species = 628, Ability = A4, Moves = new[]{ 413, 370, 442, 157 }, Index = 59 }, // Braviary
-        new(60,10,5) { Species = 845, Ability = A4, Moves = new[]{ 056, 058, 403, 057 }, Index = 59 }, // Cramorant
+        new(17,01,1) { Species = 856, Ability = A4, Moves = new(312, 093, 574, 595), Index = 59 }, // Hatenna
+        new(17,01,1) { Species = 280, Ability = A4, Moves = new(574, 093, 104, 045), Index = 59 }, // Ralts
+        new(17,01,1) { Species = 109, Ability = A4, Moves = new(499, 053, 124, 372), Index = 59 }, // Koffing
+        new(17,01,1) { Species = 821, Ability = A4, Moves = new(403, 031, 043, 681), Index = 59 }, // Rookidee
+        new(17,01,1) { Species = 627, Ability = A4, Moves = new(043, 276, 017, 064), Index = 59 }, // Rufflet
+        new(17,01,1) { Species = 845, Ability = A4, Moves = new(055, 254, 064, 562), Index = 59 }, // Cramorant
+        new(30,03,2) { Species = 856, Ability = A4, Moves = new(605, 060, 574, 595), Index = 59 }, // Hatenna
+        new(30,03,2) { Species = 281, Ability = A4, Moves = new(574, 060, 104, 085), Index = 59 }, // Kirlia
+        new(30,03,2) { Species = 109, Ability = A4, Moves = new(499, 053, 482, 372), Index = 59 }, // Koffing
+        new(30,03,2) { Species = 822, Ability = A4, Moves = new(403, 263, 279, 681), Index = 59 }, // Corvisquire
+        new(30,03,2) { Species = 627, Ability = A4, Moves = new(184, 276, 017, 157), Index = 59 }, // Rufflet
+        new(30,03,2) { Species = 845, Ability = A4, Moves = new(055, 058, 064, 562), Index = 59 }, // Cramorant
+        new(40,05,3) { Species = 857, Ability = A4, Moves = new(605, 060, 595, 574), Index = 59, CanGigantamax = true }, // Hattrem
+        new(40,05,3) { Species = 282, Ability = A4, Moves = new(585, 060, 595, 085), Index = 59 }, // Gardevoir
+        new(40,05,3) { Species = 110, Ability = A4, Moves = new(790, 053, 482, 372), Index = 59, Form = 1 }, // Weezing-1
+        new(40,05,3) { Species = 823, Ability = A4, Moves = new(403, 442, 034, 681), Index = 59, CanGigantamax = true }, // Corviknight
+        new(40,05,3) { Species = 628, Ability = A4, Moves = new(403, 276, 163, 157), Index = 59 }, // Braviary
+        new(40,05,3) { Species = 845, Ability = A4, Moves = new(503, 058, 403, 065), Index = 59 }, // Cramorant
+        new(50,08,4) { Species = 858, Ability = A4, Moves = new(605, 094, 595, 247), Index = 59, CanGigantamax = true }, // Hatterene
+        new(50,08,4) { Species = 282, Ability = A4, Moves = new(585, 094, 595, 085), Index = 59 }, // Gardevoir
+        new(50,08,4) { Species = 110, Ability = A4, Moves = new(790, 126, 482, 372), Index = 59, Form = 1 }, // Weezing-1
+        new(50,08,4) { Species = 823, Ability = A4, Moves = new(413, 442, 034, 681), Index = 59, CanGigantamax = true }, // Corviknight
+        new(50,08,4) { Species = 628, Ability = A4, Moves = new(403, 276, 442, 157), Index = 59 }, // Braviary
+        new(50,08,4) { Species = 845, Ability = A4, Moves = new(056, 058, 403, 065), Index = 59 }, // Cramorant
+        new(60,10,5) { Species = 858, Ability = A4, Moves = new(605, 094, 438, 247), Index = 59, CanGigantamax = true }, // Hatterene
+        new(60,10,5) { Species = 282, Ability = A4, Moves = new(585, 094, 261, 085), Index = 59 }, // Gardevoir
+        new(60,10,5) { Species = 110, Ability = A4, Moves = new(790, 126, 482, 399), Index = 59, Form = 1 }, // Weezing-1
+        new(60,10,5) { Species = 823, Ability = A4, Moves = new(413, 442, 776, 372), Index = 59, CanGigantamax = true }, // Corviknight
+        new(60,10,5) { Species = 628, Ability = A4, Moves = new(413, 370, 442, 157), Index = 59 }, // Braviary
+        new(60,10,5) { Species = 845, Ability = A4, Moves = new(056, 058, 403, 057), Index = 59 }, // Cramorant
 
-        new(17,01,1) { Species = 067, Ability = A4, Moves = new[]{ 279, 009, 490, 067 }, Index = 58 }, // Machoke
-        new(17,01,1) { Species = 447, Ability = A4, Moves = new[]{ 280, 098, 317, 523 }, Index = 58 }, // Riolu
-        new(17,01,1) { Species = 870, Ability = A4, Moves = new[]{ 442, 029, 249, 157 }, Index = 58 }, // Falinks
-        new(17,01,1) { Species = 825, Ability = A4, Moves = new[]{ 522, 263, 371, 247 }, Index = 58 }, // Dottler
-        new(17,01,1) { Species = 577, Ability = A4, Moves = new[]{ 060, 086, 360, 283 }, Index = 58 }, // Solosis
-        new(17,01,1) { Species = 574, Ability = A4, Moves = new[]{ 060, 086, 412, 157 }, Index = 58 }, // Gothita
-        new(30,03,2) { Species = 068, Ability = A4, Moves = new[]{ 279, 009, 233, 372 }, Index = 58, CanGigantamax = true }, // Machamp
-        new(30,03,2) { Species = 447, Ability = A4, Moves = new[]{ 280, 232, 317, 523 }, Index = 58 }, // Riolu
-        new(30,03,2) { Species = 870, Ability = A4, Moves = new[]{ 442, 029, 179, 157 }, Index = 58 }, // Falinks
-        new(30,03,2) { Species = 826, Ability = A4, Moves = new[]{ 405, 277, 371, 109 }, Index = 58, CanGigantamax = true }, // Orbeetle
-        new(30,03,2) { Species = 577, Ability = A4, Moves = new[]{ 473, 086, 360, 283 }, Index = 58 }, // Solosis
-        new(30,03,2) { Species = 574, Ability = A4, Moves = new[]{ 473, 086, 412, 157 }, Index = 58 }, // Gothita
-        new(40,05,3) { Species = 068, Ability = A4, Moves = new[]{ 530, 009, 233, 372 }, Index = 58, CanGigantamax = true }, // Machamp
-        new(40,05,3) { Species = 448, Ability = A4, Moves = new[]{ 612, 232, 444, 089 }, Index = 58 }, // Lucario
-        new(40,05,3) { Species = 870, Ability = A4, Moves = new[]{ 442, 029, 179, 317 }, Index = 58 }, // Falinks
-        new(40,05,3) { Species = 826, Ability = A4, Moves = new[]{ 405, 277, 371, 247 }, Index = 58, CanGigantamax = true }, // Orbeetle
-        new(40,05,3) { Species = 578, Ability = A4, Moves = new[]{ 094, 086, 360, 247 }, Index = 58 }, // Duosion
-        new(40,05,3) { Species = 575, Ability = A4, Moves = new[]{ 094, 085, 412, 157 }, Index = 58 }, // Gothorita
-        new(50,08,4) { Species = 068, Ability = A4, Moves = new[]{ 223, 009, 370, 372 }, Index = 58, CanGigantamax = true }, // Machamp
-        new(50,08,4) { Species = 448, Ability = A4, Moves = new[]{ 612, 309, 444, 089 }, Index = 58 }, // Lucario
-        new(50,08,4) { Species = 870, Ability = A4, Moves = new[]{ 442, 224, 179, 317 }, Index = 58 }, // Falinks
-        new(50,08,4) { Species = 826, Ability = A4, Moves = new[]{ 405, 277, 776, 247 }, Index = 58, CanGigantamax = true }, // Orbeetle
-        new(50,08,4) { Species = 579, Ability = A4, Moves = new[]{ 094, 009, 411, 247 }, Index = 58 }, // Reuniclus
-        new(50,08,4) { Species = 576, Ability = A4, Moves = new[]{ 094, 085, 412, 322 }, Index = 58 }, // Gothitelle
-        new(60,10,5) { Species = 025, Ability = A4, Moves = new[]{ 804, 435, 057, 574 }, Index = 58, CanGigantamax = true, Shiny = Shiny.Always }, // Pikachu
-        new(60,10,5) { Species = 025, Ability = A4, Moves = new[]{ 344, 280, 583, 231 }, Index = 58, CanGigantamax = true, Shiny = Shiny.Always }, // Pikachu
-        new(60,10,5) { Species = 025, Ability = A4, Moves = new[]{ 804, 435, 057, 574 }, Index = 58, CanGigantamax = true }, // Pikachu
-        new(60,10,5) { Species = 025, Ability = A4, Moves = new[]{ 344, 280, 583, 231 }, Index = 58, CanGigantamax = true }, // Pikachu
+        new(17,01,1) { Species = 067, Ability = A4, Moves = new(279, 009, 490, 067), Index = 58 }, // Machoke
+        new(17,01,1) { Species = 447, Ability = A4, Moves = new(280, 098, 317, 523), Index = 58 }, // Riolu
+        new(17,01,1) { Species = 870, Ability = A4, Moves = new(442, 029, 249, 157), Index = 58 }, // Falinks
+        new(17,01,1) { Species = 825, Ability = A4, Moves = new(522, 263, 371, 247), Index = 58 }, // Dottler
+        new(17,01,1) { Species = 577, Ability = A4, Moves = new(060, 086, 360, 283), Index = 58 }, // Solosis
+        new(17,01,1) { Species = 574, Ability = A4, Moves = new(060, 086, 412, 157), Index = 58 }, // Gothita
+        new(30,03,2) { Species = 068, Ability = A4, Moves = new(279, 009, 233, 372), Index = 58, CanGigantamax = true }, // Machamp
+        new(30,03,2) { Species = 447, Ability = A4, Moves = new(280, 232, 317, 523), Index = 58 }, // Riolu
+        new(30,03,2) { Species = 870, Ability = A4, Moves = new(442, 029, 179, 157), Index = 58 }, // Falinks
+        new(30,03,2) { Species = 826, Ability = A4, Moves = new(405, 277, 371, 109), Index = 58, CanGigantamax = true }, // Orbeetle
+        new(30,03,2) { Species = 577, Ability = A4, Moves = new(473, 086, 360, 283), Index = 58 }, // Solosis
+        new(30,03,2) { Species = 574, Ability = A4, Moves = new(473, 086, 412, 157), Index = 58 }, // Gothita
+        new(40,05,3) { Species = 068, Ability = A4, Moves = new(530, 009, 233, 372), Index = 58, CanGigantamax = true }, // Machamp
+        new(40,05,3) { Species = 448, Ability = A4, Moves = new(612, 232, 444, 089), Index = 58 }, // Lucario
+        new(40,05,3) { Species = 870, Ability = A4, Moves = new(442, 029, 179, 317), Index = 58 }, // Falinks
+        new(40,05,3) { Species = 826, Ability = A4, Moves = new(405, 277, 371, 247), Index = 58, CanGigantamax = true }, // Orbeetle
+        new(40,05,3) { Species = 578, Ability = A4, Moves = new(094, 086, 360, 247), Index = 58 }, // Duosion
+        new(40,05,3) { Species = 575, Ability = A4, Moves = new(094, 085, 412, 157), Index = 58 }, // Gothorita
+        new(50,08,4) { Species = 068, Ability = A4, Moves = new(223, 009, 370, 372), Index = 58, CanGigantamax = true }, // Machamp
+        new(50,08,4) { Species = 448, Ability = A4, Moves = new(612, 309, 444, 089), Index = 58 }, // Lucario
+        new(50,08,4) { Species = 870, Ability = A4, Moves = new(442, 224, 179, 317), Index = 58 }, // Falinks
+        new(50,08,4) { Species = 826, Ability = A4, Moves = new(405, 277, 776, 247), Index = 58, CanGigantamax = true }, // Orbeetle
+        new(50,08,4) { Species = 579, Ability = A4, Moves = new(094, 009, 411, 247), Index = 58 }, // Reuniclus
+        new(50,08,4) { Species = 576, Ability = A4, Moves = new(094, 085, 412, 322), Index = 58 }, // Gothitelle
+        new(60,10,5) { Species = 025, Ability = A4, Moves = new(804, 435, 057, 574), Index = 58, CanGigantamax = true, Shiny = Shiny.Always }, // Pikachu
+        new(60,10,5) { Species = 025, Ability = A4, Moves = new(344, 280, 583, 231), Index = 58, CanGigantamax = true, Shiny = Shiny.Always }, // Pikachu
+        new(60,10,5) { Species = 025, Ability = A4, Moves = new(804, 435, 057, 574), Index = 58, CanGigantamax = true }, // Pikachu
+        new(60,10,5) { Species = 025, Ability = A4, Moves = new(344, 280, 583, 231), Index = 58, CanGigantamax = true }, // Pikachu
 
-        new(17,01,1) { Species = 868, Ability = A4, Moves = new[]{ 033, 186, 577, 496 }, Index = 56, CanGigantamax = true }, // Milcery
-        new(30,03,2) { Species = 868, Ability = A4, Moves = new[]{ 577, 186, 263, 500 }, Index = 56, CanGigantamax = true }, // Milcery
-        new(40,05,3) { Species = 868, Ability = A4, Moves = new[]{ 577, 605, 496, 213 }, Index = 56, CanGigantamax = true }, // Milcery
-        new(50,08,4) { Species = 868, Ability = A4, Moves = new[]{ 577, 605, 496, 500 }, Index = 56, CanGigantamax = true }, // Milcery
-        new(60,10,5) { Species = 868, Ability = A4, Moves = new[]{ 577, 605, 496, 500 }, Index = 56, CanGigantamax = true, Shiny = Shiny.Always }, // Milcery
-        new(60,10,5) { Species = 868, Ability = A4, Moves = new[]{ 577, 605, 496, 500 }, Index = 56, CanGigantamax = true }, // Milcery
+        new(17,01,1) { Species = 868, Ability = A4, Moves = new(033, 186, 577, 496), Index = 56, CanGigantamax = true }, // Milcery
+        new(30,03,2) { Species = 868, Ability = A4, Moves = new(577, 186, 263, 500), Index = 56, CanGigantamax = true }, // Milcery
+        new(40,05,3) { Species = 868, Ability = A4, Moves = new(577, 605, 496, 213), Index = 56, CanGigantamax = true }, // Milcery
+        new(50,08,4) { Species = 868, Ability = A4, Moves = new(577, 605, 496, 500), Index = 56, CanGigantamax = true }, // Milcery
+        new(60,10,5) { Species = 868, Ability = A4, Moves = new(577, 605, 496, 500), Index = 56, CanGigantamax = true, Shiny = Shiny.Always }, // Milcery
+        new(60,10,5) { Species = 868, Ability = A4, Moves = new(577, 605, 496, 500), Index = 56, CanGigantamax = true }, // Milcery
 
-        new(17,01,1) { Species = 845, Ability = A4, Moves = new[]{ 057, 056, 503, 000 }, Index = 54 }, // Cramorant
-        new(17,01,1) { Species = 330, Ability = A4, Moves = new[]{ 225, 129, 693, 048 }, Index = 54 }, // Flygon
-        new(17,01,1) { Species = 623, Ability = A4, Moves = new[]{ 089, 157, 707, 009 }, Index = 54 }, // Golurk
-        new(17,01,1) { Species = 195, Ability = A4, Moves = new[]{ 055, 157, 281, 034 }, Index = 54 }, // Quagsire
-        new(17,01,1) { Species = 876, Ability = A4, Moves = new[]{ 574, 129, 304, 000 }, Index = 54, Form = 1 }, // Indeedee-1
-        new(30,03,2) { Species = 845, Ability = A4, Moves = new[]{ 057, 056, 503, 000 }, Index = 54 }, // Cramorant
-        new(30,03,2) { Species = 330, Ability = A4, Moves = new[]{ 225, 129, 693, 048 }, Index = 54 }, // Flygon
-        new(30,03,2) { Species = 623, Ability = A4, Moves = new[]{ 089, 157, 707, 009 }, Index = 54 }, // Golurk
-        new(30,03,2) { Species = 195, Ability = A4, Moves = new[]{ 055, 157, 281, 034 }, Index = 54 }, // Quagsire
-        new(30,03,2) { Species = 876, Ability = A4, Moves = new[]{ 574, 129, 304, 000 }, Index = 54, Form = 1 }, // Indeedee-1
-        new(40,05,3) { Species = 845, Ability = A4, Moves = new[]{ 057, 056, 503, 000 }, Index = 54 }, // Cramorant
-        new(40,05,3) { Species = 330, Ability = A4, Moves = new[]{ 225, 129, 693, 586 }, Index = 54 }, // Flygon
-        new(40,05,3) { Species = 623, Ability = A4, Moves = new[]{ 089, 157, 523, 009 }, Index = 54 }, // Golurk
-        new(40,05,3) { Species = 195, Ability = A4, Moves = new[]{ 330, 157, 281, 034 }, Index = 54 }, // Quagsire
-        new(40,05,3) { Species = 876, Ability = A4, Moves = new[]{ 574, 129, 304, 000 }, Index = 54, Form = 1 }, // Indeedee-1
-        new(50,08,4) { Species = 845, Ability = A4, Moves = new[]{ 057, 056, 503, 000 }, Index = 54 }, // Cramorant
-        new(50,08,4) { Species = 330, Ability = A4, Moves = new[]{ 225, 129, 693, 586 }, Index = 54 }, // Flygon
-        new(50,08,4) { Species = 623, Ability = A4, Moves = new[]{ 089, 157, 523, 009 }, Index = 54 }, // Golurk
-        new(50,08,4) { Species = 195, Ability = A4, Moves = new[]{ 330, 157, 281, 034 }, Index = 54 }, // Quagsire
-        new(50,08,4) { Species = 876, Ability = A4, Moves = new[]{ 574, 129, 304, 000 }, Index = 54, Form = 1 }, // Indeedee-1
-        new(60,10,5) { Species = 845, Ability = A4, Moves = new[]{ 057, 056, 503, 000 }, Index = 54 }, // Cramorant
-        new(60,10,5) { Species = 845, Ability = A4, Moves = new[]{ 057, 056, 503, 000 }, Index = 54, Shiny = Shiny.Always }, // Cramorant
-        new(60,10,5) { Species = 330, Ability = A4, Moves = new[]{ 225, 129, 693, 586 }, Index = 54 }, // Flygon
-        new(60,10,5) { Species = 623, Ability = A4, Moves = new[]{ 089, 157, 523, 009 }, Index = 54 }, // Golurk
-        new(60,10,5) { Species = 195, Ability = A4, Moves = new[]{ 330, 157, 281, 034 }, Index = 54 }, // Quagsire
-        new(60,10,5) { Species = 876, Ability = A4, Moves = new[]{ 574, 129, 304, 000 }, Index = 54, Form = 1 }, // Indeedee-1
+        new(17,01,1) { Species = 845, Ability = A4, Moves = new(057, 056, 503, 000), Index = 54 }, // Cramorant
+        new(17,01,1) { Species = 330, Ability = A4, Moves = new(225, 129, 693, 048), Index = 54 }, // Flygon
+        new(17,01,1) { Species = 623, Ability = A4, Moves = new(089, 157, 707, 009), Index = 54 }, // Golurk
+        new(17,01,1) { Species = 195, Ability = A4, Moves = new(055, 157, 281, 034), Index = 54 }, // Quagsire
+        new(17,01,1) { Species = 876, Ability = A4, Moves = new(574, 129, 304, 000), Index = 54, Form = 1 }, // Indeedee-1
+        new(30,03,2) { Species = 845, Ability = A4, Moves = new(057, 056, 503, 000), Index = 54 }, // Cramorant
+        new(30,03,2) { Species = 330, Ability = A4, Moves = new(225, 129, 693, 048), Index = 54 }, // Flygon
+        new(30,03,2) { Species = 623, Ability = A4, Moves = new(089, 157, 707, 009), Index = 54 }, // Golurk
+        new(30,03,2) { Species = 195, Ability = A4, Moves = new(055, 157, 281, 034), Index = 54 }, // Quagsire
+        new(30,03,2) { Species = 876, Ability = A4, Moves = new(574, 129, 304, 000), Index = 54, Form = 1 }, // Indeedee-1
+        new(40,05,3) { Species = 845, Ability = A4, Moves = new(057, 056, 503, 000), Index = 54 }, // Cramorant
+        new(40,05,3) { Species = 330, Ability = A4, Moves = new(225, 129, 693, 586), Index = 54 }, // Flygon
+        new(40,05,3) { Species = 623, Ability = A4, Moves = new(089, 157, 523, 009), Index = 54 }, // Golurk
+        new(40,05,3) { Species = 195, Ability = A4, Moves = new(330, 157, 281, 034), Index = 54 }, // Quagsire
+        new(40,05,3) { Species = 876, Ability = A4, Moves = new(574, 129, 304, 000), Index = 54, Form = 1 }, // Indeedee-1
+        new(50,08,4) { Species = 845, Ability = A4, Moves = new(057, 056, 503, 000), Index = 54 }, // Cramorant
+        new(50,08,4) { Species = 330, Ability = A4, Moves = new(225, 129, 693, 586), Index = 54 }, // Flygon
+        new(50,08,4) { Species = 623, Ability = A4, Moves = new(089, 157, 523, 009), Index = 54 }, // Golurk
+        new(50,08,4) { Species = 195, Ability = A4, Moves = new(330, 157, 281, 034), Index = 54 }, // Quagsire
+        new(50,08,4) { Species = 876, Ability = A4, Moves = new(574, 129, 304, 000), Index = 54, Form = 1 }, // Indeedee-1
+        new(60,10,5) { Species = 845, Ability = A4, Moves = new(057, 056, 503, 000), Index = 54 }, // Cramorant
+        new(60,10,5) { Species = 845, Ability = A4, Moves = new(057, 056, 503, 000), Index = 54, Shiny = Shiny.Always }, // Cramorant
+        new(60,10,5) { Species = 330, Ability = A4, Moves = new(225, 129, 693, 586), Index = 54 }, // Flygon
+        new(60,10,5) { Species = 623, Ability = A4, Moves = new(089, 157, 523, 009), Index = 54 }, // Golurk
+        new(60,10,5) { Species = 195, Ability = A4, Moves = new(330, 157, 281, 034), Index = 54 }, // Quagsire
+        new(60,10,5) { Species = 876, Ability = A4, Moves = new(574, 129, 304, 000), Index = 54, Form = 1 }, // Indeedee-1
 
-        new(17,01,1) { Species = 067, Ability = A4, Moves = new[]{ 279, 009, 490, 067 }, Index = 53 }, // Machoke
-        new(17,01,1) { Species = 447, Ability = A4, Moves = new[]{ 280, 098, 317, 523 }, Index = 53 }, // Riolu
-        new(17,01,1) { Species = 870, Ability = A4, Moves = new[]{ 442, 029, 249, 157 }, Index = 53 }, // Falinks
-        new(17,01,1) { Species = 825, Ability = A4, Moves = new[]{ 522, 263, 371, 247 }, Index = 53 }, // Dottler
-        new(17,01,1) { Species = 577, Ability = A4, Moves = new[]{ 060, 086, 360, 283 }, Index = 53 }, // Solosis
-        new(17,01,1) { Species = 574, Ability = A4, Moves = new[]{ 060, 086, 412, 157 }, Index = 53 }, // Gothita
-        new(30,03,2) { Species = 068, Ability = A4, Moves = new[]{ 279, 009, 233, 372 }, Index = 53, CanGigantamax = true }, // Machamp
-        new(30,03,2) { Species = 447, Ability = A4, Moves = new[]{ 280, 232, 317, 523 }, Index = 53 }, // Riolu
-        new(30,03,2) { Species = 870, Ability = A4, Moves = new[]{ 442, 029, 179, 157 }, Index = 53 }, // Falinks
-        new(30,03,2) { Species = 826, Ability = A4, Moves = new[]{ 405, 277, 371, 109 }, Index = 53, CanGigantamax = true }, // Orbeetle
-        new(30,03,2) { Species = 577, Ability = A4, Moves = new[]{ 473, 086, 360, 283 }, Index = 53 }, // Solosis
-        new(30,03,2) { Species = 574, Ability = A4, Moves = new[]{ 473, 086, 412, 157 }, Index = 53 }, // Gothita
-        new(40,05,3) { Species = 068, Ability = A4, Moves = new[]{ 530, 009, 233, 372 }, Index = 53, CanGigantamax = true }, // Machamp
-        new(40,05,3) { Species = 448, Ability = A4, Moves = new[]{ 612, 232, 444, 089 }, Index = 53 }, // Lucario
-        new(40,05,3) { Species = 870, Ability = A4, Moves = new[]{ 442, 029, 179, 317 }, Index = 53 }, // Falinks
-        new(40,05,3) { Species = 826, Ability = A4, Moves = new[]{ 405, 277, 371, 247 }, Index = 53, CanGigantamax = true }, // Orbeetle
-        new(40,05,3) { Species = 578, Ability = A4, Moves = new[]{ 094, 086, 360, 247 }, Index = 53 }, // Duosion
-        new(40,05,3) { Species = 575, Ability = A4, Moves = new[]{ 094, 085, 412, 157 }, Index = 53 }, // Gothorita
-        new(50,08,4) { Species = 068, Ability = A4, Moves = new[]{ 223, 009, 370, 372 }, Index = 53, CanGigantamax = true }, // Machamp
-        new(50,08,4) { Species = 448, Ability = A4, Moves = new[]{ 612, 309, 444, 089 }, Index = 53 }, // Lucario
-        new(50,08,4) { Species = 870, Ability = A4, Moves = new[]{ 442, 224, 179, 317 }, Index = 53 }, // Falinks
-        new(50,08,4) { Species = 826, Ability = A4, Moves = new[]{ 405, 277, 776, 247 }, Index = 53, CanGigantamax = true }, // Orbeetle
-        new(50,08,4) { Species = 579, Ability = A4, Moves = new[]{ 094, 009, 411, 247 }, Index = 53 }, // Reuniclus
-        new(50,08,4) { Species = 576, Ability = A4, Moves = new[]{ 094, 085, 412, 322 }, Index = 53 }, // Gothitelle
-        new(60,10,5) { Species = 068, Ability = A4, Moves = new[]{ 223, 009, 523, 372 }, Index = 53, CanGigantamax = true }, // Machamp
-        new(60,10,5) { Species = 448, Ability = A4, Moves = new[]{ 370, 309, 444, 089 }, Index = 53 }, // Lucario
-        new(60,10,5) { Species = 870, Ability = A4, Moves = new[]{ 442, 224, 370, 317 }, Index = 53 }, // Falinks
-        new(60,10,5) { Species = 826, Ability = A4, Moves = new[]{ 405, 277, 776, 412 }, Index = 53, CanGigantamax = true }, // Orbeetle
-        new(60,10,5) { Species = 579, Ability = A4, Moves = new[]{ 094, 087, 411, 247 }, Index = 53 }, // Reuniclus
-        new(60,10,5) { Species = 576, Ability = A4, Moves = new[]{ 094, 085, 412, 322 }, Index = 53 }, // Gothitelle
+        new(17,01,1) { Species = 067, Ability = A4, Moves = new(279, 009, 490, 067), Index = 53 }, // Machoke
+        new(17,01,1) { Species = 447, Ability = A4, Moves = new(280, 098, 317, 523), Index = 53 }, // Riolu
+        new(17,01,1) { Species = 870, Ability = A4, Moves = new(442, 029, 249, 157), Index = 53 }, // Falinks
+        new(17,01,1) { Species = 825, Ability = A4, Moves = new(522, 263, 371, 247), Index = 53 }, // Dottler
+        new(17,01,1) { Species = 577, Ability = A4, Moves = new(060, 086, 360, 283), Index = 53 }, // Solosis
+        new(17,01,1) { Species = 574, Ability = A4, Moves = new(060, 086, 412, 157), Index = 53 }, // Gothita
+        new(30,03,2) { Species = 068, Ability = A4, Moves = new(279, 009, 233, 372), Index = 53, CanGigantamax = true }, // Machamp
+        new(30,03,2) { Species = 447, Ability = A4, Moves = new(280, 232, 317, 523), Index = 53 }, // Riolu
+        new(30,03,2) { Species = 870, Ability = A4, Moves = new(442, 029, 179, 157), Index = 53 }, // Falinks
+        new(30,03,2) { Species = 826, Ability = A4, Moves = new(405, 277, 371, 109), Index = 53, CanGigantamax = true }, // Orbeetle
+        new(30,03,2) { Species = 577, Ability = A4, Moves = new(473, 086, 360, 283), Index = 53 }, // Solosis
+        new(30,03,2) { Species = 574, Ability = A4, Moves = new(473, 086, 412, 157), Index = 53 }, // Gothita
+        new(40,05,3) { Species = 068, Ability = A4, Moves = new(530, 009, 233, 372), Index = 53, CanGigantamax = true }, // Machamp
+        new(40,05,3) { Species = 448, Ability = A4, Moves = new(612, 232, 444, 089), Index = 53 }, // Lucario
+        new(40,05,3) { Species = 870, Ability = A4, Moves = new(442, 029, 179, 317), Index = 53 }, // Falinks
+        new(40,05,3) { Species = 826, Ability = A4, Moves = new(405, 277, 371, 247), Index = 53, CanGigantamax = true }, // Orbeetle
+        new(40,05,3) { Species = 578, Ability = A4, Moves = new(094, 086, 360, 247), Index = 53 }, // Duosion
+        new(40,05,3) { Species = 575, Ability = A4, Moves = new(094, 085, 412, 157), Index = 53 }, // Gothorita
+        new(50,08,4) { Species = 068, Ability = A4, Moves = new(223, 009, 370, 372), Index = 53, CanGigantamax = true }, // Machamp
+        new(50,08,4) { Species = 448, Ability = A4, Moves = new(612, 309, 444, 089), Index = 53 }, // Lucario
+        new(50,08,4) { Species = 870, Ability = A4, Moves = new(442, 224, 179, 317), Index = 53 }, // Falinks
+        new(50,08,4) { Species = 826, Ability = A4, Moves = new(405, 277, 776, 247), Index = 53, CanGigantamax = true }, // Orbeetle
+        new(50,08,4) { Species = 579, Ability = A4, Moves = new(094, 009, 411, 247), Index = 53 }, // Reuniclus
+        new(50,08,4) { Species = 576, Ability = A4, Moves = new(094, 085, 412, 322), Index = 53 }, // Gothitelle
+        new(60,10,5) { Species = 068, Ability = A4, Moves = new(223, 009, 523, 372), Index = 53, CanGigantamax = true }, // Machamp
+        new(60,10,5) { Species = 448, Ability = A4, Moves = new(370, 309, 444, 089), Index = 53 }, // Lucario
+        new(60,10,5) { Species = 870, Ability = A4, Moves = new(442, 224, 370, 317), Index = 53 }, // Falinks
+        new(60,10,5) { Species = 826, Ability = A4, Moves = new(405, 277, 776, 412), Index = 53, CanGigantamax = true }, // Orbeetle
+        new(60,10,5) { Species = 579, Ability = A4, Moves = new(094, 087, 411, 247), Index = 53 }, // Reuniclus
+        new(60,10,5) { Species = 576, Ability = A4, Moves = new(094, 085, 412, 322), Index = 53 }, // Gothitelle
 
-        new(17,01,1) { Species = 128, Ability = A4, Moves = new[]{ 033, 157, 030, 371 }, Index = 51 }, // Tauros
-        new(17,01,1) { Species = 626, Ability = A4, Moves = new[]{ 033, 030, 031, 523 }, Index = 51 }, // Bouffalant
-        new(17,01,1) { Species = 241, Ability = A4, Moves = new[]{ 707, 033, 023, 205 }, Index = 51 }, // Miltank
-        new(30,03,2) { Species = 128, Ability = A4, Moves = new[]{ 033, 157, 030, 370 }, Index = 51 }, // Tauros
-        new(30,03,2) { Species = 626, Ability = A4, Moves = new[]{ 279, 030, 675, 523 }, Index = 51 }, // Bouffalant
-        new(30,03,2) { Species = 241, Ability = A4, Moves = new[]{ 707, 428, 023, 205 }, Index = 51 }, // Miltank
-        new(40,05,3) { Species = 128, Ability = A4, Moves = new[]{ 036, 157, 030, 370 }, Index = 51 }, // Tauros
-        new(40,05,3) { Species = 626, Ability = A4, Moves = new[]{ 279, 543, 675, 523 }, Index = 51 }, // Bouffalant
-        new(40,05,3) { Species = 241, Ability = A4, Moves = new[]{ 707, 428, 034, 205 }, Index = 51 }, // Miltank
-        new(50,08,4) { Species = 128, Ability = A4, Moves = new[]{ 034, 157, 030, 370 }, Index = 51 }, // Tauros
-        new(50,08,4) { Species = 626, Ability = A4, Moves = new[]{ 224, 543, 675, 523 }, Index = 51 }, // Bouffalant
-        new(50,08,4) { Species = 241, Ability = A4, Moves = new[]{ 707, 428, 034, 583 }, Index = 51 }, // Miltank
-        new(60,10,5) { Species = 128, Ability = A4, Moves = new[]{ 034, 157, 372, 370 }, Index = 51 }, // Tauros
-        new(60,10,5) { Species = 128, Ability = A4, Moves = new[]{ 034, 157, 372, 370 }, Index = 51, Shiny = Shiny.Always }, // Tauros
-        new(60,10,5) { Species = 626, Ability = A4, Moves = new[]{ 224, 543, 675, 089 }, Index = 51 }, // Bouffalant
-        new(60,10,5) { Species = 241, Ability = A4, Moves = new[]{ 667, 428, 034, 583 }, Index = 51 }, // Miltank
+        new(17,01,1) { Species = 128, Ability = A4, Moves = new(033, 157, 030, 371), Index = 51 }, // Tauros
+        new(17,01,1) { Species = 626, Ability = A4, Moves = new(033, 030, 031, 523), Index = 51 }, // Bouffalant
+        new(17,01,1) { Species = 241, Ability = A4, Moves = new(707, 033, 023, 205), Index = 51 }, // Miltank
+        new(30,03,2) { Species = 128, Ability = A4, Moves = new(033, 157, 030, 370), Index = 51 }, // Tauros
+        new(30,03,2) { Species = 626, Ability = A4, Moves = new(279, 030, 675, 523), Index = 51 }, // Bouffalant
+        new(30,03,2) { Species = 241, Ability = A4, Moves = new(707, 428, 023, 205), Index = 51 }, // Miltank
+        new(40,05,3) { Species = 128, Ability = A4, Moves = new(036, 157, 030, 370), Index = 51 }, // Tauros
+        new(40,05,3) { Species = 626, Ability = A4, Moves = new(279, 543, 675, 523), Index = 51 }, // Bouffalant
+        new(40,05,3) { Species = 241, Ability = A4, Moves = new(707, 428, 034, 205), Index = 51 }, // Miltank
+        new(50,08,4) { Species = 128, Ability = A4, Moves = new(034, 157, 030, 370), Index = 51 }, // Tauros
+        new(50,08,4) { Species = 626, Ability = A4, Moves = new(224, 543, 675, 523), Index = 51 }, // Bouffalant
+        new(50,08,4) { Species = 241, Ability = A4, Moves = new(707, 428, 034, 583), Index = 51 }, // Miltank
+        new(60,10,5) { Species = 128, Ability = A4, Moves = new(034, 157, 372, 370), Index = 51 }, // Tauros
+        new(60,10,5) { Species = 128, Ability = A4, Moves = new(034, 157, 372, 370), Index = 51, Shiny = Shiny.Always }, // Tauros
+        new(60,10,5) { Species = 626, Ability = A4, Moves = new(224, 543, 675, 089), Index = 51 }, // Bouffalant
+        new(60,10,5) { Species = 241, Ability = A4, Moves = new(667, 428, 034, 583), Index = 51 }, // Miltank
 
-        new(17,01,1) { Species = 420, Ability = A4, Moves = new[]{ 033, 572, 074, 670 }, Index = 49 }, // Cherubi
-        new(17,01,1) { Species = 590, Ability = A4, Moves = new[]{ 078, 492, 310, 412 }, Index = 49 }, // Foongus
-        new(17,01,1) { Species = 755, Ability = A4, Moves = new[]{ 402, 109, 605, 310 }, Index = 49 }, // Morelull
-        new(17,01,1) { Species = 819, Ability = A4, Moves = new[]{ 747, 231, 371, 033 }, Index = 49 }, // Skwovet
-        new(30,03,2) { Species = 420, Ability = A4, Moves = new[]{ 033, 572, 074, 402 }, Index = 49 }, // Cherubi
-        new(30,03,2) { Species = 590, Ability = A4, Moves = new[]{ 078, 492, 310, 412 }, Index = 49 }, // Foongus
-        new(30,03,2) { Species = 756, Ability = A4, Moves = new[]{ 402, 109, 605, 310 }, Index = 49 }, // Shiinotic
-        new(30,03,2) { Species = 819, Ability = A4, Moves = new[]{ 747, 231, 371, 033 }, Index = 49 }, // Skwovet
-        new(30,03,2) { Species = 820, Ability = A4, Moves = new[]{ 747, 231, 371, 034 }, Index = 49 }, // Greedent
-        new(40,05,3) { Species = 420, Ability = A4, Moves = new[]{ 311, 572, 074, 402 }, Index = 49 }, // Cherubi
-        new(40,05,3) { Species = 591, Ability = A4, Moves = new[]{ 078, 492, 092, 412 }, Index = 49 }, // Amoonguss
-        new(40,05,3) { Species = 756, Ability = A4, Moves = new[]{ 402, 585, 605, 310 }, Index = 49 }, // Shiinotic
-        new(40,05,3) { Species = 819, Ability = A4, Moves = new[]{ 747, 360, 371, 044 }, Index = 49 }, // Skwovet
-        new(40,05,3) { Species = 820, Ability = A4, Moves = new[]{ 747, 360, 371, 424 }, Index = 49 }, // Greedent
-        new(50,08,4) { Species = 420, Ability = A4, Moves = new[]{ 311, 572, 605, 402 }, Index = 49 }, // Cherubi
-        new(50,08,4) { Species = 591, Ability = A4, Moves = new[]{ 188, 492, 092, 412 }, Index = 49 }, // Amoonguss
-        new(50,08,4) { Species = 756, Ability = A4, Moves = new[]{ 412, 585, 605, 188 }, Index = 49 }, // Shiinotic
-        new(50,08,4) { Species = 819, Ability = A4, Moves = new[]{ 747, 360, 371, 331 }, Index = 49 }, // Skwovet
-        new(50,08,4) { Species = 820, Ability = A4, Moves = new[]{ 747, 360, 371, 424 }, Index = 49 }, // Greedent
-        new(60,10,5) { Species = 420, Ability = A4, Moves = new[]{ 311, 572, 605, 412 }, Index = 49 }, // Cherubi
-        new(60,10,5) { Species = 820, Ability = A4, Moves = new[]{ 747, 360, 371, 089 }, Index = 49, Shiny = Shiny.Always }, // Greedent
-        new(60,10,5) { Species = 756, Ability = A4, Moves = new[]{ 147, 585, 605, 188 }, Index = 49 }, // Shiinotic
-        new(60,10,5) { Species = 819, Ability = A4, Moves = new[]{ 747, 360, 371, 034 }, Index = 49 }, // Skwovet
-        new(60,10,5) { Species = 819, Ability = A4, Moves = new[]{ 747, 360, 371, 034 }, Index = 49, Shiny = Shiny.Always }, // Skwovet
-        new(60,10,5) { Species = 820, Ability = A4, Moves = new[]{ 747, 360, 371, 089 }, Index = 49 }, // Greedent
+        new(17,01,1) { Species = 420, Ability = A4, Moves = new(033, 572, 074, 670), Index = 49 }, // Cherubi
+        new(17,01,1) { Species = 590, Ability = A4, Moves = new(078, 492, 310, 412), Index = 49 }, // Foongus
+        new(17,01,1) { Species = 755, Ability = A4, Moves = new(402, 109, 605, 310), Index = 49 }, // Morelull
+        new(17,01,1) { Species = 819, Ability = A4, Moves = new(747, 231, 371, 033), Index = 49 }, // Skwovet
+        new(30,03,2) { Species = 420, Ability = A4, Moves = new(033, 572, 074, 402), Index = 49 }, // Cherubi
+        new(30,03,2) { Species = 590, Ability = A4, Moves = new(078, 492, 310, 412), Index = 49 }, // Foongus
+        new(30,03,2) { Species = 756, Ability = A4, Moves = new(402, 109, 605, 310), Index = 49 }, // Shiinotic
+        new(30,03,2) { Species = 819, Ability = A4, Moves = new(747, 231, 371, 033), Index = 49 }, // Skwovet
+        new(30,03,2) { Species = 820, Ability = A4, Moves = new(747, 231, 371, 034), Index = 49 }, // Greedent
+        new(40,05,3) { Species = 420, Ability = A4, Moves = new(311, 572, 074, 402), Index = 49 }, // Cherubi
+        new(40,05,3) { Species = 591, Ability = A4, Moves = new(078, 492, 092, 412), Index = 49 }, // Amoonguss
+        new(40,05,3) { Species = 756, Ability = A4, Moves = new(402, 585, 605, 310), Index = 49 }, // Shiinotic
+        new(40,05,3) { Species = 819, Ability = A4, Moves = new(747, 360, 371, 044), Index = 49 }, // Skwovet
+        new(40,05,3) { Species = 820, Ability = A4, Moves = new(747, 360, 371, 424), Index = 49 }, // Greedent
+        new(50,08,4) { Species = 420, Ability = A4, Moves = new(311, 572, 605, 402), Index = 49 }, // Cherubi
+        new(50,08,4) { Species = 591, Ability = A4, Moves = new(188, 492, 092, 412), Index = 49 }, // Amoonguss
+        new(50,08,4) { Species = 756, Ability = A4, Moves = new(412, 585, 605, 188), Index = 49 }, // Shiinotic
+        new(50,08,4) { Species = 819, Ability = A4, Moves = new(747, 360, 371, 331), Index = 49 }, // Skwovet
+        new(50,08,4) { Species = 820, Ability = A4, Moves = new(747, 360, 371, 424), Index = 49 }, // Greedent
+        new(60,10,5) { Species = 420, Ability = A4, Moves = new(311, 572, 605, 412), Index = 49 }, // Cherubi
+        new(60,10,5) { Species = 820, Ability = A4, Moves = new(747, 360, 371, 089), Index = 49, Shiny = Shiny.Always }, // Greedent
+        new(60,10,5) { Species = 756, Ability = A4, Moves = new(147, 585, 605, 188), Index = 49 }, // Shiinotic
+        new(60,10,5) { Species = 819, Ability = A4, Moves = new(747, 360, 371, 034), Index = 49 }, // Skwovet
+        new(60,10,5) { Species = 819, Ability = A4, Moves = new(747, 360, 371, 034), Index = 49, Shiny = Shiny.Always }, // Skwovet
+        new(60,10,5) { Species = 820, Ability = A4, Moves = new(747, 360, 371, 089), Index = 49 }, // Greedent
 
-        new(17,01,1) { Species = 884, Ability = A4, Moves = new[]{ 232, 043, 468, 249 }, Index = 48, CanGigantamax = true }, // Duraludon
-        new(17,01,1) { Species = 610, Ability = A4, Moves = new[]{ 044, 163, 372, 010 }, Index = 48 }, // Axew
-        new(17,01,1) { Species = 704, Ability = A4, Moves = new[]{ 225, 352, 033, 175 }, Index = 48 }, // Goomy
-        new(17,01,1) { Species = 446, Ability = A4, Moves = new[]{ 033, 044, 122, 111 }, Index = 48 }, // Munchlax
-        new(17,01,1) { Species = 759, Ability = A4, Moves = new[]{ 693, 371, 608, 033 }, Index = 48 }, // Stufful
-        new(17,01,1) { Species = 572, Ability = A4, Moves = new[]{ 497, 204, 402, 001 }, Index = 48 }, // Minccino
-        new(30,03,2) { Species = 884, Ability = A4, Moves = new[]{ 232, 784, 468, 249 }, Index = 48, CanGigantamax = true }, // Duraludon
-        new(30,03,2) { Species = 610, Ability = A4, Moves = new[]{ 337, 163, 242, 530 }, Index = 48 }, // Axew
-        new(30,03,2) { Species = 704, Ability = A4, Moves = new[]{ 225, 352, 033, 341 }, Index = 48 }, // Goomy
-        new(30,03,2) { Species = 143, Ability = A4, Moves = new[]{ 034, 242, 118, 111 }, Index = 48, CanGigantamax = true }, // Snorlax
-        new(30,03,2) { Species = 759, Ability = A4, Moves = new[]{ 693, 371, 359, 036 }, Index = 48 }, // Stufful
-        new(30,03,2) { Species = 572, Ability = A4, Moves = new[]{ 497, 231, 402, 129 }, Index = 48 }, // Minccino
-        new(40,05,3) { Species = 884, Ability = A4, Moves = new[]{ 232, 525, 085, 249 }, Index = 48, CanGigantamax = true }, // Duraludon
-        new(40,05,3) { Species = 611, Ability = A4, Moves = new[]{ 406, 231, 242, 530 }, Index = 48 }, // Fraxure
-        new(40,05,3) { Species = 705, Ability = A4, Moves = new[]{ 406, 352, 491, 341 }, Index = 48 }, // Sliggoo
-        new(40,05,3) { Species = 143, Ability = A4, Moves = new[]{ 034, 667, 242, 281 }, Index = 48, CanGigantamax = true }, // Snorlax
-        new(40,05,3) { Species = 760, Ability = A4, Moves = new[]{ 693, 034, 359, 036 }, Index = 48 }, // Bewear
-        new(40,05,3) { Species = 573, Ability = A4, Moves = new[]{ 331, 231, 350, 129 }, Index = 48 }, // Cinccino
-        new(50,08,4) { Species = 884, Ability = A4, Moves = new[]{ 232, 406, 085, 776 }, Index = 48, CanGigantamax = true }, // Duraludon
-        new(50,08,4) { Species = 612, Ability = A4, Moves = new[]{ 406, 231, 370, 530 }, Index = 48 }, // Haxorus
-        new(50,08,4) { Species = 706, Ability = A4, Moves = new[]{ 406, 034, 491, 126 }, Index = 48 }, // Goodra
-        new(50,08,4) { Species = 143, Ability = A4, Moves = new[]{ 034, 667, 280, 523 }, Index = 48, CanGigantamax = true }, // Snorlax
-        new(50,08,4) { Species = 760, Ability = A4, Moves = new[]{ 663, 034, 359, 009 }, Index = 48 }, // Bewear
-        new(50,08,4) { Species = 573, Ability = A4, Moves = new[]{ 331, 231, 350, 304 }, Index = 48 }, // Cinccino
-        new(60,10,5) { Species = 884, Ability = A4, Moves = new[]{ 430, 406, 085, 776 }, Index = 48, CanGigantamax = true }, // Duraludon
-        new(60,10,5) { Species = 612, Ability = A4, Moves = new[]{ 200, 231, 370, 089 }, Index = 48 }, // Haxorus
-        new(60,10,5) { Species = 706, Ability = A4, Moves = new[]{ 406, 438, 482, 126 }, Index = 48 }, // Goodra
-        new(60,10,5) { Species = 143, Ability = A4, Moves = new[]{ 034, 442, 242, 428 }, Index = 48, CanGigantamax = true }, // Snorlax
-        new(60,10,5) { Species = 760, Ability = A4, Moves = new[]{ 663, 038, 276, 009 }, Index = 48 }, // Bewear
-        new(60,10,5) { Species = 573, Ability = A4, Moves = new[]{ 402, 231, 350, 304 }, Index = 48 }, // Cinccino
+        new(17,01,1) { Species = 884, Ability = A4, Moves = new(232, 043, 468, 249), Index = 48, CanGigantamax = true }, // Duraludon
+        new(17,01,1) { Species = 610, Ability = A4, Moves = new(044, 163, 372, 010), Index = 48 }, // Axew
+        new(17,01,1) { Species = 704, Ability = A4, Moves = new(225, 352, 033, 175), Index = 48 }, // Goomy
+        new(17,01,1) { Species = 446, Ability = A4, Moves = new(033, 044, 122, 111), Index = 48 }, // Munchlax
+        new(17,01,1) { Species = 759, Ability = A4, Moves = new(693, 371, 608, 033), Index = 48 }, // Stufful
+        new(17,01,1) { Species = 572, Ability = A4, Moves = new(497, 204, 402, 001), Index = 48 }, // Minccino
+        new(30,03,2) { Species = 884, Ability = A4, Moves = new(232, 784, 468, 249), Index = 48, CanGigantamax = true }, // Duraludon
+        new(30,03,2) { Species = 610, Ability = A4, Moves = new(337, 163, 242, 530), Index = 48 }, // Axew
+        new(30,03,2) { Species = 704, Ability = A4, Moves = new(225, 352, 033, 341), Index = 48 }, // Goomy
+        new(30,03,2) { Species = 143, Ability = A4, Moves = new(034, 242, 118, 111), Index = 48, CanGigantamax = true }, // Snorlax
+        new(30,03,2) { Species = 759, Ability = A4, Moves = new(693, 371, 359, 036), Index = 48 }, // Stufful
+        new(30,03,2) { Species = 572, Ability = A4, Moves = new(497, 231, 402, 129), Index = 48 }, // Minccino
+        new(40,05,3) { Species = 884, Ability = A4, Moves = new(232, 525, 085, 249), Index = 48, CanGigantamax = true }, // Duraludon
+        new(40,05,3) { Species = 611, Ability = A4, Moves = new(406, 231, 242, 530), Index = 48 }, // Fraxure
+        new(40,05,3) { Species = 705, Ability = A4, Moves = new(406, 352, 491, 341), Index = 48 }, // Sliggoo
+        new(40,05,3) { Species = 143, Ability = A4, Moves = new(034, 667, 242, 281), Index = 48, CanGigantamax = true }, // Snorlax
+        new(40,05,3) { Species = 760, Ability = A4, Moves = new(693, 034, 359, 036), Index = 48 }, // Bewear
+        new(40,05,3) { Species = 573, Ability = A4, Moves = new(331, 231, 350, 129), Index = 48 }, // Cinccino
+        new(50,08,4) { Species = 884, Ability = A4, Moves = new(232, 406, 085, 776), Index = 48, CanGigantamax = true }, // Duraludon
+        new(50,08,4) { Species = 612, Ability = A4, Moves = new(406, 231, 370, 530), Index = 48 }, // Haxorus
+        new(50,08,4) { Species = 706, Ability = A4, Moves = new(406, 034, 491, 126), Index = 48 }, // Goodra
+        new(50,08,4) { Species = 143, Ability = A4, Moves = new(034, 667, 280, 523), Index = 48, CanGigantamax = true }, // Snorlax
+        new(50,08,4) { Species = 760, Ability = A4, Moves = new(663, 034, 359, 009), Index = 48 }, // Bewear
+        new(50,08,4) { Species = 573, Ability = A4, Moves = new(331, 231, 350, 304), Index = 48 }, // Cinccino
+        new(60,10,5) { Species = 884, Ability = A4, Moves = new(430, 406, 085, 776), Index = 48, CanGigantamax = true }, // Duraludon
+        new(60,10,5) { Species = 612, Ability = A4, Moves = new(200, 231, 370, 089), Index = 48 }, // Haxorus
+        new(60,10,5) { Species = 706, Ability = A4, Moves = new(406, 438, 482, 126), Index = 48 }, // Goodra
+        new(60,10,5) { Species = 143, Ability = A4, Moves = new(034, 442, 242, 428), Index = 48, CanGigantamax = true }, // Snorlax
+        new(60,10,5) { Species = 760, Ability = A4, Moves = new(663, 038, 276, 009), Index = 48 }, // Bewear
+        new(60,10,5) { Species = 573, Ability = A4, Moves = new(402, 231, 350, 304), Index = 48 }, // Cinccino
 
-        new(17,01,1) { Species = 037, Ability = A4, Moves = new[]{ 420, 196, 039, 577 }, Index = 46, Form = 1 }, // Vulpix-1
-        new(17,01,1) { Species = 124, Ability = A4, Moves = new[]{ 181, 001, 093, 122 }, Index = 46 }, // Jynx
-        new(17,01,1) { Species = 225, Ability = A4, Moves = new[]{ 217, 229, 098, 420 }, Index = 46 }, // Delibird
-        new(17,01,1) { Species = 607, Ability = A4, Moves = new[]{ 310, 052, 506, 123 }, Index = 46 }, // Litwick
-        new(17,01,1) { Species = 873, Ability = A4, Moves = new[]{ 522, 078, 181, 432 }, Index = 46 }, // Frosmoth
-        new(30,03,2) { Species = 037, Ability = A4, Moves = new[]{ 420, 058, 326, 577 }, Index = 46, Form = 1 }, // Vulpix-1
-        new(30,03,2) { Species = 124, Ability = A4, Moves = new[]{ 181, 001, 093, 313 }, Index = 46 }, // Jynx
-        new(30,03,2) { Species = 225, Ability = A4, Moves = new[]{ 217, 065, 034, 693 }, Index = 46 }, // Delibird
-        new(30,03,2) { Species = 608, Ability = A4, Moves = new[]{ 310, 261, 083, 123 }, Index = 46 }, // Lampent
-        new(30,03,2) { Species = 873, Ability = A4, Moves = new[]{ 522, 078, 062, 432 }, Index = 46 }, // Frosmoth
-        new(40,05,3) { Species = 037, Ability = A4, Moves = new[]{ 062, 058, 326, 577 }, Index = 46, Form = 1 }, // Vulpix-1
-        new(40,05,3) { Species = 124, Ability = A4, Moves = new[]{ 058, 142, 094, 247 }, Index = 46 }, // Jynx
-        new(40,05,3) { Species = 225, Ability = A4, Moves = new[]{ 217, 065, 280, 196 }, Index = 46 }, // Delibird
-        new(40,05,3) { Species = 609, Ability = A4, Moves = new[]{ 247, 261, 257, 094 }, Index = 46 }, // Chandelure
-        new(40,05,3) { Species = 873, Ability = A4, Moves = new[]{ 405, 403, 062, 432 }, Index = 46 }, // Frosmoth
-        new(50,08,4) { Species = 037, Ability = A4, Moves = new[]{ 694, 058, 326, 577 }, Index = 46, Form = 1 }, // Vulpix-1
-        new(50,08,4) { Species = 124, Ability = A4, Moves = new[]{ 058, 142, 094, 247 }, Index = 46 }, // Jynx
-        new(50,08,4) { Species = 225, Ability = A4, Moves = new[]{ 217, 059, 034, 280 }, Index = 46 }, // Delibird
-        new(50,08,4) { Species = 609, Ability = A4, Moves = new[]{ 247, 261, 315, 094 }, Index = 46 }, // Chandelure
-        new(50,08,4) { Species = 873, Ability = A4, Moves = new[]{ 405, 403, 058, 297 }, Index = 46 }, // Frosmoth
-        new(60,10,5) { Species = 037, Ability = A4, Moves = new[]{ 694, 059, 326, 577 }, Index = 46, Form = 1 }, // Vulpix-1
-        new(60,10,5) { Species = 037, Ability = A4, Moves = new[]{ 694, 059, 326, 577 }, Index = 46, Form = 1, Shiny = Shiny.Always }, // Vulpix-1
-        new(60,10,5) { Species = 124, Ability = A4, Moves = new[]{ 058, 142, 094, 247 }, Index = 46 }, // Jynx
-        new(60,10,5) { Species = 225, Ability = A4, Moves = new[]{ 217, 059, 065, 280 }, Index = 46 }, // Delibird
-        new(60,10,5) { Species = 609, Ability = A4, Moves = new[]{ 247, 412, 315, 094 }, Index = 46 }, // Chandelure
-        new(60,10,5) { Species = 873, Ability = A4, Moves = new[]{ 405, 403, 058, 542 }, Index = 46 }, // Frosmoth
+        new(17,01,1) { Species = 037, Ability = A4, Moves = new(420, 196, 039, 577), Index = 46, Form = 1 }, // Vulpix-1
+        new(17,01,1) { Species = 124, Ability = A4, Moves = new(181, 001, 093, 122), Index = 46 }, // Jynx
+        new(17,01,1) { Species = 225, Ability = A4, Moves = new(217, 229, 098, 420), Index = 46 }, // Delibird
+        new(17,01,1) { Species = 607, Ability = A4, Moves = new(310, 052, 506, 123), Index = 46 }, // Litwick
+        new(17,01,1) { Species = 873, Ability = A4, Moves = new(522, 078, 181, 432), Index = 46 }, // Frosmoth
+        new(30,03,2) { Species = 037, Ability = A4, Moves = new(420, 058, 326, 577), Index = 46, Form = 1 }, // Vulpix-1
+        new(30,03,2) { Species = 124, Ability = A4, Moves = new(181, 001, 093, 313), Index = 46 }, // Jynx
+        new(30,03,2) { Species = 225, Ability = A4, Moves = new(217, 065, 034, 693), Index = 46 }, // Delibird
+        new(30,03,2) { Species = 608, Ability = A4, Moves = new(310, 261, 083, 123), Index = 46 }, // Lampent
+        new(30,03,2) { Species = 873, Ability = A4, Moves = new(522, 078, 062, 432), Index = 46 }, // Frosmoth
+        new(40,05,3) { Species = 037, Ability = A4, Moves = new(062, 058, 326, 577), Index = 46, Form = 1 }, // Vulpix-1
+        new(40,05,3) { Species = 124, Ability = A4, Moves = new(058, 142, 094, 247), Index = 46 }, // Jynx
+        new(40,05,3) { Species = 225, Ability = A4, Moves = new(217, 065, 280, 196), Index = 46 }, // Delibird
+        new(40,05,3) { Species = 609, Ability = A4, Moves = new(247, 261, 257, 094), Index = 46 }, // Chandelure
+        new(40,05,3) { Species = 873, Ability = A4, Moves = new(405, 403, 062, 432), Index = 46 }, // Frosmoth
+        new(50,08,4) { Species = 037, Ability = A4, Moves = new(694, 058, 326, 577), Index = 46, Form = 1 }, // Vulpix-1
+        new(50,08,4) { Species = 124, Ability = A4, Moves = new(058, 142, 094, 247), Index = 46 }, // Jynx
+        new(50,08,4) { Species = 225, Ability = A4, Moves = new(217, 059, 034, 280), Index = 46 }, // Delibird
+        new(50,08,4) { Species = 609, Ability = A4, Moves = new(247, 261, 315, 094), Index = 46 }, // Chandelure
+        new(50,08,4) { Species = 873, Ability = A4, Moves = new(405, 403, 058, 297), Index = 46 }, // Frosmoth
+        new(60,10,5) { Species = 037, Ability = A4, Moves = new(694, 059, 326, 577), Index = 46, Form = 1 }, // Vulpix-1
+        new(60,10,5) { Species = 037, Ability = A4, Moves = new(694, 059, 326, 577), Index = 46, Form = 1, Shiny = Shiny.Always }, // Vulpix-1
+        new(60,10,5) { Species = 124, Ability = A4, Moves = new(058, 142, 094, 247), Index = 46 }, // Jynx
+        new(60,10,5) { Species = 225, Ability = A4, Moves = new(217, 059, 065, 280), Index = 46 }, // Delibird
+        new(60,10,5) { Species = 609, Ability = A4, Moves = new(247, 412, 315, 094), Index = 46 }, // Chandelure
+        new(60,10,5) { Species = 873, Ability = A4, Moves = new(405, 403, 058, 542), Index = 46 }, // Frosmoth
 
-        new(17,01,1) { Species = 131, Ability = A4, Moves = new[]{ 055, 420, 045, 047 }, Index = 45, CanGigantamax = true }, // Lapras
-        new(17,01,1) { Species = 712, Ability = A4, Moves = new[]{ 181, 196, 033, 106 }, Index = 45 }, // Bergmite
-        new(17,01,1) { Species = 461, Ability = A4, Moves = new[]{ 420, 372, 232, 279 }, Index = 45 }, // Weavile
-        new(17,01,1) { Species = 850, Ability = A4, Moves = new[]{ 172, 044, 035, 052 }, Index = 45 }, // Sizzlipede
-        new(17,01,1) { Species = 776, Ability = A4, Moves = new[]{ 175, 123, 033, 052 }, Index = 45 }, // Turtonator
-        new(17,01,1) { Species = 077, Ability = A4, Moves = new[]{ 488, 045, 039, 052 }, Index = 45 }, // Ponyta
-        new(30,03,2) { Species = 131, Ability = A4, Moves = new[]{ 352, 420, 109, 047 }, Index = 45, CanGigantamax = true }, // Lapras
-        new(30,03,2) { Species = 712, Ability = A4, Moves = new[]{ 157, 423, 033, 044 }, Index = 45 }, // Bergmite
-        new(30,03,2) { Species = 461, Ability = A4, Moves = new[]{ 420, 372, 232, 279 }, Index = 45 }, // Weavile
-        new(30,03,2) { Species = 851, Ability = A4, Moves = new[]{ 172, 404, 422, 044 }, Index = 45, CanGigantamax = true }, // Centiskorch
-        new(30,03,2) { Species = 776, Ability = A4, Moves = new[]{ 406, 123, 033, 052 }, Index = 45 }, // Turtonator
-        new(30,03,2) { Species = 077, Ability = A4, Moves = new[]{ 488, 023, 583, 097 }, Index = 45 }, // Ponyta
-        new(40,05,3) { Species = 131, Ability = A4, Moves = new[]{ 352, 196, 109, 047 }, Index = 45, CanGigantamax = true }, // Lapras
-        new(40,05,3) { Species = 713, Ability = A4, Moves = new[]{ 157, 423, 036, 044 }, Index = 45 }, // Avalugg
-        new(40,05,3) { Species = 461, Ability = A4, Moves = new[]{ 420, 468, 232, 279 }, Index = 45 }, // Weavile
-        new(40,05,3) { Species = 851, Ability = A4, Moves = new[]{ 424, 404, 422, 044 }, Index = 45, CanGigantamax = true }, // Centiskorch
-        new(40,05,3) { Species = 776, Ability = A4, Moves = new[]{ 406, 776, 034, 053 }, Index = 45 }, // Turtonator
-        new(40,05,3) { Species = 078, Ability = A4, Moves = new[]{ 172, 023, 583, 224 }, Index = 45 }, // Rapidash
-        new(50,08,4) { Species = 131, Ability = A4, Moves = new[]{ 057, 196, 058, 047 }, Index = 45, CanGigantamax = true }, // Lapras
-        new(50,08,4) { Species = 713, Ability = A4, Moves = new[]{ 776, 059, 036, 044 }, Index = 45 }, // Avalugg
-        new(50,08,4) { Species = 461, Ability = A4, Moves = new[]{ 420, 468, 232, 279 }, Index = 45 }, // Weavile
-        new(50,08,4) { Species = 851, Ability = A4, Moves = new[]{ 680, 404, 422, 044 }, Index = 45, CanGigantamax = true }, // Centiskorch
-        new(50,08,4) { Species = 776, Ability = A4, Moves = new[]{ 406, 776, 504, 053 }, Index = 45 }, // Turtonator
-        new(50,08,4) { Species = 078, Ability = A4, Moves = new[]{ 517, 528, 583, 224 }, Index = 45 }, // Rapidash
-        new(60,10,5) { Species = 131, Ability = A4, Moves = new[]{ 057, 196, 058, 329 }, Index = 45, CanGigantamax = true }, // Lapras
-        new(60,10,5) { Species = 713, Ability = A4, Moves = new[]{ 776, 059, 038, 044 }, Index = 45 }, // Avalugg
-        new(60,10,5) { Species = 461, Ability = A4, Moves = new[]{ 420, 400, 232, 279 }, Index = 45 }, // Weavile
-        new(60,10,5) { Species = 851, Ability = A4, Moves = new[]{ 680, 679, 422, 044 }, Index = 45, CanGigantamax = true }, // Centiskorch
-        new(60,10,5) { Species = 776, Ability = A4, Moves = new[]{ 434, 776, 504, 053 }, Index = 45 }, // Turtonator
-        new(60,10,5) { Species = 078, Ability = A4, Moves = new[]{ 394, 528, 583, 224 }, Index = 45 }, // Rapidash
+        new(17,01,1) { Species = 131, Ability = A4, Moves = new(055, 420, 045, 047), Index = 45, CanGigantamax = true }, // Lapras
+        new(17,01,1) { Species = 712, Ability = A4, Moves = new(181, 196, 033, 106), Index = 45 }, // Bergmite
+        new(17,01,1) { Species = 461, Ability = A4, Moves = new(420, 372, 232, 279), Index = 45 }, // Weavile
+        new(17,01,1) { Species = 850, Ability = A4, Moves = new(172, 044, 035, 052), Index = 45 }, // Sizzlipede
+        new(17,01,1) { Species = 776, Ability = A4, Moves = new(175, 123, 033, 052), Index = 45 }, // Turtonator
+        new(17,01,1) { Species = 077, Ability = A4, Moves = new(488, 045, 039, 052), Index = 45 }, // Ponyta
+        new(30,03,2) { Species = 131, Ability = A4, Moves = new(352, 420, 109, 047), Index = 45, CanGigantamax = true }, // Lapras
+        new(30,03,2) { Species = 712, Ability = A4, Moves = new(157, 423, 033, 044), Index = 45 }, // Bergmite
+        new(30,03,2) { Species = 461, Ability = A4, Moves = new(420, 372, 232, 279), Index = 45 }, // Weavile
+        new(30,03,2) { Species = 851, Ability = A4, Moves = new(172, 404, 422, 044), Index = 45, CanGigantamax = true }, // Centiskorch
+        new(30,03,2) { Species = 776, Ability = A4, Moves = new(406, 123, 033, 052), Index = 45 }, // Turtonator
+        new(30,03,2) { Species = 077, Ability = A4, Moves = new(488, 023, 583, 097), Index = 45 }, // Ponyta
+        new(40,05,3) { Species = 131, Ability = A4, Moves = new(352, 196, 109, 047), Index = 45, CanGigantamax = true }, // Lapras
+        new(40,05,3) { Species = 713, Ability = A4, Moves = new(157, 423, 036, 044), Index = 45 }, // Avalugg
+        new(40,05,3) { Species = 461, Ability = A4, Moves = new(420, 468, 232, 279), Index = 45 }, // Weavile
+        new(40,05,3) { Species = 851, Ability = A4, Moves = new(424, 404, 422, 044), Index = 45, CanGigantamax = true }, // Centiskorch
+        new(40,05,3) { Species = 776, Ability = A4, Moves = new(406, 776, 034, 053), Index = 45 }, // Turtonator
+        new(40,05,3) { Species = 078, Ability = A4, Moves = new(172, 023, 583, 224), Index = 45 }, // Rapidash
+        new(50,08,4) { Species = 131, Ability = A4, Moves = new(057, 196, 058, 047), Index = 45, CanGigantamax = true }, // Lapras
+        new(50,08,4) { Species = 713, Ability = A4, Moves = new(776, 059, 036, 044), Index = 45 }, // Avalugg
+        new(50,08,4) { Species = 461, Ability = A4, Moves = new(420, 468, 232, 279), Index = 45 }, // Weavile
+        new(50,08,4) { Species = 851, Ability = A4, Moves = new(680, 404, 422, 044), Index = 45, CanGigantamax = true }, // Centiskorch
+        new(50,08,4) { Species = 776, Ability = A4, Moves = new(406, 776, 504, 053), Index = 45 }, // Turtonator
+        new(50,08,4) { Species = 078, Ability = A4, Moves = new(517, 528, 583, 224), Index = 45 }, // Rapidash
+        new(60,10,5) { Species = 131, Ability = A4, Moves = new(057, 196, 058, 329), Index = 45, CanGigantamax = true }, // Lapras
+        new(60,10,5) { Species = 713, Ability = A4, Moves = new(776, 059, 038, 044), Index = 45 }, // Avalugg
+        new(60,10,5) { Species = 461, Ability = A4, Moves = new(420, 400, 232, 279), Index = 45 }, // Weavile
+        new(60,10,5) { Species = 851, Ability = A4, Moves = new(680, 679, 422, 044), Index = 45, CanGigantamax = true }, // Centiskorch
+        new(60,10,5) { Species = 776, Ability = A4, Moves = new(434, 776, 504, 053), Index = 45 }, // Turtonator
+        new(60,10,5) { Species = 078, Ability = A4, Moves = new(394, 528, 583, 224), Index = 45 }, // Rapidash
 
-        new(17,01,1) { Species = 420, Ability = A4, Moves = new[]{ 033, 572, 074, 670 }, Index = 43 }, // Cherubi
-        new(17,01,1) { Species = 590, Ability = A4, Moves = new[]{ 078, 492, 310, 412 }, Index = 43 }, // Foongus
-        new(17,01,1) { Species = 755, Ability = A4, Moves = new[]{ 402, 109, 605, 310 }, Index = 43 }, // Morelull
-        new(17,01,1) { Species = 819, Ability = A4, Moves = new[]{ 747, 231, 371, 033 }, Index = 43 }, // Skwovet
-        new(30,03,2) { Species = 420, Ability = A4, Moves = new[]{ 033, 572, 074, 402 }, Index = 43 }, // Cherubi
-        new(30,03,2) { Species = 590, Ability = A4, Moves = new[]{ 078, 492, 310, 412 }, Index = 43 }, // Foongus
-        new(30,03,2) { Species = 756, Ability = A4, Moves = new[]{ 402, 109, 605, 310 }, Index = 43 }, // Shiinotic
-        new(30,03,2) { Species = 819, Ability = A4, Moves = new[]{ 747, 231, 371, 033 }, Index = 43 }, // Skwovet
-        new(30,03,2) { Species = 820, Ability = A4, Moves = new[]{ 747, 231, 371, 034 }, Index = 43 }, // Greedent
-        new(40,05,3) { Species = 420, Ability = A4, Moves = new[]{ 311, 572, 074, 402 }, Index = 43 }, // Cherubi
-        new(40,05,3) { Species = 591, Ability = A4, Moves = new[]{ 078, 492, 092, 412 }, Index = 43 }, // Amoonguss
-        new(40,05,3) { Species = 756, Ability = A4, Moves = new[]{ 402, 585, 605, 310 }, Index = 43 }, // Shiinotic
-        new(40,05,3) { Species = 819, Ability = A4, Moves = new[]{ 747, 360, 371, 044 }, Index = 43 }, // Skwovet
-        new(40,05,3) { Species = 820, Ability = A4, Moves = new[]{ 747, 360, 371, 424 }, Index = 43 }, // Greedent
-        new(50,08,4) { Species = 420, Ability = A4, Moves = new[]{ 311, 572, 605, 402 }, Index = 43 }, // Cherubi
-        new(50,08,4) { Species = 591, Ability = A4, Moves = new[]{ 188, 492, 092, 412 }, Index = 43 }, // Amoonguss
-        new(50,08,4) { Species = 756, Ability = A4, Moves = new[]{ 412, 585, 605, 188 }, Index = 43 }, // Shiinotic
-        new(50,08,4) { Species = 819, Ability = A4, Moves = new[]{ 747, 360, 371, 331 }, Index = 43 }, // Skwovet
-        new(50,08,4) { Species = 820, Ability = A4, Moves = new[]{ 747, 360, 371, 424 }, Index = 43 }, // Greedent
-        new(60,10,5) { Species = 420, Ability = A4, Moves = new[]{ 311, 572, 605, 412 }, Index = 43 }, // Cherubi
-        new(60,10,5) { Species = 591, Ability = A4, Moves = new[]{ 147, 492, 092, 412 }, Index = 43 }, // Amoonguss
-        new(60,10,5) { Species = 756, Ability = A4, Moves = new[]{ 147, 585, 605, 188 }, Index = 43 }, // Shiinotic
-        new(60,10,5) { Species = 819, Ability = A4, Moves = new[]{ 747, 360, 371, 034 }, Index = 43 }, // Skwovet
-        new(60,10,5) { Species = 819, Ability = A4, Moves = new[]{ 747, 360, 371, 034 }, Index = 43, Shiny = Shiny.Always }, // Skwovet
-        new(60,10,5) { Species = 820, Ability = A4, Moves = new[]{ 747, 360, 371, 089 }, Index = 43 }, // Greedent
+        new(17,01,1) { Species = 420, Ability = A4, Moves = new(033, 572, 074, 670), Index = 43 }, // Cherubi
+        new(17,01,1) { Species = 590, Ability = A4, Moves = new(078, 492, 310, 412), Index = 43 }, // Foongus
+        new(17,01,1) { Species = 755, Ability = A4, Moves = new(402, 109, 605, 310), Index = 43 }, // Morelull
+        new(17,01,1) { Species = 819, Ability = A4, Moves = new(747, 231, 371, 033), Index = 43 }, // Skwovet
+        new(30,03,2) { Species = 420, Ability = A4, Moves = new(033, 572, 074, 402), Index = 43 }, // Cherubi
+        new(30,03,2) { Species = 590, Ability = A4, Moves = new(078, 492, 310, 412), Index = 43 }, // Foongus
+        new(30,03,2) { Species = 756, Ability = A4, Moves = new(402, 109, 605, 310), Index = 43 }, // Shiinotic
+        new(30,03,2) { Species = 819, Ability = A4, Moves = new(747, 231, 371, 033), Index = 43 }, // Skwovet
+        new(30,03,2) { Species = 820, Ability = A4, Moves = new(747, 231, 371, 034), Index = 43 }, // Greedent
+        new(40,05,3) { Species = 420, Ability = A4, Moves = new(311, 572, 074, 402), Index = 43 }, // Cherubi
+        new(40,05,3) { Species = 591, Ability = A4, Moves = new(078, 492, 092, 412), Index = 43 }, // Amoonguss
+        new(40,05,3) { Species = 756, Ability = A4, Moves = new(402, 585, 605, 310), Index = 43 }, // Shiinotic
+        new(40,05,3) { Species = 819, Ability = A4, Moves = new(747, 360, 371, 044), Index = 43 }, // Skwovet
+        new(40,05,3) { Species = 820, Ability = A4, Moves = new(747, 360, 371, 424), Index = 43 }, // Greedent
+        new(50,08,4) { Species = 420, Ability = A4, Moves = new(311, 572, 605, 402), Index = 43 }, // Cherubi
+        new(50,08,4) { Species = 591, Ability = A4, Moves = new(188, 492, 092, 412), Index = 43 }, // Amoonguss
+        new(50,08,4) { Species = 756, Ability = A4, Moves = new(412, 585, 605, 188), Index = 43 }, // Shiinotic
+        new(50,08,4) { Species = 819, Ability = A4, Moves = new(747, 360, 371, 331), Index = 43 }, // Skwovet
+        new(50,08,4) { Species = 820, Ability = A4, Moves = new(747, 360, 371, 424), Index = 43 }, // Greedent
+        new(60,10,5) { Species = 420, Ability = A4, Moves = new(311, 572, 605, 412), Index = 43 }, // Cherubi
+        new(60,10,5) { Species = 591, Ability = A4, Moves = new(147, 492, 092, 412), Index = 43 }, // Amoonguss
+        new(60,10,5) { Species = 756, Ability = A4, Moves = new(147, 585, 605, 188), Index = 43 }, // Shiinotic
+        new(60,10,5) { Species = 819, Ability = A4, Moves = new(747, 360, 371, 034), Index = 43 }, // Skwovet
+        new(60,10,5) { Species = 819, Ability = A4, Moves = new(747, 360, 371, 034), Index = 43, Shiny = Shiny.Always }, // Skwovet
+        new(60,10,5) { Species = 820, Ability = A4, Moves = new(747, 360, 371, 089), Index = 43 }, // Greedent
 
-        new(17,01,1) { Species = 012, Ability = A4, Moves = new[]{ 081, 060, 016, 079 }, Index = 42, CanGigantamax = true }, // Butterfree
-        new(17,01,1) { Species = 213, Ability = A4, Moves = new[]{ 088, 474, 414, 522 }, Index = 42 }, // Shuckle
-        new(17,01,1) { Species = 290, Ability = A4, Moves = new[]{ 189, 206, 010, 106 }, Index = 42 }, // Nincada
-        new(17,01,1) { Species = 568, Ability = A4, Moves = new[]{ 390, 133, 491, 001 }, Index = 42 }, // Trubbish
-        new(17,01,1) { Species = 043, Ability = A4, Moves = new[]{ 078, 077, 051, 230 }, Index = 42 }, // Oddish
-        new(17,01,1) { Species = 453, Ability = A4, Moves = new[]{ 040, 269, 279, 189 }, Index = 42 }, // Croagunk
-        new(30,03,2) { Species = 012, Ability = A4, Moves = new[]{ 405, 060, 016, 079 }, Index = 42, CanGigantamax = true }, // Butterfree
-        new(30,03,2) { Species = 213, Ability = A4, Moves = new[]{ 088, 474, 414, 522 }, Index = 42 }, // Shuckle
-        new(30,03,2) { Species = 291, Ability = A4, Moves = new[]{ 210, 206, 332, 232 }, Index = 42 }, // Ninjask
-        new(30,03,2) { Species = 568, Ability = A4, Moves = new[]{ 092, 133, 491, 036 }, Index = 42 }, // Trubbish
-        new(30,03,2) { Species = 045, Ability = A4, Moves = new[]{ 080, 585, 051, 230 }, Index = 42 }, // Vileplume
-        new(30,03,2) { Species = 453, Ability = A4, Moves = new[]{ 474, 389, 279, 189 }, Index = 42 }, // Croagunk
-        new(40,05,3) { Species = 012, Ability = A4, Moves = new[]{ 405, 060, 016, 078 }, Index = 42, CanGigantamax = true }, // Butterfree
-        new(40,05,3) { Species = 213, Ability = A4, Moves = new[]{ 157, 188, 089, 522 }, Index = 42 }, // Shuckle
-        new(40,05,3) { Species = 291, Ability = A4, Moves = new[]{ 210, 206, 332, 232 }, Index = 42 }, // Ninjask
-        new(40,05,3) { Species = 569, Ability = A4, Moves = new[]{ 188, 133, 034, 707 }, Index = 42, CanGigantamax = true }, // Garbodor
-        new(40,05,3) { Species = 045, Ability = A4, Moves = new[]{ 080, 585, 051, 230 }, Index = 42 }, // Vileplume
-        new(40,05,3) { Species = 454, Ability = A4, Moves = new[]{ 188, 389, 279, 189 }, Index = 42 }, // Toxicroak
-        new(50,08,4) { Species = 012, Ability = A4, Moves = new[]{ 405, 403, 093, 078 }, Index = 42, CanGigantamax = true }, // Butterfree
-        new(50,08,4) { Species = 213, Ability = A4, Moves = new[]{ 157, 188, 089, 564 }, Index = 42 }, // Shuckle
-        new(50,08,4) { Species = 291, Ability = A4, Moves = new[]{ 210, 163, 332, 232 }, Index = 42 }, // Ninjask
-        new(50,08,4) { Species = 569, Ability = A4, Moves = new[]{ 188, 499, 034, 707 }, Index = 42, CanGigantamax = true }, // Garbodor
-        new(50,08,4) { Species = 045, Ability = A4, Moves = new[]{ 080, 585, 051, 034 }, Index = 42 }, // Vileplume
-        new(50,08,4) { Species = 454, Ability = A4, Moves = new[]{ 188, 389, 280, 189 }, Index = 42 }, // Toxicroak
-        new(60,10,5) { Species = 012, Ability = A4, Moves = new[]{ 405, 403, 527, 078 }, Index = 42, CanGigantamax = true }, // Butterfree
-        new(60,10,5) { Species = 213, Ability = A4, Moves = new[]{ 444, 188, 089, 564 }, Index = 42 }, // Shuckle
-        new(60,10,5) { Species = 291, Ability = A4, Moves = new[]{ 404, 163, 332, 232 }, Index = 42 }, // Ninjask
-        new(60,10,5) { Species = 569, Ability = A4, Moves = new[]{ 441, 499, 034, 707 }, Index = 42, CanGigantamax = true }, // Garbodor
-        new(60,10,5) { Species = 045, Ability = A4, Moves = new[]{ 080, 585, 051, 034 }, Index = 42 }, // Vileplume
-        new(60,10,5) { Species = 454, Ability = A4, Moves = new[]{ 188, 389, 280, 523 }, Index = 42 }, // Toxicroak
+        new(17,01,1) { Species = 012, Ability = A4, Moves = new(081, 060, 016, 079), Index = 42, CanGigantamax = true }, // Butterfree
+        new(17,01,1) { Species = 213, Ability = A4, Moves = new(088, 474, 414, 522), Index = 42 }, // Shuckle
+        new(17,01,1) { Species = 290, Ability = A4, Moves = new(189, 206, 010, 106), Index = 42 }, // Nincada
+        new(17,01,1) { Species = 568, Ability = A4, Moves = new(390, 133, 491, 001), Index = 42 }, // Trubbish
+        new(17,01,1) { Species = 043, Ability = A4, Moves = new(078, 077, 051, 230), Index = 42 }, // Oddish
+        new(17,01,1) { Species = 453, Ability = A4, Moves = new(040, 269, 279, 189), Index = 42 }, // Croagunk
+        new(30,03,2) { Species = 012, Ability = A4, Moves = new(405, 060, 016, 079), Index = 42, CanGigantamax = true }, // Butterfree
+        new(30,03,2) { Species = 213, Ability = A4, Moves = new(088, 474, 414, 522), Index = 42 }, // Shuckle
+        new(30,03,2) { Species = 291, Ability = A4, Moves = new(210, 206, 332, 232), Index = 42 }, // Ninjask
+        new(30,03,2) { Species = 568, Ability = A4, Moves = new(092, 133, 491, 036), Index = 42 }, // Trubbish
+        new(30,03,2) { Species = 045, Ability = A4, Moves = new(080, 585, 051, 230), Index = 42 }, // Vileplume
+        new(30,03,2) { Species = 453, Ability = A4, Moves = new(474, 389, 279, 189), Index = 42 }, // Croagunk
+        new(40,05,3) { Species = 012, Ability = A4, Moves = new(405, 060, 016, 078), Index = 42, CanGigantamax = true }, // Butterfree
+        new(40,05,3) { Species = 213, Ability = A4, Moves = new(157, 188, 089, 522), Index = 42 }, // Shuckle
+        new(40,05,3) { Species = 291, Ability = A4, Moves = new(210, 206, 332, 232), Index = 42 }, // Ninjask
+        new(40,05,3) { Species = 569, Ability = A4, Moves = new(188, 133, 034, 707), Index = 42, CanGigantamax = true }, // Garbodor
+        new(40,05,3) { Species = 045, Ability = A4, Moves = new(080, 585, 051, 230), Index = 42 }, // Vileplume
+        new(40,05,3) { Species = 454, Ability = A4, Moves = new(188, 389, 279, 189), Index = 42 }, // Toxicroak
+        new(50,08,4) { Species = 012, Ability = A4, Moves = new(405, 403, 093, 078), Index = 42, CanGigantamax = true }, // Butterfree
+        new(50,08,4) { Species = 213, Ability = A4, Moves = new(157, 188, 089, 564), Index = 42 }, // Shuckle
+        new(50,08,4) { Species = 291, Ability = A4, Moves = new(210, 163, 332, 232), Index = 42 }, // Ninjask
+        new(50,08,4) { Species = 569, Ability = A4, Moves = new(188, 499, 034, 707), Index = 42, CanGigantamax = true }, // Garbodor
+        new(50,08,4) { Species = 045, Ability = A4, Moves = new(080, 585, 051, 034), Index = 42 }, // Vileplume
+        new(50,08,4) { Species = 454, Ability = A4, Moves = new(188, 389, 280, 189), Index = 42 }, // Toxicroak
+        new(60,10,5) { Species = 012, Ability = A4, Moves = new(405, 403, 527, 078), Index = 42, CanGigantamax = true }, // Butterfree
+        new(60,10,5) { Species = 213, Ability = A4, Moves = new(444, 188, 089, 564), Index = 42 }, // Shuckle
+        new(60,10,5) { Species = 291, Ability = A4, Moves = new(404, 163, 332, 232), Index = 42 }, // Ninjask
+        new(60,10,5) { Species = 569, Ability = A4, Moves = new(441, 499, 034, 707), Index = 42, CanGigantamax = true }, // Garbodor
+        new(60,10,5) { Species = 045, Ability = A4, Moves = new(080, 585, 051, 034), Index = 42 }, // Vileplume
+        new(60,10,5) { Species = 454, Ability = A4, Moves = new(188, 389, 280, 523), Index = 42 }, // Toxicroak
 
-        new(17,01,1) { Species = 562, Ability = A4, Moves = new[]{ 261, 114, 310, 101 }, Index = 41 }, // Yamask
-        new(17,01,1) { Species = 778, Ability = A4, Moves = new[]{ 086, 452, 425, 010 }, Index = 41 }, // Mimikyu
-        new(17,01,1) { Species = 709, Ability = A4, Moves = new[]{ 785, 421, 261, 310 }, Index = 41 }, // Trevenant
-        new(17,01,1) { Species = 855, Ability = A4, Moves = new[]{ 597, 110, 668, 310 }, Index = 41 }, // Polteageist
-        new(30,03,2) { Species = 710, Ability = A4, Moves = new[]{ 567, 425, 310, 331 }, Index = 41 }, // Pumpkaboo
-        new(30,03,2) { Species = 563, Ability = A4, Moves = new[]{ 578, 421, 310, 261 }, Index = 41 }, // Cofagrigus
-        new(30,03,2) { Species = 778, Ability = A4, Moves = new[]{ 086, 452, 425, 608 }, Index = 41 }, // Mimikyu
-        new(30,03,2) { Species = 709, Ability = A4, Moves = new[]{ 785, 506, 261, 310 }, Index = 41 }, // Trevenant
-        new(30,03,2) { Species = 855, Ability = A4, Moves = new[]{ 597, 110, 389, 310 }, Index = 41 }, // Polteageist
-        new(40,05,3) { Species = 710, Ability = A4, Moves = new[]{ 567, 247, 310, 402 }, Index = 41 }, // Pumpkaboo
-        new(40,05,3) { Species = 563, Ability = A4, Moves = new[]{ 578, 421, 310, 261 }, Index = 41 }, // Cofagrigus
-        new(40,05,3) { Species = 778, Ability = A4, Moves = new[]{ 085, 452, 421, 608 }, Index = 41 }, // Mimikyu
-        new(40,05,3) { Species = 709, Ability = A4, Moves = new[]{ 785, 506, 261, 310 }, Index = 41 }, // Trevenant
-        new(40,05,3) { Species = 855, Ability = A4, Moves = new[]{ 597, 110, 389, 310 }, Index = 41 }, // Polteageist
-        new(50,08,4) { Species = 711, Ability = A4, Moves = new[]{ 567, 247, 585, 402 }, Index = 41 }, // Gourgeist
-        new(50,08,4) { Species = 711, Ability = A4, Moves = new[]{ 567, 247, 585, 402 }, Index = 41, Form = 1 }, // Gourgeist-1
-        new(50,08,4) { Species = 711, Ability = A4, Moves = new[]{ 567, 247, 585, 402 }, Index = 41, Form = 2 }, // Gourgeist-2
-        new(50,08,4) { Species = 711, Ability = A4, Moves = new[]{ 567, 247, 585, 402 }, Index = 41, Form = 3 }, // Gourgeist-3
-        new(50,08,4) { Species = 563, Ability = A4, Moves = new[]{ 578, 247, 399, 261 }, Index = 41 }, // Cofagrigus
-        new(50,08,4) { Species = 778, Ability = A4, Moves = new[]{ 085, 452, 261, 204 }, Index = 41 }, // Mimikyu
-        new(50,08,4) { Species = 709, Ability = A4, Moves = new[]{ 452, 506, 261, 310 }, Index = 41 }, // Trevenant
-        new(50,08,4) { Species = 855, Ability = A4, Moves = new[]{ 247, 417, 389, 310 }, Index = 41 }, // Polteageist
-        new(60,10,5) { Species = 711, Ability = A4, Moves = new[]{ 567, 247, 433, 402 }, Index = 41 }, // Gourgeist
-        new(60,10,5) { Species = 711, Ability = A4, Moves = new[]{ 567, 247, 433, 402 }, Index = 41, Form = 1, Shiny = Shiny.Always }, // Gourgeist-1
-        new(60,10,5) { Species = 711, Ability = A4, Moves = new[]{ 567, 247, 433, 402 }, Index = 41, Form = 2 }, // Gourgeist-2
-        new(60,10,5) { Species = 711, Ability = A4, Moves = new[]{ 567, 247, 433, 402 }, Index = 41, Form = 3, Shiny = Shiny.Always }, // Gourgeist-3
-        new(60,10,5) { Species = 563, Ability = A4, Moves = new[]{ 578, 247, 399, 261 }, Index = 41 }, // Cofagrigus
-        new(60,10,5) { Species = 778, Ability = A4, Moves = new[]{ 087, 452, 261, 583 }, Index = 41 }, // Mimikyu
-        new(60,10,5) { Species = 709, Ability = A4, Moves = new[]{ 452, 506, 261, 310 }, Index = 41 }, // Trevenant
-        new(60,10,5) { Species = 855, Ability = A4, Moves = new[]{ 247, 417, 389, 310 }, Index = 41 }, // Polteageist
+        new(17,01,1) { Species = 562, Ability = A4, Moves = new(261, 114, 310, 101), Index = 41 }, // Yamask
+        new(17,01,1) { Species = 778, Ability = A4, Moves = new(086, 452, 425, 010), Index = 41 }, // Mimikyu
+        new(17,01,1) { Species = 709, Ability = A4, Moves = new(785, 421, 261, 310), Index = 41 }, // Trevenant
+        new(17,01,1) { Species = 855, Ability = A4, Moves = new(597, 110, 668, 310), Index = 41 }, // Polteageist
+        new(30,03,2) { Species = 710, Ability = A4, Moves = new(567, 425, 310, 331), Index = 41 }, // Pumpkaboo
+        new(30,03,2) { Species = 563, Ability = A4, Moves = new(578, 421, 310, 261), Index = 41 }, // Cofagrigus
+        new(30,03,2) { Species = 778, Ability = A4, Moves = new(086, 452, 425, 608), Index = 41 }, // Mimikyu
+        new(30,03,2) { Species = 709, Ability = A4, Moves = new(785, 506, 261, 310), Index = 41 }, // Trevenant
+        new(30,03,2) { Species = 855, Ability = A4, Moves = new(597, 110, 389, 310), Index = 41 }, // Polteageist
+        new(40,05,3) { Species = 710, Ability = A4, Moves = new(567, 247, 310, 402), Index = 41 }, // Pumpkaboo
+        new(40,05,3) { Species = 563, Ability = A4, Moves = new(578, 421, 310, 261), Index = 41 }, // Cofagrigus
+        new(40,05,3) { Species = 778, Ability = A4, Moves = new(085, 452, 421, 608), Index = 41 }, // Mimikyu
+        new(40,05,3) { Species = 709, Ability = A4, Moves = new(785, 506, 261, 310), Index = 41 }, // Trevenant
+        new(40,05,3) { Species = 855, Ability = A4, Moves = new(597, 110, 389, 310), Index = 41 }, // Polteageist
+        new(50,08,4) { Species = 711, Ability = A4, Moves = new(567, 247, 585, 402), Index = 41 }, // Gourgeist
+        new(50,08,4) { Species = 711, Ability = A4, Moves = new(567, 247, 585, 402), Index = 41, Form = 1 }, // Gourgeist-1
+        new(50,08,4) { Species = 711, Ability = A4, Moves = new(567, 247, 585, 402), Index = 41, Form = 2 }, // Gourgeist-2
+        new(50,08,4) { Species = 711, Ability = A4, Moves = new(567, 247, 585, 402), Index = 41, Form = 3 }, // Gourgeist-3
+        new(50,08,4) { Species = 563, Ability = A4, Moves = new(578, 247, 399, 261), Index = 41 }, // Cofagrigus
+        new(50,08,4) { Species = 778, Ability = A4, Moves = new(085, 452, 261, 204), Index = 41 }, // Mimikyu
+        new(50,08,4) { Species = 709, Ability = A4, Moves = new(452, 506, 261, 310), Index = 41 }, // Trevenant
+        new(50,08,4) { Species = 855, Ability = A4, Moves = new(247, 417, 389, 310), Index = 41 }, // Polteageist
+        new(60,10,5) { Species = 711, Ability = A4, Moves = new(567, 247, 433, 402), Index = 41 }, // Gourgeist
+        new(60,10,5) { Species = 711, Ability = A4, Moves = new(567, 247, 433, 402), Index = 41, Form = 1, Shiny = Shiny.Always }, // Gourgeist-1
+        new(60,10,5) { Species = 711, Ability = A4, Moves = new(567, 247, 433, 402), Index = 41, Form = 2 }, // Gourgeist-2
+        new(60,10,5) { Species = 711, Ability = A4, Moves = new(567, 247, 433, 402), Index = 41, Form = 3, Shiny = Shiny.Always }, // Gourgeist-3
+        new(60,10,5) { Species = 563, Ability = A4, Moves = new(578, 247, 399, 261), Index = 41 }, // Cofagrigus
+        new(60,10,5) { Species = 778, Ability = A4, Moves = new(087, 452, 261, 583), Index = 41 }, // Mimikyu
+        new(60,10,5) { Species = 709, Ability = A4, Moves = new(452, 506, 261, 310), Index = 41 }, // Trevenant
+        new(60,10,5) { Species = 855, Ability = A4, Moves = new(247, 417, 389, 310), Index = 41 }, // Polteageist
 
-        new(17,01,1) { Species = 093, Ability = A4, Moves = new[]{ 371, 122, 095, 325 }, Index = 40 }, // Haunter
-        new(17,01,1) { Species = 425, Ability = A4, Moves = new[]{ 016, 506, 310, 371 }, Index = 40 }, // Drifloon
-        new(17,01,1) { Species = 355, Ability = A4, Moves = new[]{ 310, 425, 043, 506 }, Index = 40 }, // Duskull
-        new(17,01,1) { Species = 859, Ability = A4, Moves = new[]{ 372, 313, 260, 044 }, Index = 40 }, // Impidimp
-        new(17,01,1) { Species = 633, Ability = A4, Moves = new[]{ 225, 033, 399, 044 }, Index = 40 }, // Deino
-        new(17,01,1) { Species = 877, Ability = A4, Moves = new[]{ 084, 098, 681, 043 }, Index = 40 }, // Morpeko
-        new(30,03,2) { Species = 094, Ability = A4, Moves = new[]{ 371, 389, 095, 325 }, Index = 40, CanGigantamax = true }, // Gengar
-        new(30,03,2) { Species = 426, Ability = A4, Moves = new[]{ 016, 247, 310, 371 }, Index = 40 }, // Drifblim
-        new(30,03,2) { Species = 355, Ability = A4, Moves = new[]{ 310, 425, 371, 506 }, Index = 40 }, // Duskull
-        new(30,03,2) { Species = 859, Ability = A4, Moves = new[]{ 259, 389, 207, 044 }, Index = 40 }, // Impidimp
-        new(30,03,2) { Species = 633, Ability = A4, Moves = new[]{ 225, 021, 399, 029 }, Index = 40 }, // Deino
-        new(30,03,2) { Species = 877, Ability = A4, Moves = new[]{ 209, 098, 044, 043 }, Index = 40 }, // Morpeko
-        new(40,05,3) { Species = 094, Ability = A4, Moves = new[]{ 506, 389, 095, 325 }, Index = 40, CanGigantamax = true }, // Gengar
-        new(40,05,3) { Species = 426, Ability = A4, Moves = new[]{ 016, 247, 360, 371 }, Index = 40 }, // Drifblim
-        new(40,05,3) { Species = 477, Ability = A4, Moves = new[]{ 247, 009, 371, 157 }, Index = 40 }, // Dusknoir
-        new(40,05,3) { Species = 860, Ability = A4, Moves = new[]{ 417, 793, 421, 399 }, Index = 40 }, // Morgrem
-        new(40,05,3) { Species = 633, Ability = A4, Moves = new[]{ 406, 021, 399, 423 }, Index = 40 }, // Deino
-        new(40,05,3) { Species = 877, Ability = A4, Moves = new[]{ 209, 098, 044, 402 }, Index = 40 }, // Morpeko
-        new(50,08,4) { Species = 094, Ability = A4, Moves = new[]{ 247, 399, 094, 085 }, Index = 40, CanGigantamax = true }, // Gengar
-        new(50,08,4) { Species = 426, Ability = A4, Moves = new[]{ 366, 247, 360, 371 }, Index = 40 }, // Drifblim
-        new(50,08,4) { Species = 477, Ability = A4, Moves = new[]{ 247, 009, 280, 157 }, Index = 40 }, // Dusknoir
-        new(50,08,4) { Species = 861, Ability = A4, Moves = new[]{ 789, 492, 421, 399 }, Index = 40, CanGigantamax = true }, // Grimmsnarl
-        new(50,08,4) { Species = 634, Ability = A4, Moves = new[]{ 406, 304, 399, 423 }, Index = 40 }, // Zweilous
-        new(50,08,4) { Species = 877, Ability = A4, Moves = new[]{ 783, 098, 242, 402 }, Index = 40 }, // Morpeko
-        new(60,10,5) { Species = 094, Ability = A4, Moves = new[]{ 247, 399, 605, 085 }, Index = 40, CanGigantamax = true }, // Gengar
-        new(60,10,5) { Species = 426, Ability = A4, Moves = new[]{ 366, 247, 360, 693 }, Index = 40 }, // Drifblim
-        new(60,10,5) { Species = 477, Ability = A4, Moves = new[]{ 247, 009, 280, 089 }, Index = 40 }, // Dusknoir
-        new(60,10,5) { Species = 861, Ability = A4, Moves = new[]{ 789, 492, 421, 417 }, Index = 40, CanGigantamax = true }, // Grimmsnarl
-        new(60,10,5) { Species = 635, Ability = A4, Moves = new[]{ 406, 304, 399, 056 }, Index = 40 }, // Hydreigon
-        new(60,10,5) { Species = 877, Ability = A4, Moves = new[]{ 783, 037, 242, 402 }, Index = 40 }, // Morpeko
+        new(17,01,1) { Species = 093, Ability = A4, Moves = new(371, 122, 095, 325), Index = 40 }, // Haunter
+        new(17,01,1) { Species = 425, Ability = A4, Moves = new(016, 506, 310, 371), Index = 40 }, // Drifloon
+        new(17,01,1) { Species = 355, Ability = A4, Moves = new(310, 425, 043, 506), Index = 40 }, // Duskull
+        new(17,01,1) { Species = 859, Ability = A4, Moves = new(372, 313, 260, 044), Index = 40 }, // Impidimp
+        new(17,01,1) { Species = 633, Ability = A4, Moves = new(225, 033, 399, 044), Index = 40 }, // Deino
+        new(17,01,1) { Species = 877, Ability = A4, Moves = new(084, 098, 681, 043), Index = 40 }, // Morpeko
+        new(30,03,2) { Species = 094, Ability = A4, Moves = new(371, 389, 095, 325), Index = 40, CanGigantamax = true }, // Gengar
+        new(30,03,2) { Species = 426, Ability = A4, Moves = new(016, 247, 310, 371), Index = 40 }, // Drifblim
+        new(30,03,2) { Species = 355, Ability = A4, Moves = new(310, 425, 371, 506), Index = 40 }, // Duskull
+        new(30,03,2) { Species = 859, Ability = A4, Moves = new(259, 389, 207, 044), Index = 40 }, // Impidimp
+        new(30,03,2) { Species = 633, Ability = A4, Moves = new(225, 021, 399, 029), Index = 40 }, // Deino
+        new(30,03,2) { Species = 877, Ability = A4, Moves = new(209, 098, 044, 043), Index = 40 }, // Morpeko
+        new(40,05,3) { Species = 094, Ability = A4, Moves = new(506, 389, 095, 325), Index = 40, CanGigantamax = true }, // Gengar
+        new(40,05,3) { Species = 426, Ability = A4, Moves = new(016, 247, 360, 371), Index = 40 }, // Drifblim
+        new(40,05,3) { Species = 477, Ability = A4, Moves = new(247, 009, 371, 157), Index = 40 }, // Dusknoir
+        new(40,05,3) { Species = 860, Ability = A4, Moves = new(417, 793, 421, 399), Index = 40 }, // Morgrem
+        new(40,05,3) { Species = 633, Ability = A4, Moves = new(406, 021, 399, 423), Index = 40 }, // Deino
+        new(40,05,3) { Species = 877, Ability = A4, Moves = new(209, 098, 044, 402), Index = 40 }, // Morpeko
+        new(50,08,4) { Species = 094, Ability = A4, Moves = new(247, 399, 094, 085), Index = 40, CanGigantamax = true }, // Gengar
+        new(50,08,4) { Species = 426, Ability = A4, Moves = new(366, 247, 360, 371), Index = 40 }, // Drifblim
+        new(50,08,4) { Species = 477, Ability = A4, Moves = new(247, 009, 280, 157), Index = 40 }, // Dusknoir
+        new(50,08,4) { Species = 861, Ability = A4, Moves = new(789, 492, 421, 399), Index = 40, CanGigantamax = true }, // Grimmsnarl
+        new(50,08,4) { Species = 634, Ability = A4, Moves = new(406, 304, 399, 423), Index = 40 }, // Zweilous
+        new(50,08,4) { Species = 877, Ability = A4, Moves = new(783, 098, 242, 402), Index = 40 }, // Morpeko
+        new(60,10,5) { Species = 094, Ability = A4, Moves = new(247, 399, 605, 085), Index = 40, CanGigantamax = true }, // Gengar
+        new(60,10,5) { Species = 426, Ability = A4, Moves = new(366, 247, 360, 693), Index = 40 }, // Drifblim
+        new(60,10,5) { Species = 477, Ability = A4, Moves = new(247, 009, 280, 089), Index = 40 }, // Dusknoir
+        new(60,10,5) { Species = 861, Ability = A4, Moves = new(789, 492, 421, 417), Index = 40, CanGigantamax = true }, // Grimmsnarl
+        new(60,10,5) { Species = 635, Ability = A4, Moves = new(406, 304, 399, 056), Index = 40 }, // Hydreigon
+        new(60,10,5) { Species = 877, Ability = A4, Moves = new(783, 037, 242, 402), Index = 40 }, // Morpeko
     };
 }

--- a/PKHeX.Core/Legality/Encounters/Data/Encounters8NestLair.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Encounters8NestLair.cs
@@ -1,4 +1,4 @@
-﻿namespace PKHeX.Core;
+namespace PKHeX.Core;
 
 // Dynamax Adventures
 internal static partial class Encounters8Nest
@@ -10,279 +10,279 @@ internal static partial class Encounters8Nest
     #region Dynamax Adventures Encounters (ROM)
     internal static readonly EncounterStatic8U[] DynAdv_SWSH =
     {
-        new(002,0,65) { Ability = A2, Moves = new[] {520,235,076,188} }, // Ivysaur
-        new(005,0,65) { Ability = A2, Moves = new[] {519,406,203,517} }, // Charmeleon
-        new(008,0,65) { Ability = A2, Moves = new[] {518,058,396,056} }, // Wartortle
-        new(012,0,65) { Ability = A2, Moves = new[] {676,474,476,202}, CanGigantamax = true }, // Butterfree
-        new(026,0,65) { Ability = A2, Moves = new[] {804,683,113,411} }, // Raichu
-        new(026,1,65) { Ability = A0, Moves = new[] {085,604,094,496} }, // Raichu-1
-        new(028,0,65) { Ability = A0, Moves = new[] {306,707,444,141} }, // Sandslash
-        new(028,1,65) { Ability = A0, Moves = new[] {419,157,280,014} }, // Sandslash-1
-        new(031,0,65) { Ability = A0, Moves = new[] {815,474,204,247} }, // Nidoqueen
-        new(034,0,65) { Ability = A1, Moves = new[] {667,007,008,009} }, // Nidoking
-        new(035,0,65) { Ability = A2, Moves = new[] {791,595,345,115} }, // Clefairy
-        new(737,0,65) { Ability = A0, Moves = new[] {081,598,209,091} }, // Charjabug
-        new(743,0,65) { Ability = A2, Moves = new[] {676,577,312,313} }, // Ribombee
-        new(040,0,65) { Ability = A1, Moves = new[] {605,496,797,186} }, // Wigglytuff
-        new(553,0,65) { Ability = A2, Moves = new[] {414,207,663,201} }, // Krookodile
-        new(045,0,65) { Ability = A0, Moves = new[] {202,580,092,676} }, // Vileplume
-        new(051,0,65) { Ability = A2, Moves = new[] {667,164,189,157} }, // Dugtrio
-        new(051,1,65) { Ability = A0, Moves = new[] {442,667,389,103} }, // Dugtrio-1
-        new(053,0,65) { Ability = A1, Moves = new[] {263,583,364,496} }, // Persian
-        new(053,1,65) { Ability = A0, Moves = new[] {372,555,364,511} }, // Persian-1
-        new(055,0,65) { Ability = A2, Moves = new[] {453,103,025,362} }, // Golduck
-        new(062,0,65) { Ability = A0, Moves = new[] {409,034,811,710} }, // Poliwrath
-        new(064,0,65) { Ability = A2, Moves = new[] {473,496,203,605} }, // Kadabra
-        new(067,0,65) { Ability = A1, Moves = new[] {223,317,371,811} }, // Machoke
-        new(745,0,65) { Ability = A1, Moves = new[] {709,444,496,336} }, // Lycanroc
-        new(745,1,65) { Ability = A2, Moves = new[] {444,280,269,242} }, // Lycanroc-1
-        new(082,0,65) { Ability = A2, Moves = new[] {486,430,393,113} }, // Magneton
-        new(752,0,65) { Ability = A2, Moves = new[] {710,494,679,398} }, // Araquanid
-        new(754,0,65) { Ability = A2, Moves = new[] {437,311,404,496} }, // Lurantis
-        new(093,0,65) { Ability = A2, Moves = new[] {506,095,138,412} }, // Haunter
-        new(869,0,65) { Ability = A2, Moves = new[] {777,605,595,345}, CanGigantamax = true }, // Alcremie
-        new(099,0,65) { Ability = A0, Moves = new[] {152,469,091,276}, CanGigantamax = true }, // Kingler
-        new(105,0,65) { Ability = A2, Moves = new[] {155,675,442,103} }, // Marowak
-        new(105,1,65) { Ability = A2, Moves = new[] {394,708,261,442} }, // Marowak-1
-        new(106,0,65) { Ability = A0, Moves = new[] {370,469,299,490} }, // Hitmonlee
-        new(107,0,65) { Ability = A1, Moves = new[] {612,007,009,008} }, // Hitmonchan
-        new(108,0,65) { Ability = A1, Moves = new[] {496,059,087,330} }, // Lickitung
-        new(110,0,65) { Ability = A1, Moves = new[] {499,257,188,399} }, // Weezing
-        new(110,1,65) { Ability = A2, Moves = new[] {790,499,053,269} }, // Weezing-1
-        new(112,0,65) { Ability = A1, Moves = new[] {529,479,684,184} }, // Rhydon
-        new(113,0,65) { Ability = A2, Moves = new[] {496,505,270,113} }, // Chansey
-        new(114,0,65) { Ability = A1, Moves = new[] {438,078,803,034} }, // Tangela
-        new(115,0,65) { Ability = A0, Moves = new[] {034,389,091,200} }, // Kangaskhan
-        new(117,0,65) { Ability = A1, Moves = new[] {503,406,164,496} }, // Seadra
-        new(119,0,65) { Ability = A1, Moves = new[] {127,340,398,529} }, // Seaking
-        new(122,0,65) { Ability = A1, Moves = new[] {113,115,270,094} }, // Mr. Mime
-        new(122,1,65) { Ability = A2, Moves = new[] {113,115,196,094} }, // Mr. Mime-1
-        new(123,0,65) { Ability = A1, Moves = new[] {210,098,372,017} }, // Scyther
-        new(124,0,65) { Ability = A2, Moves = new[] {577,142,058,496} }, // Jynx
-        new(125,0,65) { Ability = A2, Moves = new[] {804,527,270,496} }, // Electabuzz
-        new(126,0,65) { Ability = A2, Moves = new[] {126,807,499,496} }, // Magmar
-        new(756,0,65) { Ability = A2, Moves = new[] {668,585,240,311} }, // Shiinotic
-        new(128,0,65) { Ability = A1, Moves = new[] {263,667,370,372} }, // Tauros
-        new(148,0,65) { Ability = A0, Moves = new[] {059,784,799,087} }, // Dragonair
-        new(164,0,65) { Ability = A2, Moves = new[] {497,115,143,095} }, // Noctowl
-        new(171,0,65) { Ability = A0, Moves = new[] {352,056,085,109} }, // Lanturn
-        new(176,0,65) { Ability = A1, Moves = new[] {791,266,583,595} }, // Togetic
-        new(178,0,65) { Ability = A2, Moves = new[] {094,493,403,109} }, // Xatu
-        new(182,0,65) { Ability = A2, Moves = new[] {580,202,270,605} }, // Bellossom
-        new(184,0,65) { Ability = A2, Moves = new[] {453,583,401,340} }, // Azumarill
-        new(185,0,65) { Ability = A0, Moves = new[] {707,444,334,776} }, // Sudowoodo
-        new(186,0,65) { Ability = A2, Moves = new[] {710,496,414,270} }, // Politoed
-        new(195,0,65) { Ability = A2, Moves = new[] {411,503,092,133} }, // Quagsire
-        new(206,0,65) { Ability = A0, Moves = new[] {806,814,247,058} }, // Dunsparce
-        new(211,0,65) { Ability = A2, Moves = new[] {014,398,710,798} }, // Qwilfish
-        new(758,0,65) { Ability = A0, Moves = new[] {092,053,440,599} }, // Salazzle
-        new(215,0,65) { Ability = A1, Moves = new[] {813,808,675,555} }, // Sneasel
-        new(221,0,65) { Ability = A2, Moves = new[] {059,317,420,276} }, // Piloswine
-        new(760,0,65) { Ability = A1, Moves = new[] {038,608,371,416} }, // Bewear
-        new(763,0,65) { Ability = A1, Moves = new[] {312,688,512,207} }, // Tsareena
-        new(224,0,65) { Ability = A1, Moves = new[] {806,430,503,491} }, // Octillery
-        new(226,0,65) { Ability = A1, Moves = new[] {403,291,469,352} }, // Mantine
-        new(227,0,65) { Ability = A2, Moves = new[] {372,211,404,019} }, // Skarmory
-        new(237,0,65) { Ability = A0, Moves = new[] {529,813,280,811} }, // Hitmontop
-        new(241,0,65) { Ability = A1, Moves = new[] {025,208,086,583} }, // Miltank
-        new(764,0,65) { Ability = A1, Moves = new[] {666,577,495,412} }, // Comfey
-        new(264,0,65) { Ability = A0, Moves = new[] {163,042,608,421} }, // Linoone
-        new(264,1,65) { Ability = A0, Moves = new[] {675,555,269,164} }, // Linoone-1
-        new(103,0,65) { Ability = A2, Moves = new[] {427,076,707,805} }, // Exeggutor
-        new(405,0,65) { Ability = A2, Moves = new[] {263,113,804,604} }, // Luxray
-        new(279,0,65) { Ability = A1, Moves = new[] {814,311,469,098} }, // Pelipper
-        new(291,0,65) { Ability = A0, Moves = new[] {210,164,189,806} }, // Ninjask
-        new(295,0,65) { Ability = A2, Moves = new[] {805,063,411,059} }, // Exploud
-        new(770,0,65) { Ability = A2, Moves = new[] {805,815,659,247} }, // Palossand
-        new(771,0,65) { Ability = A0, Moves = new[] {092,269,599,068} }, // Pyukumuku
-        new(305,0,65) { Ability = A0, Moves = new[] {798,231,157,319} }, // Lairon
-        new(310,0,65) { Ability = A1, Moves = new[] {804,129,315,706} }, // Manectric
-        new(315,0,65) { Ability = A1, Moves = new[] {437,326,311,791} }, // Roselia
-        new(319,0,65) { Ability = A2, Moves = new[] {453,372,207,799} }, // Sharpedo
-        new(320,0,65) { Ability = A0, Moves = new[] {362,798,340,203} }, // Wailmer
-        new(324,0,65) { Ability = A1, Moves = new[] {807,517,229,108} }, // Torkoal
-        new(862,0,65) { Ability = A0, Moves = new[] {808,085,263,103} }, // Obstagoon
-        new(334,0,65) { Ability = A2, Moves = new[] {605,257,538,406} }, // Altaria
-        new(844,0,65) { Ability = A0, Moves = new[] {815,799,806,137}, CanGigantamax = true }, // Sandaconda
-        new(858,0,65) { Ability = A1, Moves = new[] {797,583,791,219}, CanGigantamax = true }, // Hatterene
-        new(340,0,65) { Ability = A2, Moves = new[] {340,562,330,428} }, // Whiscash
-        new(342,0,65) { Ability = A2, Moves = new[] {808,263,330,014} }, // Crawdaunt
-        new(344,0,65) { Ability = A0, Moves = new[] {433,094,246,063} }, // Claydol
-        new(356,0,65) { Ability = A0, Moves = new[] {425,506,356,806} }, // Dusclops
-        new(359,0,65) { Ability = A0, Moves = new[] {059,400,163,126} }, // Absol
-        new(362,0,65) { Ability = A1, Moves = new[] {798,242,423,313} }, // Glalie
-        new(364,0,65) { Ability = A0, Moves = new[] {058,362,291,207} }, // Sealeo
-        new(369,0,65) { Ability = A1, Moves = new[] {710,457,175,799} }, // Relicanth
-        new(132,0,65) { Ability = A2, Moves = new[] {144,000,000,000} }, // Ditto
-        new(375,0,65) { Ability = A0, Moves = new[] {309,009,427,115} }, // Metang
-        new(416,0,65) { Ability = A0, Moves = new[] {454,207,814,279} }, // Vespiquen
-        new(421,0,65) { Ability = A0, Moves = new[] {076,388,241,311} }, // Cherrim
-        new(423,1,65) { Ability = A2, Moves = new[] {034,806,317,127} }, // Gastrodon-1
-        new(426,0,65) { Ability = A0, Moves = new[] {261,094,366,085} }, // Drifblim
-        new(428,0,65) { Ability = A0, Moves = new[] {409,025,204,340} }, // Lopunny
-        new(435,0,65) { Ability = A1, Moves = new[] {808,807,491,389} }, // Skuntank
-        new(537,0,65) { Ability = A0, Moves = new[] {497,048,188,103} }, // Seismitoad
-        new(452,0,65) { Ability = A0, Moves = new[] {808,404,367,231} }, // Drapion
-        new(777,0,65) { Ability = A2, Moves = new[] {609,398,527,442} }, // Togedemaru
-        new(460,0,65) { Ability = A2, Moves = new[] {419,694,496,803} }, // Abomasnow
-        new(478,0,65) { Ability = A0, Moves = new[] {813,524,694,247} }, // Froslass
-        new(479,0,65) { Ability = A0, Moves = new[] {486,261,417,506} }, // Rotom
-        new(508,0,65) { Ability = A2, Moves = new[] {416,263,496,608} }, // Stoutland
-        new(510,0,65) { Ability = A0, Moves = new[] {372,583,259,103} }, // Liepard
-        new(518,0,65) { Ability = A0, Moves = new[] {797,473,281,412} }, // Musharna
-        new(521,0,65) { Ability = A0, Moves = new[] {814,269,297,366} }, // Unfezant
-        new(528,0,65) { Ability = A2, Moves = new[] {493,683,094,403} }, // Swoobat
-        new(531,0,65) { Ability = A0, Moves = new[] {791,577,304,053} }, // Audino
-        new(533,0,65) { Ability = A0, Moves = new[] {264,811,280,667} }, // Gurdurr
-        new(536,0,65) { Ability = A0, Moves = new[] {497,503,414,340} }, // Palpitoad
-        new(778,0,65) { Ability = A0, Moves = new[] {421,163,608,174} }, // Mimikyu
-        new(884,0,65) { Ability = A0, Moves = new[] {784,086,442,085}, CanGigantamax = true }, // Duraludon
-        new(545,0,65) { Ability = A1, Moves = new[] {798,092,675,224} }, // Scolipede
-        new(547,0,65) { Ability = A0, Moves = new[] {542,269,412,583} }, // Whimsicott
-        new(549,0,65) { Ability = A1, Moves = new[] {080,483,113,676} }, // Lilligant
-        new(550,0,65) { Ability = A1, Moves = new[] {710,291,706,423} }, // Basculin
-        new(550,1,65) { Ability = A1, Moves = new[] {503,291,242,164} }, // Basculin-1
-        new(828,0,65) { Ability = A1, Moves = new[] {492,555,269,807} }, // Thievul
-        new(834,0,65) { Ability = A0, Moves = new[] {534,806,684,157} }, // Drednaw
-        new(556,0,65) { Ability = A2, Moves = new[] {437,412,389,367} }, // Maractus
-        new(558,0,65) { Ability = A1, Moves = new[] {504,404,317,776} }, // Crustle
-        new(830,0,65) { Ability = A2, Moves = new[] {113,311,538,437} }, // Eldegoss
-        new(561,0,65) { Ability = A0, Moves = new[] {094,240,403,430} }, // Sigilyph
-        new(446,0,65) { Ability = A1, Moves = new[] {009,007,034,441} }, // Munchlax
-        new(855,0,65) { Ability = A0, Moves = new[] {312,389,473,202} }, // Polteageist
-        new(569,0,65) { Ability = A2, Moves = new[] {441,188,409,599}, CanGigantamax = true }, // Garbodor
-        new(573,0,65) { Ability = A1, Moves = new[] {497,541,113,813} }, // Cinccino
-        new(836,0,65) { Ability = A0, Moves = new[] {804,242,204,270} }, // Boltund
-        new(820,0,65) { Ability = A0, Moves = new[] {360,706,014,034} }, // Greedent
-        new(583,0,65) { Ability = A0, Moves = new[] {054,058,059,304} }, // Vanillish
-        new(587,0,65) { Ability = A0, Moves = new[] {512,804,203,527} }, // Emolga
-        new(589,0,65) { Ability = A1, Moves = new[] {529,534,210,269} }, // Escavalier
-        new(591,0,65) { Ability = A0, Moves = new[] {499,476,202,474} }, // Amoonguss
-        new(593,0,65) { Ability = A0, Moves = new[] {605,291,433,196} }, // Jellicent
-        new(596,0,65) { Ability = A0, Moves = new[] {087,405,486,527} }, // Galvantula
-        new(601,0,65) { Ability = A0, Moves = new[] {544,508,416,319} }, // Klinklang
-        new(606,0,65) { Ability = A1, Moves = new[] {797,800,399,496} }, // Beheeyem
-        new(608,0,65) { Ability = A0, Moves = new[] {807,806,517,433} }, // Lampent
-        new(611,0,65) { Ability = A0, Moves = new[] {416,200,784,404} }, // Fraxure
-        new(614,0,65) { Ability = A1, Moves = new[] {776,059,524,362} }, // Beartic
-        new(615,0,65) { Ability = A0, Moves = new[] {059,058,115,076} }, // Cryogonal
-        new(617,0,65) { Ability = A0, Moves = new[] {522,491,240,405} }, // Accelgor
-        new(618,0,65) { Ability = A0, Moves = new[] {604,085,414,330} }, // Stunfisk
-        new(618,1,65) { Ability = A0, Moves = new[] {319,805,492,414} }, // Stunfisk-1
-        new(621,0,65) { Ability = A1, Moves = new[] {808,814,442,091} }, // Druddigon
-        new(623,0,65) { Ability = A0, Moves = new[] {264,325,815,219} }, // Golurk
-        new(625,0,65) { Ability = A1, Moves = new[] {400,398,427,319} }, // Bisharp
-        new(626,0,65) { Ability = A1, Moves = new[] {034,808,684,276} }, // Bouffalant
-        new(631,0,65) { Ability = A1, Moves = new[] {680,315,241,076} }, // Heatmor
-        new(632,0,65) { Ability = A0, Moves = new[] {422,404,319,232} }, // Durant
-        new(832,0,65) { Ability = A0, Moves = new[] {803,025,776,164} }, // Dubwool
-        new(660,0,65) { Ability = A2, Moves = new[] {444,707,091,098} }, // Diggersby
-        new(663,0,65) { Ability = A2, Moves = new[] {366,542,211,053} }, // Talonflame
-        new(675,0,65) { Ability = A0, Moves = new[] {418,359,663,811} }, // Pangoro
-        new(039,0,65) { Ability = A2, Moves = new[] {164,113,313,577} }, // Jigglypuff
-        new(525,0,65) { Ability = A0, Moves = new[] {444,334,776,707} }, // Boldore
-        new(680,0,65) { Ability = A0, Moves = new[] {442,014,533,332} }, // Doublade
-        new(687,0,65) { Ability = A0, Moves = new[] {576,797,400,085} }, // Malamar
-        new(689,0,65) { Ability = A0, Moves = new[] {534,059,130,398} }, // Barbaracle
-        new(695,0,65) { Ability = A0, Moves = new[] {486,097,496,189} }, // Heliolisk
-        new(702,0,65) { Ability = A2, Moves = new[] {494,087,605,164} }, // Dedenne
-        new(851,0,65) { Ability = A1, Moves = new[] {053,815,474,021}, CanGigantamax = true }, // Centiskorch
-        new(707,0,65) { Ability = A0, Moves = new[] {113,578,430,583} }, // Klefki
-        new(709,0,65) { Ability = A2, Moves = new[] {532,115,409,433} }, // Trevenant
-        new(711,0,65) { Ability = A0, Moves = new[] {595,425,388,184} }, // Gourgeist
-        new(847,0,65) { Ability = A0, Moves = new[] {453,799,372,203} }, // Barraskewda
-        new(845,0,65) { Ability = A0, Moves = new[] {291,203,133,675} }, // Cramorant
-        new(620,0,65) { Ability = A0, Moves = new[] {396,469,317,025} }, // Mienshao
-        new(870,0,65) { Ability = A0, Moves = new[] {660,014,684,280} }, // Falinks
-        new(701,0,65) { Ability = A0, Moves = new[] {269,398,675,490} }, // Hawlucha
-        new(879,0,65) { Ability = A0, Moves = new[] {334,776,430,798} }, // Copperajah
-        new(826,0,65) { Ability = A0, Moves = new[] {495,094,060,522}, CanGigantamax = true }, // Orbeetle
-        new(838,0,65) { Ability = A2, Moves = new[] {315,083,115,157} }, // Carkol
-        new(877,0,65) { Ability = A0, Moves = new[] {783,399,085,423} }, // Morpeko
-        new(563,0,65) { Ability = A0, Moves = new[] {247,114,094,472} }, // Cofagrigus
-        new(750,0,65) { Ability = A0, Moves = new[] {808,276,328,249} }, // Mudsdale
-        new(863,0,65) { Ability = A2, Moves = new[] {232,133,808,087} }, // Perrserker
-        new(871,0,65) { Ability = A2, Moves = new[] {056,087,367,599} }, // Pincurchin
-        new(873,0,65) { Ability = A2, Moves = new[] {311,366,522,542} }, // Frosmoth
-        new(839,0,65) { Ability = A0, Moves = new[] {108,800,053,503}, CanGigantamax = true }, // Coalossal
-        new(853,0,65) { Ability = A0, Moves = new[] {576,409,330,411} }, // Grapploct
-        new(861,0,65) { Ability = A0, Moves = new[] {612,399,384,590}, CanGigantamax = true }, // Grimmsnarl
-        new(886,0,65) { Ability = A0, Moves = new[] {407,372,261,247} }, // Drakloak
-        new(036,0,65) { Ability = A1, Moves = new[] {800,605,266,322} }, // Clefable
-        new(044,0,65) { Ability = A0, Moves = new[] {474,092,585,078} }, // Gloom
-        new(137,0,65) { Ability = A1, Moves = new[] {492,058,085,063} }, // Porygon
-        new(600,0,65) { Ability = A1, Moves = new[] {451,804,430,408} }, // Klang
-        new(738,0,65) { Ability = A0, Moves = new[] {209,189,398,405} }, // Vikavolt
-        new(254,0,65) { Ability = A2, Moves = new[] {520,784,437,404} }, // Sceptile
-        new(257,0,65) { Ability = A2, Moves = new[] {519,299,370,811} }, // Blaziken
-        new(260,0,65) { Ability = A2, Moves = new[] {518,059,414,133} }, // Swampert
-        new(073,0,65) { Ability = A0, Moves = new[] {352,056,398,014} }, // Tentacruel
-        new(080,0,65) { Ability = A1, Moves = new[] {797,244,053,473} }, // Slowbro
-        new(121,0,65) { Ability = A2, Moves = new[] {408,605,427,196} }, // Starmie
-        new(849,0,65) { Ability = A1, Moves = new[] {804,086,304,715}, CanGigantamax = true }, // Toxtricity
-        new(134,0,65) { Ability = A0, Moves = new[] {352,204,311,114} }, // Vaporeon
-        new(135,0,65) { Ability = A0, Moves = new[] {085,129,247,270} }, // Jolteon
-        new(136,0,65) { Ability = A0, Moves = new[] {807,247,608,387} }, // Flareon
-        new(199,0,65) { Ability = A1, Moves = new[] {248,417,534,008} }, // Slowking
-        new(330,0,65) { Ability = A0, Moves = new[] {211,337,405,189} }, // Flygon
-        new(346,0,65) { Ability = A0, Moves = new[] {412,246,380,188} }, // Cradily
-        new(348,0,65) { Ability = A0, Moves = new[] {404,479,707,201} }, // Armaldo
-        new(437,0,65) { Ability = A0, Moves = new[] {428,319,798,285} }, // Bronzong
-        new(697,0,65) { Ability = A0, Moves = new[] {799,350,276,034} }, // Tyrantrum
-        new(253,0,65) { Ability = A0, Moves = new[] {520,103,280,203} }, // Grovyle
-        new(256,0,65) { Ability = A0, Moves = new[] {519,411,297,490} }, // Combusken
-        new(259,0,65) { Ability = A0, Moves = new[] {518,127,091,008} }, // Marshtomp
-        new(699,0,65) { Ability = A0, Moves = new[] {034,087,246,086} }, // Aurorus
-        new(765,0,65) { Ability = A2, Moves = new[] {689,113,094,473} }, // Oranguru
-        new(766,0,65) { Ability = A0, Moves = new[] {280,317,164,512} }, // Passimian
-        new(876,0,65) { Ability = A1, Moves = new[] {595,797,347,247} }, // Indeedee
-        new(145,0,70) { Ability = A0, Moves = new[] {087,065,413,097} }, // Zapdos
-        new(146,0,70) { Ability = A0, Moves = new[] {257,017,043,083} }, // Moltres
-        new(144,0,70) { Ability = A0, Moves = new[] {058,573,542,054} }, // Articuno
-        new(150,0,70) { Ability = A0, Moves = new[] {094,050,105,059} }, // Mewtwo
-        new(245,0,70) { Ability = A0, Moves = new[] {710,326,245,347} }, // Suicune
-        new(244,0,70) { Ability = A0, Moves = new[] {053,184,245,242} }, // Entei
-        new(243,0,70) { Ability = A0, Moves = new[] {085,336,245,311} }, // Raikou
-        new(249,0,70) { Ability = A0, Moves = new[] {406,326,250,246} }, // (SH) Lugia
-        new(250,0,70) { Ability = A0, Moves = new[] {394,326,241,246} }, // (SW) Ho-Oh
-        new(380,0,70) { Ability = A0, Moves = new[] {513,225,428,057} }, // (SH) Latias
-        new(381,0,70) { Ability = A0, Moves = new[] {349,406,428,396} }, // (SW) Latios
-        new(383,0,70) { Ability = A0, Moves = new[] {089,184,436,359} }, // (SW) Groudon
-        new(382,0,70) { Ability = A0, Moves = new[] {057,034,392,087} }, // (SH) Kyogre
-        new(384,0,70) { Ability = A0, Moves = new[] {620,693,245,239} }, // Rayquaza
-        new(480,0,70) { Ability = A0, Moves = new[] {094,248,478,247} }, // Uxie
-        new(482,0,70) { Ability = A0, Moves = new[] {094,605,417,263} }, // Azelf
-        new(481,0,70) { Ability = A0, Moves = new[] {094,204,577,161} }, // Mesprit
-        new(483,0,70) { Ability = A0, Moves = new[] {163,246,430,337} }, // (SW) Dialga
-        new(484,0,70) { Ability = A0, Moves = new[] {163,057,246,337} }, // (SH) Palkia
-        new(487,0,70) { Ability = A0, Moves = new[] {337,184,247,246} }, // Giratina
-        new(485,0,70) { Ability = A0, Moves = new[] {319,436,242,442} }, // Heatran
-        new(488,0,70) { Ability = A0, Moves = new[] {196,585,427,473} }, // Cresselia
-        new(641,0,70) { Ability = A0, Moves = new[] {542,097,196,257} }, // (SW) Tornadus
-        new(642,0,70) { Ability = A0, Moves = new[] {087,240,311,482} }, // (SH) Thundurus
-        new(645,0,70) { Ability = A0, Moves = new[] {328,157,523,411} }, // Landorus
-        new(643,0,70) { Ability = A0, Moves = new[] {568,326,558,406} }, // (SW) Reshiram
-        new(644,0,70) { Ability = A0, Moves = new[] {568,163,559,337} }, // (SH) Zekrom
-        new(646,0,70) { Ability = A0, Moves = new[] {058,304,247,184} }, // Kyurem
-        new(716,0,70) { Ability = A0, Moves = new[] {275,605,585,532} }, // (SW) Xerneas
-        new(717,0,70) { Ability = A0, Moves = new[] {269,613,407,389} }, // (SH) Yveltal
-        new(718,3,70) { Ability = A0, Moves = new[] {614,616,406,020} }, // Zygarde-3
-        new(785,0,70) { Ability = A0, Moves = new[] {085,098,413,269} }, // Tapu Koko
-        new(786,0,70) { Ability = A0, Moves = new[] {094,583,478,204} }, // Tapu Lele
-        new(787,0,70) { Ability = A0, Moves = new[] {276,224,452,184} }, // Tapu Bulu
-        new(788,0,70) { Ability = A0, Moves = new[] {250,352,362,585} }, // Tapu Fini
-        new(791,0,70) { Ability = A0, Moves = new[] {428,083,231,568} }, // (SW) Solgaleo
-        new(792,0,70) { Ability = A0, Moves = new[] {247,585,277,129} }, // (SH) Lunala
-        new(800,0,70) { Ability = A0, Moves = new[] {427,451,408,475} }, // Necrozma
-        new(793,0,70) { Ability = A0, Moves = new[] {472,482,693,491} }, // Nihilego
-        new(794,0,70) { Ability = A0, Moves = new[] {612,269,141,223} }, // Buzzwole
-        new(795,0,70) { Ability = A0, Moves = new[] {136,129,675,679} }, // Pheromosa
-        new(796,0,70) { Ability = A0, Moves = new[] {438,435,598,693} }, // Xurkitree
-        new(798,0,70) { Ability = A0, Moves = new[] {410,314,348,014} }, // Kartana
-        new(797,0,70) { Ability = A0, Moves = new[] {073,479,360,089} }, // Celesteela
-        new(799,0,70) { Ability = A0, Moves = new[] {407,707,693,005} }, // Guzzlord
-        new(806,0,70) { Ability = A0, Moves = new[] {421,269,126,428} }, // Blacephalon
-        new(805,0,70) { Ability = A0, Moves = new[] {157,038,693,475} }, // Stakataka
+        new(002,0,65) { Ability = A2, Moves = new(520,235,076,188) }, // Ivysaur
+        new(005,0,65) { Ability = A2, Moves = new(519,406,203,517) }, // Charmeleon
+        new(008,0,65) { Ability = A2, Moves = new(518,058,396,056) }, // Wartortle
+        new(012,0,65) { Ability = A2, Moves = new(676,474,476,202), CanGigantamax = true }, // Butterfree
+        new(026,0,65) { Ability = A2, Moves = new(804,683,113,411) }, // Raichu
+        new(026,1,65) { Ability = A0, Moves = new(085,604,094,496) }, // Raichu-1
+        new(028,0,65) { Ability = A0, Moves = new(306,707,444,141) }, // Sandslash
+        new(028,1,65) { Ability = A0, Moves = new(419,157,280,014) }, // Sandslash-1
+        new(031,0,65) { Ability = A0, Moves = new(815,474,204,247) }, // Nidoqueen
+        new(034,0,65) { Ability = A1, Moves = new(667,007,008,009) }, // Nidoking
+        new(035,0,65) { Ability = A2, Moves = new(791,595,345,115) }, // Clefairy
+        new(737,0,65) { Ability = A0, Moves = new(081,598,209,091) }, // Charjabug
+        new(743,0,65) { Ability = A2, Moves = new(676,577,312,313) }, // Ribombee
+        new(040,0,65) { Ability = A1, Moves = new(605,496,797,186) }, // Wigglytuff
+        new(553,0,65) { Ability = A2, Moves = new(414,207,663,201) }, // Krookodile
+        new(045,0,65) { Ability = A0, Moves = new(202,580,092,676) }, // Vileplume
+        new(051,0,65) { Ability = A2, Moves = new(667,164,189,157) }, // Dugtrio
+        new(051,1,65) { Ability = A0, Moves = new(442,667,389,103) }, // Dugtrio-1
+        new(053,0,65) { Ability = A1, Moves = new(263,583,364,496) }, // Persian
+        new(053,1,65) { Ability = A0, Moves = new(372,555,364,511) }, // Persian-1
+        new(055,0,65) { Ability = A2, Moves = new(453,103,025,362) }, // Golduck
+        new(062,0,65) { Ability = A0, Moves = new(409,034,811,710) }, // Poliwrath
+        new(064,0,65) { Ability = A2, Moves = new(473,496,203,605) }, // Kadabra
+        new(067,0,65) { Ability = A1, Moves = new(223,317,371,811) }, // Machoke
+        new(745,0,65) { Ability = A1, Moves = new(709,444,496,336) }, // Lycanroc
+        new(745,1,65) { Ability = A2, Moves = new(444,280,269,242) }, // Lycanroc-1
+        new(082,0,65) { Ability = A2, Moves = new(486,430,393,113) }, // Magneton
+        new(752,0,65) { Ability = A2, Moves = new(710,494,679,398) }, // Araquanid
+        new(754,0,65) { Ability = A2, Moves = new(437,311,404,496) }, // Lurantis
+        new(093,0,65) { Ability = A2, Moves = new(506,095,138,412) }, // Haunter
+        new(869,0,65) { Ability = A2, Moves = new(777,605,595,345), CanGigantamax = true }, // Alcremie
+        new(099,0,65) { Ability = A0, Moves = new(152,469,091,276), CanGigantamax = true }, // Kingler
+        new(105,0,65) { Ability = A2, Moves = new(155,675,442,103) }, // Marowak
+        new(105,1,65) { Ability = A2, Moves = new(394,708,261,442) }, // Marowak-1
+        new(106,0,65) { Ability = A0, Moves = new(370,469,299,490) }, // Hitmonlee
+        new(107,0,65) { Ability = A1, Moves = new(612,007,009,008) }, // Hitmonchan
+        new(108,0,65) { Ability = A1, Moves = new(496,059,087,330) }, // Lickitung
+        new(110,0,65) { Ability = A1, Moves = new(499,257,188,399) }, // Weezing
+        new(110,1,65) { Ability = A2, Moves = new(790,499,053,269) }, // Weezing-1
+        new(112,0,65) { Ability = A1, Moves = new(529,479,684,184) }, // Rhydon
+        new(113,0,65) { Ability = A2, Moves = new(496,505,270,113) }, // Chansey
+        new(114,0,65) { Ability = A1, Moves = new(438,078,803,034) }, // Tangela
+        new(115,0,65) { Ability = A0, Moves = new(034,389,091,200) }, // Kangaskhan
+        new(117,0,65) { Ability = A1, Moves = new(503,406,164,496) }, // Seadra
+        new(119,0,65) { Ability = A1, Moves = new(127,340,398,529) }, // Seaking
+        new(122,0,65) { Ability = A1, Moves = new(113,115,270,094) }, // Mr. Mime
+        new(122,1,65) { Ability = A2, Moves = new(113,115,196,094) }, // Mr. Mime-1
+        new(123,0,65) { Ability = A1, Moves = new(210,098,372,017) }, // Scyther
+        new(124,0,65) { Ability = A2, Moves = new(577,142,058,496) }, // Jynx
+        new(125,0,65) { Ability = A2, Moves = new(804,527,270,496) }, // Electabuzz
+        new(126,0,65) { Ability = A2, Moves = new(126,807,499,496) }, // Magmar
+        new(756,0,65) { Ability = A2, Moves = new(668,585,240,311) }, // Shiinotic
+        new(128,0,65) { Ability = A1, Moves = new(263,667,370,372) }, // Tauros
+        new(148,0,65) { Ability = A0, Moves = new(059,784,799,087) }, // Dragonair
+        new(164,0,65) { Ability = A2, Moves = new(497,115,143,095) }, // Noctowl
+        new(171,0,65) { Ability = A0, Moves = new(352,056,085,109) }, // Lanturn
+        new(176,0,65) { Ability = A1, Moves = new(791,266,583,595) }, // Togetic
+        new(178,0,65) { Ability = A2, Moves = new(094,493,403,109) }, // Xatu
+        new(182,0,65) { Ability = A2, Moves = new(580,202,270,605) }, // Bellossom
+        new(184,0,65) { Ability = A2, Moves = new(453,583,401,340) }, // Azumarill
+        new(185,0,65) { Ability = A0, Moves = new(707,444,334,776) }, // Sudowoodo
+        new(186,0,65) { Ability = A2, Moves = new(710,496,414,270) }, // Politoed
+        new(195,0,65) { Ability = A2, Moves = new(411,503,092,133) }, // Quagsire
+        new(206,0,65) { Ability = A0, Moves = new(806,814,247,058) }, // Dunsparce
+        new(211,0,65) { Ability = A2, Moves = new(014,398,710,798) }, // Qwilfish
+        new(758,0,65) { Ability = A0, Moves = new(092,053,440,599) }, // Salazzle
+        new(215,0,65) { Ability = A1, Moves = new(813,808,675,555) }, // Sneasel
+        new(221,0,65) { Ability = A2, Moves = new(059,317,420,276) }, // Piloswine
+        new(760,0,65) { Ability = A1, Moves = new(038,608,371,416) }, // Bewear
+        new(763,0,65) { Ability = A1, Moves = new(312,688,512,207) }, // Tsareena
+        new(224,0,65) { Ability = A1, Moves = new(806,430,503,491) }, // Octillery
+        new(226,0,65) { Ability = A1, Moves = new(403,291,469,352) }, // Mantine
+        new(227,0,65) { Ability = A2, Moves = new(372,211,404,019) }, // Skarmory
+        new(237,0,65) { Ability = A0, Moves = new(529,813,280,811) }, // Hitmontop
+        new(241,0,65) { Ability = A1, Moves = new(025,208,086,583) }, // Miltank
+        new(764,0,65) { Ability = A1, Moves = new(666,577,495,412) }, // Comfey
+        new(264,0,65) { Ability = A0, Moves = new(163,042,608,421) }, // Linoone
+        new(264,1,65) { Ability = A0, Moves = new(675,555,269,164) }, // Linoone-1
+        new(103,0,65) { Ability = A2, Moves = new(427,076,707,805) }, // Exeggutor
+        new(405,0,65) { Ability = A2, Moves = new(263,113,804,604) }, // Luxray
+        new(279,0,65) { Ability = A1, Moves = new(814,311,469,098) }, // Pelipper
+        new(291,0,65) { Ability = A0, Moves = new(210,164,189,806) }, // Ninjask
+        new(295,0,65) { Ability = A2, Moves = new(805,063,411,059) }, // Exploud
+        new(770,0,65) { Ability = A2, Moves = new(805,815,659,247) }, // Palossand
+        new(771,0,65) { Ability = A0, Moves = new(092,269,599,068) }, // Pyukumuku
+        new(305,0,65) { Ability = A0, Moves = new(798,231,157,319) }, // Lairon
+        new(310,0,65) { Ability = A1, Moves = new(804,129,315,706) }, // Manectric
+        new(315,0,65) { Ability = A1, Moves = new(437,326,311,791) }, // Roselia
+        new(319,0,65) { Ability = A2, Moves = new(453,372,207,799) }, // Sharpedo
+        new(320,0,65) { Ability = A0, Moves = new(362,798,340,203) }, // Wailmer
+        new(324,0,65) { Ability = A1, Moves = new(807,517,229,108) }, // Torkoal
+        new(862,0,65) { Ability = A0, Moves = new(808,085,263,103) }, // Obstagoon
+        new(334,0,65) { Ability = A2, Moves = new(605,257,538,406) }, // Altaria
+        new(844,0,65) { Ability = A0, Moves = new(815,799,806,137), CanGigantamax = true }, // Sandaconda
+        new(858,0,65) { Ability = A1, Moves = new(797,583,791,219), CanGigantamax = true }, // Hatterene
+        new(340,0,65) { Ability = A2, Moves = new(340,562,330,428) }, // Whiscash
+        new(342,0,65) { Ability = A2, Moves = new(808,263,330,014) }, // Crawdaunt
+        new(344,0,65) { Ability = A0, Moves = new(433,094,246,063) }, // Claydol
+        new(356,0,65) { Ability = A0, Moves = new(425,506,356,806) }, // Dusclops
+        new(359,0,65) { Ability = A0, Moves = new(059,400,163,126) }, // Absol
+        new(362,0,65) { Ability = A1, Moves = new(798,242,423,313) }, // Glalie
+        new(364,0,65) { Ability = A0, Moves = new(058,362,291,207) }, // Sealeo
+        new(369,0,65) { Ability = A1, Moves = new(710,457,175,799) }, // Relicanth
+        new(132,0,65) { Ability = A2, Moves = new(144,000,000,000) }, // Ditto
+        new(375,0,65) { Ability = A0, Moves = new(309,009,427,115) }, // Metang
+        new(416,0,65) { Ability = A0, Moves = new(454,207,814,279) }, // Vespiquen
+        new(421,0,65) { Ability = A0, Moves = new(076,388,241,311) }, // Cherrim
+        new(423,1,65) { Ability = A2, Moves = new(034,806,317,127) }, // Gastrodon-1
+        new(426,0,65) { Ability = A0, Moves = new(261,094,366,085) }, // Drifblim
+        new(428,0,65) { Ability = A0, Moves = new(409,025,204,340) }, // Lopunny
+        new(435,0,65) { Ability = A1, Moves = new(808,807,491,389) }, // Skuntank
+        new(537,0,65) { Ability = A0, Moves = new(497,048,188,103) }, // Seismitoad
+        new(452,0,65) { Ability = A0, Moves = new(808,404,367,231) }, // Drapion
+        new(777,0,65) { Ability = A2, Moves = new(609,398,527,442) }, // Togedemaru
+        new(460,0,65) { Ability = A2, Moves = new(419,694,496,803) }, // Abomasnow
+        new(478,0,65) { Ability = A0, Moves = new(813,524,694,247) }, // Froslass
+        new(479,0,65) { Ability = A0, Moves = new(486,261,417,506) }, // Rotom
+        new(508,0,65) { Ability = A2, Moves = new(416,263,496,608) }, // Stoutland
+        new(510,0,65) { Ability = A0, Moves = new(372,583,259,103) }, // Liepard
+        new(518,0,65) { Ability = A0, Moves = new(797,473,281,412) }, // Musharna
+        new(521,0,65) { Ability = A0, Moves = new(814,269,297,366) }, // Unfezant
+        new(528,0,65) { Ability = A2, Moves = new(493,683,094,403) }, // Swoobat
+        new(531,0,65) { Ability = A0, Moves = new(791,577,304,053) }, // Audino
+        new(533,0,65) { Ability = A0, Moves = new(264,811,280,667) }, // Gurdurr
+        new(536,0,65) { Ability = A0, Moves = new(497,503,414,340) }, // Palpitoad
+        new(778,0,65) { Ability = A0, Moves = new(421,163,608,174) }, // Mimikyu
+        new(884,0,65) { Ability = A0, Moves = new(784,086,442,085), CanGigantamax = true }, // Duraludon
+        new(545,0,65) { Ability = A1, Moves = new(798,092,675,224) }, // Scolipede
+        new(547,0,65) { Ability = A0, Moves = new(542,269,412,583) }, // Whimsicott
+        new(549,0,65) { Ability = A1, Moves = new(080,483,113,676) }, // Lilligant
+        new(550,0,65) { Ability = A1, Moves = new(710,291,706,423) }, // Basculin
+        new(550,1,65) { Ability = A1, Moves = new(503,291,242,164) }, // Basculin-1
+        new(828,0,65) { Ability = A1, Moves = new(492,555,269,807) }, // Thievul
+        new(834,0,65) { Ability = A0, Moves = new(534,806,684,157) }, // Drednaw
+        new(556,0,65) { Ability = A2, Moves = new(437,412,389,367) }, // Maractus
+        new(558,0,65) { Ability = A1, Moves = new(504,404,317,776) }, // Crustle
+        new(830,0,65) { Ability = A2, Moves = new(113,311,538,437) }, // Eldegoss
+        new(561,0,65) { Ability = A0, Moves = new(094,240,403,430) }, // Sigilyph
+        new(446,0,65) { Ability = A1, Moves = new(009,007,034,441) }, // Munchlax
+        new(855,0,65) { Ability = A0, Moves = new(312,389,473,202) }, // Polteageist
+        new(569,0,65) { Ability = A2, Moves = new(441,188,409,599), CanGigantamax = true }, // Garbodor
+        new(573,0,65) { Ability = A1, Moves = new(497,541,113,813) }, // Cinccino
+        new(836,0,65) { Ability = A0, Moves = new(804,242,204,270) }, // Boltund
+        new(820,0,65) { Ability = A0, Moves = new(360,706,014,034) }, // Greedent
+        new(583,0,65) { Ability = A0, Moves = new(054,058,059,304) }, // Vanillish
+        new(587,0,65) { Ability = A0, Moves = new(512,804,203,527) }, // Emolga
+        new(589,0,65) { Ability = A1, Moves = new(529,534,210,269) }, // Escavalier
+        new(591,0,65) { Ability = A0, Moves = new(499,476,202,474) }, // Amoonguss
+        new(593,0,65) { Ability = A0, Moves = new(605,291,433,196) }, // Jellicent
+        new(596,0,65) { Ability = A0, Moves = new(087,405,486,527) }, // Galvantula
+        new(601,0,65) { Ability = A0, Moves = new(544,508,416,319) }, // Klinklang
+        new(606,0,65) { Ability = A1, Moves = new(797,800,399,496) }, // Beheeyem
+        new(608,0,65) { Ability = A0, Moves = new(807,806,517,433) }, // Lampent
+        new(611,0,65) { Ability = A0, Moves = new(416,200,784,404) }, // Fraxure
+        new(614,0,65) { Ability = A1, Moves = new(776,059,524,362) }, // Beartic
+        new(615,0,65) { Ability = A0, Moves = new(059,058,115,076) }, // Cryogonal
+        new(617,0,65) { Ability = A0, Moves = new(522,491,240,405) }, // Accelgor
+        new(618,0,65) { Ability = A0, Moves = new(604,085,414,330) }, // Stunfisk
+        new(618,1,65) { Ability = A0, Moves = new(319,805,492,414) }, // Stunfisk-1
+        new(621,0,65) { Ability = A1, Moves = new(808,814,442,091) }, // Druddigon
+        new(623,0,65) { Ability = A0, Moves = new(264,325,815,219) }, // Golurk
+        new(625,0,65) { Ability = A1, Moves = new(400,398,427,319) }, // Bisharp
+        new(626,0,65) { Ability = A1, Moves = new(034,808,684,276) }, // Bouffalant
+        new(631,0,65) { Ability = A1, Moves = new(680,315,241,076) }, // Heatmor
+        new(632,0,65) { Ability = A0, Moves = new(422,404,319,232) }, // Durant
+        new(832,0,65) { Ability = A0, Moves = new(803,025,776,164) }, // Dubwool
+        new(660,0,65) { Ability = A2, Moves = new(444,707,091,098) }, // Diggersby
+        new(663,0,65) { Ability = A2, Moves = new(366,542,211,053) }, // Talonflame
+        new(675,0,65) { Ability = A0, Moves = new(418,359,663,811) }, // Pangoro
+        new(039,0,65) { Ability = A2, Moves = new(164,113,313,577) }, // Jigglypuff
+        new(525,0,65) { Ability = A0, Moves = new(444,334,776,707) }, // Boldore
+        new(680,0,65) { Ability = A0, Moves = new(442,014,533,332) }, // Doublade
+        new(687,0,65) { Ability = A0, Moves = new(576,797,400,085) }, // Malamar
+        new(689,0,65) { Ability = A0, Moves = new(534,059,130,398) }, // Barbaracle
+        new(695,0,65) { Ability = A0, Moves = new(486,097,496,189) }, // Heliolisk
+        new(702,0,65) { Ability = A2, Moves = new(494,087,605,164) }, // Dedenne
+        new(851,0,65) { Ability = A1, Moves = new(053,815,474,021), CanGigantamax = true }, // Centiskorch
+        new(707,0,65) { Ability = A0, Moves = new(113,578,430,583) }, // Klefki
+        new(709,0,65) { Ability = A2, Moves = new(532,115,409,433) }, // Trevenant
+        new(711,0,65) { Ability = A0, Moves = new(595,425,388,184) }, // Gourgeist
+        new(847,0,65) { Ability = A0, Moves = new(453,799,372,203) }, // Barraskewda
+        new(845,0,65) { Ability = A0, Moves = new(291,203,133,675) }, // Cramorant
+        new(620,0,65) { Ability = A0, Moves = new(396,469,317,025) }, // Mienshao
+        new(870,0,65) { Ability = A0, Moves = new(660,014,684,280) }, // Falinks
+        new(701,0,65) { Ability = A0, Moves = new(269,398,675,490) }, // Hawlucha
+        new(879,0,65) { Ability = A0, Moves = new(334,776,430,798) }, // Copperajah
+        new(826,0,65) { Ability = A0, Moves = new(495,094,060,522), CanGigantamax = true }, // Orbeetle
+        new(838,0,65) { Ability = A2, Moves = new(315,083,115,157) }, // Carkol
+        new(877,0,65) { Ability = A0, Moves = new(783,399,085,423) }, // Morpeko
+        new(563,0,65) { Ability = A0, Moves = new(247,114,094,472) }, // Cofagrigus
+        new(750,0,65) { Ability = A0, Moves = new(808,276,328,249) }, // Mudsdale
+        new(863,0,65) { Ability = A2, Moves = new(232,133,808,087) }, // Perrserker
+        new(871,0,65) { Ability = A2, Moves = new(056,087,367,599) }, // Pincurchin
+        new(873,0,65) { Ability = A2, Moves = new(311,366,522,542) }, // Frosmoth
+        new(839,0,65) { Ability = A0, Moves = new(108,800,053,503), CanGigantamax = true }, // Coalossal
+        new(853,0,65) { Ability = A0, Moves = new(576,409,330,411) }, // Grapploct
+        new(861,0,65) { Ability = A0, Moves = new(612,399,384,590), CanGigantamax = true }, // Grimmsnarl
+        new(886,0,65) { Ability = A0, Moves = new(407,372,261,247) }, // Drakloak
+        new(036,0,65) { Ability = A1, Moves = new(800,605,266,322) }, // Clefable
+        new(044,0,65) { Ability = A0, Moves = new(474,092,585,078) }, // Gloom
+        new(137,0,65) { Ability = A1, Moves = new(492,058,085,063) }, // Porygon
+        new(600,0,65) { Ability = A1, Moves = new(451,804,430,408) }, // Klang
+        new(738,0,65) { Ability = A0, Moves = new(209,189,398,405) }, // Vikavolt
+        new(254,0,65) { Ability = A2, Moves = new(520,784,437,404) }, // Sceptile
+        new(257,0,65) { Ability = A2, Moves = new(519,299,370,811) }, // Blaziken
+        new(260,0,65) { Ability = A2, Moves = new(518,059,414,133) }, // Swampert
+        new(073,0,65) { Ability = A0, Moves = new(352,056,398,014) }, // Tentacruel
+        new(080,0,65) { Ability = A1, Moves = new(797,244,053,473) }, // Slowbro
+        new(121,0,65) { Ability = A2, Moves = new(408,605,427,196) }, // Starmie
+        new(849,0,65) { Ability = A1, Moves = new(804,086,304,715), CanGigantamax = true }, // Toxtricity
+        new(134,0,65) { Ability = A0, Moves = new(352,204,311,114) }, // Vaporeon
+        new(135,0,65) { Ability = A0, Moves = new(085,129,247,270) }, // Jolteon
+        new(136,0,65) { Ability = A0, Moves = new(807,247,608,387) }, // Flareon
+        new(199,0,65) { Ability = A1, Moves = new(248,417,534,008) }, // Slowking
+        new(330,0,65) { Ability = A0, Moves = new(211,337,405,189) }, // Flygon
+        new(346,0,65) { Ability = A0, Moves = new(412,246,380,188) }, // Cradily
+        new(348,0,65) { Ability = A0, Moves = new(404,479,707,201) }, // Armaldo
+        new(437,0,65) { Ability = A0, Moves = new(428,319,798,285) }, // Bronzong
+        new(697,0,65) { Ability = A0, Moves = new(799,350,276,034) }, // Tyrantrum
+        new(253,0,65) { Ability = A0, Moves = new(520,103,280,203) }, // Grovyle
+        new(256,0,65) { Ability = A0, Moves = new(519,411,297,490) }, // Combusken
+        new(259,0,65) { Ability = A0, Moves = new(518,127,091,008) }, // Marshtomp
+        new(699,0,65) { Ability = A0, Moves = new(034,087,246,086) }, // Aurorus
+        new(765,0,65) { Ability = A2, Moves = new(689,113,094,473) }, // Oranguru
+        new(766,0,65) { Ability = A0, Moves = new(280,317,164,512) }, // Passimian
+        new(876,0,65) { Ability = A1, Moves = new(595,797,347,247) }, // Indeedee
+        new(145,0,70) { Ability = A0, Moves = new(087,065,413,097) }, // Zapdos
+        new(146,0,70) { Ability = A0, Moves = new(257,017,043,083) }, // Moltres
+        new(144,0,70) { Ability = A0, Moves = new(058,573,542,054) }, // Articuno
+        new(150,0,70) { Ability = A0, Moves = new(094,050,105,059) }, // Mewtwo
+        new(245,0,70) { Ability = A0, Moves = new(710,326,245,347) }, // Suicune
+        new(244,0,70) { Ability = A0, Moves = new(053,184,245,242) }, // Entei
+        new(243,0,70) { Ability = A0, Moves = new(085,336,245,311) }, // Raikou
+        new(249,0,70) { Ability = A0, Moves = new(406,326,250,246) }, // (SH) Lugia
+        new(250,0,70) { Ability = A0, Moves = new(394,326,241,246) }, // (SW) Ho-Oh
+        new(380,0,70) { Ability = A0, Moves = new(513,225,428,057) }, // (SH) Latias
+        new(381,0,70) { Ability = A0, Moves = new(349,406,428,396) }, // (SW) Latios
+        new(383,0,70) { Ability = A0, Moves = new(089,184,436,359) }, // (SW) Groudon
+        new(382,0,70) { Ability = A0, Moves = new(057,034,392,087) }, // (SH) Kyogre
+        new(384,0,70) { Ability = A0, Moves = new(620,693,245,239) }, // Rayquaza
+        new(480,0,70) { Ability = A0, Moves = new(094,248,478,247) }, // Uxie
+        new(482,0,70) { Ability = A0, Moves = new(094,605,417,263) }, // Azelf
+        new(481,0,70) { Ability = A0, Moves = new(094,204,577,161) }, // Mesprit
+        new(483,0,70) { Ability = A0, Moves = new(163,246,430,337) }, // (SW) Dialga
+        new(484,0,70) { Ability = A0, Moves = new(163,057,246,337) }, // (SH) Palkia
+        new(487,0,70) { Ability = A0, Moves = new(337,184,247,246) }, // Giratina
+        new(485,0,70) { Ability = A0, Moves = new(319,436,242,442) }, // Heatran
+        new(488,0,70) { Ability = A0, Moves = new(196,585,427,473) }, // Cresselia
+        new(641,0,70) { Ability = A0, Moves = new(542,097,196,257) }, // (SW) Tornadus
+        new(642,0,70) { Ability = A0, Moves = new(087,240,311,482) }, // (SH) Thundurus
+        new(645,0,70) { Ability = A0, Moves = new(328,157,523,411) }, // Landorus
+        new(643,0,70) { Ability = A0, Moves = new(568,326,558,406) }, // (SW) Reshiram
+        new(644,0,70) { Ability = A0, Moves = new(568,163,559,337) }, // (SH) Zekrom
+        new(646,0,70) { Ability = A0, Moves = new(058,304,247,184) }, // Kyurem
+        new(716,0,70) { Ability = A0, Moves = new(275,605,585,532) }, // (SW) Xerneas
+        new(717,0,70) { Ability = A0, Moves = new(269,613,407,389) }, // (SH) Yveltal
+        new(718,3,70) { Ability = A0, Moves = new(614,616,406,020) }, // Zygarde-3
+        new(785,0,70) { Ability = A0, Moves = new(085,098,413,269) }, // Tapu Koko
+        new(786,0,70) { Ability = A0, Moves = new(094,583,478,204) }, // Tapu Lele
+        new(787,0,70) { Ability = A0, Moves = new(276,224,452,184) }, // Tapu Bulu
+        new(788,0,70) { Ability = A0, Moves = new(250,352,362,585) }, // Tapu Fini
+        new(791,0,70) { Ability = A0, Moves = new(428,083,231,568) }, // (SW) Solgaleo
+        new(792,0,70) { Ability = A0, Moves = new(247,585,277,129) }, // (SH) Lunala
+        new(800,0,70) { Ability = A0, Moves = new(427,451,408,475) }, // Necrozma
+        new(793,0,70) { Ability = A0, Moves = new(472,482,693,491) }, // Nihilego
+        new(794,0,70) { Ability = A0, Moves = new(612,269,141,223) }, // Buzzwole
+        new(795,0,70) { Ability = A0, Moves = new(136,129,675,679) }, // Pheromosa
+        new(796,0,70) { Ability = A0, Moves = new(438,435,598,693) }, // Xurkitree
+        new(798,0,70) { Ability = A0, Moves = new(410,314,348,014) }, // Kartana
+        new(797,0,70) { Ability = A0, Moves = new(073,479,360,089) }, // Celesteela
+        new(799,0,70) { Ability = A0, Moves = new(407,707,693,005) }, // Guzzlord
+        new(806,0,70) { Ability = A0, Moves = new(421,269,126,428) }, // Blacephalon
+        new(805,0,70) { Ability = A0, Moves = new(157,038,693,475) }, // Stakataka
     };
     #endregion
 }

--- a/PKHeX.Core/Legality/Encounters/Data/Encounters8a.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Encounters8a.cs
@@ -1,4 +1,4 @@
-﻿using static PKHeX.Core.EncounterUtil;
+using static PKHeX.Core.EncounterUtil;
 using static PKHeX.Core.Shiny;
 using static PKHeX.Core.GameVersion;
 using static PKHeX.Core.EncounterStatic8aCorrelation;
@@ -25,16 +25,16 @@ internal static class Encounters8a
         new(493,000,75,M,M) { Location = 109, FlawlessIVCount = 3, Gift = true, Method = Fixed, Ball = (int)Ball.LAPoke, Fateful = true }, // Arceus
 
         // Static Encounters - Scripted Table Slots
-        new(480,000,70,M,M) { Location = 111, FlawlessIVCount = 3, Moves = new[] {129,326,832,095} }, // Uxie
-        new(481,000,70,M,M) { Location = 104, FlawlessIVCount = 3, Moves = new[] {129,326,832,105} }, // Mesprit
-        new(482,000,70,M,M) { Location = 105, FlawlessIVCount = 3, Moves = new[] {129,458,326,832} }, // Azelf
-        new(485,000,70,M,M) { Location = 068, FlawlessIVCount = 3, Moves = new[] {442,242,414,463} }, // Heatran
-        new(488,000,70,M,M) { Location = 082, FlawlessIVCount = 3, Moves = new[] {427,094,585,849} }, // Cresselia
+        new(480,000,70,M,M) { Location = 111, FlawlessIVCount = 3, Moves = new(129,326,832,095) }, // Uxie
+        new(481,000,70,M,M) { Location = 104, FlawlessIVCount = 3, Moves = new(129,326,832,105) }, // Mesprit
+        new(482,000,70,M,M) { Location = 105, FlawlessIVCount = 3, Moves = new(129,458,326,832) }, // Azelf
+        new(485,000,70,M,M) { Location = 068, FlawlessIVCount = 3, Moves = new(442,242,414,463) }, // Heatran
+        new(488,000,70,M,M) { Location = 082, FlawlessIVCount = 3, Moves = new(427,094,585,849) }, // Cresselia
 
-        new(641,000,70,M,M) { Location = 090, FlawlessIVCount = 3, Moves = new[] {326,242,542,846} }, // Tornadus
-        new(642,000,70,M,M) { Location = 009, FlawlessIVCount = 3, Moves = new[] {326,242,087,847} }, // Thundurus
-        new(645,000,70,M,M) { Location = 027, FlawlessIVCount = 3, Moves = new[] {326,242,414,848} }, // Landorus
-        new(905,000,70,M,M) { Location = 038, FlawlessIVCount = 3, Moves = new[] {326,242,585,831} }, // Enamorus
+        new(641,000,70,M,M) { Location = 090, FlawlessIVCount = 3, Moves = new(326,242,542,846) }, // Tornadus
+        new(642,000,70,M,M) { Location = 009, FlawlessIVCount = 3, Moves = new(326,242,087,847) }, // Thundurus
+        new(645,000,70,M,M) { Location = 027, FlawlessIVCount = 3, Moves = new(326,242,414,848) }, // Landorus
+        new(905,000,70,M,M) { Location = 038, FlawlessIVCount = 3, Moves = new(326,242,585,831) }, // Enamorus
 
         new(077,000,15    ) { Location = 014, Shiny = Always}, // Ponyta*
         new(442,000,60,M,M) { Location = 043, FlawlessIVCount = 3 }, // Spiritomb
@@ -42,13 +42,13 @@ internal static class Encounters8a
         new(570,001,28    ) { Location = 027 }, // Zorua
         new(570,001,29    ) { Location = 027 }, // Zorua
 
-        new(489,000,33    ) { Location = 064, Fateful = true,                      Moves = new[] {145,352,151,428} }, // Phione
-        new(489,000,34    ) { Location = 064, Fateful = true,                      Moves = new[] {145,352,151,428} }, // Phione
-        new(489,000,35    ) { Location = 064, Fateful = true,                      Moves = new[] {145,352,151,428} }, // Phione
-        new(489,000,36    ) { Location = 064, Fateful = true,                      Moves = new[] {145,352,151,428} }, // Phione
-        new(490,000,50,M,M) { Location = 064, FlawlessIVCount = 3, Fateful = true, Moves = new[] {352,428,585,145} }, // Manaphy
-        new(491,000,70,M,M) { Location = 010, FlawlessIVCount = 3, Fateful = true, Moves = new[] {506,399,094,464} }, // Darkrai
-        new(492,000,70,M,M) { Location = 026, FlawlessIVCount = 3, Fateful = true, Moves = new[] {403,412,414,465} }, // Shaymin
+        new(489,000,33    ) { Location = 064, Fateful = true,                      Moves = new(145,352,151,428) }, // Phione
+        new(489,000,34    ) { Location = 064, Fateful = true,                      Moves = new(145,352,151,428) }, // Phione
+        new(489,000,35    ) { Location = 064, Fateful = true,                      Moves = new(145,352,151,428) }, // Phione
+        new(489,000,36    ) { Location = 064, Fateful = true,                      Moves = new(145,352,151,428) }, // Phione
+        new(490,000,50,M,M) { Location = 064, FlawlessIVCount = 3, Fateful = true, Moves = new(352,428,585,145) }, // Manaphy
+        new(491,000,70,M,M) { Location = 010, FlawlessIVCount = 3, Fateful = true, Moves = new(506,399,094,464) }, // Darkrai
+        new(492,000,70,M,M) { Location = 026, FlawlessIVCount = 3, Fateful = true, Moves = new(403,412,414,465) }, // Shaymin
 
         // Unown Notes
         new(201,000,25,U) { Location = 040, Method = Fixed }, // Unown A
@@ -88,10 +88,10 @@ internal static class Encounters8a
         new(201,024,25,U) { Location = 097, Method = Fixed }, // Unown Y
         new(201,006,25,U) { Location = 007, Method = Fixed }, // Unown G
 
-        new(642,000,70,M,M) { Location = 059, FlawlessIVCount = 3,                 Moves = new[] {326,242,087,847} }, // Thundurus (Lunker’s Lair)
-        new(642,000,70,M,M) { Location = 129, FlawlessIVCount = 3,                 Moves = new[] {326,242,087,847} }, // Thundurus (Sand’s Reach)
-        new(488,000,70,M,M) { Location = 010, FlawlessIVCount = 3,                 Moves = new[] {427,094,585,849} }, // Cresselia (Coronet Highlands)
-        new(491,000,70,M,M) { Location = 074, FlawlessIVCount = 3, Fateful = true, Moves = new[] {506,399,094,464} }, // Darkrai (Lonely Spring)
+        new(642,000,70,M,M) { Location = 059, FlawlessIVCount = 3,                 Moves = new(326,242,087,847) }, // Thundurus (Lunker’s Lair)
+        new(642,000,70,M,M) { Location = 129, FlawlessIVCount = 3,                 Moves = new(326,242,087,847) }, // Thundurus (Sand’s Reach)
+        new(488,000,70,M,M) { Location = 010, FlawlessIVCount = 3,                 Moves = new(427,094,585,849) }, // Cresselia (Coronet Highlands)
+        new(491,000,70,M,M) { Location = 074, FlawlessIVCount = 3, Fateful = true, Moves = new(506,399,094,464) }, // Darkrai (Lonely Spring)
 
         // Static Encounters
         new(046,000,50,M,M) { Location = 019, Method = Fixed }, // paras01: Paras
@@ -106,11 +106,11 @@ internal static class Encounters8a
         new(486,000,70,M,M) { Location = 095, Method = Fixed, FlawlessIVCount = 3 }, // regigigas01: Regigigas
         new(487,001,70,M,M) { Location = 067, Method = Fixed, FlawlessIVCount = 3 }, // giratina02: Giratina-1
 
-        new(362,000,64,A,A) { Location = 011, Method = Fixed, IsAlpha = true,                                  Moves = new[] {442,059,556,242} }, // onigohri01: Glalie
-        new(402,000,12,A,A) { Location = 007, Method = Fixed, IsAlpha = true, Gender = 0,                      Moves = new[] {206,071,033,332} }, // mev002: Kricketune
-        new(416,000,60,A,A) { Location = 022, Method = Fixed, IsAlpha = true, Gender = 1, FlawlessIVCount = 3, Moves = new[] {188,403,408,405} }, // beequen01: Vespiquen
-        new(571,001,58,M,M) { Location = 111, Method = Fixed, IsAlpha = true,                                  Moves = new[] {555,421,841,417} }, // zoroark01: Zoroark-1
-        new(706,001,58,M,M) { Location = 104, Method = Fixed, IsAlpha = true,                                  Moves = new[] {231,406,842,056} }, // numelgon01: Goodra-1
-        new(904,000,58,M,M) { Location = 105, Method = Fixed, IsAlpha = true,                                  Moves = new[] {301,398,401,038} }, // harysen01: Overqwil
+        new(362,000,64,A,A) { Location = 011, Method = Fixed, IsAlpha = true,                                  Moves = new(442,059,556,242) }, // onigohri01: Glalie
+        new(402,000,12,A,A) { Location = 007, Method = Fixed, IsAlpha = true, Gender = 0,                      Moves = new(206,071,033,332) }, // mev002: Kricketune
+        new(416,000,60,A,A) { Location = 022, Method = Fixed, IsAlpha = true, Gender = 1, FlawlessIVCount = 3, Moves = new(188,403,408,405) }, // beequen01: Vespiquen
+        new(571,001,58,M,M) { Location = 111, Method = Fixed, IsAlpha = true,                                  Moves = new(555,421,841,417) }, // zoroark01: Zoroark-1
+        new(706,001,58,M,M) { Location = 104, Method = Fixed, IsAlpha = true,                                  Moves = new(231,406,842,056) }, // numelgon01: Goodra-1
+        new(904,000,58,M,M) { Location = 105, Method = Fixed, IsAlpha = true,                                  Moves = new(301,398,401,038) }, // harysen01: Overqwil
     };
 }

--- a/PKHeX.Core/Legality/Encounters/Data/Encounters8b.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Encounters8b.cs
@@ -94,9 +94,9 @@ internal static class Encounters8b
 
     internal static readonly EncounterTrade8b[] TradeGift_BDSP =
     {
-        new(BDSP) { Species = 063, EncryptionConstant = 0x0000008E, PID = 0xFF50A8F5, Level = 09, Ability = OnlyFirst,  Gender = 0, OTGender = 0, TID = 25643, IVs = new[] {28,10,09,31,11,03}, Moves = new(100,000,000,000), HeightScalar = 029, WeightScalar = 202, Nature = Nature.Quiet  }, // Abra
-        new(BDSP) { Species = 441, EncryptionConstant = 0x00000867, PID = 0x17DAAB19, Level = 15, Ability = OnlySecond, Gender = 1, OTGender = 0, TID = 44142, IVs = new[] {17,08,29,25,17,23}, Moves = new(448,047,064,045), HeightScalar = 088, WeightScalar = 091, Nature = Nature.Lonely }, // Chatot
-        new(BDSP) { Species = 093, EncryptionConstant = 0x00000088, PID = 0xF60AB5BB, Level = 33, Ability = OnlyFirst,  Gender = 0, OTGender = 0, TID = 19248, IVs = new[] {18,24,28,02,22,30}, Moves = new(247,371,389,109), HeightScalar = 096, WeightScalar = 208, Nature = Nature.Hasty  }, // Haunter
-        new(BDSP) { Species = 129, EncryptionConstant = 0x0000045C, PID = 0xFCE82F88, Level = 45, Ability = OnlyFirst,  Gender = 1, OTGender = 0, TID = 53277, IVs = new[] {03,03,31,02,11,03}, Moves = new(150,000,000,000), HeightScalar = 169, WeightScalar = 068, Nature = Nature.Mild   }, // Magikarp
+        new(BDSP) { Species = 063, EncryptionConstant = 0x0000008E, PID = 0xFF50A8F5, Level = 09, Ability = OnlyFirst,  Gender = 0, OTGender = 0, TID = 25643, IVs = new(28,10,09,31,11,03), Moves = new(100,000,000,000), HeightScalar = 029, WeightScalar = 202, Nature = Nature.Quiet  }, // Abra
+        new(BDSP) { Species = 441, EncryptionConstant = 0x00000867, PID = 0x17DAAB19, Level = 15, Ability = OnlySecond, Gender = 1, OTGender = 0, TID = 44142, IVs = new(17,08,29,25,17,23), Moves = new(448,047,064,045), HeightScalar = 088, WeightScalar = 091, Nature = Nature.Lonely }, // Chatot
+        new(BDSP) { Species = 093, EncryptionConstant = 0x00000088, PID = 0xF60AB5BB, Level = 33, Ability = OnlyFirst,  Gender = 0, OTGender = 0, TID = 19248, IVs = new(18,24,28,02,22,30), Moves = new(247,371,389,109), HeightScalar = 096, WeightScalar = 208, Nature = Nature.Hasty  }, // Haunter
+        new(BDSP) { Species = 129, EncryptionConstant = 0x0000045C, PID = 0xFCE82F88, Level = 45, Ability = OnlyFirst,  Gender = 1, OTGender = 0, TID = 53277, IVs = new(03,03,31,02,11,03), Moves = new(150,000,000,000), HeightScalar = 169, WeightScalar = 068, Nature = Nature.Mild   }, // Magikarp
     };
 }

--- a/PKHeX.Core/Legality/Encounters/Data/Encounters8b.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Encounters8b.cs
@@ -1,4 +1,4 @@
-﻿using static PKHeX.Core.EncounterUtil;
+using static PKHeX.Core.EncounterUtil;
 using static PKHeX.Core.Shiny;
 using static PKHeX.Core.GameVersion;
 using static PKHeX.Core.AbilityPermission;
@@ -94,9 +94,9 @@ internal static class Encounters8b
 
     internal static readonly EncounterTrade8b[] TradeGift_BDSP =
     {
-        new(BDSP) { Species = 063, EncryptionConstant = 0x0000008E, PID = 0xFF50A8F5, Level = 09, Ability = OnlyFirst,  Gender = 0, OTGender = 0, TID = 25643, IVs = new[] {28,10,09,31,11,03}, Moves = new[] {100,000,000,000}, HeightScalar = 029, WeightScalar = 202, Nature = Nature.Quiet  }, // Abra
-        new(BDSP) { Species = 441, EncryptionConstant = 0x00000867, PID = 0x17DAAB19, Level = 15, Ability = OnlySecond, Gender = 1, OTGender = 0, TID = 44142, IVs = new[] {17,08,29,25,17,23}, Moves = new[] {448,047,064,045}, HeightScalar = 088, WeightScalar = 091, Nature = Nature.Lonely }, // Chatot
-        new(BDSP) { Species = 093, EncryptionConstant = 0x00000088, PID = 0xF60AB5BB, Level = 33, Ability = OnlyFirst,  Gender = 0, OTGender = 0, TID = 19248, IVs = new[] {18,24,28,02,22,30}, Moves = new[] {247,371,389,109}, HeightScalar = 096, WeightScalar = 208, Nature = Nature.Hasty  }, // Haunter
-        new(BDSP) { Species = 129, EncryptionConstant = 0x0000045C, PID = 0xFCE82F88, Level = 45, Ability = OnlyFirst,  Gender = 1, OTGender = 0, TID = 53277, IVs = new[] {03,03,31,02,11,03}, Moves = new[] {150,000,000,000}, HeightScalar = 169, WeightScalar = 068, Nature = Nature.Mild   }, // Magikarp
+        new(BDSP) { Species = 063, EncryptionConstant = 0x0000008E, PID = 0xFF50A8F5, Level = 09, Ability = OnlyFirst,  Gender = 0, OTGender = 0, TID = 25643, IVs = new[] {28,10,09,31,11,03}, Moves = new(100,000,000,000), HeightScalar = 029, WeightScalar = 202, Nature = Nature.Quiet  }, // Abra
+        new(BDSP) { Species = 441, EncryptionConstant = 0x00000867, PID = 0x17DAAB19, Level = 15, Ability = OnlySecond, Gender = 1, OTGender = 0, TID = 44142, IVs = new[] {17,08,29,25,17,23}, Moves = new(448,047,064,045), HeightScalar = 088, WeightScalar = 091, Nature = Nature.Lonely }, // Chatot
+        new(BDSP) { Species = 093, EncryptionConstant = 0x00000088, PID = 0xF60AB5BB, Level = 33, Ability = OnlyFirst,  Gender = 0, OTGender = 0, TID = 19248, IVs = new[] {18,24,28,02,22,30}, Moves = new(247,371,389,109), HeightScalar = 096, WeightScalar = 208, Nature = Nature.Hasty  }, // Haunter
+        new(BDSP) { Species = 129, EncryptionConstant = 0x0000045C, PID = 0xFCE82F88, Level = 45, Ability = OnlyFirst,  Gender = 1, OTGender = 0, TID = 53277, IVs = new[] {03,03,31,02,11,03}, Moves = new(150,000,000,000), HeightScalar = 169, WeightScalar = 068, Nature = Nature.Mild   }, // Magikarp
     };
 }

--- a/PKHeX.Core/Legality/Encounters/Data/EncountersWC3.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/EncountersWC3.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace PKHeX.Core;
@@ -37,13 +37,13 @@ internal static class EncountersWC3
                 // Colosseum
                 new() { Species = 025, Level = 10, Language = l, Location = 255, TID = 31121, SID =  0, OT_Gender = 0, OT_Name = p[l], Version = GameVersion.R,    CardTitle = $"Colosseum Pikachu ({id})",Method = PIDType.CXD, Shiny = Shiny.Never, NotDistributed = nd }, // Colosseum Pikachu bonus gift
                 new() { Species = 251, Level = 10, Language = l, Location = 255, TID = 31121, SID =  0, OT_Gender = 1, OT_Name = c[l], Version = GameVersion.R,    CardTitle = $"Agate Celebi ({id})",     Method = PIDType.CXD, Shiny = Shiny.Never, NotDistributed = nd }, // Ageto Celebi bonus gift
-                new() { Species = 311, Level = 13, Language = l, Location = 254, TID = 37149, SID =  0, OT_Gender = 0, OT_Name = d[l], Version = GameVersion.COLO, CardTitle = $"Special Gift ({id})",     Method = PIDType.CXD, Shiny = Shiny.Never, Moves = new[] { 045, 086, 098, 270 } }, // Plusle @ Ingame Trade
-                new() { Species = 250, Level = 70, Language = l, Location = 255, TID = 10048, SID =  0, OT_Gender = 0, OT_Name = m[l], Version = GameVersion.S,    CardTitle = $"Mt. Battle Ho-Oh ({id})", Method = PIDType.CXD, Shiny = Shiny.Never, Moves = new[] { 105, 126, 241, 129 } }, // Ho-oh @ Mt. Battle
+                new() { Species = 311, Level = 13, Language = l, Location = 254, TID = 37149, SID =  0, OT_Gender = 0, OT_Name = d[l], Version = GameVersion.COLO, CardTitle = $"Special Gift ({id})",     Method = PIDType.CXD, Shiny = Shiny.Never, Moves = new(045, 086, 098, 270) }, // Plusle @ Ingame Trade
+                new() { Species = 250, Level = 70, Language = l, Location = 255, TID = 10048, SID =  0, OT_Gender = 0, OT_Name = m[l], Version = GameVersion.S,    CardTitle = $"Mt. Battle Ho-Oh ({id})", Method = PIDType.CXD, Shiny = Shiny.Never, Moves = new(105, 126, 241, 129) }, // Ho-oh @ Mt. Battle
                 // XD
-                new() { Species = 239, Level = 20, Language = l, Location = 164, TID = 41400, SID = -1, OT_Gender = 0, OT_Name = h[l], Version = GameVersion.XD,   CardTitle = $"Trade Togepi ({id})",     Method = PIDType.CXD, Moves = new[] { 008, 007, 009, 238 }, Fateful = true, Nickname = z[l] }, // Elekid @ Snagem Hideout
-                new() { Species = 307, Level = 20, Language = l, Location = 116, TID = 37149, SID = -1, OT_Gender = 0, OT_Name = d[l], Version = GameVersion.XD,   CardTitle = $"Trade Trapinch ({id})",   Method = PIDType.CXD, Moves = new[] { 223, 093, 247, 197 }, Fateful = true }, // Meditite @ Pyrite Town
-                new() { Species = 213, Level = 20, Language = l, Location = 116, TID = 37149, SID = -1, OT_Gender = 0, OT_Name = d[l], Version = GameVersion.XD,   CardTitle = $"Trade Surskit ({id})",    Method = PIDType.CXD, Moves = new[] { 092, 164, 188, 227 }, Fateful = true }, // Shuckle @ Pyrite Town
-                new() { Species = 246, Level = 20, Language = l, Location = 116, TID = 37149, SID = -1, OT_Gender = 0, OT_Name = d[l], Version = GameVersion.XD,   CardTitle = $"Trade Wooper ({id})",     Method = PIDType.CXD, Moves = new[] { 201, 349, 044, 200 }, Fateful = true }, // Larvitar @ Pyrite Town
+                new() { Species = 239, Level = 20, Language = l, Location = 164, TID = 41400, SID = -1, OT_Gender = 0, OT_Name = h[l], Version = GameVersion.XD,   CardTitle = $"Trade Togepi ({id})",     Method = PIDType.CXD, Moves = new(008, 007, 009, 238), Fateful = true, Nickname = z[l] }, // Elekid @ Snagem Hideout
+                new() { Species = 307, Level = 20, Language = l, Location = 116, TID = 37149, SID = -1, OT_Gender = 0, OT_Name = d[l], Version = GameVersion.XD,   CardTitle = $"Trade Trapinch ({id})",   Method = PIDType.CXD, Moves = new(223, 093, 247, 197), Fateful = true }, // Meditite @ Pyrite Town
+                new() { Species = 213, Level = 20, Language = l, Location = 116, TID = 37149, SID = -1, OT_Gender = 0, OT_Name = d[l], Version = GameVersion.XD,   CardTitle = $"Trade Surskit ({id})",    Method = PIDType.CXD, Moves = new(092, 164, 188, 227), Fateful = true }, // Shuckle @ Pyrite Town
+                new() { Species = 246, Level = 20, Language = l, Location = 116, TID = 37149, SID = -1, OT_Gender = 0, OT_Name = d[l], Version = GameVersion.XD,   CardTitle = $"Trade Wooper ({id})",     Method = PIDType.CXD, Moves = new(201, 349, 044, 200), Fateful = true }, // Larvitar @ Pyrite Town
             };
         }
     }
@@ -53,50 +53,50 @@ internal static class EncountersWC3
     internal static readonly WC3[] Encounter_Event3_FRLG =
     {
         // PCJP - Egg Pokémon Present Eggs (March 21 to April 4, 2004)
-        new() { Species = 043, IsEgg = true, Fateful = true, Level = 05, TID = -1, SID = -1, Version = GameVersion.FRLG, Method = PIDType.Method_2, Moves = new[]{073} }, // Oddish with Leech Seed
-        new() { Species = 052, IsEgg = true, Fateful = true, Level = 05, TID = -1, SID = -1, Version = GameVersion.FRLG, Method = PIDType.Method_2, Moves = new[]{080} }, // Meowth with Petal Dance
-        new() { Species = 060, IsEgg = true, Fateful = true, Level = 05, TID = -1, SID = -1, Version = GameVersion.FRLG, Method = PIDType.Method_2, Moves = new[]{186} }, // Poliwag with Sweet Kiss
-        new() { Species = 069, IsEgg = true, Fateful = true, Level = 05, TID = -1, SID = -1, Version = GameVersion.FRLG, Method = PIDType.Method_2, Moves = new[]{298} }, // Bellsprout with Teeter Dance
+        new() { Species = 043, IsEgg = true, Fateful = true, Level = 05, TID = -1, SID = -1, Version = GameVersion.FRLG, Method = PIDType.Method_2, Moves = new(073) }, // Oddish with Leech Seed
+        new() { Species = 052, IsEgg = true, Fateful = true, Level = 05, TID = -1, SID = -1, Version = GameVersion.FRLG, Method = PIDType.Method_2, Moves = new(080) }, // Meowth with Petal Dance
+        new() { Species = 060, IsEgg = true, Fateful = true, Level = 05, TID = -1, SID = -1, Version = GameVersion.FRLG, Method = PIDType.Method_2, Moves = new(186) }, // Poliwag with Sweet Kiss
+        new() { Species = 069, IsEgg = true, Fateful = true, Level = 05, TID = -1, SID = -1, Version = GameVersion.FRLG, Method = PIDType.Method_2, Moves = new(298) }, // Bellsprout with Teeter Dance
 
         // PCNY - Wish Eggs (December 16, 2004, to January 2, 2005)
-        new() { Species = 083, IsEgg = true, Fateful = true, Level = 05, TID = -1, SID = -1, Version = GameVersion.FRLG, Method = PIDType.Method_2, Moves = new[]{273, 281} }, // Farfetch'd with Wish & Yawn
-        new() { Species = 096, IsEgg = true, Fateful = true, Level = 05, TID = -1, SID = -1, Version = GameVersion.FRLG, Method = PIDType.Method_2, Moves = new[]{273, 187} }, // Drowzee with Wish & Belly Drum
-        new() { Species = 102, IsEgg = true, Fateful = true, Level = 05, TID = -1, SID = -1, Version = GameVersion.FRLG, Method = PIDType.Method_2, Moves = new[]{273, 230} }, // Exeggcute with Wish & Sweet Scent
-        new() { Species = 108, IsEgg = true, Fateful = true, Level = 05, TID = -1, SID = -1, Version = GameVersion.FRLG, Method = PIDType.Method_2, Moves = new[]{273, 215} }, // Lickitung with Wish & Heal Bell
-        new() { Species = 113, IsEgg = true, Fateful = true, Level = 05, TID = -1, SID = -1, Version = GameVersion.FRLG, Method = PIDType.Method_2, Moves = new[]{273, 230} }, // Chansey with Wish & Sweet Scent
-        new() { Species = 115, IsEgg = true, Fateful = true, Level = 05, TID = -1, SID = -1, Version = GameVersion.FRLG, Method = PIDType.Method_2, Moves = new[]{273, 281} }, // Kangaskhan with Wish & Yawn
+        new() { Species = 083, IsEgg = true, Fateful = true, Level = 05, TID = -1, SID = -1, Version = GameVersion.FRLG, Method = PIDType.Method_2, Moves = new(273, 281) }, // Farfetch'd with Wish & Yawn
+        new() { Species = 096, IsEgg = true, Fateful = true, Level = 05, TID = -1, SID = -1, Version = GameVersion.FRLG, Method = PIDType.Method_2, Moves = new(273, 187) }, // Drowzee with Wish & Belly Drum
+        new() { Species = 102, IsEgg = true, Fateful = true, Level = 05, TID = -1, SID = -1, Version = GameVersion.FRLG, Method = PIDType.Method_2, Moves = new(273, 230) }, // Exeggcute with Wish & Sweet Scent
+        new() { Species = 108, IsEgg = true, Fateful = true, Level = 05, TID = -1, SID = -1, Version = GameVersion.FRLG, Method = PIDType.Method_2, Moves = new(273, 215) }, // Lickitung with Wish & Heal Bell
+        new() { Species = 113, IsEgg = true, Fateful = true, Level = 05, TID = -1, SID = -1, Version = GameVersion.FRLG, Method = PIDType.Method_2, Moves = new(273, 230) }, // Chansey with Wish & Sweet Scent
+        new() { Species = 115, IsEgg = true, Fateful = true, Level = 05, TID = -1, SID = -1, Version = GameVersion.FRLG, Method = PIDType.Method_2, Moves = new(273, 281) }, // Kangaskhan with Wish & Yawn
 
         // PokePark Eggs - Wondercard
-        new() { Species = 054, IsEgg = true, Fateful = true, Level = 05, TID = -1, SID = -1, Version = GameVersion.FRLG, Moves = new[]{300}, Method = PIDType.Method_2 }, // Psyduck with Mud Sport
-        new() { Species = 172, IsEgg = true, Fateful = true, Level = 05, TID = -1, SID = -1, Version = GameVersion.FRLG, Moves = new[]{266}, Method = PIDType.Method_2 }, // Pichu with Follow me
-        new() { Species = 174, IsEgg = true, Fateful = true, Level = 05, TID = -1, SID = -1, Version = GameVersion.FRLG, Moves = new[]{321}, Method = PIDType.Method_2 }, // Igglybuff with Tickle
-        new() { Species = 222, IsEgg = true, Fateful = true, Level = 05, TID = -1, SID = -1, Version = GameVersion.FRLG, Moves = new[]{300}, Method = PIDType.Method_2 }, // Corsola with Mud Sport
-        new() { Species = 276, IsEgg = true, Fateful = true, Level = 05, TID = -1, SID = -1, Version = GameVersion.FRLG, Moves = new[]{297}, Method = PIDType.Method_2 }, // Taillow with Feather Dance
-        new() { Species = 283, IsEgg = true, Fateful = true, Level = 05, TID = -1, SID = -1, Version = GameVersion.FRLG, Moves = new[]{300}, Method = PIDType.Method_2 }, // Surskit with Mud Sport
-        new() { Species = 293, IsEgg = true, Fateful = true, Level = 05, TID = -1, SID = -1, Version = GameVersion.FRLG, Moves = new[]{298}, Method = PIDType.Method_2 }, // Whismur with Teeter Dance
-        new() { Species = 300, IsEgg = true, Fateful = true, Level = 05, TID = -1, SID = -1, Version = GameVersion.FRLG, Moves = new[]{205}, Method = PIDType.Method_2 }, // Skitty with Rollout
-        new() { Species = 311, IsEgg = true, Fateful = true, Level = 05, TID = -1, SID = -1, Version = GameVersion.FRLG, Moves = new[]{346}, Method = PIDType.Method_2 }, // Plusle with Water Sport
-        new() { Species = 312, IsEgg = true, Fateful = true, Level = 05, TID = -1, SID = -1, Version = GameVersion.FRLG, Moves = new[]{300}, Method = PIDType.Method_2 }, // Minun with Mud Sport
-        new() { Species = 325, IsEgg = true, Fateful = true, Level = 05, TID = -1, SID = -1, Version = GameVersion.FRLG, Moves = new[]{253}, Method = PIDType.Method_2 }, // Spoink with Uproar
-        new() { Species = 327, IsEgg = true, Fateful = true, Level = 05, TID = -1, SID = -1, Version = GameVersion.FRLG, Moves = new[]{047}, Method = PIDType.Method_2 }, // Spinda with Sing
-        new() { Species = 331, IsEgg = true, Fateful = true, Level = 05, TID = -1, SID = -1, Version = GameVersion.FRLG, Moves = new[]{227}, Method = PIDType.Method_2 }, // Cacnea with Encore
-        new() { Species = 341, IsEgg = true, Fateful = true, Level = 05, TID = -1, SID = -1, Version = GameVersion.FRLG, Moves = new[]{346}, Method = PIDType.Method_2 }, // Corphish with Water Sport
-        new() { Species = 360, IsEgg = true, Fateful = true, Level = 05, TID = -1, SID = -1, Version = GameVersion.FRLG, Moves = new[]{321}, Method = PIDType.Method_2 }, // Wynaut with Tickle
+        new() { Species = 054, IsEgg = true, Fateful = true, Level = 05, TID = -1, SID = -1, Version = GameVersion.FRLG, Moves = new(300), Method = PIDType.Method_2 }, // Psyduck with Mud Sport
+        new() { Species = 172, IsEgg = true, Fateful = true, Level = 05, TID = -1, SID = -1, Version = GameVersion.FRLG, Moves = new(266), Method = PIDType.Method_2 }, // Pichu with Follow me
+        new() { Species = 174, IsEgg = true, Fateful = true, Level = 05, TID = -1, SID = -1, Version = GameVersion.FRLG, Moves = new(321), Method = PIDType.Method_2 }, // Igglybuff with Tickle
+        new() { Species = 222, IsEgg = true, Fateful = true, Level = 05, TID = -1, SID = -1, Version = GameVersion.FRLG, Moves = new(300), Method = PIDType.Method_2 }, // Corsola with Mud Sport
+        new() { Species = 276, IsEgg = true, Fateful = true, Level = 05, TID = -1, SID = -1, Version = GameVersion.FRLG, Moves = new(297), Method = PIDType.Method_2 }, // Taillow with Feather Dance
+        new() { Species = 283, IsEgg = true, Fateful = true, Level = 05, TID = -1, SID = -1, Version = GameVersion.FRLG, Moves = new(300), Method = PIDType.Method_2 }, // Surskit with Mud Sport
+        new() { Species = 293, IsEgg = true, Fateful = true, Level = 05, TID = -1, SID = -1, Version = GameVersion.FRLG, Moves = new(298), Method = PIDType.Method_2 }, // Whismur with Teeter Dance
+        new() { Species = 300, IsEgg = true, Fateful = true, Level = 05, TID = -1, SID = -1, Version = GameVersion.FRLG, Moves = new(205), Method = PIDType.Method_2 }, // Skitty with Rollout
+        new() { Species = 311, IsEgg = true, Fateful = true, Level = 05, TID = -1, SID = -1, Version = GameVersion.FRLG, Moves = new(346), Method = PIDType.Method_2 }, // Plusle with Water Sport
+        new() { Species = 312, IsEgg = true, Fateful = true, Level = 05, TID = -1, SID = -1, Version = GameVersion.FRLG, Moves = new(300), Method = PIDType.Method_2 }, // Minun with Mud Sport
+        new() { Species = 325, IsEgg = true, Fateful = true, Level = 05, TID = -1, SID = -1, Version = GameVersion.FRLG, Moves = new(253), Method = PIDType.Method_2 }, // Spoink with Uproar
+        new() { Species = 327, IsEgg = true, Fateful = true, Level = 05, TID = -1, SID = -1, Version = GameVersion.FRLG, Moves = new(047), Method = PIDType.Method_2 }, // Spinda with Sing
+        new() { Species = 331, IsEgg = true, Fateful = true, Level = 05, TID = -1, SID = -1, Version = GameVersion.FRLG, Moves = new(227), Method = PIDType.Method_2 }, // Cacnea with Encore
+        new() { Species = 341, IsEgg = true, Fateful = true, Level = 05, TID = -1, SID = -1, Version = GameVersion.FRLG, Moves = new(346), Method = PIDType.Method_2 }, // Corphish with Water Sport
+        new() { Species = 360, IsEgg = true, Fateful = true, Level = 05, TID = -1, SID = -1, Version = GameVersion.FRLG, Moves = new(321), Method = PIDType.Method_2 }, // Wynaut with Tickle
     };
 
     internal static readonly WC3[] Encounter_Event3_RS =
     {
         // PCJP - Pokémon Center 5th Anniversary Eggs (April 25 to May 18, 2003)
-        new() { Species = 172, IsEgg = true, Level = 05, OT_Name = "オヤＮＡＭＥ", TID = -1, SID = -1, Version = GameVersion.R, Method = PIDType.BACD_R, Moves = new[]{298} }, // Pichu with Teeter Dance
-        new() { Species = 172, IsEgg = true, Level = 05, OT_Name = "オヤＮＡＭＥ", TID = -1, SID = -1, Version = GameVersion.R, Method = PIDType.BACD_R, Moves = new[]{273} }, // Pichu with Wish
-        new() { Species = 172, IsEgg = true, Level = 05, OT_Name = "オヤＮＡＭＥ", TID = -1, SID = -1, Version = GameVersion.R, Method = PIDType.BACD_R_S, Moves = new[]{298} }, // Pichu with Teeter Dance
-        new() { Species = 172, IsEgg = true, Level = 05, OT_Name = "オヤＮＡＭＥ", TID = -1, SID = -1, Version = GameVersion.R, Method = PIDType.BACD_R_S, Moves = new[]{273} }, // Pichu with Wish
-        new() { Species = 280, IsEgg = true, Level = 05, OT_Name = "オヤＮＡＭＥ", TID = -1, SID = -1, Version = GameVersion.R, Method = PIDType.BACD_R, Moves = new[]{204 } }, // Ralts with Charm
-        new() { Species = 280, IsEgg = true, Level = 05, OT_Name = "オヤＮＡＭＥ", TID = -1, SID = -1, Version = GameVersion.R, Method = PIDType.BACD_R, Moves = new[]{273} }, // Ralts with Wish
-        new() { Species = 359, IsEgg = true, Level = 05, OT_Name = "オヤＮＡＭＥ", TID = -1, SID = -1, Version = GameVersion.R, Method = PIDType.BACD_R, Moves = new[]{180} }, // Absol with Spite
-        new() { Species = 359, IsEgg = true, Level = 05, OT_Name = "オヤＮＡＭＥ", TID = -1, SID = -1, Version = GameVersion.R, Method = PIDType.BACD_R, Moves = new[]{273} }, // Absol with Wish
-        new() { Species = 371, IsEgg = true, Level = 05, OT_Name = "オヤＮＡＭＥ", TID = -1, SID = -1, Version = GameVersion.R, Method = PIDType.BACD_R, Moves = new[]{334} }, // Bagon with Iron Defense
-        new() { Species = 371, IsEgg = true, Level = 05, OT_Name = "オヤＮＡＭＥ", TID = -1, SID = -1, Version = GameVersion.R, Method = PIDType.BACD_R, Moves = new[]{273} }, // Bagon with Wish
+        new() { Species = 172, IsEgg = true, Level = 05, OT_Name = "オヤＮＡＭＥ", TID = -1, SID = -1, Version = GameVersion.R, Method = PIDType.BACD_R, Moves = new(298) }, // Pichu with Teeter Dance
+        new() { Species = 172, IsEgg = true, Level = 05, OT_Name = "オヤＮＡＭＥ", TID = -1, SID = -1, Version = GameVersion.R, Method = PIDType.BACD_R, Moves = new(273) }, // Pichu with Wish
+        new() { Species = 172, IsEgg = true, Level = 05, OT_Name = "オヤＮＡＭＥ", TID = -1, SID = -1, Version = GameVersion.R, Method = PIDType.BACD_R_S, Moves = new(298) }, // Pichu with Teeter Dance
+        new() { Species = 172, IsEgg = true, Level = 05, OT_Name = "オヤＮＡＭＥ", TID = -1, SID = -1, Version = GameVersion.R, Method = PIDType.BACD_R_S, Moves = new(273) }, // Pichu with Wish
+        new() { Species = 280, IsEgg = true, Level = 05, OT_Name = "オヤＮＡＭＥ", TID = -1, SID = -1, Version = GameVersion.R, Method = PIDType.BACD_R, Moves = new(204 ) }, // Ralts with Charm
+        new() { Species = 280, IsEgg = true, Level = 05, OT_Name = "オヤＮＡＭＥ", TID = -1, SID = -1, Version = GameVersion.R, Method = PIDType.BACD_R, Moves = new(273) }, // Ralts with Wish
+        new() { Species = 359, IsEgg = true, Level = 05, OT_Name = "オヤＮＡＭＥ", TID = -1, SID = -1, Version = GameVersion.R, Method = PIDType.BACD_R, Moves = new(180) }, // Absol with Spite
+        new() { Species = 359, IsEgg = true, Level = 05, OT_Name = "オヤＮＡＭＥ", TID = -1, SID = -1, Version = GameVersion.R, Method = PIDType.BACD_R, Moves = new(273) }, // Absol with Wish
+        new() { Species = 371, IsEgg = true, Level = 05, OT_Name = "オヤＮＡＭＥ", TID = -1, SID = -1, Version = GameVersion.R, Method = PIDType.BACD_R, Moves = new(334) }, // Bagon with Iron Defense
+        new() { Species = 371, IsEgg = true, Level = 05, OT_Name = "オヤＮＡＭＥ", TID = -1, SID = -1, Version = GameVersion.R, Method = PIDType.BACD_R, Moves = new(273) }, // Bagon with Wish
 
         // Negai Boshi Jirachi
         new() { Species = 385, Level = 05, TID = 30719, OT_Gender = 0, OT_Name = "ネガイボシ", Version = GameVersion.R, Method = PIDType.BACD_R, Language = (int)LanguageID.Japanese, Shiny = Shiny.Never },
@@ -122,146 +122,146 @@ internal static class EncountersWC3
         new() { Species = 151, Level = 10, Version = GameVersion.R, Language = (int)LanguageID.Spanish, Method = PIDType.BACD_R, TID = 20078, OT_Name = "Aura", Fateful = true, Shiny = Shiny.Never }, // Mew
 
         // English Events
-        new() { Species = 006, Level = 70, Version = GameVersion.R, Moves = new[] {017,163,082,083}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNIV", Shiny = Shiny.Never }, // Charizard
-        new() { Species = 025, Level = 70, Version = GameVersion.R, Moves = new[] {085,097,087,113}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNIV", Shiny = Shiny.Never }, // Pikachu
-        new() { Species = 144, Level = 70, Version = GameVersion.R, Moves = new[] {097,170,058,115}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNIV", Shiny = Shiny.Never }, // Articuno
-        new() { Species = 243, Level = 70, Version = GameVersion.R, Moves = new[] {098,209,115,242}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNIV", Shiny = Shiny.Never }, // Raikou
-        new() { Species = 244, Level = 70, Version = GameVersion.R, Moves = new[] {083,023,053,207}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNIV", Shiny = Shiny.Never }, // Entei
-        new() { Species = 245, Level = 70, Version = GameVersion.R, Moves = new[] {016,062,054,243}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNIV", Shiny = Shiny.Never }, // Suicune
-        new() { Species = 249, Level = 70, Version = GameVersion.R, Moves = new[] {105,056,240,129}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNIV", Shiny = Shiny.Never }, // Lugia
-        new() { Species = 250, Level = 70, Version = GameVersion.R, Moves = new[] {105,126,241,129}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNIV", Shiny = Shiny.Never }, // Ho-Oh
-        new() { Species = 380, Level = 70, Version = GameVersion.R, Moves = new[] {296,094,105,204}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNIV", Shiny = Shiny.Never }, // Latias
-        new() { Species = 381, Level = 70, Version = GameVersion.R, Moves = new[] {295,094,105,349}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNIV", Shiny = Shiny.Never }, // Latios
+        new() { Species = 006, Level = 70, Version = GameVersion.R, Moves = new(017,163,082,083), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNIV", Shiny = Shiny.Never }, // Charizard
+        new() { Species = 025, Level = 70, Version = GameVersion.R, Moves = new(085,097,087,113), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNIV", Shiny = Shiny.Never }, // Pikachu
+        new() { Species = 144, Level = 70, Version = GameVersion.R, Moves = new(097,170,058,115), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNIV", Shiny = Shiny.Never }, // Articuno
+        new() { Species = 243, Level = 70, Version = GameVersion.R, Moves = new(098,209,115,242), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNIV", Shiny = Shiny.Never }, // Raikou
+        new() { Species = 244, Level = 70, Version = GameVersion.R, Moves = new(083,023,053,207), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNIV", Shiny = Shiny.Never }, // Entei
+        new() { Species = 245, Level = 70, Version = GameVersion.R, Moves = new(016,062,054,243), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNIV", Shiny = Shiny.Never }, // Suicune
+        new() { Species = 249, Level = 70, Version = GameVersion.R, Moves = new(105,056,240,129), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNIV", Shiny = Shiny.Never }, // Lugia
+        new() { Species = 250, Level = 70, Version = GameVersion.R, Moves = new(105,126,241,129), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNIV", Shiny = Shiny.Never }, // Ho-Oh
+        new() { Species = 380, Level = 70, Version = GameVersion.R, Moves = new(296,094,105,204), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNIV", Shiny = Shiny.Never }, // Latias
+        new() { Species = 381, Level = 70, Version = GameVersion.R, Moves = new(295,094,105,349), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNIV", Shiny = Shiny.Never }, // Latios
 
         // French
-        new() { Species = 006, Level = 70, Version = GameVersion.R, Moves = new[] {017,163,082,083}, Language = (int)LanguageID.French, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNIV", Shiny = Shiny.Never }, // Charizard
-        new() { Species = 025, Level = 70, Version = GameVersion.R, Moves = new[] {085,097,087,113}, Language = (int)LanguageID.French, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNIV", Shiny = Shiny.Never }, // Pikachu
-        new() { Species = 144, Level = 70, Version = GameVersion.R, Moves = new[] {097,170,058,115}, Language = (int)LanguageID.French, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNIV", Shiny = Shiny.Never }, // Articuno
-        new() { Species = 243, Level = 70, Version = GameVersion.R, Moves = new[] {098,209,115,242}, Language = (int)LanguageID.French, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNIV", Shiny = Shiny.Never }, // Raikou
-        new() { Species = 244, Level = 70, Version = GameVersion.R, Moves = new[] {083,023,053,207}, Language = (int)LanguageID.French, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNIV", Shiny = Shiny.Never }, // Entei
-        new() { Species = 245, Level = 70, Version = GameVersion.R, Moves = new[] {016,062,054,243}, Language = (int)LanguageID.French, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNIV", Shiny = Shiny.Never }, // Suicune
-        new() { Species = 249, Level = 70, Version = GameVersion.R, Moves = new[] {105,056,240,129}, Language = (int)LanguageID.French, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNIV", Shiny = Shiny.Never }, // Lugia
-        new() { Species = 250, Level = 70, Version = GameVersion.R, Moves = new[] {105,126,241,129}, Language = (int)LanguageID.French, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNIV", Shiny = Shiny.Never }, // Ho-Oh
-        new() { Species = 380, Level = 70, Version = GameVersion.R, Moves = new[] {296,094,105,204}, Language = (int)LanguageID.French, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNIV", Shiny = Shiny.Never }, // Latias
-        new() { Species = 381, Level = 70, Version = GameVersion.R, Moves = new[] {295,094,105,349}, Language = (int)LanguageID.French, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNIV", Shiny = Shiny.Never }, // Latios
+        new() { Species = 006, Level = 70, Version = GameVersion.R, Moves = new(017,163,082,083), Language = (int)LanguageID.French, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNIV", Shiny = Shiny.Never }, // Charizard
+        new() { Species = 025, Level = 70, Version = GameVersion.R, Moves = new(085,097,087,113), Language = (int)LanguageID.French, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNIV", Shiny = Shiny.Never }, // Pikachu
+        new() { Species = 144, Level = 70, Version = GameVersion.R, Moves = new(097,170,058,115), Language = (int)LanguageID.French, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNIV", Shiny = Shiny.Never }, // Articuno
+        new() { Species = 243, Level = 70, Version = GameVersion.R, Moves = new(098,209,115,242), Language = (int)LanguageID.French, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNIV", Shiny = Shiny.Never }, // Raikou
+        new() { Species = 244, Level = 70, Version = GameVersion.R, Moves = new(083,023,053,207), Language = (int)LanguageID.French, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNIV", Shiny = Shiny.Never }, // Entei
+        new() { Species = 245, Level = 70, Version = GameVersion.R, Moves = new(016,062,054,243), Language = (int)LanguageID.French, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNIV", Shiny = Shiny.Never }, // Suicune
+        new() { Species = 249, Level = 70, Version = GameVersion.R, Moves = new(105,056,240,129), Language = (int)LanguageID.French, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNIV", Shiny = Shiny.Never }, // Lugia
+        new() { Species = 250, Level = 70, Version = GameVersion.R, Moves = new(105,126,241,129), Language = (int)LanguageID.French, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNIV", Shiny = Shiny.Never }, // Ho-Oh
+        new() { Species = 380, Level = 70, Version = GameVersion.R, Moves = new(296,094,105,204), Language = (int)LanguageID.French, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNIV", Shiny = Shiny.Never }, // Latias
+        new() { Species = 381, Level = 70, Version = GameVersion.R, Moves = new(295,094,105,349), Language = (int)LanguageID.French, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNIV", Shiny = Shiny.Never }, // Latios
 
         // Italian
-        new() { Species = 006, Level = 70, Version = GameVersion.R, Moves = new[] {017,163,082,083}, Language = (int)LanguageID.Italian, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNI", Shiny = Shiny.Never }, // Charizard
-        new() { Species = 025, Level = 70, Version = GameVersion.R, Moves = new[] {085,097,087,113}, Language = (int)LanguageID.Italian, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNI", Shiny = Shiny.Never }, // Pikachu
-        new() { Species = 144, Level = 70, Version = GameVersion.R, Moves = new[] {097,170,058,115}, Language = (int)LanguageID.Italian, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNI", Shiny = Shiny.Never }, // Articuno
-        new() { Species = 243, Level = 70, Version = GameVersion.R, Moves = new[] {098,209,115,242}, Language = (int)LanguageID.Italian, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNI", Shiny = Shiny.Never }, // Raikou
-        new() { Species = 244, Level = 70, Version = GameVersion.R, Moves = new[] {083,023,053,207}, Language = (int)LanguageID.Italian, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNI", Shiny = Shiny.Never }, // Entei
-        new() { Species = 245, Level = 70, Version = GameVersion.R, Moves = new[] {016,062,054,243}, Language = (int)LanguageID.Italian, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNI", Shiny = Shiny.Never }, // Suicune
-        new() { Species = 249, Level = 70, Version = GameVersion.R, Moves = new[] {105,056,240,129}, Language = (int)LanguageID.Italian, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNI", Shiny = Shiny.Never }, // Lugia
-        new() { Species = 250, Level = 70, Version = GameVersion.R, Moves = new[] {105,126,241,129}, Language = (int)LanguageID.Italian, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNI", Shiny = Shiny.Never }, // Ho-Oh
-        new() { Species = 380, Level = 70, Version = GameVersion.R, Moves = new[] {296,094,105,204}, Language = (int)LanguageID.Italian, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNI", Shiny = Shiny.Never }, // Latias
-        new() { Species = 381, Level = 70, Version = GameVersion.R, Moves = new[] {295,094,105,349}, Language = (int)LanguageID.Italian, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNI", Shiny = Shiny.Never }, // Latios
+        new() { Species = 006, Level = 70, Version = GameVersion.R, Moves = new(017,163,082,083), Language = (int)LanguageID.Italian, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNI", Shiny = Shiny.Never }, // Charizard
+        new() { Species = 025, Level = 70, Version = GameVersion.R, Moves = new(085,097,087,113), Language = (int)LanguageID.Italian, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNI", Shiny = Shiny.Never }, // Pikachu
+        new() { Species = 144, Level = 70, Version = GameVersion.R, Moves = new(097,170,058,115), Language = (int)LanguageID.Italian, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNI", Shiny = Shiny.Never }, // Articuno
+        new() { Species = 243, Level = 70, Version = GameVersion.R, Moves = new(098,209,115,242), Language = (int)LanguageID.Italian, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNI", Shiny = Shiny.Never }, // Raikou
+        new() { Species = 244, Level = 70, Version = GameVersion.R, Moves = new(083,023,053,207), Language = (int)LanguageID.Italian, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNI", Shiny = Shiny.Never }, // Entei
+        new() { Species = 245, Level = 70, Version = GameVersion.R, Moves = new(016,062,054,243), Language = (int)LanguageID.Italian, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNI", Shiny = Shiny.Never }, // Suicune
+        new() { Species = 249, Level = 70, Version = GameVersion.R, Moves = new(105,056,240,129), Language = (int)LanguageID.Italian, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNI", Shiny = Shiny.Never }, // Lugia
+        new() { Species = 250, Level = 70, Version = GameVersion.R, Moves = new(105,126,241,129), Language = (int)LanguageID.Italian, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNI", Shiny = Shiny.Never }, // Ho-Oh
+        new() { Species = 380, Level = 70, Version = GameVersion.R, Moves = new(296,094,105,204), Language = (int)LanguageID.Italian, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNI", Shiny = Shiny.Never }, // Latias
+        new() { Species = 381, Level = 70, Version = GameVersion.R, Moves = new(295,094,105,349), Language = (int)LanguageID.Italian, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANNI", Shiny = Shiny.Never }, // Latios
 
         // German
-        new() { Species = 006, Level = 70, Version = GameVersion.R, Moves = new[] {017,163,082,083}, Language = (int)LanguageID.German, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10JAHRE", Shiny = Shiny.Never }, // Charizard
-        new() { Species = 025, Level = 70, Version = GameVersion.R, Moves = new[] {085,097,087,113}, Language = (int)LanguageID.German, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10JAHRE", Shiny = Shiny.Never }, // Pikachu
-        new() { Species = 144, Level = 70, Version = GameVersion.R, Moves = new[] {097,170,058,115}, Language = (int)LanguageID.German, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10JAHRE", Shiny = Shiny.Never }, // Articuno
-        new() { Species = 243, Level = 70, Version = GameVersion.R, Moves = new[] {098,209,115,242}, Language = (int)LanguageID.German, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10JAHRE", Shiny = Shiny.Never }, // Raikou
-        new() { Species = 244, Level = 70, Version = GameVersion.R, Moves = new[] {083,023,053,207}, Language = (int)LanguageID.German, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10JAHRE", Shiny = Shiny.Never }, // Entei
-        new() { Species = 245, Level = 70, Version = GameVersion.R, Moves = new[] {016,062,054,243}, Language = (int)LanguageID.German, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10JAHRE", Shiny = Shiny.Never }, // Suicune
-        new() { Species = 249, Level = 70, Version = GameVersion.R, Moves = new[] {105,056,240,129}, Language = (int)LanguageID.German, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10JAHRE", Shiny = Shiny.Never }, // Lugia
-        new() { Species = 250, Level = 70, Version = GameVersion.R, Moves = new[] {105,126,241,129}, Language = (int)LanguageID.German, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10JAHRE", Shiny = Shiny.Never }, // Ho-Oh
-        new() { Species = 380, Level = 70, Version = GameVersion.R, Moves = new[] {296,094,105,204}, Language = (int)LanguageID.German, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10JAHRE", Shiny = Shiny.Never }, // Latias
-        new() { Species = 381, Level = 70, Version = GameVersion.R, Moves = new[] {295,094,105,349}, Language = (int)LanguageID.German, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10JAHRE", Shiny = Shiny.Never }, // Latios
+        new() { Species = 006, Level = 70, Version = GameVersion.R, Moves = new(017,163,082,083), Language = (int)LanguageID.German, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10JAHRE", Shiny = Shiny.Never }, // Charizard
+        new() { Species = 025, Level = 70, Version = GameVersion.R, Moves = new(085,097,087,113), Language = (int)LanguageID.German, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10JAHRE", Shiny = Shiny.Never }, // Pikachu
+        new() { Species = 144, Level = 70, Version = GameVersion.R, Moves = new(097,170,058,115), Language = (int)LanguageID.German, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10JAHRE", Shiny = Shiny.Never }, // Articuno
+        new() { Species = 243, Level = 70, Version = GameVersion.R, Moves = new(098,209,115,242), Language = (int)LanguageID.German, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10JAHRE", Shiny = Shiny.Never }, // Raikou
+        new() { Species = 244, Level = 70, Version = GameVersion.R, Moves = new(083,023,053,207), Language = (int)LanguageID.German, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10JAHRE", Shiny = Shiny.Never }, // Entei
+        new() { Species = 245, Level = 70, Version = GameVersion.R, Moves = new(016,062,054,243), Language = (int)LanguageID.German, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10JAHRE", Shiny = Shiny.Never }, // Suicune
+        new() { Species = 249, Level = 70, Version = GameVersion.R, Moves = new(105,056,240,129), Language = (int)LanguageID.German, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10JAHRE", Shiny = Shiny.Never }, // Lugia
+        new() { Species = 250, Level = 70, Version = GameVersion.R, Moves = new(105,126,241,129), Language = (int)LanguageID.German, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10JAHRE", Shiny = Shiny.Never }, // Ho-Oh
+        new() { Species = 380, Level = 70, Version = GameVersion.R, Moves = new(296,094,105,204), Language = (int)LanguageID.German, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10JAHRE", Shiny = Shiny.Never }, // Latias
+        new() { Species = 381, Level = 70, Version = GameVersion.R, Moves = new(295,094,105,349), Language = (int)LanguageID.German, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10JAHRE", Shiny = Shiny.Never }, // Latios
 
         // Spanish
-        new() { Species = 006, Level = 70, Version = GameVersion.R, Moves = new[] {017,163,082,083}, Language = (int)LanguageID.Spanish, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANIV", Shiny = Shiny.Never }, // Charizard
-        new() { Species = 025, Level = 70, Version = GameVersion.R, Moves = new[] {085,097,087,113}, Language = (int)LanguageID.Spanish, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANIV", Shiny = Shiny.Never }, // Pikachu
-        new() { Species = 144, Level = 70, Version = GameVersion.R, Moves = new[] {097,170,058,115}, Language = (int)LanguageID.Spanish, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANIV", Shiny = Shiny.Never }, // Articuno
-        new() { Species = 243, Level = 70, Version = GameVersion.R, Moves = new[] {098,209,115,242}, Language = (int)LanguageID.Spanish, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANIV", Shiny = Shiny.Never }, // Raikou
-        new() { Species = 244, Level = 70, Version = GameVersion.R, Moves = new[] {083,023,053,207}, Language = (int)LanguageID.Spanish, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANIV", Shiny = Shiny.Never }, // Entei
-        new() { Species = 245, Level = 70, Version = GameVersion.R, Moves = new[] {016,062,054,243}, Language = (int)LanguageID.Spanish, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANIV", Shiny = Shiny.Never }, // Suicune
-        new() { Species = 249, Level = 70, Version = GameVersion.R, Moves = new[] {105,056,240,129}, Language = (int)LanguageID.Spanish, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANIV", Shiny = Shiny.Never }, // Lugia
-        new() { Species = 250, Level = 70, Version = GameVersion.R, Moves = new[] {105,126,241,129}, Language = (int)LanguageID.Spanish, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANIV", Shiny = Shiny.Never }, // Ho-Oh
-        new() { Species = 380, Level = 70, Version = GameVersion.R, Moves = new[] {296,094,105,204}, Language = (int)LanguageID.Spanish, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANIV", Shiny = Shiny.Never }, // Latias
-        new() { Species = 381, Level = 70, Version = GameVersion.R, Moves = new[] {295,094,105,349}, Language = (int)LanguageID.Spanish, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANIV", Shiny = Shiny.Never }, // Latios
+        new() { Species = 006, Level = 70, Version = GameVersion.R, Moves = new(017,163,082,083), Language = (int)LanguageID.Spanish, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANIV", Shiny = Shiny.Never }, // Charizard
+        new() { Species = 025, Level = 70, Version = GameVersion.R, Moves = new(085,097,087,113), Language = (int)LanguageID.Spanish, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANIV", Shiny = Shiny.Never }, // Pikachu
+        new() { Species = 144, Level = 70, Version = GameVersion.R, Moves = new(097,170,058,115), Language = (int)LanguageID.Spanish, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANIV", Shiny = Shiny.Never }, // Articuno
+        new() { Species = 243, Level = 70, Version = GameVersion.R, Moves = new(098,209,115,242), Language = (int)LanguageID.Spanish, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANIV", Shiny = Shiny.Never }, // Raikou
+        new() { Species = 244, Level = 70, Version = GameVersion.R, Moves = new(083,023,053,207), Language = (int)LanguageID.Spanish, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANIV", Shiny = Shiny.Never }, // Entei
+        new() { Species = 245, Level = 70, Version = GameVersion.R, Moves = new(016,062,054,243), Language = (int)LanguageID.Spanish, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANIV", Shiny = Shiny.Never }, // Suicune
+        new() { Species = 249, Level = 70, Version = GameVersion.R, Moves = new(105,056,240,129), Language = (int)LanguageID.Spanish, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANIV", Shiny = Shiny.Never }, // Lugia
+        new() { Species = 250, Level = 70, Version = GameVersion.R, Moves = new(105,126,241,129), Language = (int)LanguageID.Spanish, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANIV", Shiny = Shiny.Never }, // Ho-Oh
+        new() { Species = 380, Level = 70, Version = GameVersion.R, Moves = new(296,094,105,204), Language = (int)LanguageID.Spanish, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANIV", Shiny = Shiny.Never }, // Latias
+        new() { Species = 381, Level = 70, Version = GameVersion.R, Moves = new(295,094,105,349), Language = (int)LanguageID.Spanish, Method = PIDType.BACD_R, TID = 06227, OT_Name = "10ANIV", Shiny = Shiny.Never }, // Latios
 
-        new() { Species = 375, Level = 30, Version = GameVersion.R, Moves = new[] {036,093,232,287}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 02005, OT_Name = "ROCKS", OT_Gender = 0, RibbonNational = true, Shiny = Shiny.Never }, // Metang
-        new() { Species = 386, Level = 70, Version = GameVersion.R, Moves = new[] {322,105,354,063}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 28606, OT_Name = "DOEL", Fateful = true, Shiny = Shiny.Never }, // Deoxys
-        new() { Species = 386, Level = 70, Version = GameVersion.R, Moves = new[] {322,105,354,063}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 00010, OT_Name = "SPACE C", Fateful = true, Shiny = Shiny.Never }, // Deoxys
+        new() { Species = 375, Level = 30, Version = GameVersion.R, Moves = new(036,093,232,287), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 02005, OT_Name = "ROCKS", OT_Gender = 0, RibbonNational = true, Shiny = Shiny.Never }, // Metang
+        new() { Species = 386, Level = 70, Version = GameVersion.R, Moves = new(322,105,354,063), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 28606, OT_Name = "DOEL", Fateful = true, Shiny = Shiny.Never }, // Deoxys
+        new() { Species = 386, Level = 70, Version = GameVersion.R, Moves = new(322,105,354,063), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 00010, OT_Name = "SPACE C", Fateful = true, Shiny = Shiny.Never }, // Deoxys
         new() { Species = 151, Level = 10, Version = GameVersion.R, Language = (int)LanguageID.English, Method = PIDType.BACD_U, TID = 06930, OT_Name = "MYSTRY", Fateful = true, Shiny = Shiny.Never }, // Mew
         new() { Species = 151, Level = 10, Version = GameVersion.R, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06930, OT_Name = "MYSTRY", Fateful = true, Shiny = Shiny.Never }, // Mew
 
         // Party of the Decade
-        new() { Species = 001, Level = 70, Version = GameVersion.R, Moves = new[] {230,074,076,235}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06808, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Bulbasaur
-        new() { Species = 006, Level = 70, Version = GameVersion.R, Moves = new[] {017,163,082,083}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06808, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Charizard
-        new() { Species = 009, Level = 70, Version = GameVersion.R, Moves = new[] {182,240,130,056}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06808, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Blastoise
-        new() { Species = 025, Level = 70, Version = GameVersion.R, Moves = new[] {085,087,113,019}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06808, OT_Name = "10 ANIV", HeldItem = 202, Shiny = Shiny.Never }, // Pikachu (Fly)
-        new() { Species = 065, Level = 70, Version = GameVersion.R, Moves = new[] {248,347,094,271}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06808, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Alakazam
-        new() { Species = 144, Level = 70, Version = GameVersion.R, Moves = new[] {097,170,058,115}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06808, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Articuno
-        new() { Species = 145, Level = 70, Version = GameVersion.R, Moves = new[] {097,197,065,268}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06808, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Zapdos
-        new() { Species = 146, Level = 70, Version = GameVersion.R, Moves = new[] {097,203,053,219}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06808, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Moltres
-        new() { Species = 149, Level = 70, Version = GameVersion.R, Moves = new[] {097,219,017,200}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06808, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Dragonite
-        new() { Species = 157, Level = 70, Version = GameVersion.R, Moves = new[] {098,172,129,053}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06808, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Typhlosion
-        new() { Species = 196, Level = 70, Version = GameVersion.R, Moves = new[] {060,244,094,234}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06808, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Espeon
-        new() { Species = 197, Level = 70, Version = GameVersion.R, Moves = new[] {185,212,103,236}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06808, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Umbreon
-        new() { Species = 243, Level = 70, Version = GameVersion.R, Moves = new[] {098,209,115,242}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06808, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Raikou
-        new() { Species = 244, Level = 70, Version = GameVersion.R, Moves = new[] {083,023,053,207}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06808, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Entei
-        new() { Species = 245, Level = 70, Version = GameVersion.R, Moves = new[] {016,062,054,243}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06808, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Suicune
-        new() { Species = 248, Level = 70, Version = GameVersion.R, Moves = new[] {037,184,242,089}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06808, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Tyranitar
-        new() { Species = 257, Level = 70, Version = GameVersion.R, Moves = new[] {299,163,119,327}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06808, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Blaziken
-        new() { Species = 359, Level = 70, Version = GameVersion.R, Moves = new[] {104,163,248,195}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06808, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Absol
-        new() { Species = 380, Level = 70, Version = GameVersion.R, Moves = new[] {296,094,105,204}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06808, OT_Name = "10 ANIV", HeldItem = 191, Shiny = Shiny.Never }, // Latias
-        new() { Species = 381, Level = 70, Version = GameVersion.R, Moves = new[] {295,094,105,349}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06808, OT_Name = "10 ANIV", HeldItem = 191, Shiny = Shiny.Never }, // Latios
+        new() { Species = 001, Level = 70, Version = GameVersion.R, Moves = new(230,074,076,235), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06808, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Bulbasaur
+        new() { Species = 006, Level = 70, Version = GameVersion.R, Moves = new(017,163,082,083), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06808, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Charizard
+        new() { Species = 009, Level = 70, Version = GameVersion.R, Moves = new(182,240,130,056), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06808, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Blastoise
+        new() { Species = 025, Level = 70, Version = GameVersion.R, Moves = new(085,087,113,019), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06808, OT_Name = "10 ANIV", HeldItem = 202, Shiny = Shiny.Never }, // Pikachu (Fly)
+        new() { Species = 065, Level = 70, Version = GameVersion.R, Moves = new(248,347,094,271), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06808, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Alakazam
+        new() { Species = 144, Level = 70, Version = GameVersion.R, Moves = new(097,170,058,115), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06808, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Articuno
+        new() { Species = 145, Level = 70, Version = GameVersion.R, Moves = new(097,197,065,268), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06808, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Zapdos
+        new() { Species = 146, Level = 70, Version = GameVersion.R, Moves = new(097,203,053,219), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06808, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Moltres
+        new() { Species = 149, Level = 70, Version = GameVersion.R, Moves = new(097,219,017,200), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06808, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Dragonite
+        new() { Species = 157, Level = 70, Version = GameVersion.R, Moves = new(098,172,129,053), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06808, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Typhlosion
+        new() { Species = 196, Level = 70, Version = GameVersion.R, Moves = new(060,244,094,234), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06808, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Espeon
+        new() { Species = 197, Level = 70, Version = GameVersion.R, Moves = new(185,212,103,236), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06808, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Umbreon
+        new() { Species = 243, Level = 70, Version = GameVersion.R, Moves = new(098,209,115,242), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06808, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Raikou
+        new() { Species = 244, Level = 70, Version = GameVersion.R, Moves = new(083,023,053,207), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06808, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Entei
+        new() { Species = 245, Level = 70, Version = GameVersion.R, Moves = new(016,062,054,243), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06808, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Suicune
+        new() { Species = 248, Level = 70, Version = GameVersion.R, Moves = new(037,184,242,089), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06808, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Tyranitar
+        new() { Species = 257, Level = 70, Version = GameVersion.R, Moves = new(299,163,119,327), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06808, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Blaziken
+        new() { Species = 359, Level = 70, Version = GameVersion.R, Moves = new(104,163,248,195), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06808, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Absol
+        new() { Species = 380, Level = 70, Version = GameVersion.R, Moves = new(296,094,105,204), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06808, OT_Name = "10 ANIV", HeldItem = 191, Shiny = Shiny.Never }, // Latias
+        new() { Species = 381, Level = 70, Version = GameVersion.R, Moves = new(295,094,105,349), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 06808, OT_Name = "10 ANIV", HeldItem = 191, Shiny = Shiny.Never }, // Latios
 
         // Journey Across America
-        new() { Species = 001, Level = 70, Version = GameVersion.R, Moves = new[] {230,074,076,235}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 00010, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Bulbasaur
-        new() { Species = 006, Level = 70, Version = GameVersion.R, Moves = new[] {017,163,082,083}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 00010, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Charizard
-        new() { Species = 009, Level = 70, Version = GameVersion.R, Moves = new[] {182,240,130,056}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 00010, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Blastoise
-        new() { Species = 025, Level = 70, Version = GameVersion.R, Moves = new[] {085,097,087,113}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 00010, OT_Name = "10 ANIV", HeldItem = 202, Shiny = Shiny.Never }, // Pikachu (No Fly)
-        new() { Species = 065, Level = 70, Version = GameVersion.R, Moves = new[] {248,347,094,271}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 00010, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Alakazam
-        new() { Species = 144, Level = 70, Version = GameVersion.R, Moves = new[] {097,170,058,115}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 00010, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Articuno
-        new() { Species = 145, Level = 70, Version = GameVersion.R, Moves = new[] {097,197,065,268}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 00010, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Zapdos
-        new() { Species = 146, Level = 70, Version = GameVersion.R, Moves = new[] {097,203,053,219}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 00010, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Moltres
-        new() { Species = 149, Level = 70, Version = GameVersion.R, Moves = new[] {097,219,017,200}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 00010, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Dragonite
-        new() { Species = 157, Level = 70, Version = GameVersion.R, Moves = new[] {098,172,129,053}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 00010, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Typhlosion
-        new() { Species = 196, Level = 70, Version = GameVersion.R, Moves = new[] {060,244,094,234}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 00010, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Espeon
-        new() { Species = 197, Level = 70, Version = GameVersion.R, Moves = new[] {185,212,103,236}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 00010, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Umbreon
-        new() { Species = 243, Level = 70, Version = GameVersion.R, Moves = new[] {098,209,115,242}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 00010, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Raikou
-        new() { Species = 244, Level = 70, Version = GameVersion.R, Moves = new[] {083,023,053,207}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 00010, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Entei
-        new() { Species = 245, Level = 70, Version = GameVersion.R, Moves = new[] {016,062,054,243}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 00010, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Suicune
-        new() { Species = 248, Level = 70, Version = GameVersion.R, Moves = new[] {037,184,242,089}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 00010, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Tyranitar
-        new() { Species = 251, Level = 70, Version = GameVersion.R, Moves = new[] {246,248,226,195}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 00010, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Celebi
-        new() { Species = 257, Level = 70, Version = GameVersion.R, Moves = new[] {299,163,119,327}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 00010, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Blaziken
-        new() { Species = 359, Level = 70, Version = GameVersion.R, Moves = new[] {104,163,248,195}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 00010, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Absol
-        new() { Species = 380, Level = 70, Version = GameVersion.R, Moves = new[] {296,094,105,204}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 00010, OT_Name = "10 ANIV", HeldItem = 191, Shiny = Shiny.Never }, // Latias
-        new() { Species = 381, Level = 70, Version = GameVersion.R, Moves = new[] {295,094,105,349}, Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 00010, OT_Name = "10 ANIV", HeldItem = 191, Shiny = Shiny.Never }, // Latios
+        new() { Species = 001, Level = 70, Version = GameVersion.R, Moves = new(230,074,076,235), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 00010, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Bulbasaur
+        new() { Species = 006, Level = 70, Version = GameVersion.R, Moves = new(017,163,082,083), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 00010, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Charizard
+        new() { Species = 009, Level = 70, Version = GameVersion.R, Moves = new(182,240,130,056), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 00010, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Blastoise
+        new() { Species = 025, Level = 70, Version = GameVersion.R, Moves = new(085,097,087,113), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 00010, OT_Name = "10 ANIV", HeldItem = 202, Shiny = Shiny.Never }, // Pikachu (No Fly)
+        new() { Species = 065, Level = 70, Version = GameVersion.R, Moves = new(248,347,094,271), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 00010, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Alakazam
+        new() { Species = 144, Level = 70, Version = GameVersion.R, Moves = new(097,170,058,115), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 00010, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Articuno
+        new() { Species = 145, Level = 70, Version = GameVersion.R, Moves = new(097,197,065,268), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 00010, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Zapdos
+        new() { Species = 146, Level = 70, Version = GameVersion.R, Moves = new(097,203,053,219), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 00010, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Moltres
+        new() { Species = 149, Level = 70, Version = GameVersion.R, Moves = new(097,219,017,200), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 00010, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Dragonite
+        new() { Species = 157, Level = 70, Version = GameVersion.R, Moves = new(098,172,129,053), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 00010, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Typhlosion
+        new() { Species = 196, Level = 70, Version = GameVersion.R, Moves = new(060,244,094,234), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 00010, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Espeon
+        new() { Species = 197, Level = 70, Version = GameVersion.R, Moves = new(185,212,103,236), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 00010, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Umbreon
+        new() { Species = 243, Level = 70, Version = GameVersion.R, Moves = new(098,209,115,242), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 00010, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Raikou
+        new() { Species = 244, Level = 70, Version = GameVersion.R, Moves = new(083,023,053,207), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 00010, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Entei
+        new() { Species = 245, Level = 70, Version = GameVersion.R, Moves = new(016,062,054,243), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 00010, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Suicune
+        new() { Species = 248, Level = 70, Version = GameVersion.R, Moves = new(037,184,242,089), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 00010, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Tyranitar
+        new() { Species = 251, Level = 70, Version = GameVersion.R, Moves = new(246,248,226,195), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 00010, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Celebi
+        new() { Species = 257, Level = 70, Version = GameVersion.R, Moves = new(299,163,119,327), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 00010, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Blaziken
+        new() { Species = 359, Level = 70, Version = GameVersion.R, Moves = new(104,163,248,195), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 00010, OT_Name = "10 ANIV", Shiny = Shiny.Never }, // Absol
+        new() { Species = 380, Level = 70, Version = GameVersion.R, Moves = new(296,094,105,204), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 00010, OT_Name = "10 ANIV", HeldItem = 191, Shiny = Shiny.Never }, // Latias
+        new() { Species = 381, Level = 70, Version = GameVersion.R, Moves = new(295,094,105,349), Language = (int)LanguageID.English, Method = PIDType.BACD_R, TID = 00010, OT_Name = "10 ANIV", HeldItem = 191, Shiny = Shiny.Never }, // Latios
     };
 
     internal static readonly WC3[] Encounter_Event3_Common =
     {
         // Pokémon Box -- RSE Recipient
-        new() { Species = 333, IsEgg = true, Level = 05, Moves = new[]{206}, Method = PIDType.BACD_U, OT_Gender = 1, OT_Name = "ＡＺＵＳＡ", Version = GameVersion.RSE }, // Swablu Egg with False Swipe
-        new() { Species = 263, IsEgg = true, Level = 05, Moves = new[]{245}, Method = PIDType.BACD_U, OT_Gender = 1, OT_Name = "ＡＺＵＳＡ", Version = GameVersion.RSE }, // Zigzagoon Egg with Extreme Speed
-        new() { Species = 300, IsEgg = true, Level = 05, Moves = new[]{006}, Method = PIDType.BACD_U, OT_Gender = 1, OT_Name = "ＡＺＵＳＡ", Version = GameVersion.RSE }, // Skitty Egg with Pay Day
-        new() { Species = 172, IsEgg = true, Level = 05, Moves = new[]{057}, Method = PIDType.BACD_U, OT_Gender = 1, OT_Name = "ＡＺＵＳＡ", Version = GameVersion.RSE }, // Pichu Egg with Surf
+        new() { Species = 333, IsEgg = true, Level = 05, Moves = new(206), Method = PIDType.BACD_U, OT_Gender = 1, OT_Name = "ＡＺＵＳＡ", Version = GameVersion.RSE }, // Swablu Egg with False Swipe
+        new() { Species = 263, IsEgg = true, Level = 05, Moves = new(245), Method = PIDType.BACD_U, OT_Gender = 1, OT_Name = "ＡＺＵＳＡ", Version = GameVersion.RSE }, // Zigzagoon Egg with Extreme Speed
+        new() { Species = 300, IsEgg = true, Level = 05, Moves = new(006), Method = PIDType.BACD_U, OT_Gender = 1, OT_Name = "ＡＺＵＳＡ", Version = GameVersion.RSE }, // Skitty Egg with Pay Day
+        new() { Species = 172, IsEgg = true, Level = 05, Moves = new(057), Method = PIDType.BACD_U, OT_Gender = 1, OT_Name = "ＡＺＵＳＡ", Version = GameVersion.RSE }, // Pichu Egg with Surf
         // Pokémon Box -- FRLG Recipient
-        new() { Species = 333, IsEgg = true, Level = 05, Moves = new[]{206}, Method = PIDType.BACD_U, OT_Gender = 1, OT_Name = "ＡＺＵＳＡ", Version = GameVersion.FRLG }, // Swablu Egg with False Swipe
-        new() { Species = 263, IsEgg = true, Level = 05, Moves = new[]{245}, Method = PIDType.BACD_U, OT_Gender = 1, OT_Name = "ＡＺＵＳＡ", Version = GameVersion.FRLG }, // Zigzagoon Egg with Extreme Speed
-        new() { Species = 300, IsEgg = true, Level = 05, Moves = new[]{006}, Method = PIDType.BACD_U, OT_Gender = 1, OT_Name = "ＡＺＵＳＡ", Version = GameVersion.FRLG }, // Skitty Egg with Pay Day
-        new() { Species = 172, IsEgg = true, Level = 05, Moves = new[]{057}, Method = PIDType.BACD_U, OT_Gender = 1, OT_Name = "ＡＺＵＳＡ", Version = GameVersion.FRLG }, // Pichu Egg with Surf
+        new() { Species = 333, IsEgg = true, Level = 05, Moves = new(206), Method = PIDType.BACD_U, OT_Gender = 1, OT_Name = "ＡＺＵＳＡ", Version = GameVersion.FRLG }, // Swablu Egg with False Swipe
+        new() { Species = 263, IsEgg = true, Level = 05, Moves = new(245), Method = PIDType.BACD_U, OT_Gender = 1, OT_Name = "ＡＺＵＳＡ", Version = GameVersion.FRLG }, // Zigzagoon Egg with Extreme Speed
+        new() { Species = 300, IsEgg = true, Level = 05, Moves = new(006), Method = PIDType.BACD_U, OT_Gender = 1, OT_Name = "ＡＺＵＳＡ", Version = GameVersion.FRLG }, // Skitty Egg with Pay Day
+        new() { Species = 172, IsEgg = true, Level = 05, Moves = new(057), Method = PIDType.BACD_U, OT_Gender = 1, OT_Name = "ＡＺＵＳＡ", Version = GameVersion.FRLG }, // Pichu Egg with Surf
 
         // PokePark Eggs - DS Download Play
-        new() { Species = 054, IsEgg = true, Level = 05, Met_Level = 05, TID = 50318, OT_Gender = 0, OT_Name = "ポケパーク", Version = GameVersion.R, Moves = new[]{300}, Method = PIDType.BACD_R }, // Psyduck with Mud Sport
-        new() { Species = 172, IsEgg = true, Level = 05, Met_Level = 05, TID = 50318, OT_Gender = 0, OT_Name = "ポケパーク", Version = GameVersion.R, Moves = new[]{266}, Method = PIDType.BACD_R }, // Pichu with Follow me
-        new() { Species = 174, IsEgg = true, Level = 05, Met_Level = 05, TID = 50318, OT_Gender = 0, OT_Name = "ポケパーク", Version = GameVersion.R, Moves = new[]{321}, Method = PIDType.BACD_R }, // Igglybuff with Tickle
-        new() { Species = 222, IsEgg = true, Level = 05, Met_Level = 05, TID = 50318, OT_Gender = 0, OT_Name = "ポケパーク", Version = GameVersion.R, Moves = new[]{300}, Method = PIDType.BACD_R }, // Corsola with Mud Sport
-        new() { Species = 276, IsEgg = true, Level = 05, Met_Level = 05, TID = 50318, OT_Gender = 0, OT_Name = "ポケパーク", Version = GameVersion.R, Moves = new[]{297}, Method = PIDType.BACD_R }, // Taillow with Feather Dance
-        new() { Species = 283, IsEgg = true, Level = 05, Met_Level = 05, TID = 50318, OT_Gender = 0, OT_Name = "ポケパーク", Version = GameVersion.R, Moves = new[]{300}, Method = PIDType.BACD_R }, // Surskit with Mud Sport
-        new() { Species = 293, IsEgg = true, Level = 05, Met_Level = 05, TID = 50318, OT_Gender = 0, OT_Name = "ポケパーク", Version = GameVersion.R, Moves = new[]{298}, Method = PIDType.BACD_R }, // Whismur with Teeter Dance
-        new() { Species = 300, IsEgg = true, Level = 05, Met_Level = 05, TID = 50318, OT_Gender = 0, OT_Name = "ポケパーク", Version = GameVersion.R, Moves = new[]{205}, Method = PIDType.BACD_R }, // Skitty with Rollout
-        new() { Species = 311, IsEgg = true, Level = 05, Met_Level = 05, TID = 50318, OT_Gender = 0, OT_Name = "ポケパーク", Version = GameVersion.R, Moves = new[]{346}, Method = PIDType.BACD_R }, // Plusle with Water Sport
-        new() { Species = 312, IsEgg = true, Level = 05, Met_Level = 05, TID = 50318, OT_Gender = 0, OT_Name = "ポケパーク", Version = GameVersion.R, Moves = new[]{300}, Method = PIDType.BACD_R }, // Minun with Mud Sport
-        new() { Species = 325, IsEgg = true, Level = 05, Met_Level = 05, TID = 50318, OT_Gender = 0, OT_Name = "ポケパーク", Version = GameVersion.R, Moves = new[]{253}, Method = PIDType.BACD_R }, // Spoink with Uproar
-        new() { Species = 327, IsEgg = true, Level = 05, Met_Level = 05, TID = 50318, OT_Gender = 0, OT_Name = "ポケパーク", Version = GameVersion.R, Moves = new[]{047}, Method = PIDType.BACD_R }, // Spinda with Sing
-        new() { Species = 331, IsEgg = true, Level = 05, Met_Level = 05, TID = 50318, OT_Gender = 0, OT_Name = "ポケパーク", Version = GameVersion.R, Moves = new[]{227}, Method = PIDType.BACD_R }, // Cacnea with Encore
-        new() { Species = 341, IsEgg = true, Level = 05, Met_Level = 05, TID = 50318, OT_Gender = 0, OT_Name = "ポケパーク", Version = GameVersion.R, Moves = new[]{346}, Method = PIDType.BACD_R }, // Corphish with Water Sport
-        new() { Species = 360, IsEgg = true, Level = 05, Met_Level = 05, TID = 50318, OT_Gender = 0, OT_Name = "ポケパーク", Version = GameVersion.R, Moves = new[]{321}, Method = PIDType.BACD_R }, // Wynaut with Tickle
+        new() { Species = 054, IsEgg = true, Level = 05, Met_Level = 05, TID = 50318, OT_Gender = 0, OT_Name = "ポケパーク", Version = GameVersion.R, Moves = new(300), Method = PIDType.BACD_R }, // Psyduck with Mud Sport
+        new() { Species = 172, IsEgg = true, Level = 05, Met_Level = 05, TID = 50318, OT_Gender = 0, OT_Name = "ポケパーク", Version = GameVersion.R, Moves = new(266), Method = PIDType.BACD_R }, // Pichu with Follow me
+        new() { Species = 174, IsEgg = true, Level = 05, Met_Level = 05, TID = 50318, OT_Gender = 0, OT_Name = "ポケパーク", Version = GameVersion.R, Moves = new(321), Method = PIDType.BACD_R }, // Igglybuff with Tickle
+        new() { Species = 222, IsEgg = true, Level = 05, Met_Level = 05, TID = 50318, OT_Gender = 0, OT_Name = "ポケパーク", Version = GameVersion.R, Moves = new(300), Method = PIDType.BACD_R }, // Corsola with Mud Sport
+        new() { Species = 276, IsEgg = true, Level = 05, Met_Level = 05, TID = 50318, OT_Gender = 0, OT_Name = "ポケパーク", Version = GameVersion.R, Moves = new(297), Method = PIDType.BACD_R }, // Taillow with Feather Dance
+        new() { Species = 283, IsEgg = true, Level = 05, Met_Level = 05, TID = 50318, OT_Gender = 0, OT_Name = "ポケパーク", Version = GameVersion.R, Moves = new(300), Method = PIDType.BACD_R }, // Surskit with Mud Sport
+        new() { Species = 293, IsEgg = true, Level = 05, Met_Level = 05, TID = 50318, OT_Gender = 0, OT_Name = "ポケパーク", Version = GameVersion.R, Moves = new(298), Method = PIDType.BACD_R }, // Whismur with Teeter Dance
+        new() { Species = 300, IsEgg = true, Level = 05, Met_Level = 05, TID = 50318, OT_Gender = 0, OT_Name = "ポケパーク", Version = GameVersion.R, Moves = new(205), Method = PIDType.BACD_R }, // Skitty with Rollout
+        new() { Species = 311, IsEgg = true, Level = 05, Met_Level = 05, TID = 50318, OT_Gender = 0, OT_Name = "ポケパーク", Version = GameVersion.R, Moves = new(346), Method = PIDType.BACD_R }, // Plusle with Water Sport
+        new() { Species = 312, IsEgg = true, Level = 05, Met_Level = 05, TID = 50318, OT_Gender = 0, OT_Name = "ポケパーク", Version = GameVersion.R, Moves = new(300), Method = PIDType.BACD_R }, // Minun with Mud Sport
+        new() { Species = 325, IsEgg = true, Level = 05, Met_Level = 05, TID = 50318, OT_Gender = 0, OT_Name = "ポケパーク", Version = GameVersion.R, Moves = new(253), Method = PIDType.BACD_R }, // Spoink with Uproar
+        new() { Species = 327, IsEgg = true, Level = 05, Met_Level = 05, TID = 50318, OT_Gender = 0, OT_Name = "ポケパーク", Version = GameVersion.R, Moves = new(047), Method = PIDType.BACD_R }, // Spinda with Sing
+        new() { Species = 331, IsEgg = true, Level = 05, Met_Level = 05, TID = 50318, OT_Gender = 0, OT_Name = "ポケパーク", Version = GameVersion.R, Moves = new(227), Method = PIDType.BACD_R }, // Cacnea with Encore
+        new() { Species = 341, IsEgg = true, Level = 05, Met_Level = 05, TID = 50318, OT_Gender = 0, OT_Name = "ポケパーク", Version = GameVersion.R, Moves = new(346), Method = PIDType.BACD_R }, // Corphish with Water Sport
+        new() { Species = 360, IsEgg = true, Level = 05, Met_Level = 05, TID = 50318, OT_Gender = 0, OT_Name = "ポケパーク", Version = GameVersion.R, Moves = new(321), Method = PIDType.BACD_R }, // Wynaut with Tickle
     };
 
     internal static readonly WC3[] Encounter_WC3 = ArrayUtil.ConcatAll(Encounter_Event3, Encounter_Event3_RS, Encounter_Event3_FRLG, Encounter_Event3_Common);

--- a/PKHeX.Core/Legality/Encounters/EncounterSlot/EncounterSlot3Swarm.cs
+++ b/PKHeX.Core/Legality/Encounters/EncounterSlot/EncounterSlot3Swarm.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace PKHeX.Core;
 
 /// <summary>
@@ -11,15 +9,14 @@ namespace PKHeX.Core;
 /// <inheritdoc cref="EncounterSlot"/>
 internal sealed record EncounterSlot3Swarm : EncounterSlot3, IMoveset
 {
-    public IReadOnlyList<int> Moves { get; }
+    public Moveset Moves { get; }
 
     public EncounterSlot3Swarm(EncounterArea3 area, ushort species, byte min, byte max, byte slot,
-        IReadOnlyList<int> moves) : base(area, species, 0, min, max, slot, 0, 0, 0, 0) => Moves = moves;
+        Moveset moves) : base(area, species, 0, min, max, slot, 0, 0, 0, 0) => Moves = moves;
 
     protected override void SetEncounterMoves(PKM pk, GameVersion version, int level)
     {
-        var moves = (int[])Moves;
-        pk.SetMoves(moves);
-        pk.SetMaximumPPCurrent(moves);
+        pk.SetMoves(Moves);
+        pk.SetMaximumPPCurrent(Moves);
     }
 }

--- a/PKHeX.Core/Legality/Encounters/EncounterStatic/DreamWorldEntry.cs
+++ b/PKHeX.Core/Legality/Encounters/EncounterStatic/DreamWorldEntry.cs
@@ -37,7 +37,7 @@ internal record DreamWorldEntry(ushort Species, byte Level, ushort Move1 = 0, us
         result[ctr++] = Create(game, a, Move3);
     }
 
-    private EncounterStatic5 Create(GameVersion game, AbilityPermission ability, int move) => new(game)
+    private EncounterStatic5 Create(GameVersion game, AbilityPermission ability, ushort move) => new(game)
     {
         Species = Species,
         Form = Form,
@@ -46,7 +46,7 @@ internal record DreamWorldEntry(ushort Species, byte Level, ushort Move1 = 0, us
         Ability = ability,
         Location = 075,
         Shiny = Shiny.Never,
-        Moves = new[] { move },
+        Moves = new(move),
     };
 
     public static EncounterStatic5[] GetArray(GameVersion game, IReadOnlyList<DreamWorldEntry> t)

--- a/PKHeX.Core/Legality/Encounters/EncounterStatic/EncounterStatic.cs
+++ b/PKHeX.Core/Legality/Encounters/EncounterStatic/EncounterStatic.cs
@@ -37,7 +37,7 @@ public abstract record EncounterStatic(GameVersion Version) : IEncounterable, IM
 
     public Ball FixedBall => Gift ? (Ball)Ball : Core.Ball.None;
 
-    public IReadOnlyList<int> Moves { get; init; } = Array.Empty<int>();
+    public Moveset Moves { get; init; }
     public IReadOnlyList<int> IVs { get; init; } = Array.Empty<int>();
 
     public virtual bool EggEncounter => EggLocation != 0;
@@ -159,9 +159,17 @@ public abstract record EncounterStatic(GameVersion Version) : IEncounterable, IM
 
     protected virtual void SetEncounterMoves(PKM pk, GameVersion version, int level)
     {
-        var moves = Moves.Count > 0 ? (int[])Moves : MoveLevelUp.GetEncounterMoves(pk, level, version);
-        pk.SetMoves(moves);
-        pk.SetMaximumPPCurrent(moves);
+        if (Moves.HasMoves)
+        {
+            pk.SetMoves(Moves);
+            pk.SetMaximumPPCurrent(Moves);
+        }
+        else
+        {
+            var moves = MoveLevelUp.GetEncounterMoves(pk, level, version);
+            pk.SetMoves(moves);
+            pk.SetMaximumPPCurrent(moves);
+        }
     }
 
     protected void SetIVs(PKM pk)

--- a/PKHeX.Core/Legality/Encounters/EncounterStatic/EncounterStatic.cs
+++ b/PKHeX.Core/Legality/Encounters/EncounterStatic/EncounterStatic.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 
 namespace PKHeX.Core;
 
@@ -38,7 +37,7 @@ public abstract record EncounterStatic(GameVersion Version) : IEncounterable, IM
     public Ball FixedBall => Gift ? (Ball)Ball : Core.Ball.None;
 
     public Moveset Moves { get; init; }
-    public IReadOnlyList<int> IVs { get; init; } = Array.Empty<int>();
+    public IndividualValueSet IVs { get; init; }
 
     public virtual bool EggEncounter => EggLocation != 0;
 
@@ -174,8 +173,8 @@ public abstract record EncounterStatic(GameVersion Version) : IEncounterable, IM
 
     protected void SetIVs(PKM pk)
     {
-        if (IVs.Count != 0)
-            pk.SetRandomIVsTemplate((int[])IVs, FlawlessIVCount);
+        if (IVs.IsSpecified)
+            pk.SetRandomIVsTemplate(IVs, FlawlessIVCount);
         else if (FlawlessIVCount > 0)
             pk.SetRandomIVs(minFlawless: FlawlessIVCount);
     }
@@ -257,12 +256,12 @@ public abstract record EncounterStatic(GameVersion Version) : IEncounterable, IM
 
     private bool IsMatchIVs(PKM pk)
     {
-        if (IVs.Count == 0)
+        if (!IVs.IsSpecified)
             return true; // nothing to check, IVs are random
         if (Generation <= 2 && pk.Format > 2)
             return true; // IVs are regenerated on VC transfer upward
 
-        return Legal.GetIsFixedIVSequenceValidSkipRand((int[])IVs, pk);
+        return Legal.GetIsFixedIVSequenceValidSkipRand(IVs, pk);
     }
 
     protected virtual bool IsMatchForm(PKM pk, EvoCriteria evo)

--- a/PKHeX.Core/Legality/Encounters/EncounterStatic/EncounterStatic1.cs
+++ b/PKHeX.Core/Legality/Encounters/EncounterStatic/EncounterStatic1.cs
@@ -23,7 +23,7 @@ public record EncounterStatic1 : EncounterStatic
         base.ApplyDetails(tr, criteria, pk);
 
         var pk1 = (PK1) pk;
-        if (Species == (int) Core.Species.Pikachu && Version == GameVersion.YW && Level == 5 && Moves.Count == 0)
+        if (Species == (int) Core.Species.Pikachu && Version == GameVersion.YW && Level == 5 && !Moves.HasMoves)
         {
             pk1.Catch_Rate = LightBallPikachuCatchRate; // Light Ball
             return;

--- a/PKHeX.Core/Legality/Encounters/EncounterStatic/EncounterStatic7.cs
+++ b/PKHeX.Core/Legality/Encounters/EncounterStatic/EncounterStatic7.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-
 namespace PKHeX.Core;
 
 /// <summary>
@@ -11,7 +8,7 @@ public sealed record EncounterStatic7(GameVersion Version) : EncounterStatic(Ver
 {
     public override int Generation => 7;
     public override EntityContext Context => EntityContext.Gen7;
-    public IReadOnlyList<int> Relearn { get; init; } = Array.Empty<int>();
+    public Moveset Relearn { get; init; }
 
     public bool IsTotem => FormInfo.IsTotemForm(Species, Form);
     public bool IsTotemNoTransfer => Legal.Totem_NoTransfer.Contains(Species);
@@ -19,7 +16,7 @@ public sealed record EncounterStatic7(GameVersion Version) : EncounterStatic(Ver
 
     protected override bool IsMatchLocation(PKM pk)
     {
-        if (EggLocation == Locations.Daycare5 && Relearn.Count == 0 && pk.RelearnMove1 != 0) // Gift Eevee edge case
+        if (EggLocation == Locations.Daycare5 && !Relearn.HasMoves && pk.RelearnMove1 != 0) // Gift Eevee edge case
             return false;
         return base.IsMatchLocation(pk);
     }

--- a/PKHeX.Core/Legality/Encounters/EncounterStatic/EncounterStatic8.cs
+++ b/PKHeX.Core/Legality/Encounters/EncounterStatic/EncounterStatic8.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using static PKHeX.Core.OverworldCorrelation8Requirement;
 
 namespace PKHeX.Core;
@@ -15,7 +13,7 @@ public record EncounterStatic8(GameVersion Version) : EncounterStatic(Version), 
     public bool ScriptedNoMarks { get; init; }
     public bool CanGigantamax { get; set; }
     public byte DynamaxLevel { get; set; }
-    public IReadOnlyList<int> Relearn { get; init; } = Array.Empty<int>();
+    public Moveset Relearn { get; init; }
 
     public AreaWeather8 Weather {get; init; } = AreaWeather8.Normal;
 

--- a/PKHeX.Core/Legality/Encounters/EncounterStatic/EncounterStatic8a.cs
+++ b/PKHeX.Core/Legality/Encounters/EncounterStatic/EncounterStatic8a.cs
@@ -124,9 +124,9 @@ public sealed record EncounterStatic8a(GameVersion Version) : EncounterStatic(Ve
     public bool IsForcedMasteryCorrect(PKM pk)
     {
         ushort alpha = 0;
-        if (IsAlpha && Moves.Count != 0)
+        if (IsAlpha && Moves.HasMoves)
         {
-            if (pk is PA8 pa && (alpha = pa.AlphaMove) != Moves[0])
+            if (pk is PA8 pa && (alpha = pa.AlphaMove) != Moves.Move1)
                 return false;
         }
 
@@ -142,8 +142,8 @@ public sealed record EncounterStatic8a(GameVersion Version) : EncounterStatic(Ve
 
         Span<int> moves = stackalloc int[4];
         var mastery = Legal.MasteryLA[index];
-        if (Moves.Count != 0)
-            moves = (int[])Moves;
+        if (Moves.HasMoves)
+            Moves.CopyTo(moves);
         else
             learn.SetEncounterMoves(level, moves);
 
@@ -171,10 +171,10 @@ public sealed record EncounterStatic8a(GameVersion Version) : EncounterStatic(Ve
 
     public void LoadInitialMoveset(PA8 pa8, Span<int> moves, Learnset learn, int level)
     {
-        if (Moves.Count == 0)
-            learn.SetEncounterMoves(level, moves);
+        if (Moves.HasMoves)
+            Moves.CopyTo(moves);
         else
-            ((int[])Moves).CopyTo(moves);
+            learn.SetEncounterMoves(level, moves);
         if (IsAlpha)
             pa8.AlphaMove = (ushort)moves[0];
     }

--- a/PKHeX.Core/Legality/Encounters/EncounterStatic/EncounterStaticShadow.cs
+++ b/PKHeX.Core/Legality/Encounters/EncounterStatic/EncounterStaticShadow.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace PKHeX.Core;
 
 /// <summary>
@@ -19,9 +17,7 @@ public sealed record EncounterStaticShadow(GameVersion Version, byte ID, short G
     /// <summary>
     /// Originates from the EReader scans (Japanese Only)
     /// </summary>
-    public bool EReader => ReferenceEquals(IVs, EReaderEmpty);
-
-    public static readonly IReadOnlyList<int> EReaderEmpty = new[] {0,0,0,0,0,0};
+    public bool EReader => IVs.IsSpecified;
 
     protected override bool IsMatchLocation(PKM pk)
     {
@@ -89,7 +85,7 @@ public sealed record EncounterStaticShadow(GameVersion Version, byte ID, short G
     private void SetPINGA_EReader(PKM pk)
     {
         // E-Reader have all IVs == 0
-        for (int i = 0; i < IVs.Count; i++)
+        for (int i = 0; i < 6; i++)
             pk.SetIV(i, 0);
 
         // All E-Reader shadows are actually nature/gender locked.

--- a/PKHeX.Core/Legality/Encounters/EncounterTrade/EncounterTrade.cs
+++ b/PKHeX.Core/Legality/Encounters/EncounterTrade/EncounterTrade.cs
@@ -38,7 +38,7 @@ public abstract record EncounterTrade(GameVersion Version) : IEncounterable, IMo
     public ushort SID { get; init; }
 
     public Moveset Moves { get; init; }
-    public IReadOnlyList<int> IVs { get; init; } = Array.Empty<int>();
+    public IndividualValueSet IVs { get; init; }
 
     public Ball FixedBall => (Ball)Ball;
     public bool EggEncounter => false;
@@ -150,8 +150,8 @@ public abstract record EncounterTrade(GameVersion Version) : IEncounterable, IMo
 
     protected void SetIVs(PKM pk)
     {
-        if (IVs.Count != 0)
-            pk.SetRandomIVsTemplate((int[])IVs, 0);
+        if (IVs.IsSpecified)
+            pk.SetRandomIVsTemplate(IVs, 0);
         else
             pk.SetRandomIVs(minFlawless: 3);
     }
@@ -186,9 +186,9 @@ public abstract record EncounterTrade(GameVersion Version) : IEncounterable, IMo
 
     public virtual bool IsMatchExact(PKM pk, EvoCriteria evo)
     {
-        if (IVs.Count != 0)
+        if (IVs.IsSpecified)
         {
-            if (!Legal.GetIsFixedIVSequenceValidSkipRand((int[])IVs, pk))
+            if (!Legal.GetIsFixedIVSequenceValidSkipRand(IVs, pk))
                 return false;
         }
 

--- a/PKHeX.Core/Legality/Encounters/EncounterTrade/EncounterTrade.cs
+++ b/PKHeX.Core/Legality/Encounters/EncounterTrade/EncounterTrade.cs
@@ -37,7 +37,7 @@ public abstract record EncounterTrade(GameVersion Version) : IEncounterable, IMo
     public ushort TID { get; init; }
     public ushort SID { get; init; }
 
-    public IReadOnlyList<int> Moves { get; init; } = Array.Empty<int>();
+    public Moveset Moves { get; init; }
     public IReadOnlyList<int> IVs { get; init; } = Array.Empty<int>();
 
     public Ball FixedBall => (Ball)Ball;
@@ -158,9 +158,17 @@ public abstract record EncounterTrade(GameVersion Version) : IEncounterable, IMo
 
     private void SetMoves(PKM pk, GameVersion version, int level)
     {
-        var moves = Moves.Count != 0 ? Moves : MoveLevelUp.GetEncounterMoves(pk, level, version);
-        pk.SetMoves((int[])moves);
-        pk.SetMaximumPPCurrent((int[])moves);
+        if (Moves.HasMoves)
+        {
+            pk.SetMoves(Moves);
+            pk.SetMaximumPPCurrent(Moves);
+        }
+        else
+        {
+            var moves = MoveLevelUp.GetEncounterMoves(pk, level, version);
+            pk.SetMoves(moves);
+            pk.SetMaximumPPCurrent(moves);
+        }
     }
 
     private void SetEggMetData(PKM pk, DateTime time)

--- a/PKHeX.Core/Legality/Encounters/EncounterTrade/EncounterTrade2.cs
+++ b/PKHeX.Core/Legality/Encounters/EncounterTrade/EncounterTrade2.cs
@@ -28,7 +28,7 @@ public sealed record EncounterTrade2 : EncounterTradeGB
         {
             if (Gender >= 0 && Gender != pk.Gender)
                 return false;
-            if (IVs.Count != 0 && !Legal.GetIsFixedIVSequenceValidNoRand((int[])IVs, pk))
+            if (IVs.IsSpecified && !Legal.GetIsFixedIVSequenceValidNoRand(IVs, pk))
                 return false;
             if (pk.Format == 2 && pk.Met_Location is not (0 or 126))
                 return false;

--- a/PKHeX.Core/Legality/Encounters/EncounterTrade/EncounterTrade8.cs
+++ b/PKHeX.Core/Legality/Encounters/EncounterTrade/EncounterTrade8.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-
 namespace PKHeX.Core;
 
 /// <summary>
@@ -12,7 +9,7 @@ public sealed record EncounterTrade8 : EncounterTrade, IDynamaxLevel, IRelearn, 
     public override int Generation => 8;
     public override EntityContext Context => EntityContext.Gen8;
     public override int Location => Locations.LinkTrade6NPC;
-    public IReadOnlyList<int> Relearn { get; init; } = Array.Empty<int>();
+    public Moveset Relearn { get; init; }
 
     public ushort OT_TextVar { get; set; }
     public byte OT_Memory { get; set; }

--- a/PKHeX.Core/Legality/Encounters/Generator/ByGeneration/EncounterGenerator3.cs
+++ b/PKHeX.Core/Legality/Encounters/Generator/ByGeneration/EncounterGenerator3.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
 
 using static PKHeX.Core.MysteryGiftGenerator;
@@ -225,7 +225,7 @@ public static class EncounterGenerator3
 
     private static bool GetIsShadowLockValid(PKM pk, LegalInfo info, EncounterStaticShadow s)
     {
-        if (s.IVs.Count == 0) // not E-Reader
+        if (!s.EReader)
             return LockFinder.IsAllShadowLockValid(s, info.PIDIV, pk);
 
         // E-Reader have fixed IVs, and aren't recognized as CXD (no PID-IV correlation).

--- a/PKHeX.Core/Legality/Encounters/Information/EncounterSuggestionData.cs
+++ b/PKHeX.Core/Legality/Encounters/Information/EncounterSuggestionData.cs
@@ -1,6 +1,3 @@
-using System;
-using System.Collections.Generic;
-
 namespace PKHeX.Core;
 
 /// <summary>
@@ -17,7 +14,7 @@ public sealed class EncounterSuggestionData : ISpeciesForm, IRelearn
     public byte LevelMin { get; }
     public byte LevelMax { get; }
 
-    public IReadOnlyList<int> Relearn => Encounter is IRelearn { Relearn: int[] { Length: not 0 } r } ? r : Array.Empty<int>();
+    public Moveset Relearn => Encounter is IRelearn r ? r.Relearn : default;
 
     public EncounterSuggestionData(PKM pk, IEncounterable enc, int met)
     {

--- a/PKHeX.Core/Legality/LearnSource/Group/LearnGroup1.cs
+++ b/PKHeX.Core/Legality/LearnSource/Group/LearnGroup1.cs
@@ -130,7 +130,7 @@ public sealed class LearnGroup1 : ILearnGroup
     private static void CheckEncounterMoves(Span<MoveResult> result, ReadOnlySpan<int> current, IEncounterTemplate enc, PKM pk)
     {
         Span<int> moves = stackalloc int[4];
-        if (enc is IMoveset {Moves: int[] {Length: not 0} x})
+        if (enc is IMoveset {Moves: {HasMoves: true} x})
             x.CopyTo(moves);
         else
             GetEncounterMoves(enc, moves);
@@ -235,10 +235,12 @@ public sealed class LearnGroup1 : ILearnGroup
 
     private static void FlagEncounterMoves(IEncounterTemplate enc, Span<bool> result)
     {
-        if (enc is IMoveset { Moves: int[] { Length: not 0 } x })
+        if (enc is IMoveset { Moves: { HasMoves: true } x })
         {
-            foreach (var move in x)
-                result[move] = true;
+            result[x.Move4] = true;
+            result[x.Move3] = true;
+            result[x.Move2] = true;
+            result[x.Move1] = true;
         }
         else
         {

--- a/PKHeX.Core/Legality/LearnSource/Group/LearnGroup2.cs
+++ b/PKHeX.Core/Legality/LearnSource/Group/LearnGroup2.cs
@@ -38,7 +38,7 @@ public sealed class LearnGroup2 : ILearnGroup
     private static void CheckEncounterMoves(Span<MoveResult> result, ReadOnlySpan<int> current, IEncounterTemplate enc)
     {
         Span<int> moves = stackalloc int[4];
-        if (enc is IMoveset { Moves: int[] { Length: not 0 } x })
+        if (enc is IMoveset { Moves: { HasMoves: true } x })
             x.CopyTo(moves);
         else
             GetEncounterMoves(enc, moves);
@@ -168,10 +168,12 @@ public sealed class LearnGroup2 : ILearnGroup
 
     private static void FlagEncounterMoves(IEncounterTemplate enc, Span<bool> result)
     {
-        if (enc is IMoveset { Moves: int[] { Length: not 0 } x })
+        if (enc is IMoveset { Moves: { HasMoves: true } x })
         {
-            foreach (var move in x)
-                result[move] = true;
+            result[x.Move4] = true;
+            result[x.Move3] = true;
+            result[x.Move2] = true;
+            result[x.Move1] = true;
         }
         else
         {

--- a/PKHeX.Core/Legality/LearnSource/Group/LearnGroup3.cs
+++ b/PKHeX.Core/Legality/LearnSource/Group/LearnGroup3.cs
@@ -192,10 +192,12 @@ public sealed class LearnGroup3 : ILearnGroup
 
     private static void FlagEncounterMoves(IEncounterTemplate enc, Span<bool> result)
     {
-        if (enc is IMoveset { Moves: int[] { Length: not 0 } x })
+        if (enc is IMoveset { Moves: { HasMoves: true } x })
         {
-            foreach (var move in x)
-                result[move] = true;
+            result[x.Move4] = true;
+            result[x.Move3] = true;
+            result[x.Move2] = true;
+            result[x.Move1] = true;
         }
     }
 }

--- a/PKHeX.Core/Legality/LearnSource/Group/LearnGroup4.cs
+++ b/PKHeX.Core/Legality/LearnSource/Group/LearnGroup4.cs
@@ -189,10 +189,12 @@ public sealed class LearnGroup4 : ILearnGroup
 
     private static void FlagEncounterMoves(IEncounterTemplate enc, Span<bool> result)
     {
-        if (enc is IMoveset { Moves: int[] { Length: not 0 } x })
+        if (enc is IMoveset { Moves: { HasMoves: true } x })
         {
-            foreach (var move in x)
-                result[move] = true;
+            result[x.Move4] = true;
+            result[x.Move3] = true;
+            result[x.Move2] = true;
+            result[x.Move1] = true;
         }
     }
 }

--- a/PKHeX.Core/Legality/LearnSource/Group/LearnGroup5.cs
+++ b/PKHeX.Core/Legality/LearnSource/Group/LearnGroup5.cs
@@ -142,10 +142,12 @@ public sealed class LearnGroup5 : ILearnGroup
 
     private static void FlagEncounterMoves(IEncounterTemplate enc, Span<bool> result)
     {
-        if (enc is IMoveset { Moves: int[] { Length: not 0 } x })
+        if (enc is IMoveset { Moves: { HasMoves: true } x })
         {
-            foreach (var move in x)
-                result[move] = true;
+            result[x.Move4] = true;
+            result[x.Move3] = true;
+            result[x.Move2] = true;
+            result[x.Move1] = true;
         }
     }
 }

--- a/PKHeX.Core/Legality/LearnSource/Group/LearnGroup6.cs
+++ b/PKHeX.Core/Legality/LearnSource/Group/LearnGroup6.cs
@@ -202,15 +202,19 @@ public sealed class LearnGroup6 : ILearnGroup
 
     private static void FlagEncounterMoves(IEncounterTemplate enc, Span<bool> result)
     {
-        if (enc is IMoveset { Moves: int[] { Length: not 0 } x })
+        if (enc is IMoveset { Moves: { Move1: not 0 } x })
         {
-            foreach (var move in x)
-                result[move] = true;
+            result[x.Move4] = true;
+            result[x.Move3] = true;
+            result[x.Move2] = true;
+            result[x.Move1] = true;
         }
-        if (enc is IRelearn { Relearn: int[] { Length: not 0 } r })
+        if (enc is IRelearn { Relearn: {Move1: not 0} r})
         {
-            foreach (var move in r)
-                result[move] = true;
+            result[r.Move4] = true;
+            result[r.Move3] = true;
+            result[r.Move2] = true;
+            result[r.Move1] = true;
         }
     }
 }

--- a/PKHeX.Core/Legality/LearnSource/Group/LearnGroup7.cs
+++ b/PKHeX.Core/Legality/LearnSource/Group/LearnGroup7.cs
@@ -213,15 +213,19 @@ public sealed class LearnGroup7 : ILearnGroup
 
     private static void FlagEncounterMoves(IEncounterTemplate enc, Span<bool> result)
     {
-        if (enc is IMoveset { Moves: int[] { Length: not 0 } x })
+        if (enc is IMoveset { Moves: { HasMoves: true } x })
         {
-            foreach (var move in x)
-                result[move] = true;
+            result[x.Move4] = true;
+            result[x.Move3] = true;
+            result[x.Move2] = true;
+            result[x.Move1] = true;
         }
-        if (enc is IRelearn { Relearn: int[] { Length: not 0 } r })
+        if (enc is IRelearn { Relearn: { HasMoves: true } r })
         {
-            foreach (var move in r)
-                result[move] = true;
+            result[r.Move4] = true;
+            result[r.Move3] = true;
+            result[r.Move2] = true;
+            result[r.Move1] = true;
         }
     }
 }

--- a/PKHeX.Core/Legality/LearnSource/Group/LearnGroup7b.cs
+++ b/PKHeX.Core/Legality/LearnSource/Group/LearnGroup7b.cs
@@ -52,15 +52,19 @@ public sealed class LearnGroup7b : ILearnGroup
 
     private static void FlagEncounterMoves(IEncounterTemplate enc, Span<bool> result)
     {
-        if (enc is IMoveset { Moves: int[] { Length: not 0 } x })
+        if (enc is IMoveset { Moves: { HasMoves: true } x })
         {
-            foreach (var move in x)
-                result[move] = true;
+            result[x.Move4] = true;
+            result[x.Move3] = true;
+            result[x.Move2] = true;
+            result[x.Move1] = true;
         }
-        if (enc is IRelearn { Relearn: int[] { Length: not 0 } r })
+        if (enc is IRelearn { Relearn: { HasMoves: true } r })
         {
-            foreach (var move in r)
-                result[move] = true;
+            result[r.Move4] = true;
+            result[r.Move3] = true;
+            result[r.Move2] = true;
+            result[r.Move1] = true;
         }
     }
 }

--- a/PKHeX.Core/Legality/LearnSource/Group/LearnGroup8.cs
+++ b/PKHeX.Core/Legality/LearnSource/Group/LearnGroup8.cs
@@ -171,15 +171,19 @@ public sealed class LearnGroup8 : ILearnGroup
 
     private static void FlagEncounterMoves(IEncounterTemplate enc, Span<bool> result)
     {
-        if (enc is IMoveset { Moves: int[] { Length: not 0 } m })
+        if (enc is IMoveset { Moves: { HasMoves: true } x })
         {
-            foreach (var move in m)
-                result[move] = true;
+            result[x.Move4] = true;
+            result[x.Move3] = true;
+            result[x.Move2] = true;
+            result[x.Move1] = true;
         }
-        if (enc is IRelearn { Relearn: int[] { Length: not 0 } r })
+        if (enc is IRelearn { Relearn: { HasMoves: true } r })
         {
-            foreach (var move in r)
-                result[move] = true;
+            result[r.Move4] = true;
+            result[r.Move3] = true;
+            result[r.Move2] = true;
+            result[r.Move1] = true;
         }
     }
 }

--- a/PKHeX.Core/Legality/LearnSource/Group/LearnGroup8a.cs
+++ b/PKHeX.Core/Legality/LearnSource/Group/LearnGroup8a.cs
@@ -75,15 +75,19 @@ public sealed class LearnGroup8a : ILearnGroup
 
     private static void FlagEncounterMoves(IEncounterTemplate enc, Span<bool> result)
     {
-        if (enc is IMoveset { Moves: int[] { Length: not 0 } x })
+        if (enc is IMoveset { Moves: { HasMoves: true } x })
         {
-            foreach (var move in x)
-                result[move] = true;
+            result[x.Move4] = true;
+            result[x.Move3] = true;
+            result[x.Move2] = true;
+            result[x.Move1] = true;
         }
-        if (enc is IRelearn { Relearn: int[] { Length: not 0 } r })
+        if (enc is IRelearn { Relearn: { HasMoves: true } r })
         {
-            foreach (var move in r)
-                result[move] = true;
+            result[r.Move4] = true;
+            result[r.Move3] = true;
+            result[r.Move2] = true;
+            result[r.Move1] = true;
         }
     }
 }

--- a/PKHeX.Core/Legality/LearnSource/Group/LearnGroup8b.cs
+++ b/PKHeX.Core/Legality/LearnSource/Group/LearnGroup8b.cs
@@ -116,15 +116,19 @@ public sealed class LearnGroup8b : ILearnGroup
 
     private static void FlagEncounterMoves(IEncounterTemplate enc, Span<bool> result)
     {
-        if (enc is IMoveset { Moves: int[] { Length: not 0 } x })
+        if (enc is IMoveset { Moves: { HasMoves: true } x })
         {
-            foreach (var move in x)
-                result[move] = true;
+            result[x.Move4] = true;
+            result[x.Move3] = true;
+            result[x.Move2] = true;
+            result[x.Move1] = true;
         }
-        if (enc is IRelearn { Relearn: int[] { Length: not 0 } r })
+        if (enc is IRelearn { Relearn: { HasMoves: true } r })
         {
-            foreach (var move in r)
-                result[move] = true;
+            result[r.Move4] = true;
+            result[r.Move3] = true;
+            result[r.Move2] = true;
+            result[r.Move1] = true;
         }
     }
 }

--- a/PKHeX.Core/Legality/LearnSource/Verify/LearnVerifierHistory.cs
+++ b/PKHeX.Core/Legality/LearnSource/Verify/LearnVerifierHistory.cs
@@ -49,7 +49,7 @@ internal static class LearnVerifierHistory
 
     private static void MarkSpecialMoves(Span<MoveResult> result, ReadOnlySpan<int> current, IEncounterTemplate enc, PKM pk)
     {
-        if (enc is IMoveset { Moves: int[] {Length: not 0} moves})
+        if (enc is IMoveset { Moves: {HasMoves: true} moves})
             MarkInitialMoves(result, current, moves);
         else if (enc is EncounterSlot8GO g)
             MarkInitialMoves(result, current, g.GetInitialMoves(pk.Met_Level));
@@ -69,6 +69,22 @@ internal static class LearnVerifierHistory
 
             game = next;
         }
+    }
+
+    public static void MarkInitialMoves(Span<MoveResult> result, ReadOnlySpan<int> current, Moveset moves)
+    {
+        // If the initial move is present in the current moves, mark that current move index as an initial move.
+        if (moves.Move1 == 0) return;
+        var index = current.IndexOf(moves.Move1); if (index != -1) result[index] = MoveResult.Initial;
+
+        if (moves.Move2 == 0) return;
+        index = current.IndexOf(moves.Move2); if (index != -1) result[index] = MoveResult.Initial;
+
+        if (moves.Move3 == 0) return;
+        index = current.IndexOf(moves.Move3); if (index != -1) result[index] = MoveResult.Initial;
+
+        if (moves.Move4 == 0) return;
+        index = current.IndexOf(moves.Move4); if (index != -1) result[index] = MoveResult.Initial;
     }
 
     public static void MarkInitialMoves(Span<MoveResult> result, ReadOnlySpan<int> current, ReadOnlySpan<int> moves)

--- a/PKHeX.Core/Legality/LearnSource/Verify/LearnVerifierRelearn.cs
+++ b/PKHeX.Core/Legality/LearnSource/Verify/LearnVerifierRelearn.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
 namespace PKHeX.Core;
@@ -13,7 +12,7 @@ public static class LearnVerifierRelearn
     {
         if (ShouldNotHaveRelearnMoves(enc, pk))
             VerifyRelearnNone(pk, result);
-        else if (enc is IRelearn {Relearn: int[] {Length: not 0} x})
+        else if (enc is IRelearn {Relearn: {HasMoves: true} x})
             VerifyRelearnSpecifiedMoveset(pk, x, result);
         else if (enc is EncounterEgg e)
             VerifyEggMoveset(e, result, pk.RelearnMoves);
@@ -27,14 +26,12 @@ public static class LearnVerifierRelearn
 
     public static bool ShouldNotHaveRelearnMoves(IGeneration enc, PKM pk) => enc.Generation < 6 || pk.IsOriginalMovesetDeleted();
 
-    private static void VerifyRelearnSpecifiedMoveset(PKM pk, IReadOnlyList<int> required, Span<MoveResult> result)
+    private static void VerifyRelearnSpecifiedMoveset(PKM pk, Moveset required, Span<MoveResult> result)
     {
-        for (int i = result.Length - 1; i >= 0; i--)
-        {
-            var current = pk.GetRelearnMove(i);
-            var expect = required[i];
-            result[i] = ParseExpect(current, expect);
-        }
+        result[3] = ParseExpect(pk.RelearnMove4, required.Move4);
+        result[2] = ParseExpect(pk.RelearnMove3, required.Move3);
+        result[1] = ParseExpect(pk.RelearnMove2, required.Move2);
+        result[0] = ParseExpect(pk.RelearnMove1, required.Move1);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/PKHeX.Core/Legality/Learnset/Learnset.cs
+++ b/PKHeX.Core/Legality/Learnset/Learnset.cs
@@ -65,45 +65,6 @@ public sealed class Learnset
         return (true, start, end);
     }
 
-    /// <summary>
-    /// Adds the moves a Pokémon can learn between the specified level range.
-    /// </summary>
-    /// <param name="moves">Movepool</param>
-    /// <param name="maxLevel">Maximum level</param>
-    /// <param name="minLevel">Minimum level</param>
-    /// <returns>Array of Move IDs</returns>
-    public List<int> AddMoves(List<int> moves, int maxLevel, int minLevel = 0)
-    {
-        if (minLevel <= 1 && maxLevel >= 100)
-        {
-            moves.AddRange(Moves);
-            return moves;
-        }
-        if (minLevel > maxLevel)
-            return moves;
-        int start = Array.FindIndex(Levels, z => z >= minLevel);
-        if (start < 0)
-            return moves;
-        int end = Array.FindLastIndex(Levels, z => z <= maxLevel);
-        if (end < 0)
-            return moves;
-        for (int i = start; i < end + 1; i++)
-            moves.Add(Moves[i]);
-        return moves;
-    }
-
-    /// <summary>
-    /// Gets the moves a Pokémon can learn between the specified level range as a list.
-    /// </summary>
-    /// <param name="maxLevel">Maximum level</param>
-    /// <param name="minLevel">Minimum level</param>
-    /// <returns>Array of Move IDs</returns>
-    public List<int> GetMoveList(int maxLevel, int minLevel = 0)
-    {
-        var list = new List<int>();
-        return AddMoves(list, maxLevel, minLevel);
-    }
-
     /// <summary>Returns the moves a Pokémon would have if it were encountered at the specified level.</summary>
     /// <remarks>In Generation 1, it is not possible to learn any moves lower than these encounter moves.</remarks>
     /// <param name="level">The level the Pokémon was encountered at.</param>

--- a/PKHeX.Core/Legality/MoveList.cs
+++ b/PKHeX.Core/Legality/MoveList.cs
@@ -9,113 +9,79 @@ namespace PKHeX.Core;
 /// </summary>
 internal static class MoveList
 {
-    internal static int[] GetBaseEggMoves(PKM pk, int species, int form, GameVersion gameSource, int lvl)
+    internal static void GetCurrentMoves(PKM pk, int species, int form, GameVersion gameSource, int lvl, Span<int> moves)
     {
         if (gameSource == Any)
             gameSource = (GameVersion)pk.Version;
 
-        switch (gameSource)
+        _ = gameSource switch
         {
-            case GSC or GS:
-                // If checking back-transfer specimen (GSC->RBY), remove moves that must be deleted prior to transfer
-                static int[] getRBYCompatibleMoves(int format, int[] moves) => format == 1 ? Array.FindAll(moves, m => m <= MaxMoveID_1) : moves;
-                if (pk.InhabitedGeneration(2))
-                    return getRBYCompatibleMoves(pk.Format, LevelUpGS[species].GetMoves(lvl));
-                break;
-            case C:
-                if (pk.InhabitedGeneration(2))
-                    return getRBYCompatibleMoves(pk.Format, LevelUpC[species].GetMoves(lvl));
-                break;
+            GSC or GS => Get(moves, LevelUpGS, species, lvl, pk.Format),
+            C => Get(moves, LevelUpC, species, lvl, pk.Format),
 
-            case R or S or RS:
-                if (pk.InhabitedGeneration(3))
-                    return LevelUpRS[species].GetMoves(lvl);
-                break;
-            case E:
-                if (pk.InhabitedGeneration(3))
-                    return LevelUpE[species].GetMoves(lvl);
-                break;
-            case FR or LG or FRLG:
-                // The only difference in FR/LG is Deoxys, which doesn't breed.
-                if (pk.InhabitedGeneration(3))
-                    return LevelUpFR[species].GetMoves(lvl);
-                break;
+            R or S or RS => Get(moves, LevelUpRS, species, lvl),
+            E => Get(moves, LevelUpE, species, lvl),
+            FR or LG or FRLG => Get(moves, LevelUpFR, species, lvl),
 
-            case D or P or DP:
-                if (pk.InhabitedGeneration(4))
-                    return LevelUpDP[species].GetMoves(lvl);
-                break;
-            case Pt:
-                if (pk.InhabitedGeneration(4))
-                    return LevelUpPt[species].GetMoves(lvl);
-                break;
-            case HG or SS or HGSS:
-                if (pk.InhabitedGeneration(4))
-                    return LevelUpHGSS[species].GetMoves(lvl);
-                break;
+            D or P or DP => Get(moves, LevelUpDP, species, lvl),
+            Pt => Get(moves, LevelUpPt, species, lvl),
+            HG or SS or HGSS => Get(moves, LevelUpHGSS, species, lvl),
 
-            case B or W or BW:
-                if (pk.InhabitedGeneration(5))
-                    return LevelUpBW[species].GetMoves(lvl);
-                break;
+            B or W or BW => Get(moves, LevelUpBW, species, lvl),
+            B2 or W2 or B2W2 => Get(moves, LevelUpB2W2, species, lvl),
 
-            case B2 or W2 or B2W2:
-                if (pk.InhabitedGeneration(5))
-                    return LevelUpB2W2[species].GetMoves(lvl);
-                break;
+            X or Y or XY => Get(moves, LevelUpXY, species, lvl),
+            AS or OR or ORAS => Get(moves, LevelUpAO, species, lvl),
 
-            case X or Y or XY:
-                if (pk.InhabitedGeneration(6))
-                    return LevelUpXY[species].GetMoves(lvl);
-                break;
+            SN or MN or SM => Get(moves, LevelUpSM, PersonalTable.SM, species, form, lvl),
+            US or UM or USUM => Get(moves, LevelUpUSUM, PersonalTable.USUM, species, form, lvl),
+            SW or SH or SWSH => Get(moves, LevelUpSWSH, PersonalTable.SWSH, species, form, lvl),
+            BD or SP or BDSP => Get(moves, LevelUpBDSP, PersonalTable.BDSP, species, form, lvl),
+            PLA => Get(moves, LevelUpLA, PersonalTable.LA, species, form, lvl),
+            _ => moves,
+        };
+    }
 
-            case AS or OR or ORAS:
-                if (pk.InhabitedGeneration(6))
-                    return LevelUpAO[species].GetMoves(lvl);
-                break;
+    private static Span<int> Get(Span<int> moves, Learnset[] source, int species, int lvl)
+    {
+        if ((uint)species >= source.Length)
+            return moves;
+        source[species].SetLevelUpMoves(1, lvl, moves);
+        return moves;
+    }
 
-            case SN or MN or SM:
-                if (species > MaxSpeciesID_7)
-                    break;
-                if (pk.InhabitedGeneration(7))
-                {
-                    int index = PersonalTable.SM.GetFormIndex(species, form);
-                    return LevelUpSM[index].GetMoves(lvl);
-                }
-                break;
+    private static Span<int> Get(Span<int> moves, Learnset[] source, IPersonalTable pt, int species, int form, int lvl)
+    {
+        if (!pt.IsPresentInGame(species, form))
+            return moves;
 
-            case US or UM or USUM:
-                if (pk.InhabitedGeneration(7))
-                {
-                    int index = PersonalTable.USUM.GetFormIndex(species, form);
-                    return LevelUpUSUM[index].GetMoves(lvl);
-                }
-                break;
+        int index = pt.GetFormIndex(species, form);
+        source[index].SetLevelUpMoves(1, lvl, moves);
+        return moves;
+    }
 
-            case SW or SH or SWSH:
-                if (pk.InhabitedGeneration(8))
-                {
-                    int index = PersonalTable.SWSH.GetFormIndex(species, form);
-                    return LevelUpSWSH[index].GetMoves(lvl);
-                }
-                break;
+    private static Span<int> Get(Span<int> moves, Learnset[] source, int species, int lvl, int format)
+    {
+        if ((uint)species > MaxSpeciesID_2)
+            return moves;
 
-            case PLA:
-                if (pk.InhabitedGeneration(8))
-                {
-                    int index = PersonalTable.LA.GetFormIndex(species, form);
-                    return LevelUpLA[index].GetMoves(lvl);
-                }
-                break;
+        source[species].SetLevelUpMoves(1, lvl, moves);
+        if (format != 1)
+            return moves;
 
-            case BD or SP or BDSP:
-                if (pk.InhabitedGeneration(8))
-                {
-                    int index = PersonalTable.BDSP.GetFormIndex(species, form);
-                    return LevelUpBDSP[index].GetMoves(lvl);
-                }
-                break;
+        // If checking back-transfer specimen (GSC->RBY), remove moves that must be deleted prior to transfer
+        // Remove all values greater than MaxMoveID_1, and shift the remaining indexes down.
+        for (int i = 0; i < moves.Length; i++)
+        {
+            if (moves[i] <= MaxMoveID_1)
+                continue;
+            // Shift remaining indexes down, set last index to 0
+            for (int j = i; j < moves.Length - 1; j++)
+                moves[j] = moves[j + 1];
+
+            moves[^1] = 0;
         }
-        return Array.Empty<int>();
+
+        return moves;
     }
 }

--- a/PKHeX.Core/Legality/MoveListSuggest.cs
+++ b/PKHeX.Core/Legality/MoveListSuggest.cs
@@ -12,7 +12,11 @@ public static class MoveListSuggest
     private static int[] GetSuggestedMoves(PKM pk, EvolutionHistory evoChains, MoveSourceType types, IEncounterTemplate enc)
     {
         if (pk.IsEgg && pk.Format <= 5) // pre relearn
-            return MoveList.GetBaseEggMoves(pk, pk.Species, 0, (GameVersion)pk.Version, pk.CurrentLevel);
+        {
+            int[] moves = new int[4];
+            MoveList.GetCurrentMoves(pk, pk.Species, 0, (GameVersion)pk.Version, pk.CurrentLevel, moves);
+            return moves;
+        }
 
         if (types != MoveSourceType.None)
             return GetValidMoves(pk, enc, evoChains, types);
@@ -89,7 +93,7 @@ public static class MoveListSuggest
     // Invalid encounters won't be recognized as an EncounterEgg; check if it *should* be a bred egg.
     private static IReadOnlyList<int> GetSuggestedRelearnInternal(this IEncounterTemplate enc, PKM pk) => enc switch
     {
-        IRelearn { Relearn: int[] { Length: not 0 } r } => r,
+        IRelearn { Relearn: { HasMoves: true } r } => r.ToArray(),
         EncounterEgg or EncounterInvalid {EggEncounter: true} => GetSuggestedRelearnEgg(enc, pk),
         _ => Empty,
     };

--- a/PKHeX.Core/Legality/RNG/Locks/LockFinder.cs
+++ b/PKHeX.Core/Legality/RNG/Locks/LockFinder.cs
@@ -32,7 +32,6 @@ public static class LockFinder
     /// <param name="pv">RNG result PID and IV seed state</param>
     /// <param name="teams">Possible team data setups the NPC trainer has that need to generate before the shadow.</param>
     /// <param name="tsv">Trainer shiny value that is disallowed in XD</param>
-    /// <returns></returns>
     public static bool IsAllShadowLockValid(PIDIV pv, IEnumerable<TeamLock> teams, int tsv = -1)
     {
         foreach (var t in teams)
@@ -69,7 +68,6 @@ public static class LockFinder
     /// <param name="pkPID">PID of the entity</param>
     /// <param name="IV1">First 3 IVs combined</param>
     /// <param name="IV2">Last 3 IVs combined</param>
-    /// <returns></returns>
     public static bool IsColoStarterValid(int species, ref uint seed, int TID, int SID, uint pkPID, uint IV1, uint IV2)
     {
         // reverse the seed the bare minimum

--- a/PKHeX.Core/Legality/RNG/RaidRNG.cs
+++ b/PKHeX.Core/Legality/RNG/RaidRNG.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.CompilerServices;
 
 namespace PKHeX.Core;
@@ -33,23 +33,14 @@ public static class RaidRNG
         ApplyDetailsTo(pk8, seed, IVs, raid.FlawlessIVCount, abil, ratio);
     }
 
-    private static void LoadIVs<T>(T raid, Span<int> IVs) where T : EncounterStatic8Nest<T>
+    private static void LoadIVs<T>(T raid, Span<int> span) where T : EncounterStatic8Nest<T>
     {
-        if (raid.IVs.Count == 0)
-        {
-            IVs.Fill(-1);
-        }
+        // Template stores with speed in middle (standard), convert for generator purpose.
+        var ivs = raid.IVs;
+        if (ivs.IsSpecified)
+            ivs.CopyToSpeedLast(span);
         else
-        {
-            // Template stores with speed in middle (standard), convert for generator purpose.
-            var value = raid.IVs;
-            IVs[5] = value[3]; // spe
-            IVs[4] = value[5]; // spd
-            IVs[3] = value[4]; // spa
-            IVs[2] = value[2]; // def
-            IVs[1] = value[1]; // atk
-            IVs[0] = value[0]; // hp
-        }
+            span.Fill(-1);
     }
 
     private static int RemapAbilityToParam(AbilityPermission a) => a switch

--- a/PKHeX.Core/Legality/Restrictions/EvolutionRestrictions.cs
+++ b/PKHeX.Core/Legality/Restrictions/EvolutionRestrictions.cs
@@ -165,7 +165,7 @@ internal static class EvolutionRestrictions
         else if (enc is IMoveset s)
         {
             var moves = s.Moves;
-            var result = move == 0 ? moves.Any(FairyMoves.Contains) : moves.Contains(move);
+            var result = move == 0 ? moves.ContainsAny(FairyMoves) : moves.Contains(move);
             if (result)
                 return true;
         }

--- a/PKHeX.Core/Legality/Structures/IMoveset.cs
+++ b/PKHeX.Core/Legality/Structures/IMoveset.cs
@@ -1,5 +1,3 @@
-﻿using System.Collections.Generic;
-
 namespace PKHeX.Core;
 
 /// <summary>
@@ -7,5 +5,5 @@ namespace PKHeX.Core;
 /// </summary>
 public interface IMoveset
 {
-    IReadOnlyList<int> Moves { get; }
+    Moveset Moves { get; }
 }

--- a/PKHeX.Core/Legality/Structures/IRelearn.cs
+++ b/PKHeX.Core/Legality/Structures/IRelearn.cs
@@ -10,5 +10,5 @@ public interface IRelearn
     /// <summary>
     /// Move IDs are in the relearn moves list on encounter.
     /// </summary>
-    IReadOnlyList<int> Relearn { get; }
+    Moveset Relearn { get; }
 }

--- a/PKHeX.Core/Legality/Structures/IndividualValueSet.cs
+++ b/PKHeX.Core/Legality/Structures/IndividualValueSet.cs
@@ -1,0 +1,51 @@
+using System;
+// ReSharper disable RedundantExplicitPositionalPropertyDeclaration
+
+namespace PKHeX.Core;
+
+/// <summary>
+/// Stores an IV template.
+/// </summary>
+/// <param name="HP "><see cref="PKM.IV_HP "/></param>
+/// <param name="ATK"><see cref="PKM.IV_ATK"/></param>
+/// <param name="DEF"><see cref="PKM.IV_DEF"/></param>
+/// <param name="SPE"><see cref="PKM.IV_SPE"/></param>
+/// <param name="SPA"><see cref="PKM.IV_SPA"/></param>
+/// <param name="SPD"><see cref="PKM.IV_SPD"/></param>
+/// <param name="Type">Differentiate between different IV templates, or lack thereof (0).</param>
+public readonly record struct IndividualValueSet(sbyte HP, sbyte ATK, sbyte DEF, sbyte SPE, sbyte SPA, sbyte SPD, byte Type = 1)
+{
+    // 8 BYTES MAX STRUCTURE
+    public byte Type { get; init; } = Type;
+
+    public sbyte HP { get; init; } = HP;
+    public sbyte ATK { get; init; } = ATK;
+    public sbyte DEF { get; init; } = DEF;
+    public sbyte SPE { get; init; } = SPE;
+    public sbyte SPA { get; init; } = SPA;
+    public sbyte SPD { get; init; } = SPD;
+
+    // Default struct will be zero type.
+    public bool IsSpecified => Type != 0;
+
+    public sbyte this[int index] => index switch
+    {
+        0 => HP,
+        1 => ATK,
+        2 => DEF,
+        3 => SPE,
+        4 => SPA,
+        5 => SPD,
+        _ => throw new ArgumentOutOfRangeException(nameof(index), index, null),
+    };
+
+    public void CopyToSpeedLast(Span<int> span)
+    {
+        span[5] = SPE;
+        span[4] = SPD;
+        span[3] = SPA;
+        span[2] = DEF;
+        span[1] = ATK;
+        span[0] = HP;
+    }
+}

--- a/PKHeX.Core/Legality/Structures/Moveset.cs
+++ b/PKHeX.Core/Legality/Structures/Moveset.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace PKHeX.Core;
+
+/// <summary>
+/// Set of 4 moves that are in a list of moves.
+/// </summary>
+public readonly record struct Moveset(ushort Move1, ushort Move2 = 0, ushort Move3 = 0, ushort Move4 = 0)
+{
+    public bool HasMoves => Move1 != 0;
+
+    public bool Contains(int move) => move == Move1 || move == Move2 || move == Move3 || move == Move4;
+    public bool AnyAbove(int max) => Move1 > max || Move2 > max || Move3 > max || Move4 > max;
+
+    public int[] ToArray() => new int[] { Move1, Move2, Move3, Move4 };
+
+    public void CopyTo(Span<int> moves)
+    {
+        moves[3] = Move4;
+        moves[2] = Move3;
+        moves[1] = Move2;
+        moves[0] = Move1;
+    }
+
+    public bool ContainsAny(ReadOnlySpan<int> moves)
+    {
+        foreach (var move in moves)
+        {
+            if (Contains(move))
+                return true;
+        }
+        return false;
+    }
+
+    public bool ContainsAll(ReadOnlySpan<int> needs)
+    {
+        foreach (var move in needs)
+        {
+            if (!Contains(move))
+                return false;
+        }
+        return true;
+    }
+
+    public string GetMovesetLine(IReadOnlyList<string> names, string split = " / ")
+    {
+        var sb = new StringBuilder(128);
+        sb.Append(names[Move1]);
+        if (Move2 != 0)
+        {
+            sb.Append(split).Append(names[Move2]);
+            if (Move3 != 0)
+            {
+                sb.Append(split).Append(names[Move3]);
+                if (Move4 != 0)
+                    sb.Append(split).Append(names[Move4]);
+            }
+        }
+        return sb.ToString();
+    }
+
+    public int BitOverlap(ReadOnlySpan<int> span)
+    {
+        // Flag each present index; having all moves will have all bitflags.
+        int flags = 0;
+        for (var i = 0; i < span.Length; i++)
+        {
+            int move = span[i];
+            if (Contains(move))
+                flags |= 1 << i;
+        }
+        return flags;
+    }
+
+    public static int BitOverlap(Span<int> moves, Span<int> span)
+    {
+        // Flag each present index; having all moves will have all bitflags.
+        int flags = 0;
+        for (var i = 0; i < span.Length; i++)
+        {
+            int move = span[i];
+            if (moves.Contains(move))
+                flags |= 1 << i;
+        }
+        return flags;
+    }
+}

--- a/PKHeX.Core/Legality/Tables/FormChangeUtil.cs
+++ b/PKHeX.Core/Legality/Tables/FormChangeUtil.cs
@@ -15,7 +15,6 @@ public static class FormChangeUtil
     /// <param name="form">Entity form</param>
     /// <param name="generation">Generation we're checking in</param>
     /// <param name="option">Conditions we're checking with</param>
-    /// <returns></returns>
     public static bool ShouldIterateForms(ushort species, byte form, int generation, LearnOption option)
     {
         if (option is not LearnOption.Current)

--- a/PKHeX.Core/MysteryGifts/MysteryGift.cs
+++ b/PKHeX.Core/MysteryGifts/MysteryGift.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using static System.Buffers.Binary.BinaryPrimitives;
 
 namespace PKHeX.Core;
@@ -131,8 +130,8 @@ public abstract class MysteryGift : IEncounterable, IMoveset, IRelearn
     public virtual string CardHeader => (CardID > 0 ? $"Card #: {CardID:0000}" : "N/A") + $" - {CardTitle.Replace('\u3000',' ').Trim()}";
 
     // Search Properties
-    public virtual IReadOnlyList<int> Moves { get => Array.Empty<int>(); set { } }
-    public virtual IReadOnlyList<int> Relearn { get => Array.Empty<int>(); set { } }
+    public virtual Moveset Moves { get => default; set { } }
+    public virtual Moveset Relearn { get => default; set { } }
     public virtual int[] IVs { get => Array.Empty<int>(); set { } }
     public virtual bool HasFixedIVs => true;
     public virtual void GetIVs(Span<int> value) { }

--- a/PKHeX.Core/MysteryGifts/MysteryUtil.cs
+++ b/PKHeX.Core/MysteryGifts/MysteryUtil.cs
@@ -1,6 +1,5 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 
 using static PKHeX.Core.MessageStrings;
 
@@ -109,7 +108,7 @@ public static class MysteryUtil
             $"{strings.Species[gift.Species]} @ {strings.Item[gift.HeldItem >= 0 ? gift.HeldItem : 0]}  --- "
             + (gift.IsEgg ? strings.EggName : $"{gift.OT_Name} - {id}");
         result.Add(first);
-        result.Add(string.Join(" / ", gift.Moves.Select(z => strings.Move[z])));
+        result.Add(gift.Moves.GetMovesetLine(strings.Move));
 
         if (gift is WC7 wc7)
         {
@@ -163,7 +162,7 @@ public static class MysteryUtil
     {
         if (gift.Species > sav.MaxSpeciesID)
             return false;
-        if (gift.Moves.Any(move => move > sav.MaxMoveID))
+        if (gift.Moves.AnyAbove(sav.MaxMoveID))
             return false;
         if (gift.HeldItem > sav.MaxItemID)
             return false;

--- a/PKHeX.Core/MysteryGifts/PCD.cs
+++ b/PKHeX.Core/MysteryGifts/PCD.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using static System.Buffers.Binary.BinaryPrimitives;
 
 namespace PKHeX.Core;
@@ -80,7 +79,7 @@ public sealed class PCD : DataMysteryGift, IRibbonSetEvent3, IRibbonSetEvent4
     public ushort CardCompatibility => ReadUInt16LittleEndian(Data.AsSpan(0x14C)); // rest of bytes we don't really care about
 
     public override int Species { get => Gift.IsManaphyEgg ? 490 : Gift.Species; set => Gift.Species = value; }
-    public override IReadOnlyList<int> Moves { get => Gift.Moves; set => Gift.Moves = value; }
+    public override Moveset Moves { get => Gift.Moves; set => Gift.Moves = value; }
     public override int HeldItem { get => Gift.HeldItem; set => Gift.HeldItem = value; }
     public override bool IsShiny => Gift.IsShiny;
     public override Shiny Shiny => Gift.Shiny;

--- a/PKHeX.Core/MysteryGifts/PGF.cs
+++ b/PKHeX.Core/MysteryGifts/PGF.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using static System.Buffers.Binary.BinaryPrimitives;
 
 namespace PKHeX.Core;
@@ -171,7 +170,7 @@ public sealed class PGF : DataMysteryGift, IRibbonSetEvent3, IRibbonSetEvent4, I
     public bool IsNicknamed => Nickname.Length > 0;
     public override bool IsShiny => PIDType == 2;
     public override int Location { get => MetLocation; set => MetLocation = (ushort)value; }
-    public override IReadOnlyList<int> Moves => new[] { Move1, Move2, Move3, Move4 };
+    public override Moveset Moves => new((ushort)Move1, (ushort)Move2, (ushort)Move3, (ushort)Move4);
     public override bool IsEntity { get => CardType == 1; set { if (value) CardType = 1; } }
     public override bool IsItem { get => CardType == 2; set { if (value) CardType = 2; } }
     public bool IsPower { get => CardType == 3; set { if (value) CardType = 3; } }

--- a/PKHeX.Core/MysteryGifts/PGT.cs
+++ b/PKHeX.Core/MysteryGifts/PGT.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using static System.Buffers.Binary.BinaryPrimitives;
 
 namespace PKHeX.Core;
@@ -112,7 +110,7 @@ public sealed class PGT : DataMysteryGift, IRibbonSetEvent3, IRibbonSetEvent4
     public override bool IsEntity { get => PGTGiftType is GiftType.Pokémon or GiftType.PokémonEgg or GiftType.ManaphyEgg; set { } }
 
     public override int Species { get => IsManaphyEgg ? 490 : PK.Species; set => PK.Species = value; }
-    public override IReadOnlyList<int> Moves { get => PK.Moves; set => PK.SetMoves(value.ToArray()); }
+    public override Moveset Moves { get => new((ushort)PK.Move1, (ushort)PK.Move2, (ushort)PK.Move3, (ushort)PK.Move4); set => PK.SetMoves(value); }
     public override int HeldItem { get => PK.HeldItem; set => PK.HeldItem = value; }
     public override bool IsShiny => PK.IsShiny;
     public override int Gender { get => PK.Gender; set => PK.Gender = value; }

--- a/PKHeX.Core/MysteryGifts/WA8.cs
+++ b/PKHeX.Core/MysteryGifts/WA8.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using static PKHeX.Core.RibbonIndex;
 using static System.Buffers.Binary.BinaryPrimitives;
 
@@ -328,27 +327,27 @@ public sealed class WA8 : DataMysteryGift, ILangNick, INature, IGigantamax, IDyn
 
     public override int Location { get => MetLocation; set => MetLocation = (ushort)value; }
 
-    public override IReadOnlyList<int> Moves
+    public override Moveset Moves
     {
-        get => new[] { Move1, Move2, Move3, Move4 };
+        get => new((ushort)Move1, (ushort)Move2, (ushort)Move3, (ushort)Move4);
         set
         {
-            if (value.Count > 0) Move1 = value[0];
-            if (value.Count > 1) Move2 = value[1];
-            if (value.Count > 2) Move3 = value[2];
-            if (value.Count > 3) Move4 = value[3];
+            Move1 = value.Move1;
+            Move2 = value.Move2;
+            Move3 = value.Move3;
+            Move4 = value.Move4;
         }
     }
 
-    public override IReadOnlyList<int> Relearn
+    public override Moveset Relearn
     {
-        get => new[] { RelearnMove1, RelearnMove2, RelearnMove3, RelearnMove4 };
+        get => new((ushort)RelearnMove1, (ushort)RelearnMove2, (ushort)RelearnMove3, (ushort)RelearnMove4);
         set
         {
-            if (value.Count > 0) RelearnMove1 = value[0];
-            if (value.Count > 1) RelearnMove2 = value[1];
-            if (value.Count > 2) RelearnMove3 = value[2];
-            if (value.Count > 3) RelearnMove4 = value[3];
+            RelearnMove1 = value.Move1;
+            RelearnMove2 = value.Move2;
+            RelearnMove3 = value.Move3;
+            RelearnMove4 = value.Move4;
         }
     }
 

--- a/PKHeX.Core/MysteryGifts/WB7.cs
+++ b/PKHeX.Core/MysteryGifts/WB7.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using static System.Buffers.Binary. BinaryPrimitives;
 
 namespace PKHeX.Core;
@@ -269,27 +268,27 @@ public sealed class WB7 : DataMysteryGift, ILangNick, IAwakened, INature, ILangN
 
     public override int Location { get => MetLocation; set => MetLocation = (ushort)value; }
 
-    public override IReadOnlyList<int> Moves
+    public override Moveset Moves
     {
-        get => new[] { Move1, Move2, Move3, Move4 };
+        get => new((ushort)Move1, (ushort)Move2, (ushort)Move3, (ushort)Move4);
         set
         {
-            if (value.Count > 0) Move1 = value[0];
-            if (value.Count > 1) Move2 = value[1];
-            if (value.Count > 2) Move3 = value[2];
-            if (value.Count > 3) Move4 = value[3];
+            Move1 = value.Move1;
+            Move2 = value.Move2;
+            Move3 = value.Move3;
+            Move4 = value.Move4;
         }
     }
 
-    public override IReadOnlyList<int> Relearn
+    public override Moveset Relearn
     {
-        get => new[] { RelearnMove1, RelearnMove2, RelearnMove3, RelearnMove4 };
+        get => new((ushort)RelearnMove1, (ushort)RelearnMove2, (ushort)RelearnMove3, (ushort)RelearnMove4);
         set
         {
-            if (value.Count > 0) RelearnMove1 = value[0];
-            if (value.Count > 1) RelearnMove2 = value[1];
-            if (value.Count > 2) RelearnMove3 = value[2];
-            if (value.Count > 3) RelearnMove4 = value[3];
+            RelearnMove1 = value.Move1;
+            RelearnMove2 = value.Move2;
+            RelearnMove3 = value.Move3;
+            RelearnMove4 = value.Move4;
         }
     }
 

--- a/PKHeX.Core/MysteryGifts/WB8.cs
+++ b/PKHeX.Core/MysteryGifts/WB8.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using static PKHeX.Core.RibbonIndex;
 using static System.Buffers.Binary.BinaryPrimitives;
 
@@ -323,27 +322,27 @@ public sealed class WB8 : DataMysteryGift, ILangNick, INature, IRibbonIndex, ICo
 
     public override int Location { get => MetLocation; set => MetLocation = (ushort)value; }
 
-    public override IReadOnlyList<int> Moves
+    public override Moveset Moves
     {
-        get => new[] { Move1, Move2, Move3, Move4 };
+        get => new((ushort)Move1, (ushort)Move2, (ushort)Move3, (ushort)Move4);
         set
         {
-            if (value.Count > 0) Move1 = value[0];
-            if (value.Count > 1) Move2 = value[1];
-            if (value.Count > 2) Move3 = value[2];
-            if (value.Count > 3) Move4 = value[3];
+            Move1 = value.Move1;
+            Move2 = value.Move2;
+            Move3 = value.Move3;
+            Move4 = value.Move4;
         }
     }
 
-    public override IReadOnlyList<int> Relearn
+    public override Moveset Relearn
     {
-        get => new[] { RelearnMove1, RelearnMove2, RelearnMove3, RelearnMove4 };
+        get => new((ushort)RelearnMove1, (ushort)RelearnMove2, (ushort)RelearnMove3, (ushort)RelearnMove4);
         set
         {
-            if (value.Count > 0) RelearnMove1 = value[0];
-            if (value.Count > 1) RelearnMove2 = value[1];
-            if (value.Count > 2) RelearnMove3 = value[2];
-            if (value.Count > 3) RelearnMove4 = value[3];
+            RelearnMove1 = value.Move1;
+            RelearnMove2 = value.Move2;
+            RelearnMove3 = value.Move3;
+            RelearnMove4 = value.Move4;
         }
     }
 

--- a/PKHeX.Core/MysteryGifts/WC3.cs
+++ b/PKHeX.Core/MysteryGifts/WC3.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace PKHeX.Core;
 
@@ -30,7 +28,7 @@ public sealed class WC3 : MysteryGift, IRibbonSetEvent3, ILangNicknamedTemplate
     public int Language { get; init; } = -1;
     public override int Species { get; set; }
     public override bool IsEgg { get; set; }
-    public override IReadOnlyList<int> Moves { get; set; } = Array.Empty<int>();
+    public override Moveset Moves { get; set; }
     public bool NotDistributed { get; init; }
     public override Shiny Shiny { get; init; }
     public bool Fateful { get; init; } // Obedience Flag
@@ -160,18 +158,15 @@ public sealed class WC3 : MysteryGift, IRibbonSetEvent3, ILangNicknamedTemplate
 
     private void SetMoves(PK3 pk)
     {
-        if (Moves.Count == 0) // not completely defined
-            Moves = MoveList.GetBaseEggMoves(pk, Species, Form, (GameVersion)pk.Version, Level);
-        if (Moves.Count != 4)
+        if (!Moves.HasMoves) // not completely defined
         {
-            int[] moves = Moves.ToArray();
-            Array.Resize(ref moves, 4);
-            Moves = moves;
+            Span<int> moves = stackalloc int[4];
+            MoveList.GetCurrentMoves(pk, Species, Form, (GameVersion)pk.Version, Level, moves);
+            Moves = new((ushort)moves[0], (ushort)moves[1], (ushort)moves[2], (ushort)moves[3]);
         }
 
-        var m = (int[])Moves;
-        pk.SetMoves(m);
-        pk.SetMaximumPPCurrent(m);
+        pk.SetMoves(Moves);
+        pk.SetMaximumPPCurrent(Moves);
     }
 
     private void SetPINGA(PK3 pk, EncounterCriteria _)

--- a/PKHeX.Core/MysteryGifts/WC6.cs
+++ b/PKHeX.Core/MysteryGifts/WC6.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using static System.Buffers.Binary.BinaryPrimitives;
 
 namespace PKHeX.Core;
@@ -268,27 +267,27 @@ public sealed class WC6 : DataMysteryGift, IRibbonSetEvent3, IRibbonSetEvent4, I
     public bool IsNicknamed => Nickname.Length > 0;
     public override int Location { get => MetLocation; set => MetLocation = (ushort)value; }
 
-    public override IReadOnlyList<int> Moves
+    public override Moveset Moves
     {
-        get => new[] { Move1, Move2, Move3, Move4 };
+        get => new((ushort)Move1, (ushort)Move2, (ushort)Move3, (ushort)Move4);
         set
         {
-            if (value.Count > 0) Move1 = value[0];
-            if (value.Count > 1) Move2 = value[1];
-            if (value.Count > 2) Move3 = value[2];
-            if (value.Count > 3) Move4 = value[3];
+            Move1 = value.Move1;
+            Move2 = value.Move2;
+            Move3 = value.Move3;
+            Move4 = value.Move4;
         }
     }
 
-    public override IReadOnlyList<int> Relearn
+    public override Moveset Relearn
     {
-        get => new[] { RelearnMove1, RelearnMove2, RelearnMove3, RelearnMove4 };
+        get => new((ushort)RelearnMove1, (ushort)RelearnMove2, (ushort)RelearnMove3, (ushort)RelearnMove4);
         set
         {
-            if (value.Count > 0) RelearnMove1 = value[0];
-            if (value.Count > 1) RelearnMove2 = value[1];
-            if (value.Count > 2) RelearnMove3 = value[2];
-            if (value.Count > 3) RelearnMove4 = value[3];
+            RelearnMove1 = value.Move1;
+            RelearnMove2 = value.Move2;
+            RelearnMove3 = value.Move3;
+            RelearnMove4 = value.Move4;
         }
     }
 

--- a/PKHeX.Core/MysteryGifts/WC7.cs
+++ b/PKHeX.Core/MysteryGifts/WC7.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using static System.Buffers.Binary.BinaryPrimitives;
 
 namespace PKHeX.Core;
@@ -322,27 +321,27 @@ public sealed class WC7 : DataMysteryGift, IRibbonSetEvent3, IRibbonSetEvent4, I
     public bool IsNicknamed => Nickname.Length > 0 || IsEgg;
     public override int Location { get => MetLocation; set => MetLocation = (ushort)value; }
 
-    public override IReadOnlyList<int> Moves
+    public override Moveset Moves
     {
-        get => new[] { Move1, Move2, Move3, Move4 };
+        get => new((ushort)Move1, (ushort)Move2, (ushort)Move3, (ushort)Move4);
         set
         {
-            if (value.Count > 0) Move1 = value[0];
-            if (value.Count > 1) Move2 = value[1];
-            if (value.Count > 2) Move3 = value[2];
-            if (value.Count > 3) Move4 = value[3];
+            Move1 = value.Move1;
+            Move2 = value.Move2;
+            Move3 = value.Move3;
+            Move4 = value.Move4;
         }
     }
 
-    public override IReadOnlyList<int> Relearn
+    public override Moveset Relearn
     {
-        get => new[] { RelearnMove1, RelearnMove2, RelearnMove3, RelearnMove4 };
+        get => new((ushort)RelearnMove1, (ushort)RelearnMove2, (ushort)RelearnMove3, (ushort)RelearnMove4);
         set
         {
-            if (value.Count > 0) RelearnMove1 = value[0];
-            if (value.Count > 1) RelearnMove2 = value[1];
-            if (value.Count > 2) RelearnMove3 = value[2];
-            if (value.Count > 3) RelearnMove4 = value[3];
+            RelearnMove1 = value.Move1;
+            RelearnMove2 = value.Move2;
+            RelearnMove3 = value.Move3;
+            RelearnMove4 = value.Move4;
         }
     }
 

--- a/PKHeX.Core/MysteryGifts/WC8.cs
+++ b/PKHeX.Core/MysteryGifts/WC8.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using static PKHeX.Core.RibbonIndex;
 using static System.Buffers.Binary.BinaryPrimitives;
 
@@ -314,27 +313,27 @@ public sealed class WC8 : DataMysteryGift, ILangNick, INature, IGigantamax, IDyn
 
     public override int Location { get => MetLocation; set => MetLocation = (ushort)value; }
 
-    public override IReadOnlyList<int> Moves
+    public override Moveset Moves
     {
-        get => new[] { Move1, Move2, Move3, Move4 };
+        get => new((ushort)Move1, (ushort)Move2, (ushort)Move3, (ushort)Move4);
         set
         {
-            if (value.Count > 0) Move1 = value[0];
-            if (value.Count > 1) Move2 = value[1];
-            if (value.Count > 2) Move3 = value[2];
-            if (value.Count > 3) Move4 = value[3];
+            Move1 = value.Move1;
+            Move2 = value.Move2;
+            Move3 = value.Move3;
+            Move4 = value.Move4;
         }
     }
 
-    public override IReadOnlyList<int> Relearn
+    public override Moveset Relearn
     {
-        get => new[] { RelearnMove1, RelearnMove2, RelearnMove3, RelearnMove4 };
+        get => new((ushort)RelearnMove1, (ushort)RelearnMove2, (ushort)RelearnMove3, (ushort)RelearnMove4);
         set
         {
-            if (value.Count > 0) RelearnMove1 = value[0];
-            if (value.Count > 1) RelearnMove2 = value[1];
-            if (value.Count > 2) RelearnMove3 = value[2];
-            if (value.Count > 3) RelearnMove4 = value[3];
+            RelearnMove1 = value.Move1;
+            RelearnMove2 = value.Move2;
+            RelearnMove3 = value.Move3;
+            RelearnMove4 = value.Move4;
         }
     }
 

--- a/PKHeX.Core/PKM/PKM.cs
+++ b/PKHeX.Core/PKM/PKM.cs
@@ -458,6 +458,14 @@ public abstract class PKM : ISpeciesForm, ITrainerID, IGeneration, IShiny, ILang
         value[0] = Move1;
     }
 
+    public void SetMoves(Moveset value)
+    {
+        Move1 = value.Move1;
+        Move2 = value.Move2;
+        Move3 = value.Move3;
+        Move4 = value.Move4;
+    }
+
     public void SetMoves(ReadOnlySpan<int> value)
     {
         Move1 = value.Length > 0 ? value[0] : 0;
@@ -470,6 +478,14 @@ public abstract class PKM : ISpeciesForm, ITrainerID, IGeneration, IShiny, ILang
     {
         get => new[] { RelearnMove1, RelearnMove2, RelearnMove3, RelearnMove4 };
         set => SetRelearnMoves(value);
+    }
+
+    public void SetRelearnMoves(Moveset value)
+    {
+        RelearnMove1 = value.Move1;
+        RelearnMove2 = value.Move2;
+        RelearnMove3 = value.Move3;
+        RelearnMove4 = value.Move4;
     }
 
     public void SetRelearnMoves(IReadOnlyList<int> value)

--- a/PKHeX.Core/PKM/PKM.cs
+++ b/PKHeX.Core/PKM/PKM.cs
@@ -984,7 +984,7 @@ public abstract class PKM : ISpeciesForm, ITrainerID, IGeneration, IShiny, ILang
     /// <param name="template">IV template to generate from</param>
     /// <param name="minFlawless">Count of flawless IVs to set. If none provided, a count will be detected.</param>
     /// <returns>Randomized IVs if desired.</returns>
-    public void SetRandomIVsTemplate(ReadOnlySpan<int> template, int minFlawless = -1)
+    public void SetRandomIVsTemplate(IndividualValueSet template, int minFlawless = -1)
     {
         int count = minFlawless == -1 ? GetFlawlessIVCount() : minFlawless;
         Span<int> ivs = stackalloc int[6];

--- a/PKHeX.Drawing.PokeSprite/Builder/SpriteBuilder.cs
+++ b/PKHeX.Drawing.PokeSprite/Builder/SpriteBuilder.cs
@@ -99,10 +99,9 @@ public abstract class SpriteBuilder : ISpriteBuilder<Image>
     /// <param name="formarg">Entity <see cref="IFormArgument.FormArgument"/> raw value</param>
     /// <param name="heldItem">Entity held item ID</param>
     /// <param name="isEgg">Is currently in an egg</param>
-    /// <param name="isShiny">Is it shiny</param>
+    /// <param name="shiny">Is it shiny</param>
     /// <param name="generation"></param>
     /// <param name="tweak"></param>
-    /// <returns></returns>
     public Image GetSprite(int species, int form, int gender, uint formarg, int heldItem, bool isEgg, Shiny shiny = Shiny.Never, int generation = -1, SpriteBuilderTweak tweak = SpriteBuilderTweak.None)
     {
         if (species == 0)

--- a/PKHeX.WinForms/Controls/Slots/SummaryPreviewer.cs
+++ b/PKHeX.WinForms/Controls/Slots/SummaryPreviewer.cs
@@ -1,6 +1,5 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Windows.Forms;
 using PKHeX.Core;
 
@@ -66,9 +65,12 @@ public sealed class SummaryPreviewer
         }
         else if (enc is IMoveset m)
         {
-            var nonzero = m.Moves.Where(z => z != 0).ToList();
-            if (nonzero.Count != 0)
-                lines.Add(string.Join(" / ", nonzero.Select(z => GameInfo.Strings.Move[z])));
+            var moves = m.Moves;
+            if (moves.HasMoves)
+            {
+                string result = moves.GetMovesetLine(GameInfo.Strings.movelist);
+                lines.Add(result);
+            }
         }
 
         var el = enc as ILocation;

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen5/SAV_Misc5.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen5/SAV_Misc5.cs
@@ -571,6 +571,7 @@ public partial class SAV_Misc5 : Form
     {
         var source = (SAV is SAV5BW ? Encounters5.DreamWorld_BW : Encounters5.DreamWorld_B2W2).Concat(Encounters5.DreamWorld_Common).ToList();
         var rnd = Util.Rand;
+        Span<int> moves = stackalloc int[4];
         foreach (var s in AllSlots)
         {
             int index = rnd.Next(source.Count);
@@ -578,8 +579,11 @@ public partial class SAV_Misc5 : Form
             source.Remove(slot);
             s.Species = slot.Species;
             s.Form = slot.Form;
-            s.Move = slot.Moves.Count > 0 ? slot.Moves[rnd.Next(slot.Moves.Count)] : 0;
             s.Gender = slot.Gender == -1 ? PersonalTable.B2W2[slot.Species].RandomGender() : slot.Gender;
+
+            slot.Moves.CopyTo(moves);
+            var count = moves.Length - moves.Count(0);
+            s.Move = count == 0 ? 0 : moves[rnd.Next(count)];
         }
         ChangeArea(this, EventArgs.Empty); // refresh
         NUD_Unlocked.Value = 8;

--- a/Tests/PKHeX.Core.Tests/General/MarshalTests.cs
+++ b/Tests/PKHeX.Core.Tests/General/MarshalTests.cs
@@ -14,5 +14,6 @@ public class MarshalTests
         Marshal.SizeOf(typeof(PIDIV)).Should().Be(8);
         Marshal.SizeOf(typeof(MoveResult)).Should().Be(8);
         Marshal.SizeOf(typeof(EvolutionMethod)).Should().Be(8);
+        Marshal.SizeOf(typeof(Moveset)).Should().Be(8);
     }
 }

--- a/Tests/PKHeX.Core.Tests/General/MarshalTests.cs
+++ b/Tests/PKHeX.Core.Tests/General/MarshalTests.cs
@@ -15,5 +15,6 @@ public class MarshalTests
         Marshal.SizeOf(typeof(MoveResult)).Should().Be(8);
         Marshal.SizeOf(typeof(EvolutionMethod)).Should().Be(8);
         Marshal.SizeOf(typeof(Moveset)).Should().Be(8);
+        Marshal.SizeOf(typeof(IndividualValueSet)).Should().BeLessOrEqualTo(8);
     }
 }


### PR DESCRIPTION
`Moveset` struct stores 4 moves, and exposes methods to interact with a moveset.
`IndividualValueSet` stores a 6 IV template (signed).

Performance impact:
* Less allocating on the heap: Moves - (8 bytes member ptr, 20 bytes heap->8 bytes member)
* Less allocating on the heap: IVs - (8 bytes member ptr, 28 bytes heap->8 bytes member)
* No heap pointers, no need to jump to grab data.
* Easy to inline logic for checking if moves are present (no linq usage with temporary collections).

End result is faster ctor times, less memory used, faster program.