### PR TITLE
Add Toys from the My Pokémon Ranch Platinum Update

### DIFF
--- a/PKHeX.Core/Saves/Substructures/Gen4/Ranch/RanchLevel.cs
+++ b/PKHeX.Core/Saves/Substructures/Gen4/Ranch/RanchLevel.cs
@@ -7,7 +7,7 @@ public static class RanchLevel
 {
     public static int GetLevel(byte levelIndex) => levelIndex + 1;
 
-    public static int GetMaxMiis(byte levelIndex) => levelIndex switch
+    public static int GetMaxMiiCount(byte levelIndex) => levelIndex switch
     {
         >= 11 => 20,
         >= 08 => 15,
@@ -15,7 +15,7 @@ public static class RanchLevel
         _ => 5,
     };
 
-    public static int GetMaxToys(byte levelIndex) => levelIndex switch
+    public static int GetMaxToyCount(byte levelIndex) => levelIndex switch
     {
         >= 25 => 6,
         >= 20 => 5,

--- a/PKHeX.Core/Saves/Substructures/Gen4/Ranch/RanchToyType.cs
+++ b/PKHeX.Core/Saves/Substructures/Gen4/Ranch/RanchToyType.cs
@@ -30,5 +30,21 @@ public enum RanchToyType : byte
     Sprint_Stand = 22,
     Attractor = 23,
     Challenger = 24,
-    Toy_Box = 25,
+    Toy_Box = 25, // Supports metadata - Metadata value is the index of the contained toy.
+    Poke_Ball = 26, // Normally unused
+
+    // Pt Update:
+    Birthday_Cake = 27,
+    Apple_Box_S = 28, // Small Apple Box
+    Apple_Box_L = 29, // Large Apple Box
+    Dice = 30,
+    Picture_Frame_S = 31, // Small Picture Frame
+    Picture_Frame_L = 32, // Large Picture Frame
+    Flower = 33,
+    Lamp = 34,
+    Magnet = 35,
+    Twirler = 36,
+    Bound_Mat = 37,
+    Tree = 38,
+    Water = 39 // Normally unused; creates a massive plane of water in the sky
 }


### PR DESCRIPTION
These changes expand the RanchToyType enum with new entries for the Toys introduced in the Platinum Update, as well as the seemingly unused Poke Ball!

For compatibility, a check has also been added to prevent the Platinum Update toys being applied to the base game, as trying to load these new toys will cause the game to throw a corrupted save error.