### PR TITLE
ResetBoxNames in UpdateBoxViewers

### DIFF
--- a/PKHeX.WinForms/Controls/SAV Editor/SAVEditor.cs
+++ b/PKHeX.WinForms/Controls/SAV Editor/SAVEditor.cs
@@ -158,6 +158,7 @@ public partial class SAVEditor : UserControl, ISlotViewer<PictureBox>, ISaveFile
         {
             v.FlagIllegal = Box.FlagIllegal;
             v.ResetSlots();
+            v.ResetBoxNames();
         }
     }
 


### PR DESCRIPTION
I am making a plugin to automatize a Living Dex sorting and after sorting the boxes in the plugin and changing the box names, I noticed the method UpdateBoxViewers only reload the box content, not the names, so I added a call to ResetBoxNames.
