### PR TITLE
Add Box Count to support: Show ride legend stored data

### DIFF
--- a/PKHeX.Core/Saves/Substructures/Gen9/BoxLayout9.cs
+++ b/PKHeX.Core/Saves/Substructures/Gen9/BoxLayout9.cs
@@ -4,7 +4,7 @@ namespace PKHeX.Core;
 
 public sealed class BoxLayout9 : SaveBlock<SAV9SV>, IBoxDetailName
 {
-    public const int BoxCount = 32;
+    public const int BoxCount = 33;
 
     private const int StringMaxLength = SAV6.LongStringLength / 2;
 


### PR DESCRIPTION
Shows Box 33 containing Ride Pokemon for Gen9 saves