### PR TITLE
Fix Griseous Orb being incorrectly removed from Pt inventory

### DIFF
--- a/PKHeX.Core/Items/ItemStorage4HGSS.cs
+++ b/PKHeX.Core/Items/ItemStorage4HGSS.cs
@@ -20,7 +20,7 @@ public sealed class ItemStorage4HGSS : ItemStorage4, IItemStorage
 
     public ReadOnlySpan<ushort> GetItems(InventoryType type) => type switch
     {
-        InventoryType.Items => Pouch_Items_DP,
+        InventoryType.Items => Pouch_Items_Pt,
         InventoryType.KeyItems => Pouch_Key_HGSS,
         InventoryType.TMHMs => Pouch_TMHM_DP,
         InventoryType.MailItems => Pouch_Mail_DP,

--- a/PKHeX.Core/Items/ItemStorage4Pt.cs
+++ b/PKHeX.Core/Items/ItemStorage4Pt.cs
@@ -20,7 +20,7 @@ public sealed class ItemStorage4Pt : ItemStorage4, IItemStorage
 
     public ReadOnlySpan<ushort> GetItems(InventoryType type) => type switch
     {
-        InventoryType.Items => Pouch_Items_DP,
+        InventoryType.Items => Pouch_Items_Pt,
         InventoryType.KeyItems => Pouch_Key_Pt,
         InventoryType.TMHMs => Pouch_TMHM_DP,
         InventoryType.MailItems => Pouch_Mail_DP,


### PR DESCRIPTION
As part of #3860, ItemStorage4Pt was created to reference Pouch_Items_DP instead of Pouch_Items_Pt, which causes the Griseous Orb in a Pt inventory to be declared nominally invalid. This PR is a trivial fix for this issue.