### PR TITLE
Correct SAV4Ranch's SetChecksums() passing the wrong pkEnd offset argument to UpdateMetadata()

### DIFF
--- a/PKHeX.Core/Saves/Storage/SAV4Ranch.cs
+++ b/PKHeX.Core/Saves/Storage/SAV4Ranch.cs
@@ -155,7 +155,8 @@ public sealed class SAV4Ranch : BulkStorage, ISaveFileRevision
     {
         var data = Data.AsSpan();
         var slotCount = GetOccupiedSlotCount();
-        UpdateMetadata(slotCount * SIZE_STORED);
+        int pkStart = PokemonCountOffset + 4;
+        UpdateMetadata(pkStart + (slotCount * SIZE_STORED));
 
         // 20 byte SHA checksum at the top of the file, which covers all data that follows.
         var hash = data[..sha1HashSize];


### PR DESCRIPTION
Spotted the cause! Wound up just being a case of a missing offset for an address calculation!

The data was getting zeroed out due to a bit of a domino effect - Because this argument was wonky, the data end marker was being put in the wrong place, then any data after that marker gets 0'd!