### PR TITLE
Label Active Outbreaks Number Save Block

### DIFF
--- a/PKHeX.Core/Saves/Access/SaveBlockAccessor9SV.cs
+++ b/PKHeX.Core/Saves/Access/SaveBlockAccessor9SV.cs
@@ -982,6 +982,8 @@ public sealed class SaveBlockAccessor9SV : SCBlockAccessor, ISaveBlock9Main
     #endregion
 
     #region EncountOutbreakSave
+    private const uint KMassOutbreakAmountActive  = 0x6C375C8A;
+
     private const uint KMassOutbreak01CenterPos   = 0x2ED42F4D; // EncountOutbreakSave_centerPos[0]
     private const uint KMassOutbreak01DummyPos    = 0x4A13BE7C; // EncountOutbreakSave_dummyPos[0]
     private const uint KMassOutbreak01Species     = 0x76A2F996; // EncountOutbreakSave_monsno[0]

--- a/PKHeX.Core/Saves/Access/SaveBlockAccessor9SV.cs
+++ b/PKHeX.Core/Saves/Access/SaveBlockAccessor9SV.cs
@@ -982,7 +982,7 @@ public sealed class SaveBlockAccessor9SV : SCBlockAccessor, ISaveBlock9Main
     #endregion
 
     #region EncountOutbreakSave
-    private const uint KMassOutbreakAmountActive  = 0x6C375C8A;
+    private const uint KMassOutbreakNumActive     = 0x6C375C8A;
 
     private const uint KMassOutbreak01CenterPos   = 0x2ED42F4D; // EncountOutbreakSave_centerPos[0]
     private const uint KMassOutbreak01DummyPos    = 0x4A13BE7C; // EncountOutbreakSave_dummyPos[0]


### PR DESCRIPTION
Data for a total amount of 8 outbreaks is always present within the game states, but the amount of those outbreaks that are effectively enabled (meaning visible in the map and that can produce spawns in the game world) is determined by block 0x6C375C8A.

For example, if block 0x6C375C8A contains the value "7", only the first 7 outbreaks will be effectively active. If the block contains "8", then all the outbreaks will be effectively active.

I tried to stay consistent with your block nomenclatures, but feel free to edit the label if you wish to.

Do note that since this is an SByte block, editing its value will require a fix to correctly handle the cast from object to data byte value. PR https://github.com/kwsch/PKHeX/pull/3843 can eventually be used for this.