### PR TITLE
Fix MetDate for WC9 templates

### DIFF
--- a/PKHeX.Core/Legality/Encounters/Data/Live/EncounterServerDate.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Live/EncounterServerDate.cs
@@ -106,5 +106,6 @@ public static class EncounterServerDate
     public static readonly Dictionary<int, (DateOnly Start, DateOnly? End)> WC9Gifts = new()
     {
         {0001,  (new(2022, 11, 17), Never)}, // PokéCenter Flabébé
+        {0006, (new(2022, 12, 16), new(2023, 02, 01))}, //Jump Festa Gyarados
     };
 }

--- a/PKHeX.Core/Legality/Encounters/Data/Live/EncounterServerDate.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Live/EncounterServerDate.cs
@@ -105,7 +105,7 @@ public static class EncounterServerDate
     /// </summary>
     public static readonly Dictionary<int, (DateOnly Start, DateOnly? End)> WC9Gifts = new()
     {
-        {0001,  (new(2022, 11, 17), Never)}, // PokéCenter Flabébé
-        {0006, (new(2022, 12, 16), new(2023, 02, 01))}, //Jump Festa Gyarados
+        {0001, (new(2022, 11, 17), Never)}, // PokéCenter Flabébé
+        {0006, (new(2022, 12, 16), new(2023, 02, 01))}, // Jump Festa Gyarados
     };
 }

--- a/PKHeX.Core/Legality/Encounters/Data/Live/EncounterServerDate.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Live/EncounterServerDate.cs
@@ -105,6 +105,6 @@ public static class EncounterServerDate
     /// </summary>
     public static readonly Dictionary<int, (DateOnly Start, DateOnly? End)> WC9Gifts = new()
     {
-        {1501,  (new(2022, 11, 17), Never)}, // Flabébé Pokécenter
+        {0001,  (new(2022, 11, 17), Never)}, // PokéCenter Flabébé
     };
 }

--- a/PKHeX.Core/MysteryGifts/WC9.cs
+++ b/PKHeX.Core/MysteryGifts/WC9.cs
@@ -507,7 +507,8 @@ public sealed class WC9 : DataMysteryGift, ILangNick, INature, ITeraType, IRibbo
             }
         }
 
-        pk.MetDate = IsDateRestricted && EncounterServerDate.WC9GiftsChk.TryGetValue(CardID, out var dt) ? dt.Start : DateOnly.FromDateTime(DateTime.Now);
+        pk.MetDate = EncounterServerDate.WC9GiftsChk.TryGetValue(Checksum, out var dct) ? dct.Start :
+            EncounterServerDate.WC9Gifts.TryGetValue(CardID, out var dt) ? dt.Start : DateOnly.FromDateTime(DateTime.Now);
 
         var nickname_language = GetLanguage(language);
         pk.Language = nickname_language != 0 ? nickname_language : tr.Language;

--- a/PKHeX.Core/MysteryGifts/WC9.cs
+++ b/PKHeX.Core/MysteryGifts/WC9.cs
@@ -507,8 +507,7 @@ public sealed class WC9 : DataMysteryGift, ILangNick, INature, ITeraType, IRibbo
             }
         }
 
-        pk.MetDate = EncounterServerDate.WC9GiftsChk.TryGetValue(Checksum, out var dct) ? dct.Start :
-            EncounterServerDate.WC9Gifts.TryGetValue(CardID, out var dt) ? dt.Start : DateOnly.FromDateTime(DateTime.Now);
+        pk.MetDate = GetSuggestedDate();
 
         var nickname_language = GetLanguage(language);
         pk.Language = nickname_language != 0 ? nickname_language : tr.Language;
@@ -537,6 +536,17 @@ public sealed class WC9 : DataMysteryGift, ILangNick, INature, ITeraType, IRibbo
         pk.ResetPartyStats();
         pk.RefreshChecksum();
         return pk;
+    }
+
+    private DateOnly GetSuggestedDate()
+    {
+        if (!IsDateRestricted)
+            return DateOnly.FromDateTime(DateTime.Now);
+        if (EncounterServerDate.WC9GiftsChk.TryGetValue(Checksum, out var range))
+            return range.Start;
+        if (EncounterServerDate.WC9Gifts.TryGetValue(CardID, out range))
+            return range.Start;
+        return DateOnly.FromDateTime(DateTime.Now);
     }
 
     private void SetEggMetData(PKM pk)


### PR DESCRIPTION
Adjusted the Flabébé entry and added the Gyarados entry in the EncounterServerDate class.
I didn't add the Garganacl entry yet, since its redemption code is supposed to be available later today (2023-02-16) at 10pm UTC.

Fixed the MetDate during a PK9 generation from a wondercard template:
   1) I removed the `IsDateRestricted` bool check since all events are restricted anyways.
   1) The `EncounterServerDate.WC9GiftsChk` was incorrectly called with `CardID` instead of card `Checksum`.
   1) Added the `EncounterServerDate.WC9Gifts.TryGetValue` method call, which was missing.