### PR TITLE
Show star square for everything in Gen9

### DIFF
--- a/PKHeX.Core/Editing/ISpriteBuilder.cs
+++ b/PKHeX.Core/Editing/ISpriteBuilder.cs
@@ -10,14 +10,14 @@ public interface ISpriteBuilder<T>
     /// Gets a sprite using the requested parameters.
     /// </summary>
     T GetSprite(ushort species, byte form, int gender, uint formarg, int heldItem, bool isEgg, Shiny shiny,
-        int generation = -1,
+        EntityContext context = EntityContext.None,
         SpriteBuilderTweak tweak = SpriteBuilderTweak.None);
 
     /// <summary>
     /// Revises the sprite using the requested parameters.
     /// </summary>
     T GetSprite(T baseSprite, ushort species, int heldItem, bool isEgg, Shiny shiny,
-        int generation = -1,
+        EntityContext context = EntityContext.None,
         SpriteBuilderTweak tweak = SpriteBuilderTweak.None);
 
     /// <summary>

--- a/PKHeX.Core/Legality/Breeding.cs
+++ b/PKHeX.Core/Legality/Breeding.cs
@@ -104,16 +104,16 @@ public static class Breeding
     /// <remarks>Chained with the other 2 overloads for incremental checks with different parameters.</remarks>
     /// <param name="species">Current species</param>
     /// <param name="form">Current form</param>
-    /// <param name="generation">Generation of origin</param>
-    public static bool CanHatchAsEgg(ushort species, byte form, int generation)
+    /// <param name="context">Generation of origin</param>
+    public static bool CanHatchAsEgg(ushort species, byte form, EntityContext context)
     {
         if (form == 0)
             return true;
 
-        if (FormInfo.IsTotemForm(species, form, generation))
+        if (FormInfo.IsTotemForm(species, form, context))
             return false;
 
-        if (FormInfo.IsLordForm(species, form, generation))
+        if (FormInfo.IsLordForm(species, form, context))
             return false;
 
         return IsBreedableForm(species, form);

--- a/PKHeX.Core/Legality/Encounters/Generator/Specific/EncounterEggGenerator.cs
+++ b/PKHeX.Core/Legality/Encounters/Generator/Specific/EncounterEggGenerator.cs
@@ -21,10 +21,6 @@ public static class EncounterEggGenerator
         if (!Breeding.CanHatchAsEgg(currentSpecies))
             yield break;
 
-        var currentForm = pk.Form;
-        if (!Breeding.CanHatchAsEgg(currentSpecies, currentForm, generation))
-            yield break; // can't originate from eggs
-
         // version is a true indicator for all generation 3-5 origins
         var ver = (GameVersion)pk.Version;
         if (!Breeding.CanGameGenerateEggs(ver))
@@ -36,6 +32,10 @@ public static class EncounterEggGenerator
         }
 
         var context = ver.GetContext();
+        var currentForm = pk.Form;
+        if (!Breeding.CanHatchAsEgg(currentSpecies, currentForm, context))
+            yield break; // can't originate from eggs
+
         var lvl = EggStateLegality.GetEggLevel(generation);
         int max = GetMaxSpeciesOrigin(generation);
 

--- a/PKHeX.Core/Legality/Restrictions/HeldItemLumpImage.cs
+++ b/PKHeX.Core/Legality/Restrictions/HeldItemLumpImage.cs
@@ -11,7 +11,7 @@ public static class HeldItemLumpUtil
 {
     public static bool IsLump(this HeldItemLumpImage image) => image != HeldItemLumpImage.NotLump;
 
-    public static HeldItemLumpImage GetIsLump(int item, int generation) => generation switch
+    public static HeldItemLumpImage GetIsLump(int item, EntityContext context) => context.Generation() switch
     {
         <= 4 when item is (>= 0328 and <= 0419) => HeldItemLumpImage.TechnicalMachine, // gen2/3/4 TM
         8 when item is (>= 0328 and <= 0427) => HeldItemLumpImage.TechnicalMachine, // BDSP TMs

--- a/PKHeX.Core/Legality/Tables/FormInfo.cs
+++ b/PKHeX.Core/Legality/Tables/FormInfo.cs
@@ -237,13 +237,13 @@ public static class FormInfo
     /// </summary>
     /// <param name="species">Entity species</param>
     /// <param name="form">Entity form</param>
-    /// <param name="format">Current generation format</param>
-    public static bool IsTotemForm(ushort species, byte form, int format) => format == 7 && IsTotemForm(species, form);
+    /// <param name="context">Current generation format</param>
+    public static bool IsTotemForm(ushort species, byte form, EntityContext context) => context == EntityContext.Gen7 && IsTotemForm(species, form);
 
     /// <summary>
     /// Checks if the <see cref="form"/> for the <see cref="species"/> is a Totem form.
     /// </summary>
-    /// <remarks>Use <see cref="IsTotemForm(ushort,byte,int)"/> if you aren't 100% sure the format is 7.</remarks>
+    /// <remarks>Use <see cref="IsTotemForm(ushort,byte,EntityContext)"/> if you aren't 100% sure the format is 7.</remarks>
     /// <param name="species">Entity species</param>
     /// <param name="form">Entity form</param>
     public static bool IsTotemForm(ushort species, byte form)
@@ -271,9 +271,9 @@ public static class FormInfo
         return --form;
     }
 
-    public static bool IsLordForm(ushort species, byte form, int generation)
+    public static bool IsLordForm(ushort species, byte form, EntityContext context)
     {
-        if (generation != 8)
+        if (context != EntityContext.Gen8a)
             return false;
         return IsLordForm(species, form);
     }

--- a/PKHeX.Drawing.PokeSprite/Builder/SpriteBuilder5668.cs
+++ b/PKHeX.Drawing.PokeSprite/Builder/SpriteBuilder5668.cs
@@ -20,8 +20,8 @@ public sealed class SpriteBuilder5668s : SpriteBuilder
     public override bool HasFallbackMethod => true;
 
     protected override string GetSpriteStringSpeciesOnly(ushort species) => 'b' + $"_{species}";
-    protected override string GetSpriteAll(ushort species, byte form, int gender, uint formarg, bool shiny, int generation) => 'b' + SpriteName.GetResourceStringSprite(species, form, gender, formarg, generation, shiny);
-    protected override string GetSpriteAllSecondary(ushort species, byte form, int gender, uint formarg, bool shiny, int generation) => 'c' + SpriteName.GetResourceStringSprite(species, form, gender, formarg, generation, shiny);
+    protected override string GetSpriteAll(ushort species, byte form, int gender, uint formarg, bool shiny, EntityContext context) => 'b' + SpriteName.GetResourceStringSprite(species, form, gender, formarg, context, shiny);
+    protected override string GetSpriteAllSecondary(ushort species, byte form, int gender, uint formarg, bool shiny, EntityContext context) => 'c' + SpriteName.GetResourceStringSprite(species, form, gender, formarg, context, shiny);
     protected override string GetItemResourceName(int item) => 'b' + $"item_{item}";
     protected override Bitmap Unknown => Resources.b_unknown;
     protected override Bitmap GetEggSprite(ushort species) => species == (int)Species.Manaphy ? Resources.b_490_e : Resources.b_egg;

--- a/PKHeX.Drawing.PokeSprite/Builder/SpriteBuilder5668a.cs
+++ b/PKHeX.Drawing.PokeSprite/Builder/SpriteBuilder5668a.cs
@@ -20,8 +20,8 @@ public sealed class SpriteBuilder5668a : SpriteBuilder
     public override bool HasFallbackMethod => true;
 
     protected override string GetSpriteStringSpeciesOnly(ushort species) => 'a' + $"_{species}";
-    protected override string GetSpriteAll(ushort species, byte form, int gender, uint formarg, bool shiny, int generation) => 'a' + SpriteName.GetResourceStringSprite(species, form, gender, formarg, generation, shiny);
-    protected override string GetSpriteAllSecondary(ushort species, byte form, int gender, uint formarg, bool shiny, int generation) => 'b' + SpriteName.GetResourceStringSprite(species, form, gender, formarg, generation, shiny);
+    protected override string GetSpriteAll(ushort species, byte form, int gender, uint formarg, bool shiny, EntityContext context) => 'a' + SpriteName.GetResourceStringSprite(species, form, gender, formarg, context, shiny);
+    protected override string GetSpriteAllSecondary(ushort species, byte form, int gender, uint formarg, bool shiny, EntityContext context) => 'b' + SpriteName.GetResourceStringSprite(species, form, gender, formarg, context, shiny);
     protected override string GetItemResourceName(int item) => 'a' + $"item_{item}";
     protected override Bitmap Unknown => Resources.b_unknown;
     protected override Bitmap GetEggSprite(ushort species) => species == (int)Species.Manaphy ? Resources.a_490_e : Resources.a_egg;

--- a/PKHeX.Drawing.PokeSprite/Builder/SpriteBuilder5668c.cs
+++ b/PKHeX.Drawing.PokeSprite/Builder/SpriteBuilder5668c.cs
@@ -20,8 +20,8 @@ public sealed class SpriteBuilder5668c : SpriteBuilder
     public override bool HasFallbackMethod => true;
 
     protected override string GetSpriteStringSpeciesOnly(ushort species) => 'c' + $"_{species}";
-    protected override string GetSpriteAll(ushort species, byte form, int gender, uint formarg, bool shiny, int generation) => 'c' + SpriteName.GetResourceStringSprite(species, form, gender, formarg, generation, shiny);
-    protected override string GetSpriteAllSecondary(ushort species, byte form, int gender, uint formarg, bool shiny, int generation) => 'b' + SpriteName.GetResourceStringSprite(species, form, gender, formarg, generation, shiny);
+    protected override string GetSpriteAll(ushort species, byte form, int gender, uint formarg, bool shiny, EntityContext context) => 'c' + SpriteName.GetResourceStringSprite(species, form, gender, formarg, context, shiny);
+    protected override string GetSpriteAllSecondary(ushort species, byte form, int gender, uint formarg, bool shiny, EntityContext context) => 'b' + SpriteName.GetResourceStringSprite(species, form, gender, formarg, context, shiny);
     protected override string GetItemResourceName(int item) => 'b' + $"item_{item}";
     protected override Bitmap Unknown => Resources.b_unknown;
     protected override Bitmap GetEggSprite(ushort species) => species == (int)Species.Manaphy ? Resources.b_490_e : Resources.b_egg;

--- a/PKHeX.Drawing.PokeSprite/Util/SpriteName.cs
+++ b/PKHeX.Drawing.PokeSprite/Util/SpriteName.cs
@@ -21,7 +21,7 @@ public static class SpriteName
     /// <summary>
     /// Gets the resource name of the Pokémon sprite.
     /// </summary>
-    public static string GetResourceStringSprite(ushort species, byte form, int gender, uint formarg, int generation = PKX.Generation, bool shiny = false)
+    public static string GetResourceStringSprite(ushort species, byte form, int gender, uint formarg, EntityContext context = PKX.Context, bool shiny = false)
     {
         if (SpeciesDefaultFormSprite.Contains(species)) // Species who show their default sprite regardless of Form
             form = 0;
@@ -35,7 +35,7 @@ public static class SpriteName
 
             if (species == (int) Species.Pikachu)
             {
-                if (generation == 6)
+                if (context == EntityContext.Gen6)
                 {
                     sb.Append(Cosplay);
                     gender = 1; // Cosplay Pikachu gift can only be Female, but personal entries are set to be either Gender

--- a/PKHeX.Drawing.PokeSprite/Util/SpriteUtil.cs
+++ b/PKHeX.Drawing.PokeSprite/Util/SpriteUtil.cs
@@ -59,9 +59,9 @@ public static class SpriteUtil
 
     public static Image? GetItemSprite(int item) => Resources.ResourceManager.GetObject($"item_{item}") as Image;
 
-    public static Image GetSprite(ushort species, byte form, int gender, uint formarg, int item, bool isegg, Shiny shiny, int generation = -1, SpriteBuilderTweak tweak = SpriteBuilderTweak.None)
+    public static Image GetSprite(ushort species, byte form, int gender, uint formarg, int item, bool isegg, Shiny shiny, EntityContext context = EntityContext.None, SpriteBuilderTweak tweak = SpriteBuilderTweak.None)
     {
-        return Spriter.GetSprite(species, form, gender, formarg, item, isegg, shiny, generation, tweak);
+        return Spriter.GetSprite(species, form, gender, formarg, item, isegg, shiny, context, tweak);
     }
 
     private static Image GetSprite(PKM pk, SpriteBuilderTweak tweak = SpriteBuilderTweak.None)
@@ -69,12 +69,12 @@ public static class SpriteUtil
         var formarg = pk is IFormArgument f ? f.FormArgument : 0;
         var shiny = !pk.IsShiny ? Shiny.Never : (ShinyExtensions.IsSquareShinyExist(pk) ? Shiny.AlwaysSquare : Shiny.AlwaysStar);
 
-        var img = GetSprite(pk.Species, pk.Form, pk.Gender, formarg, pk.SpriteItem, pk.IsEgg, shiny, pk.Format, tweak);
+        var img = GetSprite(pk.Species, pk.Form, pk.Gender, formarg, pk.SpriteItem, pk.IsEgg, shiny, pk.Context, tweak);
         if (pk is IShadowCapture {IsShadow: true})
         {
             const int Lugia = (int)Species.Lugia;
             if (pk.Species == Lugia) // show XD shadow sprite
-                img = Spriter.GetSprite(Spriter.ShadowLugia, Lugia, pk.SpriteItem, pk.IsEgg, shiny, pk.Format, tweak);
+                img = Spriter.GetSprite(Spriter.ShadowLugia, Lugia, pk.SpriteItem, pk.IsEgg, shiny, pk.Context, tweak);
 
             GetSpriteGlow(pk, 75, 0, 130, out var pixels, out var baseSprite, true);
             var glowImg = ImageUtil.GetBitmap(pixels, baseSprite.Width, baseSprite.Height, baseSprite.PixelFormat);
@@ -219,7 +219,7 @@ public static class SpriteUtil
     {
         bool egg = pk.IsEgg;
         var formarg = pk is IFormArgument f ? f.FormArgument : 0;
-        baseSprite = GetSprite(pk.Species, pk.Form, pk.Gender, formarg, 0, egg, Shiny.Never, pk.Format);
+        baseSprite = GetSprite(pk.Species, pk.Form, pk.Gender, formarg, 0, egg, Shiny.Never, pk.Context);
         GetSpriteGlow(baseSprite, blue, green, red, out pixels, forceHollow || egg);
     }
 
@@ -251,7 +251,7 @@ public static class SpriteUtil
         if (enc is MysteryGift g)
             return GetMysteryGiftPreviewPoke(g);
         var gender = GetDisplayGender(enc);
-        var img = GetSprite(enc.Species, enc.Form, gender, 0, 0, enc.EggEncounter, enc.IsShiny ? Shiny.Always : Shiny.Never, enc.Generation);
+        var img = GetSprite(enc.Species, enc.Form, gender, 0, 0, enc.EggEncounter, enc.IsShiny ? Shiny.Always : Shiny.Never, enc.Context);
         if (SpriteBuilder.ShowEncounterBall && enc is IFixedBall {FixedBall: not Ball.None} b)
         {
             var ballSprite = GetBallSprite((int)b.FixedBall);
@@ -286,10 +286,10 @@ public static class SpriteUtil
     public static Image GetMysteryGiftPreviewPoke(MysteryGift gift)
     {
         if (gift.IsEgg && gift.Species == (int)Species.Manaphy) // Manaphy Egg
-            return GetSprite((int)Species.Manaphy, 0, 2, 0, 0, true, Shiny.Never, gift.Generation);
+            return GetSprite((int)Species.Manaphy, 0, 2, 0, 0, true, Shiny.Never, gift.Context);
 
         var gender = Math.Max(0, gift.Gender);
-        var img = GetSprite(gift.Species, gift.Form, gender, 0, gift.HeldItem, gift.IsEgg, gift.IsShiny ? Shiny.Always : Shiny.Never, gift.Generation);
+        var img = GetSprite(gift.Species, gift.Form, gender, 0, gift.HeldItem, gift.IsEgg, gift.IsShiny ? Shiny.Always : Shiny.Never, gift.Context);
 
         if (SpriteBuilder.ShowEncounterBall && gift is IFixedBall { FixedBall: not Ball.None } b)
         {

--- a/PKHeX.WinForms/Controls/Slots/CryPlayer.cs
+++ b/PKHeX.WinForms/Controls/Slots/CryPlayer.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.IO;
 using System.Media;
 using PKHeX.Core;
@@ -10,12 +10,12 @@ public sealed class CryPlayer
 {
     private readonly SoundPlayer Sounds = new();
 
-    public void PlayCry(ISpeciesForm pk, int format)
+    public void PlayCry(ISpeciesForm pk, EntityContext context)
     {
         if (pk.Species == 0)
             return;
 
-        string path = GetCryPath(pk, Main.CryPath, format);
+        string path = GetCryPath(pk, Main.CryPath, context);
         if (!File.Exists(path))
             return;
 
@@ -33,22 +33,22 @@ public sealed class CryPlayer
         catch { Debug.WriteLine("Failed to stop sound."); }
     }
 
-    private static string GetCryPath(ISpeciesForm pk, string cryFolder, int format)
+    private static string GetCryPath(ISpeciesForm pk, string cryFolder, EntityContext context)
     {
-        var name = GetCryFileName(pk, format);
+        var name = GetCryFileName(pk, context);
         var path = Path.Combine(cryFolder, $"{name}.wav");
         if (!File.Exists(path))
             path = Path.Combine(cryFolder, $"{pk.Species}.wav");
         return path;
     }
 
-    private static string GetCryFileName(ISpeciesForm pk, int format)
+    private static string GetCryFileName(ISpeciesForm pk, EntityContext context)
     {
         if (pk.Species == (int)Species.Urshifu && pk.Form == 1) // same sprite for both forms, but different cries
             return "892-1";
 
         // don't grab sprite of pk, no gender specific cries
-        var res = SpriteName.GetResourceStringSprite(pk.Species, pk.Form, 0, 0, format);
+        var res = SpriteName.GetResourceStringSprite(pk.Species, pk.Form, 0, 0, context);
 
         // people like - instead of _ file names ;)
         return res.Replace('_', '-')[1..]; // skip leading underscore

--- a/PKHeX.WinForms/Controls/Slots/SummaryPreviewer.cs
+++ b/PKHeX.WinForms/Controls/Slots/SummaryPreviewer.cs
@@ -30,7 +30,7 @@ public sealed class SummaryPreviewer
         }
 
         if (Main.Settings.Hover.HoverSlotPlayCry)
-            Cry.PlayCry(pk, pk.Format);
+            Cry.PlayCry(pk, pk.Context);
     }
 
     public void Show(Control pb, IEncounterInfo enc)
@@ -49,7 +49,7 @@ public sealed class SummaryPreviewer
         }
 
         if (Main.Settings.Hover.HoverSlotPlayCry)
-            Cry.PlayCry(enc, enc.Generation);
+            Cry.PlayCry(enc, enc.Context);
     }
 
     public static IEnumerable<string> GetTextLines(IEncounterInfo enc)

--- a/PKHeX.WinForms/Subforms/KChart.cs
+++ b/PKHeX.WinForms/Subforms/KChart.cs
@@ -58,7 +58,7 @@ public partial class KChart : Form
 
         var bst = p.GetBaseStatTotal();
         cells[c++].Value = species.ToString(pt.MaxSpeciesID > 999 ? "0000" : "000") + (form > 0 ? $"-{form:00}" : "");
-        cells[c++].Value = SpriteUtil.GetSprite(species, form, 0, 0, 0, false, Shiny.Never, SAV.Generation);
+        cells[c++].Value = SpriteUtil.GetSprite(species, form, 0, 0, 0, false, Shiny.Never, SAV.Context);
         cells[c++].Value = name;
         cells[c++].Value = GetIsNative(p, species);
         cells[c].Style.BackColor = ColorUtil.ColorBaseStatTotal(bst);

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen5/SAV_Misc5.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen5/SAV_Misc5.cs
@@ -562,7 +562,7 @@ public partial class SAV_Misc5 : Form
 
     private void SetSprite(EntreeSlot slot)
     {
-        PB_SlotPreview.Image = SpriteUtil.GetSprite(slot.Species, slot.Form, slot.Gender, 0, 0, false, Shiny.Never, 5);
+        PB_SlotPreview.Image = SpriteUtil.GetSprite(slot.Species, slot.Form, slot.Gender, 0, 0, false, Shiny.Never, EntityContext.Gen5);
     }
 
     private void SetGenders(EntreeSlot slot)

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen6/SAV_HallOfFame.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen6/SAV_HallOfFame.cs
@@ -193,7 +193,7 @@ public partial class SAV_HallOfFame : Form
         Label_OTGender.Text = gendersymbols[(int)entry.OT_Gender];
         UpdateNickname(sender, e);
         var shiny = entry.IsShiny ? Shiny.Always : Shiny.Never;
-        bpkx.Image = SpriteUtil.GetSprite(entry.Species, entry.Form, (int)entry.Gender, 0, entry.HeldItem, false, shiny, 6);
+        bpkx.Image = SpriteUtil.GetSprite(entry.Species, entry.Form, (int)entry.Gender, 0, entry.HeldItem, false, shiny, EntityContext.Gen6);
         editing = true;
     }
 
@@ -244,7 +244,7 @@ public partial class SAV_HallOfFame : Form
         WriteUInt32LittleEndian(data.AsSpan(offset + 0x1B0), vnd);
 
         var shiny = entry.IsShiny ? Shiny.Always : Shiny.Never;
-        bpkx.Image = SpriteUtil.GetSprite(entry.Species, entry.Form, (int)entry.Gender, 0, entry.HeldItem, false, shiny, 6);
+        bpkx.Image = SpriteUtil.GetSprite(entry.Species, entry.Form, (int)entry.Gender, 0, entry.HeldItem, false, shiny, EntityContext.Gen6);
         DisplayEntry(this, EventArgs.Empty); // refresh text view
     }
 
@@ -297,7 +297,7 @@ public partial class SAV_HallOfFame : Form
         var gender = EntityGender.GetFromString(Label_Gender.Text);
         var item = WinFormsUtil.GetIndex(CB_HeldItem);
         var shiny = CHK_Shiny.Checked ? Shiny.Always : Shiny.Never;
-        bpkx.Image = SpriteUtil.GetSprite(species, form, gender, 0, item, false, shiny, 6);
+        bpkx.Image = SpriteUtil.GetSprite(species, form, gender, 0, item, false, shiny, EntityContext.Gen6);
 
         Write_Entry(this, EventArgs.Empty);
     }


### PR DESCRIPTION
Changes the API for sprite building to use `EntityContext context` instead of `int Generation`.