### PR TITLE
Crystal (International) Checksum 2 Fix

### DIFF
--- a/PKHeX.Core/Saves/SAV2.cs
+++ b/PKHeX.Core/Saves/SAV2.cs
@@ -308,17 +308,22 @@ public sealed class SAV2 : SaveFile, ILangDeviantSave, IEventFlagArray, IEventWo
         WriteUInt16LittleEndian(Data.AsSpan(Offsets.OverallChecksumPosition2), accum);
     }
 
-    public override bool ChecksumsValid
+    public override bool ChecksumsValid => !ChecksumInfo.Contains("Invalid");
+
+    public override string ChecksumInfo
     {
         get
         {
             ushort accum = GetChecksum();
             ushort actual = ReadUInt16LittleEndian(Data.AsSpan(Offsets.OverallChecksumPosition));
-            return accum == actual;
+            ushort actual2 = ReadUInt16LittleEndian(Data.AsSpan(Offsets.OverallChecksumPosition2));
+
+            bool checksum1Valid = (accum == actual);
+            bool checksum2Valid = (accum == actual2);
+            static string valid(bool s) => s ? "Valid" : "Invalid";
+            return $"Checksum 1 {valid(checksum1Valid)}, Checksum 2 {valid(checksum2Valid)}.";
         }
     }
-
-    public override string ChecksumInfo => ChecksumsValid ? "Checksum valid." : "Checksum invalid";
 
     // Trainer Info
     public override GameVersion Version { get; protected set; }

--- a/PKHeX.Core/Saves/Substructures/Gen12/SAV2Offsets.cs
+++ b/PKHeX.Core/Saves/Substructures/Gen12/SAV2Offsets.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace PKHeX.Core;
 
@@ -100,7 +100,7 @@ internal sealed class SAV2Offsets
                 Gender = 0x3E3D;
                 AccumulatedChecksumEnd = 0x2B82;
                 OverallChecksumPosition = 0x2D0D;
-                OverallChecksumPosition2 = 0x7F0D;
+                OverallChecksumPosition2 = 0x1F0D;
 
                 PouchTMHM = 0x23E7;
                 PouchItem = 0x2420;


### PR DESCRIPTION
'Ello 'ello! Me again!

This PR addresses the issues @pikavees reported in #3890! - Looks like it was just a classic typo problem! I was able to recreate their scenario and confirmed that with these changes, it no longer occurs!
I've also added their suggestion to rejig the Checksum verification logic a bit to compare against both values, with it reporting which one(s) pass/fail!

Ta'!

