### PR TITLE
WC3 fixes/improvements (?)

### DIFF
--- a/PKHeX.Core/Legality/Encounters/Data/Gen3/EncountersWC3.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Gen3/EncountersWC3.cs
@@ -14,7 +14,7 @@ internal static class EncountersWC3
 {
     internal static readonly WC3[] Encounter_Event3_Special =
     {
-        new() { Species = 385, Level = 05, TID16 = 20043, OT_Gender = 0, Version = GameVersion.R, Method = PIDType.BACD_R, OT_Name = "WISHMKR", CardTitle = "Wishmaker Jirachi", Language = (int)LanguageID.English },
+        new() { Species = 385, Level = 05, ID32 = 20043, OT_Gender = 0, Version = GameVersion.R, Method = PIDType.BACD_R, OT_Name = "WISHMKR", CardTitle = "Wishmaker Jirachi", Language = (int)LanguageID.English },
     };
 
     private static IEnumerable<WC3> GetIngameCXDData()


### PR DESCRIPTION
Firstly: Wishmaker Jirachi has a static SID of 00000, so ID32 should probably be used instead of TID16. Otherwise Mystery Gift Database gives it an SID of 65535, and legality checker ends up accepting any SID for it even though 00000 is the only legal one.

Secondly: Duking trades (and Elekid) from XD have unspecified SIDs, which is normal because as far as I can tell, the game gives them the same SID as the player's. So any SID should be valid, but because unspecified SID = 65535, Mystery Gift Database only gives them 65535 SID. It's not a big deal, you can manually edit them for yourself, but I figured it would be nice if it would use the SID from the save file instead of defaulting to 65535, since that's what the game already does anyway.

https://github.com/kwsch/PKHeX/blob/cb0ef526764ef7a70930bede6aa89ea928dd2769/PKHeX.Core/MysteryGifts/WC3.cs#L114

Here I did `pk.SID16 = SID16 != UnspecifiedID ? SID16 : tr.SID16;` instead. Hacky, but it only affects Elekid/Duking trades. Channel Jirachi gets its random SID from somewhere else already, and Poképark eggs don't realistically matter; everything else already has a specified SID of 00000, and nothing actually has a specified SID of 65535, so it shouldn't interfere with anything else. Still, it's not a super clean way of doing it, so I'd rather get your opinion first before I push something like this.