### PR TITLE
Add そらみつ's Bronzong Server Date

### DIFF
--- a/PKHeX.Core/Legality/Encounters/Data/Live/EncounterServerDate.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Live/EncounterServerDate.cs
@@ -135,6 +135,7 @@ public static class EncounterServerDate
         {0025, (new(2023, 04, 21), new(2023, 07, 01))}, // Pokémon Center Pikachu (Mini & Jumbo)
         {1003, (new(2023, 05, 29), new(2023, 08, 01))}, // Arceus and the Jewel of Life Distribution - Pokémon Store Tie-In Bronzong
         {1002, (new(2023, 05, 31), new(2023, 08, 01))}, // Arceus and the Jewel of Life Distribution Pichu
+        {0028, (new(2023, 06, 09), new(2023, 06, 12))}, // そらみつ's Bronzong
 
         {9021, (new(2023, 05, 30), Never)}, // Hidden Ability Sprigatito
         {9022, (new(2023, 05, 30), Never)}, // Hidden Ability Fuecoco


### PR DESCRIPTION
The gift code was given on stream on June 10 at around 4:00 A.M UTC.
The wondercard was removed from the servers on June 11 at around 3:00 PM UTC.