### PR TITLE
Fix Greyscale Calculation

### DIFF
--- a/PKHeX.Drawing/ImageUtil.cs
+++ b/PKHeX.Drawing/ImageUtil.cs
@@ -231,7 +231,7 @@ public static class ImageUtil
         {
             if (data[i + 3] == 0)
                 continue;
-            byte greyS = (byte)(((0.3 * data[i + 2]) + (0.59 * data[i + 1]) + (0.11 * data[i + 0])) / 3);
+            byte greyS = (byte)(((0.3 * data[i + 2]) + (0.59 * data[i + 1]) + (0.11 * data[i + 0])));
             data[i + 0] = greyS;
             data[i + 1] = greyS;
             data[i + 2] = greyS;


### PR DESCRIPTION
The calculation done appears to be both luminosity and average methods mixed together which is causing the image to be much darker but I am assuming it should only be luminosity.