### PR TITLE
Update "SetStringKeepTerminatorStyle" to resolve "?" OT bug.

### DIFF
--- a/PKHeX.Core/PKM/Shared/GBPKML.cs
+++ b/PKHeX.Core/PKM/Shared/GBPKML.cs
@@ -107,10 +107,7 @@ public abstract class GBPKML : GBPKM
     {
         // Reset the destination buffer based on the termination style of the existing string.
         bool zeroed = exist.IndexOf((byte)0) != -1;
-        byte fill = zeroed ? (byte)0 : StringConverter12.G1TerminatorCode;
-        exist.Fill(fill);
-
-        int finalLength = Math.Min(value.Length + 1, exist.Length);
-        SetString(value, exist, finalLength);
+        StringConverterOption converterOption = (zeroed) ? StringConverterOption.ClearZero : StringConverterOption.Clear50;
+        SetString(value, exist, value.Length, converterOption);
     }
 }


### PR DESCRIPTION
Fixes a simple bug in Gen 2, where setting the "OT" field in PKHeX would cause the OT to appear as "?" in game:
![image](https://media.discordapp.net/attachments/367479180398428170/1074113000996352060/image.png?width=432&height=389)

I've tested this with my English copy of Crystal, but don't have any other languages or Gen 1 games to try it out on.
Being as this change mostly just removes duplicate functionality that got outdated in favour of another existing working implementation, it should hopefully be fine!