### PR TITLE
Fix: Check if property can be written to

### DIFF
--- a/PKHeX.Core/Editing/Bulk/BatchEditing.cs
+++ b/PKHeX.Core/Editing/Bulk/BatchEditing.cs
@@ -135,7 +135,7 @@ public static class BatchEditing
         }
         var props = Props[index];
         bool exits = props.TryGetValue(name, out pi);
-        if (!pi.CanWrite)
+        if (exits & !pi.CanWrite)
         {
             return false;
         }

--- a/PKHeX.Core/Editing/Bulk/BatchEditing.cs
+++ b/PKHeX.Core/Editing/Bulk/BatchEditing.cs
@@ -134,7 +134,12 @@ public static class BatchEditing
             return false;
         }
         var props = Props[index];
-        return props.TryGetValue(name, out pi);
+        bool exits = props.TryGetValue(name, out pi);
+        if (!pi.CanWrite)
+        {
+            return false;
+        }
+        return exits;
     }
 
     /// <summary>


### PR DESCRIPTION
Check if the property can be written to before attempting to write it.
This is important as PK1 does not define a set method for the Valid property and so trying to write that property causes the PropertyInfo.SetValue to throw `System.ArgumentException: 'Property set method not found.'`