### PR TITLE
Fix tera-type typo in Encounter9RNG

### DIFF
--- a/PKHeX.Core/Legality/Encounters/Generator/EncounterCriteria.cs
+++ b/PKHeX.Core/Legality/Encounters/Generator/EncounterCriteria.cs
@@ -25,7 +25,7 @@ public sealed record EncounterCriteria
     /// <remarks> Leave as <see cref="Core.Nature.Random"/> to not restrict nature. </remarks>
     public Nature Nature { get; init; } = Nature.Random;
 
-    /// <summary> End result's nature. </summary>
+    /// <summary> End result's shininess. </summary>
     /// <remarks> Leave as <see cref="Core.Shiny.Random"/> to not restrict shininess. </remarks>
     public Shiny Shiny { get; init; }
 
@@ -103,6 +103,7 @@ public sealed record EncounterCriteria
         AbilityNumber = GetAbilityNumber(s.Ability, pi),
         Nature = NatureUtil.GetNature(s.Nature),
         Shiny = s.Shiny ? Shiny.Always : Shiny.Never,
+        TeraType = (sbyte)s.TeraType,
     };
 
     private static AbilityPermission GetAbilityNumber(int ability, IPersonalAbility pi)

--- a/PKHeX.Core/Legality/RNG/Methods/Encounter9RNG.cs
+++ b/PKHeX.Core/Legality/RNG/Methods/Encounter9RNG.cs
@@ -21,7 +21,7 @@ public static class Encounter9RNG
             var type = Tera9RNG.GetTeraType(seed, enc.TeraType, enc.Species, enc.Form);
             pk.TeraTypeOriginal = (MoveType)type;
             if (criteria.TeraType != -1 && type != criteria.TeraType)
-                pk.SetTeraType(type); // sets the override type
+                pk.SetTeraType((MoveType)criteria.TeraType); // sets the override type
             return true; // done.
         }
         return false;
@@ -41,7 +41,7 @@ public static class Encounter9RNG
             var type = Tera9RNG.GetTeraType(seed, enc.TeraType, enc.Species, enc.Form);
             pk.TeraTypeOriginal = (MoveType)type;
             if (criteria.TeraType != -1 && type != criteria.TeraType)
-                pk.SetTeraType(type); // sets the override type
+                pk.SetTeraType((MoveType)criteria.TeraType); // sets the override type
             return true; // done.
         }
         return false;


### PR DESCRIPTION
In `Encounter9RNG`, the intention was to apply the override tera-type if the caller requested it, but the code was instead trying to assign the original type to the override type, meaning the criteria's tera-type was ignored by mistake

This PR corrects that and `EncounterCriteria` ignoring the `ShowdownSet` tera-type