### PR TITLE
Fix Gen 7 map position

### DIFF
--- a/PKHeX.Core/Saves/Substructures/Gen7/FieldMoveModelSave7.cs
+++ b/PKHeX.Core/Saves/Substructures/Gen7/FieldMoveModelSave7.cs
@@ -12,5 +12,8 @@ public sealed class FieldMoveModelSave7 : SaveBlock<SAV7>
     public float X { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x08)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x08), value); }
     public float Z { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x0C)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x0C), value); }
     public float Y { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x10)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x10), value); }
-    public float R { get => (int)ReadSingleLittleEndian(Data.AsSpan(Offset + 0x20)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x20), value); }
+    public float RX { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x14)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x14), value); }
+    public float RZ { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x18)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x18), value); }
+    public float RY { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x1C)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x1C), value); }
+    public float RW { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x20)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x20), value); }
 }

--- a/PKHeX.Core/Saves/Substructures/Gen7/FieldMoveModelSave7.cs
+++ b/PKHeX.Core/Saves/Substructures/Gen7/FieldMoveModelSave7.cs
@@ -8,7 +8,7 @@ public sealed class FieldMoveModelSave7 : SaveBlock<SAV7>
     public FieldMoveModelSave7(SAV7SM sav, int offset) : base(sav) => Offset = offset;
     public FieldMoveModelSave7(SAV7USUM sav, int offset) : base(sav) => Offset = offset;
 
-    public int M { get => ReadUInt16LittleEndian(Data.AsSpan(Offset + 0x00)); set => WriteUInt16LittleEndian(Data.AsSpan(Offset + 0x00), (ushort)value); }
+    //public int Unknown { get => ReadUInt16LittleEndian(Data.AsSpan(Offset + 0x00)); set => WriteUInt16LittleEndian(Data.AsSpan(Offset + 0x00), (ushort)value); } // related to Ride Pokemon
     public float X { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x08)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x08), value); }
     public float Z { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x10)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x10), value); }
     public float Y { get => (int)ReadSingleLittleEndian(Data.AsSpan(Offset + 0x18)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x18), value); }

--- a/PKHeX.Core/Saves/Substructures/Gen7/FieldMoveModelSave7.cs
+++ b/PKHeX.Core/Saves/Substructures/Gen7/FieldMoveModelSave7.cs
@@ -10,7 +10,7 @@ public sealed class FieldMoveModelSave7 : SaveBlock<SAV7>
 
     //public int Unknown { get => ReadUInt16LittleEndian(Data.AsSpan(Offset + 0x00)); set => WriteUInt16LittleEndian(Data.AsSpan(Offset + 0x00), (ushort)value); } // related to Ride Pokemon
     public float X { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x08)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x08), value); }
-    public float Z { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x10)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x10), value); }
-    public float Y { get => (int)ReadSingleLittleEndian(Data.AsSpan(Offset + 0x18)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x18), value); }
+    public float Z { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x0C)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x0C), value); }
+    public float Y { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x10)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x10), value); }
     public float R { get => (int)ReadSingleLittleEndian(Data.AsSpan(Offset + 0x20)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x20), value); }
 }

--- a/PKHeX.Core/Saves/Substructures/Gen7/Situation7.cs
+++ b/PKHeX.Core/Saves/Substructures/Gen7/Situation7.cs
@@ -12,7 +12,10 @@ public sealed class Situation7 : SaveBlock<SAV7>
     public float X { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x08)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x08), value); }
     public float Z { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x0C)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x0C), value); }
     public float Y { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x10)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x10), value); }
-    public float R { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x20)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x20), value); }
+    public float RX { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x14)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x14), value); }
+    public float RZ { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x18)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x18), value); }
+    public float RY { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x1C)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x1C), value); }
+    public float RW { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x20)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x20), value); }
 
     public void UpdateOverworldCoordinates()
     {
@@ -20,7 +23,10 @@ public sealed class Situation7 : SaveBlock<SAV7>
         o.X = X;
         o.Z = Z;
         o.Y = Y;
-        o.R = R;
+        o.RX = RX;
+        o.RZ = RZ;
+        o.RY = RY;
+        o.RW = RW;
     }
 
     public int SpecialLocation

--- a/PKHeX.Core/Saves/Substructures/Gen7/Situation7.cs
+++ b/PKHeX.Core/Saves/Substructures/Gen7/Situation7.cs
@@ -10,9 +10,9 @@ public sealed class Situation7 : SaveBlock<SAV7>
     // "StartLocation"
     public int M { get => ReadUInt16LittleEndian(Data.AsSpan(Offset + 0x00)); set => WriteUInt16LittleEndian(Data.AsSpan(Offset + 0x00), (ushort)value); }
     public float X { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x08)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x08), value); }
-    public float Z { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x10)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x10), value); }
-    public float Y { get => (int)ReadSingleLittleEndian(Data.AsSpan(Offset + 0x18)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x18), value); }
-    public float R { get => (int)ReadSingleLittleEndian(Data.AsSpan(Offset + 0x20)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x20), value); }
+    public float Z { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x0C)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x0C), value); }
+    public float Y { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x10)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x10), value); }
+    public float R { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x20)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x20), value); }
 
     public void UpdateOverworldCoordinates()
     {

--- a/PKHeX.Core/Saves/Substructures/Gen7/Situation7.cs
+++ b/PKHeX.Core/Saves/Substructures/Gen7/Situation7.cs
@@ -17,7 +17,6 @@ public sealed class Situation7 : SaveBlock<SAV7>
     public void UpdateOverworldCoordinates()
     {
         var o = SAV.Overworld;
-        o.M = M;
         o.X = X;
         o.Z = Z;
         o.Y = Y;

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen7/SAV_Trainer7.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen7/SAV_Trainer7.cs
@@ -129,7 +129,7 @@ public partial class SAV_Trainer7 : Form
             NUD_X.Value = (decimal)SAV.Situation.X;
             NUD_Z.Value = (decimal)SAV.Situation.Z;
             NUD_Y.Value = (decimal)SAV.Situation.Y;
-            NUD_R.Value = (decimal)SAV.Situation.R;
+            NUD_R.Value = (decimal)(Math.Atan2(SAV.Situation.RZ, SAV.Situation.RW) * 360.0 / Math.PI);
         }
         // Sometimes the coordinates aren't really decimal/float coordinates?
         catch { GB_Map.Enabled = false; }
@@ -343,7 +343,9 @@ public partial class SAV_Trainer7 : Form
             SAV.Situation.X = (float)NUD_X.Value;
             SAV.Situation.Z = (float)NUD_Z.Value;
             SAV.Situation.Y = (float)NUD_Y.Value;
-            SAV.Situation.R = (float)NUD_R.Value;
+            var angle = (double)NUD_R.Value * Math.PI / 360.0;
+            SAV.Situation.RZ = (float)Math.Sin(angle);
+            SAV.Situation.RW = (float)Math.Cos(angle);
             SAV.Situation.UpdateOverworldCoordinates();
         }
 


### PR DESCRIPTION
## Prevent UpdateOverworldCoordinates from corrupting FieldMoveModelSave

Occasionally, changing the player's coordinates was causing the player to ride an invisible Pokémon on load. I determined that this was because FieldMoveModelSave has a uint16 value at offset 0 that appears to be correlated to the player's current Ride Pokémon, not just a copy of the map value. These are the values I observed:

- 1: on foot
- 5: Tauros
- 6: Sharpedo
- 12: Stoutland
- 13: Mudsdale
- 14: Machamp
- 15: Lapras

This doesn't appear to be the only value that determines the player's Ride Pokémon though, since changing it manually either keeps the player on their previous Ride Pokémon or has them mount an immovable, invisible Ride Pokémon. Because of this, I didn't add an accessor or form element for it.


## Fix player coordinates

The player's X/Z/Y coordinates appears to be stored as consecutive float32 values at offsets 0x08/0x0C/0x10, without any bytes in between (rather than 0x08/4-byte gap/0x10/4-byte gap/0x18). X is the left/right axis, Y is the backward/forward axis, and Z is the down/up axis (altitude). I modified the accessors to use the correct offsets.


## Fix player rotation

The player's rotation appears to be stored as a unit quaternion of four float32 values at offsets 0x14/0x18/0x1C/0x20, rather than as a single value. I recorded the following values:

| X | Z        | Y | W        | Direction  | Rotation around z-axis |
| - | -------- | - | -------- | ---------- | ---------------------- |
| 0 | -0.70711 | 0 |  0.70711 | left       |            -π/2 (-90°) |
| 0 | -0.38268 | 0 |  0.92388 | down/left  |            -π/4 (-45°) |
| 0 |  0       | 0 |  1       | down       |             0     (0°) |
| 0 |  0.38268 | 0 |  0.92388 | down/right |             π/4  (45°) |
| 0 |  0.70711 | 0 |  0.70711 | right      |             π/2  (90°) |
| 0 |  0.92388 | 0 |  0.38268 | up/right   |            3π/4 (135°) |
| 0 |  1       | 0 |  0       | up         |             π   (180°) |
| 0 |  0.92388 | 0 | -0.38268 | up/left    |            5π/4 (225°) |

The X and Y components appear to always be 0 (even when the player is on an incline), though it's possible that later games (especially for the camera controls) might actually use them. I don't think SMUSUM does, though.

![The player rotated](https://github.com/kwsch/PKHeX/assets/16735361/bab25e32-d7ac-448b-9756-629c09f3c89f)

I made it so that the editor form converts the Z and W components of the quaternion to degrees for general ease-of-use. Having the individual components be editable would also work, but I think a lot of people would find dealing with the quaternion directly confusing.

----

These findings probably have similar implications for how the coordinates in Gen 6/the Switch games are stored, but I haven't looked into them yet.