### PR TITLE
Fix SetValue for SByte blocks

### DIFF
--- a/PKHeX.Core/Saves/Encryption/SwishCrypto/SCTypeCode.cs
+++ b/PKHeX.Core/Saves/Encryption/SwishCrypto/SCTypeCode.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using static System.Buffers.Binary.BinaryPrimitives;
 
 namespace PKHeX.Core;
@@ -101,7 +101,7 @@ public static class SCTypeCodeExtensions
             case SCTypeCode.UInt32: WriteUInt32LittleEndian(data, (uint)value); break;
             case SCTypeCode.UInt64: WriteUInt64LittleEndian(data, (ulong)value); break;
 
-            case SCTypeCode.SByte: data[0] = (byte)value; break;
+            case SCTypeCode.SByte: data[0] = (byte)(sbyte)value; break;
             case SCTypeCode.Int16: WriteInt16LittleEndian(data, (short)value); break;
             case SCTypeCode.Int32: WriteInt32LittleEndian(data, (int)value); break;
             case SCTypeCode.Int64: WriteInt64LittleEndian(data, (long)value); break;


### PR DESCRIPTION
Currently, when PKHeX tries to edit the value of an SCBlock of SByte type, it tries to cast the value from `object` to `byte`, which causes the exception `Unable to cast object of type 'System.SByte' to type 'System.Byte'`. 

![immagine](https://user-images.githubusercontent.com/52102823/226304505-2d98886c-7687-4862-9fc2-f47c81e02891.png)

This can be avoided by forcing a cast from `object` to `sbyte`, and only then to `byte`.