### PR TITLE
Fixed span for PokeDexEntry9SV being too large

### DIFF
--- a/PKHeX.Core/Saves/Substructures/PokeDex/Zukan9.cs
+++ b/PKHeX.Core/Saves/Substructures/PokeDex/Zukan9.cs
@@ -26,7 +26,7 @@ public sealed class Zukan9 : ZukanBase<SAV9SV>
             throw new ArgumentOutOfRangeException(nameof(species), species, null);
 
         var internalSpecies = SpeciesConverter.GetInternal9(species);
-        var span = Paldea.Data.AsSpan(internalSpecies * EntrySize);
+        var span = Paldea.Data.AsSpan(internalSpecies * EntrySize,EntrySize);
         return new PokeDexEntry9SV(span);
     }
 

--- a/PKHeX.Core/Saves/Substructures/PokeDex/Zukan9.cs
+++ b/PKHeX.Core/Saves/Substructures/PokeDex/Zukan9.cs
@@ -26,7 +26,7 @@ public sealed class Zukan9 : ZukanBase<SAV9SV>
             throw new ArgumentOutOfRangeException(nameof(species), species, null);
 
         var internalSpecies = SpeciesConverter.GetInternal9(species);
-        var span = Paldea.Data.AsSpan(internalSpecies * EntrySize,EntrySize);
+        var span = Paldea.Data.AsSpan(internalSpecies * EntrySize, EntrySize);
         return new PokeDexEntry9SV(span);
     }
 


### PR DESCRIPTION
as explained in my discord message

the dex entry is gotten with
```
new PokeDexEntry9SV(Dex.GetScBlock().Data.AsSpan(SpeciesConverter.GetInternal9(x) * PokeDexEntry9SV.SIZE))
```
but the byte data passed into the PokeDexEntry9SV is not capped at PokeDexEntry9SV.SIZE so it just passes a lot of data into the PokeDexEntry9SV for example 48396 when getting Sprigatito instad of the PokeDexEntry9SV.SIZE 24 (0x18) the dex entry (PokeDexEntry9SV) does not seem to care about the extra data but when you call clear all the extra data that does not belong to the current dex entry also gets cleared