### PR TITLE
Added spawn points to raid editor

### DIFF
--- a/PKHeX.Core/Editing/CommonEdits.cs
+++ b/PKHeX.Core/Editing/CommonEdits.cs
@@ -353,7 +353,7 @@ public static class CommonEdits
         if (pk.IsTradedEgg)
             pk.Egg_Location = pk.Met_Location;
         if (pk.Version == 0)
-            pk.Version = EggStateLegality.GetEggHatchVersion(pk, (GameVersion)(tr?.Game ?? RecentTrainerCache.Game));
+            pk.Version = (int)EggStateLegality.GetEggHatchVersion(pk, (GameVersion)(tr?.Game ?? RecentTrainerCache.Game));
         var loc = EncounterSuggestion.GetSuggestedEggMetLocation(pk);
         if (loc >= 0)
             pk.Met_Location = loc;

--- a/PKHeX.Core/Saves/Substructures/Gen9/RaidSpawnList9.cs
+++ b/PKHeX.Core/Saves/Substructures/Gen9/RaidSpawnList9.cs
@@ -78,6 +78,13 @@ public sealed class TeraRaidDetail
         set => WriteUInt32LittleEndian(Data.AsSpan(Offset + 0x08), (uint)value);
     }
 
+    [Category(General), Description("Zone-specific overworld spawn point for the raid crystal.")]
+    public uint SpawnPointID
+    {
+        get => ReadUInt32LittleEndian(Data.AsSpan(Offset + 0x0C));
+        set => WriteUInt32LittleEndian(Data.AsSpan(Offset + 0x0C), value);
+    }
+
     [Category(General), Description("RNG Seed (32bit) for fetching the Raid data table and generating the raid."), TypeConverter(typeof(TypeConverterU32))]
     public uint Seed
     {


### PR DESCRIPTION
This field must be set to a valid spawn point, so without ability to edit this via UI it wasn't possible to (re)spawn new raid crystals without resorting to block import option.