### PR TITLE
Load plugins before loading initial files

### DIFF
--- a/PKHeX.WinForms/MainWindow/Main.cs
+++ b/PKHeX.WinForms/MainWindow/Main.cs
@@ -42,10 +42,11 @@ public partial class Main : Form
         startup.ReadArguments(args);
         startup.ReadSettings(Settings.Startup);
         startup.ReadTemplateIfNoEntity(TemplatePath);
-        FormLoadInitialFiles(startup);
 
         if (Settings.Startup.PluginLoadMethod != PluginLoadSetting.DontLoad)
             FormLoadPlugins();
+
+        FormLoadInitialFiles(startup);
 
         if (HaX)
         {


### PR DESCRIPTION
This change allows plugins to get notified about a save being loaded by startup arguments.

Related issue: https://projectpokemon.org/home/forums/topic/62222-blacksharks-pkhex-plugin-support-thread/?do=findComment&comment=285534
User was dropping the save directly onto the exe.