### PR TITLE
HGSS: Add support for editing Pokeathlon Points

### DIFF
--- a/PKHeX.Core/Saves/SAV4HGSS.cs
+++ b/PKHeX.Core/Saves/SAV4HGSS.cs
@@ -254,9 +254,11 @@ public sealed class SAV4HGSS : SAV4
 
     public void PokewalkerCoursesSetAll(uint value = 0x07FF_FFFFu) => WriteUInt32LittleEndian(General[(OFS_WALKER + 0x8)..], value);
 
+    // Swarm
     public override uint SwarmSeed { get => ReadUInt32LittleEndian(General[0x68A8..]); set => WriteUInt32LittleEndian(General[0x68A8..], value); }
     public override uint SwarmMaxCountModulo => 20;
 
+    // Roamers
     public Roamer4 RoamerRaikou => GetRoamer(0);
     public Roamer4 RoamerEntei  => GetRoamer(1);
     public Roamer4 RoamerLatias => GetRoamer(2);
@@ -269,4 +271,7 @@ public sealed class SAV4HGSS : SAV4
         var mem = GeneralBuffer.Slice(ofs, size);
         return new Roamer4(mem);
     }
+
+    // Pokeathlon
+    public uint PokeathlonPoints { get => ReadUInt32LittleEndian(General[0xE548..]); set => WriteUInt32LittleEndian(General[0xE548..], value); }
 }

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen4/SAV_Misc4.Designer.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen4/SAV_Misc4.Designer.cs
@@ -115,6 +115,8 @@
             pokeGear4Editor1 = new PokeGear4Editor();
             tip1 = new System.Windows.Forms.ToolTip(components);
             tip2 = new System.Windows.Forms.ToolTip(components);
+            NUD_PokeathlonPoints = new System.Windows.Forms.NumericUpDown();
+            L_PokeathlonPoints = new System.Windows.Forms.Label();
             TC_Misc.SuspendLayout();
             TAB_Main.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)NUD_Coin).BeginInit();
@@ -160,6 +162,7 @@
             Tab_Misc.SuspendLayout();
             Tab_Poffins.SuspendLayout();
             Tab_PokeGear.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)NUD_PokeathlonPoints).BeginInit();
             SuspendLayout();
             // 
             // B_Cancel
@@ -1086,6 +1089,8 @@
             // 
             // Tab_Misc
             // 
+            Tab_Misc.Controls.Add(NUD_PokeathlonPoints);
+            Tab_Misc.Controls.Add(L_PokeathlonPoints);
             Tab_Misc.Controls.Add(B_AllSealsIllegal);
             Tab_Misc.Controls.Add(B_AllSealsLegal);
             Tab_Misc.Location = new System.Drawing.Point(4, 24);
@@ -1161,6 +1166,26 @@
             pokeGear4Editor1.Size = new System.Drawing.Size(428, 272);
             pokeGear4Editor1.TabIndex = 0;
             // 
+            // NUD_PokeathlonPoints
+            // 
+            NUD_PokeathlonPoints.Location = new System.Drawing.Point(149, 131);
+            NUD_PokeathlonPoints.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            NUD_PokeathlonPoints.Maximum = new decimal(new int[] { 9999999, 0, 0, 0 });
+            NUD_PokeathlonPoints.Name = "NUD_PokeathlonPoints";
+            NUD_PokeathlonPoints.Size = new System.Drawing.Size(75, 23);
+            NUD_PokeathlonPoints.TabIndex = 11;
+            NUD_PokeathlonPoints.Value = new decimal(new int[] { 9999999, 0, 0, 0 });
+            // 
+            // L_PokeathlonPoints
+            // 
+            L_PokeathlonPoints.Location = new System.Drawing.Point(28, 128);
+            L_PokeathlonPoints.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            L_PokeathlonPoints.Name = "L_PokeathlonPoints";
+            L_PokeathlonPoints.Size = new System.Drawing.Size(119, 25);
+            L_PokeathlonPoints.TabIndex = 12;
+            L_PokeathlonPoints.Text = "Pokeathlon Points:";
+            L_PokeathlonPoints.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
             // SAV_Misc4
             // 
             AutoScaleMode = System.Windows.Forms.AutoScaleMode.Inherit;
@@ -1221,6 +1246,7 @@
             Tab_Misc.ResumeLayout(false);
             Tab_Poffins.ResumeLayout(false);
             Tab_PokeGear.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)NUD_PokeathlonPoints).EndInit();
             ResumeLayout(false);
         }
 
@@ -1312,5 +1338,7 @@
         private PokeGear4Editor pokeGear4Editor1;
         private System.Windows.Forms.ToolTip tip1;
         private System.Windows.Forms.ToolTip tip2;
+        private System.Windows.Forms.NumericUpDown NUD_PokeathlonPoints;
+        private System.Windows.Forms.Label L_PokeathlonPoints;
     }
 }

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen4/SAV_Misc4.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen4/SAV_Misc4.cs
@@ -142,9 +142,14 @@ public partial class SAV_Misc4 : Form
         NUD_BP.Value = valBP > 9999 ? 9999 : valBP;
 
         if (SAV is SAV4Sinnoh sinnoh)
+        {
             ReadPoketch(sinnoh);
+        }
         else if (SAV is SAV4HGSS hgss)
+        {
             ReadWalker(hgss);
+            ReadPokeathlon(hgss);
+        }
 
         if (ofsUGFlagCount > 0)
         {
@@ -184,9 +189,14 @@ public partial class SAV_Misc4 : Form
         WriteUInt16LittleEndian(SAV.General[ofsBP..], (ushort)NUD_BP.Value);
 
         if (SAV is SAV4Sinnoh sinnoh)
+        {
             SavePoketch(sinnoh);
-        if (SAV is SAV4HGSS hgss)
+        }
+        else if (SAV is SAV4HGSS hgss)
+        {
             SaveWalker(hgss);
+            SavePokeathlon(hgss);
+        }
 
         if (ofsUGFlagCount > 0)
         {
@@ -838,5 +848,15 @@ public partial class SAV_Misc4 : Form
     {
         SAV.SetAllSeals(99, sender == B_AllSealsIllegal);
         System.Media.SystemSounds.Asterisk.Play();
+    }
+
+    private void ReadPokeathlon(SAV4HGSS s)
+    {
+        NUD_PokeathlonPoints.Value = s.PokeathlonPoints;
+    }
+
+    private void SavePokeathlon(SAV4HGSS s)
+    {
+        s.PokeathlonPoints = (uint)NUD_PokeathlonPoints.Value;
     }
 }


### PR DESCRIPTION
This PR adds support for editing the Pokeathlon Points in a HGSS save, which are used to purchase various evolution items.