### PR TITLE
Fix ORAS Held Items Using XY Held Items By Mistake

### DIFF
--- a/PKHeX.Core/Items/ItemStorage6AO.cs
+++ b/PKHeX.Core/Items/ItemStorage6AO.cs
@@ -82,6 +82,11 @@ public sealed class ItemStorage6AO : IItemStorage
         065, 066, 067,
     };
 
+    public static ushort[] GetAllHeld()
+    {
+        return ArrayUtil.ConcatAll(Pouch_Items_AO, Pouch_Medicine_AO, ItemStorage6XY.Pouch_Berry_XY);
+    }
+
     public bool IsLegal(InventoryType type, int itemIndex, int itemCount)
     {
         if (type is InventoryType.KeyItems)

--- a/PKHeX.Core/Legality/Core.cs
+++ b/PKHeX.Core/Legality/Core.cs
@@ -128,7 +128,8 @@ public static class Legal
     internal static readonly ushort[] HeldItems_Pt = ItemStorage4Pt.GetAllHeld(); // Griseous Orb Added
     internal static readonly ushort[] HeldItems_HGSS = HeldItems_Pt;
     internal static readonly ushort[] HeldItems_BW = ItemStorage5.GetAllHeld();
-    internal static readonly ushort[] HeldItem_AO = ItemStorage6XY.GetAllHeld();
+    internal static readonly ushort[] HeldItems_XY = ItemStorage6XY.GetAllHeld();
+    internal static readonly ushort[] HeldItems_AO = ItemStorage6AO.GetAllHeld();
     internal static readonly ushort[] HeldItems_SM = ItemStorage7SM.GetAllHeld();
     internal static readonly ushort[] HeldItems_USUM = ItemStorage7USUM.GetAllHeld();
     internal static readonly ushort[] HeldItems_GG = Array.Empty<ushort>();

--- a/PKHeX.Core/Legality/Restrictions/ItemRestrictions.cs
+++ b/PKHeX.Core/Legality/Restrictions/ItemRestrictions.cs
@@ -52,7 +52,7 @@ public static class ItemRestrictions
     private static readonly bool[] ReleasedHeldItems_3 = GetPermitList(MaxItemID_3, HeldItems_RS, ItemStorage3RS.Unreleased); // Safari Ball
     private static readonly bool[] ReleasedHeldItems_4 = GetPermitList(MaxItemID_4_HGSS, HeldItems_HGSS, ItemStorage4.Unreleased);
     private static readonly bool[] ReleasedHeldItems_5 = GetPermitList(MaxItemID_5_B2W2, HeldItems_BW, ItemStorage5.Unreleased);
-    private static readonly bool[] ReleasedHeldItems_6 = GetPermitList(MaxItemID_6_AO, HeldItem_AO, ItemStorage6XY.Unreleased);
+    private static readonly bool[] ReleasedHeldItems_6 = GetPermitList(MaxItemID_6_AO, HeldItems_AO, ItemStorage6XY.Unreleased);
     private static readonly bool[] ReleasedHeldItems_7 = GetPermitList(MaxItemID_7_USUM, HeldItems_USUM, ItemStorage7SM.Unreleased);
     private static readonly bool[] ReleasedHeldItems_8 = GetPermitList(MaxItemID_8, HeldItems_SWSH, ItemStorage8SWSH.Unreleased);
     private static readonly bool[] ReleasedHeldItems_8b = GetPermitList(MaxItemID_8b, HeldItems_BS, ItemStorage8BDSP.Unreleased);

--- a/PKHeX.Core/Legality/Restrictions/Memories/MemoryContext6.cs
+++ b/PKHeX.Core/Legality/Restrictions/Memories/MemoryContext6.cs
@@ -40,7 +40,7 @@ public sealed partial class MemoryContext6 : MemoryContext
         return true; // todo
     }
 
-    public override IEnumerable<ushort> GetMemoryItemParams() => Legal.HeldItem_AO.Distinct()
+    public override IEnumerable<ushort> GetMemoryItemParams() => Legal.HeldItems_AO.Distinct()
         .Concat(GetKeyItemParams())
         .Concat(ItemStorage6AO.Pouch_TMHM_AO[..100].ToArray())
         .Where(z => z <= Legal.MaxItemID_6_AO);
@@ -49,7 +49,7 @@ public sealed partial class MemoryContext6 : MemoryContext
     public override bool IsUsedKeyItemSpecific(int item, ushort species) => KeyItemMemoryArgsGen6.TryGetValue(species, out var value) && value.Contains((ushort)item);
 
     public override bool CanPlantBerry(int item) => ItemStorage6XY.Pouch_Berry_XY.Contains((ushort)item);
-    public override bool CanHoldItem(int item) => Legal.HeldItem_AO.Contains((ushort)item);
+    public override bool CanHoldItem(int item) => Legal.HeldItems_AO.Contains((ushort)item);
 
     public override bool CanObtainMemoryOT(GameVersion pkmVersion, byte memory) => pkmVersion switch
     {

--- a/PKHeX.Core/Legality/Restrictions/Memories/MemoryContext8.cs
+++ b/PKHeX.Core/Legality/Restrictions/Memories/MemoryContext8.cs
@@ -12,7 +12,7 @@ public sealed partial class MemoryContext8 : MemoryContext
 
     public override IEnumerable<ushort> GetKeyItemParams() => (KeyItemMemoryArgsGen8.Values).SelectMany(z => z).Distinct();
 
-    public override IEnumerable<ushort> GetMemoryItemParams() => Legal.HeldItem_AO.Concat(Legal.HeldItems_SWSH).Distinct()
+    public override IEnumerable<ushort> GetMemoryItemParams() => Legal.HeldItems_AO.Concat(Legal.HeldItems_SWSH).Distinct()
         .Concat(GetKeyItemParams())
         .Concat(ItemStorage6AO.Pouch_TMHM_AO[..100].ToArray())
         .Where(z => z <= Legal.MaxItemID_8_R2);

--- a/PKHeX.Core/Saves/SAV6AO.cs
+++ b/PKHeX.Core/Saves/SAV6AO.cs
@@ -24,7 +24,7 @@ public sealed class SAV6AO : SAV6, ISaveBlock6AO, IMultiplayerSprite
     }
 
     public override PersonalTable6AO Personal => PersonalTable.AO;
-    public override ReadOnlySpan<ushort> HeldItems => Legal.HeldItem_AO;
+    public override ReadOnlySpan<ushort> HeldItems => Legal.HeldItems_AO;
     public SaveBlockAccessor6AO Blocks { get; }
     protected override SAV6AO CloneInternal() => new((byte[])Data.Clone());
     public override ushort MaxMoveID => Legal.MaxMoveID_6_AO;

--- a/PKHeX.Core/Saves/SAV6AODemo.cs
+++ b/PKHeX.Core/Saves/SAV6AODemo.cs
@@ -22,7 +22,7 @@ public sealed class SAV6AODemo : SAV6
     }
 
     public override PersonalTable6AO Personal => PersonalTable.AO;
-    public override ReadOnlySpan<ushort> HeldItems => Legal.HeldItem_AO;
+    public override ReadOnlySpan<ushort> HeldItems => Legal.HeldItems_AO;
     protected override SAV6AODemo CloneInternal() => new((byte[])Data.Clone());
     public override ushort MaxMoveID => Legal.MaxMoveID_6_AO;
     public override int MaxItemID => Legal.MaxItemID_6_AO;

--- a/PKHeX.Core/Saves/SAV6XY.cs
+++ b/PKHeX.Core/Saves/SAV6XY.cs
@@ -24,7 +24,7 @@ public sealed class SAV6XY : SAV6, ISaveBlock6XY, IMultiplayerSprite
     }
 
     public override PersonalTable6XY Personal => PersonalTable.XY;
-    public override ReadOnlySpan<ushort> HeldItems => Legal.HeldItem_AO;
+    public override ReadOnlySpan<ushort> HeldItems => Legal.HeldItems_XY;
     public SaveBlockAccessor6XY Blocks { get; }
     protected override SAV6XY CloneInternal() => new((byte[])Data.Clone());
     public override ushort MaxMoveID => Legal.MaxMoveID_6_XY;


### PR DESCRIPTION
- Add HeldItems_XY
- Fix that HeldItem_AO pointed to what should have been HeldItems_XY
- Fix HeldItem_AO being inconsistent with the rest of the HeldItems
- Correct HeldItems_AO only having XY  held items and not ones added in ORAS