### PR TITLE
Fix first character of Japanese country/region names getting cut off

### DIFF
--- a/PKHeX.Core/Util/ComboItemUtil.cs
+++ b/PKHeX.Core/Util/ComboItemUtil.cs
@@ -20,7 +20,7 @@ public static partial class Util
         var arr = new List<ComboItem>(inputCSV.Count);
         foreach (var line in inputCSV)
         {
-            var text = StringUtil.GetNthEntry(line, index, 4);
+            var text = StringUtil.GetNthEntry(line, index, 3);
             var value = line.AsSpan(0, 3);
             var item = new ComboItem(text, ToInt32(value));
             arr.Add(item);


### PR DESCRIPTION
When the interface language is set to Japanese, it incorrectly displayed `日本` or `アメリカ` as just `本` or `メリカ` in both the Trainer Data editor and the PK6/7 editor.