### PR TITLE
Other Additional G9 DLC Save Sizes

### DIFF
--- a/PKHeX.Core/Saves/Util/SaveUtil.cs
+++ b/PKHeX.Core/Saves/Util/SaveUtil.cs
@@ -38,6 +38,7 @@ public static class SaveUtil
 
     // 2.0.1 (2.0.0 skipped): Teal Mask
     public const int SIZE_G9_DLC1_B = 0x4329A0; // +9
+    public const int SIZE_G9_DLC1_T = 0x4329A5; // +5
     public const int SIZE_G9_DLC1_0 = 0x4329A9; // +4
     public const int SIZE_G9_DLC1_E = 0x4329AD; // +1
     public const int SIZE_G9_DLC1_1 = 0x4329AE; // +1
@@ -57,6 +58,7 @@ public static class SaveUtil
     public const int SIZE_G9_DLC1_G = 0x432EC4; // +1
     public const int SIZE_G9_DLC1_7 = 0x432EC8; // +5
     public const int SIZE_G9_DLC1_I = 0x432EC9; // +1
+    public const int SIZE_G9_DLC1_R = 0x432ECC; // +1
     public const int SIZE_G9_DLC1_8 = 0x432ECD; // +5
 
     public const int SIZE_G8LA = 0x136DDE;
@@ -172,6 +174,8 @@ public static class SaveUtil
         SIZE_G9_DLC1_I,
         SIZE_G9_DLC1_Q,
         SIZE_G9_DLC1_W,
+        SIZE_G9_DLC1_R,
+        SIZE_G9_DLC1_T,
     };
 
     private static readonly HashSet<long> SizesSWSH = new()

--- a/PKHeX.Core/Saves/Util/SaveUtil.cs
+++ b/PKHeX.Core/Saves/Util/SaveUtil.cs
@@ -52,8 +52,11 @@ public static class SaveUtil
     public const int SIZE_G9_DLC1_4 = 0x432EB6;
     public const int SIZE_G9_DLC1_C = 0x432EBB; // +5
     public const int SIZE_G9_DLC1_5 = 0x432EBF; // +4
+    public const int SIZE_G9_DLC1_H = 0x432EC0; // +1
     public const int SIZE_G9_DLC1_6 = 0x432EC3; // +4
+    public const int SIZE_G9_DLC1_G = 0x432EC4; // +1
     public const int SIZE_G9_DLC1_7 = 0x432EC8; // +5
+    public const int SIZE_G9_DLC1_I = 0x432EC9; // +1
     public const int SIZE_G9_DLC1_8 = 0x432ECD; // +5
 
     public const int SIZE_G8LA = 0x136DDE;
@@ -164,6 +167,9 @@ public static class SaveUtil
         SIZE_G9_DLC1_D,
         SIZE_G9_DLC1_E,
         SIZE_G9_DLC1_F,
+        SIZE_G9_DLC1_G,
+        SIZE_G9_DLC1_H,
+        SIZE_G9_DLC1_I,
         SIZE_G9_DLC1_Q,
         SIZE_G9_DLC1_W,
     };


### PR DESCRIPTION
Three more G9 DLC Save Sizes, with a [report from](https://github.com/kwsch/PKHeX/pull/3995#issuecomment-1722535352) @laserjagd and based on my own save file before (`0x432EC4`) and after (`0x432EC9`) connecting to GO.