### PR TITLE
Pokemon location tooltip fix for PLA + miscellaneous comment fixes

### DIFF
--- a/PKHeX.Core/Game/GameStrings/GameStrings.cs
+++ b/PKHeX.Core/Game/GameStrings/GameStrings.cs
@@ -763,7 +763,7 @@ public sealed class GameStrings : IBasicStrings
         6 => Gen6,
         7 => GameVersion.Gen7b.Contains(version) ? Gen7b : Gen7,
 
-        8 when version is GameVersion.PLA => Gen8,
+        8 when version is GameVersion.PLA => Gen8a,
         8 when GameVersion.BDSP.Contains(version) => Gen8b,
         8 => Gen8,
         9 => Gen9,

--- a/PKHeX.Core/Legality/Areas/EncounterArea8a.cs
+++ b/PKHeX.Core/Legality/Areas/EncounterArea8a.cs
@@ -6,7 +6,7 @@ namespace PKHeX.Core;
 
 /// <inheritdoc cref="EncounterArea" />
 /// <summary>
-/// <see cref="GameVersion.SWSH"/> encounter area
+/// <see cref="GameVersion.PLA"/> encounter area
 /// </summary>
 public sealed record EncounterArea8a : EncounterArea
 {

--- a/PKHeX.Core/Legality/Encounters/EncounterSlot/EncounterSlot8a.cs
+++ b/PKHeX.Core/Legality/Encounters/EncounterSlot/EncounterSlot8a.cs
@@ -3,7 +3,7 @@ using System;
 namespace PKHeX.Core;
 
 /// <summary>
-/// Encounter Slot found in <see cref="GameVersion.SWSH"/>.
+/// Encounter Slot found in <see cref="GameVersion.PLA"/>.
 /// </summary>
 /// <inheritdoc cref="EncounterSlot"/>
 public sealed record EncounterSlot8a : EncounterSlot, IAlphaReadOnly, IMasteryInitialMoveShop8

--- a/PKHeX.Core/Legality/Encounters/EncounterSlot/EncounterSlot9.cs
+++ b/PKHeX.Core/Legality/Encounters/EncounterSlot/EncounterSlot9.cs
@@ -4,7 +4,7 @@ using static PKHeX.Core.AreaWeather9;
 namespace PKHeX.Core;
 
 /// <summary>
-/// Encounter Slot found in <see cref="GameVersion.SWSH"/>.
+/// Encounter Slot found in <see cref="GameVersion.SV"/>.
 /// </summary>
 /// <inheritdoc cref="EncounterSlot"/>
 public sealed record EncounterSlot9 : EncounterSlot

--- a/PKHeX.Core/Legality/Encounters/EncounterStatic/EncounterStatic8b.cs
+++ b/PKHeX.Core/Legality/Encounters/EncounterStatic/EncounterStatic8b.cs
@@ -4,7 +4,7 @@ using static PKHeX.Core.StaticCorrelation8bRequirement;
 namespace PKHeX.Core;
 
 /// <summary>
-/// Generation 7 Static Encounter
+/// Generation 8 Static Encounter
 /// </summary>
 /// <inheritdoc cref="EncounterStatic"/>
 public sealed record EncounterStatic8b : EncounterStatic, IStaticCorrelation8b

--- a/PKHeX.Core/Legality/Encounters/EncounterTrade/EncounterTrade8b.cs
+++ b/PKHeX.Core/Legality/Encounters/EncounterTrade/EncounterTrade8b.cs
@@ -1,7 +1,7 @@
 namespace PKHeX.Core;
 
 /// <summary>
-/// Generation 7 Trade Encounter
+/// Generation 8 BD/SP Trade Encounter
 /// </summary>
 /// <inheritdoc cref="EncounterTrade"/>
 public sealed record EncounterTrade8b : EncounterTrade, IContestStatsReadOnly, IScaledSizeReadOnly, IFixedOTFriendship

--- a/PKHeX.Core/Saves/SAV9SV.cs
+++ b/PKHeX.Core/Saves/SAV9SV.cs
@@ -5,7 +5,7 @@ using static System.Buffers.Binary.BinaryPrimitives;
 namespace PKHeX.Core;
 
 /// <summary>
-/// Generation 9 <see cref="SaveFile"/> object for <see cref="GameVersion.SWSH"/> games.
+/// Generation 9 <see cref="SaveFile"/> object for <see cref="GameVersion.SV"/> games.
 /// </summary>
 public sealed class SAV9SV : SaveFile, ISaveBlock9Main, ISCBlockArray, ISaveFileRevision
 {


### PR DESCRIPTION
1. Fixes a bug where the Pokemon tooltip for PLA incorrectly looks at the SwSh location table, resulting in nonsense locations showing

Screenshot before fix
![PLA tooltip before fix](https://github.com/kwsch/PKHeX/assets/5295838/95137e07-9c59-4e58-815f-a6504955bfd2)
Screenshot after fix
![PLA tooltip after fix](https://github.com/kwsch/PKHeX/assets/5295838/08e5eec4-9dcf-4490-9c88-e9f6b35a4788)

2. Fixes comments that refer to incorrect generations/versions/games for the particular file
