### PR TITLE
RibbonExtensions public accessors

### DIFF
--- a/PKHeX.Core/Ribbons/IRibbonSetCommon3.cs
+++ b/PKHeX.Core/Ribbons/IRibbonSetCommon3.cs
@@ -8,9 +8,9 @@ public interface IRibbonSetCommon3
     bool RibbonEffort { get; set; }
 }
 
-internal static partial class RibbonExtensions
+public static partial class RibbonExtensions
 {
-    internal static void CopyRibbonSetCommon3(this IRibbonSetCommon3 set, IRibbonSetCommon3 dest)
+    public static void CopyRibbonSetCommon3(this IRibbonSetCommon3 set, IRibbonSetCommon3 dest)
     {
         dest.RibbonChampionG3 = set.RibbonChampionG3;
         dest.RibbonArtist = set.RibbonArtist;

--- a/PKHeX.Core/Ribbons/IRibbonSetCommon4.cs
+++ b/PKHeX.Core/Ribbons/IRibbonSetCommon4.cs
@@ -19,9 +19,9 @@ public interface IRibbonSetCommon4
     bool RibbonLegend { get; set; }
 }
 
-internal static partial class RibbonExtensions
+public static partial class RibbonExtensions
 {
-    internal static void CopyRibbonSetCommon4(this IRibbonSetCommon4 set, IRibbonSetCommon4 dest)
+    public static void CopyRibbonSetCommon4(this IRibbonSetCommon4 set, IRibbonSetCommon4 dest)
     {
         dest.RibbonChampionSinnoh = set.RibbonChampionSinnoh;
         dest.RibbonAlert = set.RibbonAlert;

--- a/PKHeX.Core/Ribbons/IRibbonSetCommon6.cs
+++ b/PKHeX.Core/Ribbons/IRibbonSetCommon6.cs
@@ -18,14 +18,14 @@ public interface IRibbonSetCommon6
     bool RibbonMasterToughness { get; set; }
 }
 
-internal static partial class RibbonExtensions
+public static partial class RibbonExtensions
 {
     /// <summary>
     /// Checks if the <see cref="set"/> has all five contest stat ribbons true.
     /// </summary>
     public static bool HasAllContestRibbons(this IRibbonSetCommon6 set) => set is { RibbonMasterCoolness: true, RibbonMasterBeauty: true, RibbonMasterCuteness: true, RibbonMasterCleverness: true, RibbonMasterToughness: true };
 
-    internal static void CopyRibbonSetCommon6(this IRibbonSetCommon6 set, IRibbonSetCommon6 dest)
+    public static void CopyRibbonSetCommon6(this IRibbonSetCommon6 set, IRibbonSetCommon6 dest)
     {
         dest.RibbonChampionKalos = set.RibbonChampionKalos;
         dest.RibbonChampionG6Hoenn = set.RibbonChampionG6Hoenn;

--- a/PKHeX.Core/Ribbons/IRibbonSetCommon7.cs
+++ b/PKHeX.Core/Ribbons/IRibbonSetCommon7.cs
@@ -9,9 +9,9 @@ public interface IRibbonSetCommon7
     bool RibbonBattleTreeMaster { get; set; }
 }
 
-internal static partial class RibbonExtensions
+public static partial class RibbonExtensions
 {
-    internal static void CopyRibbonSetCommon7(this IRibbonSetCommon7 set, IRibbonSetCommon7 dest)
+    public static void CopyRibbonSetCommon7(this IRibbonSetCommon7 set, IRibbonSetCommon7 dest)
     {
         dest.RibbonChampionAlola = set.RibbonChampionAlola;
         dest.RibbonBattleRoyale = set.RibbonBattleRoyale;

--- a/PKHeX.Core/Ribbons/IRibbonSetCommon8.cs
+++ b/PKHeX.Core/Ribbons/IRibbonSetCommon8.cs
@@ -10,9 +10,9 @@ public interface IRibbonSetCommon8
     bool RibbonHisui { get; set; }
 }
 
-internal static partial class RibbonExtensions
+public static partial class RibbonExtensions
 {
-    internal static void CopyRibbonSetCommon8(this IRibbonSetCommon8 set, IRibbonSetCommon8 dest)
+    public static void CopyRibbonSetCommon8(this IRibbonSetCommon8 set, IRibbonSetCommon8 dest)
     {
         dest.RibbonChampionGalar = set.RibbonChampionGalar;
         dest.RibbonTowerMaster = set.RibbonTowerMaster;

--- a/PKHeX.Core/Ribbons/IRibbonSetCommon9.cs
+++ b/PKHeX.Core/Ribbons/IRibbonSetCommon9.cs
@@ -7,9 +7,9 @@ public interface IRibbonSetCommon9
     bool RibbonOnceInALifetime { get; set; }
 }
 
-internal static partial class RibbonExtensions
+public static partial class RibbonExtensions
 {
-    internal static void CopyRibbonSetCommon9(this IRibbonSetCommon9 set, IRibbonSetCommon9 dest)
+    public static void CopyRibbonSetCommon9(this IRibbonSetCommon9 set, IRibbonSetCommon9 dest)
     {
         dest.RibbonChampionPaldea = set.RibbonChampionPaldea;
         dest.RibbonOnceInALifetime = set.RibbonOnceInALifetime;

--- a/PKHeX.Core/Ribbons/IRibbonSetEvent3.cs
+++ b/PKHeX.Core/Ribbons/IRibbonSetEvent3.cs
@@ -11,9 +11,9 @@ public interface IRibbonSetEvent3
     bool RibbonChampionNational { get; set; }
 }
 
-internal static partial class RibbonExtensions
+public static partial class RibbonExtensions
 {
-    internal static void CopyRibbonSetEvent3(this IRibbonSetEvent3 set, IRibbonSetEvent3 dest)
+    public static void CopyRibbonSetEvent3(this IRibbonSetEvent3 set, IRibbonSetEvent3 dest)
     {
         dest.RibbonEarth            = set.RibbonEarth;
         dest.RibbonNational         = set.RibbonNational;

--- a/PKHeX.Core/Ribbons/IRibbonSetEvent4.cs
+++ b/PKHeX.Core/Ribbons/IRibbonSetEvent4.cs
@@ -14,9 +14,9 @@ public interface IRibbonSetEvent4
     bool RibbonSouvenir { get; set; }
 }
 
-internal static partial class RibbonExtensions
+public static partial class RibbonExtensions
 {
-    internal static void CopyRibbonSetEvent4(this IRibbonSetEvent4 set, IRibbonSetEvent4 dest)
+    public static void CopyRibbonSetEvent4(this IRibbonSetEvent4 set, IRibbonSetEvent4 dest)
     {
         dest.RibbonClassic = set.RibbonClassic;
         dest.RibbonWishing = set.RibbonWishing;

--- a/PKHeX.Core/Ribbons/IRibbonSetMark8.cs
+++ b/PKHeX.Core/Ribbons/IRibbonSetMark8.cs
@@ -63,7 +63,7 @@ public interface IRibbonSetMarks
     int RibbonMarkCount { get; }
 }
 
-internal static partial class RibbonExtensions
+public static partial class RibbonExtensions
 {
     public static bool HasWeatherMark(this IRibbonSetMark8 m)
     {
@@ -71,7 +71,7 @@ internal static partial class RibbonExtensions
             || m.RibbonMarkBlizzard || m.RibbonMarkDry   || m.RibbonMarkSandstorm || m.RibbonMarkMisty;
     }
 
-    internal static void CopyRibbonSetMark8(this IRibbonSetMark8 set, IRibbonSetMark8 dest)
+    public static void CopyRibbonSetMark8(this IRibbonSetMark8 set, IRibbonSetMark8 dest)
     {
         dest.RibbonMarkLunchtime = set.RibbonMarkLunchtime;
         dest.RibbonMarkSleepyTime = set.RibbonMarkSleepyTime;

--- a/PKHeX.Core/Ribbons/IRibbonSetMark9.cs
+++ b/PKHeX.Core/Ribbons/IRibbonSetMark9.cs
@@ -15,9 +15,9 @@ public interface IRibbonSetMark9
     bool HasMarkEncounter9 { get; }
 }
 
-internal static partial class RibbonExtensions
+public static partial class RibbonExtensions
 {
-    internal static void CopyRibbonSetMark9(this IRibbonSetMark9 set, IRibbonSetMark9 dest)
+    public static void CopyRibbonSetMark9(this IRibbonSetMark9 set, IRibbonSetMark9 dest)
     {
         dest.RibbonMarkJumbo = set.RibbonMarkJumbo;
         dest.RibbonMarkMini = set.RibbonMarkMini;

--- a/PKHeX.Core/Ribbons/IRibbonSetMemory6.cs
+++ b/PKHeX.Core/Ribbons/IRibbonSetMemory6.cs
@@ -8,9 +8,9 @@ public interface IRibbonSetMemory6
     bool HasBattleMemoryRibbon { get; set; }
 }
 
-internal static partial class RibbonExtensions
+public static partial class RibbonExtensions
 {
-    internal static void CopyRibbonSetMemory6(this IRibbonSetMemory6 set, IRibbonSetMemory6 dest)
+    public static void CopyRibbonSetMemory6(this IRibbonSetMemory6 set, IRibbonSetMemory6 dest)
     {
         dest.HasContestMemoryRibbon = set.HasContestMemoryRibbon;
         dest.HasBattleMemoryRibbon = set.HasBattleMemoryRibbon;


### PR DESCRIPTION
Makes RibbonExtension public to be accessible from plugin projects

Notes:
Currently required for the Home Live Plugins to keep legacy support for old dumped PH1 and PH2 files.