### PR TITLE
Add Enrollment Date To SaveBlockAccessor9SV and SAV9SV

### DIFF
--- a/PKHeX.Core/Saves/Access/SaveBlockAccessor9SV.cs
+++ b/PKHeX.Core/Saves/Access/SaveBlockAccessor9SV.cs
@@ -25,6 +25,7 @@ public sealed class SaveBlockAccessor9SV : SCBlockAccessor, ISaveBlock9Main
     public PlayerAppearance9 PlayerAppearance { get; }
     public RaidSpawnList9 Raid { get; }
     public RaidSevenStar9 RaidSevenStar { get; }
+    public Epoch1900Value EnrollmentDate { get; }
 
     public SaveBlockAccessor9SV(SAV9SV sav)
     {
@@ -43,6 +44,7 @@ public sealed class SaveBlockAccessor9SV : SCBlockAccessor, ISaveBlock9Main
         PlayerAppearance = new PlayerAppearance9(sav, GetBlock(KCurrentAppearance));
         Raid = new RaidSpawnList9(sav, GetBlock(KTeraRaids));
         RaidSevenStar = new RaidSevenStar9(sav, GetBlock(KSevenStarRaids));
+        EnrollmentDate = new Epoch1900Value(GetBlock(KEnrollmentDate));
     }
 
     // Arrays (Blocks)

--- a/PKHeX.Core/Saves/SAV9SV.cs
+++ b/PKHeX.Core/Saves/SAV9SV.cs
@@ -76,6 +76,7 @@ public sealed class SAV9SV : SaveFile, ISaveBlock9Main, ISCBlockArray, ISaveFile
     public PlayerAppearance9 PlayerAppearance => Blocks.PlayerAppearance;
     public RaidSpawnList9 Raid => Blocks.Raid;
     public RaidSevenStar9 RaidSevenStar => Blocks.RaidSevenStar;
+    public Epoch1900Value EnrollmentDate => Blocks.EnrollmentDate;
     #endregion
 
     protected override SAV9SV CloneInternal()

--- a/PKHeX.Core/Saves/Substructures/Gen9/Epoch1900Value.cs
+++ b/PKHeX.Core/Saves/Substructures/Gen9/Epoch1900Value.cs
@@ -1,0 +1,49 @@
+using System;
+using System.ComponentModel;
+
+namespace PKHeX.Core;
+
+/// <summary>
+/// Stores the <see cref="Timestamp"/> to indicate the seconds since 1900 (rounded to days) that an event occurred.
+/// </summary>
+[TypeConverter(typeof(ExpandableObjectConverter))]
+public sealed class Epoch1900Value {
+
+    // Data should be 4 bytes where we only care about the first 3 bytes i.e. 24 bits
+    // First 6 bits are day, next 6 bits are 0 indexed month, last 12 bits are year from 1900
+    private readonly Memory<byte> Data;
+    private Span<byte> Span => Data.Span;
+
+    public Epoch1900Value(SCBlock block) : this(block.Data) { }
+    public Epoch1900Value(Memory<byte> data) => Data = data;
+
+    private static DateTime Epoch => new(1900, 1, 1);
+
+    public DateTime Timestamp {
+        get {
+            return Epoch
+                .AddDays(Span[2] >> 2)
+                .AddDays(-1)
+                .AddMonths(((Span[2] & 0b0000_0011) << 2) | ((Span[1] & 0b1111_0000) >> 4))
+                .AddYears(((Span[1] & 0b0000_1111) << 4) | Span[0]);
+        }
+        set {
+            int day = value.Day;
+            int month = value.Month - Epoch.Month;
+            int year = value.Year - Epoch.Year;
+            Span[2] = (byte)(((day & 0b0011_1111) << 2) | ((month & 0b0011_0000) >> 4));
+            Span[1] = (byte)(((month & 0b0000_1111) << 4) | ((year & 0b1111_0000_00000) >> 8));
+            Span[0] = (byte)(year & 0b1111_1111);
+        }
+    }
+
+    public string DisplayValue => $"{Timestamp.Year:0000}-{Timestamp.Month:00}-{Timestamp.Day:00} {Timestamp.Hour:00}ː{Timestamp.Minute:00}ː{Timestamp.Second:00}"; // not :
+
+    /// <summary>
+    /// time_t (seconds since 1900 Epoch rounded to days)
+    /// </summary>
+    public ulong Seconds {
+        get => (ulong)(Timestamp - Epoch).TotalSeconds;
+        set => Timestamp = Epoch.AddSeconds(value);
+    }
+}


### PR DESCRIPTION
Add Epoch1900Value based on Epoch1970Value's API and the method @Lusamine described in #3800 to access the Enrollment Date From Scarlet and Violet Save