### PR TITLE
Generate proper TID and SID from WC9

### DIFF
--- a/PKHeX.Core/MysteryGifts/WC9.cs
+++ b/PKHeX.Core/MysteryGifts/WC9.cs
@@ -117,16 +117,18 @@ public sealed class WC9 : DataMysteryGift, ILangNick, INature, ITeraType, IRibbo
         return psv ^ tsv;
     }
 
+    // When applying the TID32, the game sets the DisplayTID7 directly, then sets pk9.DisplaySID7 as (wc9.DisplaySID7 - wc9.CardID)
+    // Since we expose the 16bit (pk9) component values here, just adjust them accordingly with an inlined calc.
     public override int TID
     {
-        get => (ushort)((ReadUInt32LittleEndian(Data.AsSpan(CardStart + 0x18)) - (0xF4240 * CardID)) & 0xFFFF);
-        set => WriteUInt32LittleEndian(Data.AsSpan(CardStart + 0x18), (uint)((SID << 16) | value) + (uint)(0xF4240 * CardID));
+        get => (ushort)((ReadUInt32LittleEndian(Data.AsSpan(CardStart + 0x18)) - (1000000 * CardID)) & 0xFFFF);
+        set => WriteUInt32LittleEndian(Data.AsSpan(CardStart + 0x18), (uint)((SID << 16) | value) + (uint)(1000000 * CardID));
     }
 
     public override int SID
     {
-        get => (ushort)((ReadUInt32LittleEndian(Data.AsSpan(CardStart + 0x18)) - (0xF4240 * CardID)) >> 16 & 0xFFFF);
-        set => WriteUInt32LittleEndian(Data.AsSpan(CardStart + 0x18), (uint)((value << 16) | TID) + (uint)(0xF4240 * CardID));
+        get => (ushort)((ReadUInt32LittleEndian(Data.AsSpan(CardStart + 0x18)) - (1000000 * CardID)) >> 16 & 0xFFFF);
+        set => WriteUInt32LittleEndian(Data.AsSpan(CardStart + 0x18), (uint)((value << 16) | TID) + (uint)(1000000 * CardID));
     }
 
     public int OriginGame

--- a/PKHeX.Core/MysteryGifts/WC9.cs
+++ b/PKHeX.Core/MysteryGifts/WC9.cs
@@ -119,13 +119,14 @@ public sealed class WC9 : DataMysteryGift, ILangNick, INature, ITeraType, IRibbo
 
     public override int TID
     {
-        get => ReadUInt16LittleEndian(Data.AsSpan(CardStart + 0x18));
-        set => WriteUInt16LittleEndian(Data.AsSpan(CardStart + 0x20), (ushort)value);
+        get => (ushort)((ReadUInt32LittleEndian(Data.AsSpan(CardStart + 0x18)) - (0xF4240 * CardID)) & 0xFFFF);
+        set => WriteUInt32LittleEndian(Data.AsSpan(CardStart + 0x18), (uint)((SID << 16) | value) + (uint)(0xF4240 * CardID));
     }
 
-    public override int SID {
-        get => ReadUInt16LittleEndian(Data.AsSpan(CardStart + 0x1A));
-        set => WriteUInt16LittleEndian(Data.AsSpan(CardStart + 0x18), (ushort)value);
+    public override int SID
+    {
+        get => (ushort)((ReadUInt32LittleEndian(Data.AsSpan(CardStart + 0x18)) - (0xF4240 * CardID)) >> 16 & 0xFFFF);
+        set => WriteUInt32LittleEndian(Data.AsSpan(CardStart + 0x18), (uint)((value << 16) | TID) + (uint)(0xF4240 * CardID));
     }
 
     public int OriginGame


### PR DESCRIPTION
TID and SID for wc9 mystery gifts is not pulled directly from the hardcoded value in the wondercards like it was in SwSh.
For example, the PokéCenter Flabébé wondercards have an hardcoded otid of 0x0012A1FE. This would've translate to Sid7 0001 and Tid7 221118.
This isn't the case for the legitimately code-redeemed Flabébé, which have Sid7 0000 and Tid7 221118 (different SID). 

I did some experiments by fabricating BCAT data with different wondercard IDs and different hardcoded OTIDs. The resulting Pokémons never obtained the hardcoded tid/sid.

The formulas in this PR will match the SID and TID obtained by redeeming a Pokémon through the Mystery Gift directly on the SV games.

After writing the code for this PR, I did few tests: loaded custom bcat datas in my switch games and those same wondercards have also been loaded in PKHeX (with this pr code applied). Pokémons originated from both the Switch and PKHeX had the same Tid and Sid. I also took in consideration the eventuality of custom simulated wondercards for the future Home compatibility. Tested few cards with IDs >= 9000, Sid and Tid was the same when redeemed on Switch and when genned on PKHeX.

If the code/formulas can be improved, please feel free to.