### PR TITLE
My Pokemon Ranch: Level fixes and general usability improvements

### DIFF
--- a/PKHeX.Core/Saves/Storage/SAV4Ranch.cs
+++ b/PKHeX.Core/Saves/Storage/SAV4Ranch.cs
@@ -26,12 +26,12 @@ public sealed class SAV4Ranch : BulkStorage, ISaveFileRevision
     private readonly int TrainerMiiCountOffset;
     private readonly int PokemonCountOffset;
 
-    public override int SlotCount => RanchLevel.GetSlotCount(CurrentRanchLevelIndex);
+    public override int SlotCount => RanchLevel.GetSlotCount(CurrentRanchLevel);
     public override int BoxCount => (int)Math.Ceiling((decimal)SlotCount / SlotsPerBox);
     public int MiiCount { get; }
     public int TrainerMiiCount { get; }
-    public int MaxToyCount => RanchLevel.GetMaxToyCount(CurrentRanchLevelIndex);
-    public int MaxMiiCount => RanchLevel.GetMaxMiiCount(CurrentRanchLevelIndex);
+    public int MaxToyCount => RanchLevel.GetMaxToyCount(CurrentRanchLevel);
+    public int MaxMiiCount => RanchLevel.GetMaxMiiCount(CurrentRanchLevel);
 
     private readonly RanchToy BlankToy = new(new byte[RanchToy.SIZE]);
 
@@ -83,8 +83,8 @@ public sealed class SAV4Ranch : BulkStorage, ISaveFileRevision
 
     private const int ToyBaseOffset = 0x227B;
 
-    public byte CurrentRanchLevelIndex { get => Data[0x5A]; set => Data[0x5A] = value; }
-    public byte PlannedRanchLevelIndex { get => Data[0x5B]; set => Data[0x5B] = value; } // tomorrow's level
+    public int CurrentRanchLevel { get => Data[0x5A] + 1; set => Data[0x5A] = (byte)(value - 1); }
+    public int PlannedRanchLevel { get => Data[0x5B] + 1; set => Data[0x5B] = (byte)(value - 1); } // tomorrow's level
 
     public uint SecondsSince2000 { get => ReadUInt32BigEndian(Data.AsSpan(0x5C)); set => WriteUInt32BigEndian(Data.AsSpan(0x5C), value); }
     public uint TotalSeconds { get => ReadUInt32BigEndian(Data.AsSpan(0x60)); set => WriteUInt32BigEndian(Data.AsSpan(0x60), value); }

--- a/PKHeX.Core/Saves/Substructures/Gen4/Ranch/RanchLevel.cs
+++ b/PKHeX.Core/Saves/Substructures/Gen4/Ranch/RanchLevel.cs
@@ -5,9 +5,7 @@ namespace PKHeX.Core;
 /// </summary>
 public static class RanchLevel
 {
-    public static int GetLevel(byte levelIndex) => levelIndex + 1;
-
-    public static int GetMaxMiiCount(byte levelIndex) => levelIndex switch
+    public static int GetMaxMiiCount(int ranchLevel) => ranchLevel switch
     {
         >= 11 => 20,
         >= 08 => 15,
@@ -15,7 +13,7 @@ public static class RanchLevel
         _ => 5,
     };
 
-    public static int GetMaxToyCount(byte levelIndex) => levelIndex switch
+    public static int GetMaxToyCount(int ranchLevel) => ranchLevel switch
     {
         >= 25 => 6,
         >= 20 => 5,
@@ -25,36 +23,38 @@ public static class RanchLevel
         _ => 1,
     };
 
-    public static int GetSlotCount(byte levelIndex) => levelIndex switch
+    public static int GetSlotCount(int ranchLevel) => ranchLevel switch
     {
-        00 => 020,
-        01 => 025,
-        02 => 030,
-        03 => 040,
-        04 => 050,
-        05 => 060,
-        06 => 080,
+        01 => 020,
+        02 => 025,
+        03 => 030,
 
-        07 => 100,
-        08 => 150,
-        09 => 200,
-        10 => 250,
-        11 => 300,
-        12 => 350,
+        04 => 040,
+        05 => 050,
+        06 => 060,
 
-        13 => 400,
-        14 => 500,
-        15 => 600,
-        16 => 700,
-        17 => 800,
-        18 => 900,
-        19 => 1000,
+        07 => 080,
+        08 => 100,
 
+        09 => 150,
+        10 => 200,
+        11 => 250,
+        12 => 300,
+        13 => 350,
+
+        14 => 400,
+        15 => 500,
+        16 => 600,
+        17 => 700,
+        18 => 800,
+        19 => 900,
         20 => 1000,
+
         21 => 1000,
         22 => 1000,
         23 => 1000,
         24 => 1000,
+        25 => 1000,
 
         _ => 1500,
     };

--- a/PKHeX.Core/Saves/Substructures/Gen4/Ranch/RanchToyType.cs
+++ b/PKHeX.Core/Saves/Substructures/Gen4/Ranch/RanchToyType.cs
@@ -46,5 +46,5 @@ public enum RanchToyType : byte
     Twirler = 36,
     Bound_Mat = 37,
     Tree = 38,
-    Water = 39, // Normally unused; creates a massive plane of water in the sky
+    Water = 39, // Normally unobtainable; creates a massive plane of water in the sky featured in the "Surfing Jump" event
 }


### PR DESCRIPTION
This PR corrects an API/logic mismatch with the RanchLevel.cs methods, whereby the argument was labelled "levelIndex", but the logic assumed it was receiving the actual level value.

To try and simplify the implementation and reduce confusion in the future, I've changed the CurrentRanchLevelIndex and PlannedRanchLevelIndex getters/setters to just CurrentRanchLevel & PlannedRanchLevel to abstract the underlying structure, and updated the method signatures to clarify the argument they're expecting.