### PR TITLE
Gen 6/7/8/9 map position/rotation

### DIFF
--- a/PKHeX.Core/Saves/Access/SaveBlockAccessor7b.cs
+++ b/PKHeX.Core/Saves/Access/SaveBlockAccessor7b.cs
@@ -41,6 +41,7 @@ public sealed class SaveBlockAccessor7b : ISaveBlockAccessor<BlockInfo7b>, ISave
         Zukan = new Zukan7b(sav, GetBlockOffset(BelugaBlockIndex.Zukan), 0x550);
         Config = new ConfigSave7b(sav, GetBlockOffset(BelugaBlockIndex.ConfigSave));
         Items = new MyItem7b(sav, GetBlockOffset(BelugaBlockIndex.MyItem));
+        Coordinates = new Coordinates7b(sav, GetBlockOffset(BelugaBlockIndex.Coordinates));
         Storage = new PokeListHeader(sav, GetBlockOffset(BelugaBlockIndex.PokeListHeader));
         Status = new MyStatus7b(sav, GetBlockOffset(BelugaBlockIndex.MyStatus));
         Played = new PlayTime7b(sav, GetBlockOffset(BelugaBlockIndex.PlayTime));
@@ -53,6 +54,7 @@ public sealed class SaveBlockAccessor7b : ISaveBlockAccessor<BlockInfo7b>, ISave
     }
 
     public MyItem Items { get; }
+    public Coordinates7b Coordinates { get; }
     public Misc7b Misc { get; }
     public Zukan7b Zukan { get; }
     public MyStatus7b Status { get; }

--- a/PKHeX.Core/Saves/Access/SaveBlockAccessor8SWSH.cs
+++ b/PKHeX.Core/Saves/Access/SaveBlockAccessor8SWSH.cs
@@ -13,6 +13,7 @@ public sealed class SaveBlockAccessor8SWSH : SCBlockAccessor, ISaveBlock8Main
     public Box8 BoxInfo { get; }
     public Party8 PartyInfo { get; }
     public MyItem8 Items { get; }
+    public Coordinates8 Coordinates { get; }
     public MyStatus8 MyStatus { get; }
     public Misc8 Misc { get; }
     public Zukan8 Zukan { get; }
@@ -36,6 +37,7 @@ public sealed class SaveBlockAccessor8SWSH : SCBlockAccessor, ISaveBlock8Main
         BoxInfo = new Box8(sav, GetBlock(KBox));
         PartyInfo = new Party8(sav, GetBlock(KParty));
         Items = new MyItem8(sav, GetBlock(KItem));
+        Coordinates = new Coordinates8(sav, GetBlock(KCoordinates));
         Zukan = new Zukan8(sav, GetBlock(KZukan), GetBlockSafe(KZukanR1), GetBlockSafe(KZukanR2));
         MyStatus = new MyStatus8(sav, GetBlock(KMyStatus));
         Misc = new Misc8(sav, GetBlock(KMisc));

--- a/PKHeX.Core/Saves/Access/SaveBlockAccessor9SV.cs
+++ b/PKHeX.Core/Saves/Access/SaveBlockAccessor9SV.cs
@@ -105,7 +105,7 @@ public sealed class SaveBlockAccessor9SV : SCBlockAccessor, ISaveBlock9Main
 
     // PlayerSave
     public const uint KCoordinates = 0x708D1511; // PlayerSave_StartPosition
-    private const uint KPlayerRotation = 0x31EF132C; // PlayerSave_StartRotation
+    public const uint KPlayerRotation = 0x31EF132C; // PlayerSave_StartRotation
     private const uint KPlayerIsInField = 0x32645CB7; // PlayerSave_IsInField
     private const uint KPlayerLastSubField = 0x37AF0454; // PlayerSave_LastSubField
     private const uint KPlayerLastRoomMapName = 0x9F1ABF26; // PlayerSave_LastRoomMapName

--- a/PKHeX.Core/Saves/SAV7b.cs
+++ b/PKHeX.Core/Saves/SAV7b.cs
@@ -51,6 +51,7 @@ public sealed class SAV7b : SAV_BEEF, ISaveBlock7b, IGameSync, IEventFlagArray
 
     // Save Block accessors
     public MyItem Items => Blocks.Items;
+    public Coordinates7b Coordinates => Blocks.Coordinates;
     public Misc7b Misc => Blocks.Misc;
     public Zukan7b Zukan => Blocks.Zukan;
     public MyStatus7b Status => Blocks.Status;

--- a/PKHeX.Core/Saves/SAV8LA.cs
+++ b/PKHeX.Core/Saves/SAV8LA.cs
@@ -117,6 +117,7 @@ public sealed class SAV8LA : SaveFile, ISaveBlock8LA, ISCBlockArray, ISaveFileRe
     public BoxLayout8a BoxLayout => Blocks.BoxLayout;
     public MyItem8a Items => Blocks.Items;
     public Epoch1970Value AdventureStart => Blocks.AdventureStart;
+    public Coordinates8a Coordinates => Blocks.Coordinates;
     public LastSaved8a LastSaved => Blocks.LastSaved;
     public PlayTime8a Played => Blocks.Played;
     public AreaSpawnerSet8a AreaSpawners => new(Blocks.GetBlock(SaveBlockAccessor8LA.KSpawners));

--- a/PKHeX.Core/Saves/SAV8SWSH.cs
+++ b/PKHeX.Core/Saves/SAV8SWSH.cs
@@ -66,6 +66,7 @@ public sealed class SAV8SWSH : SaveFile, ISaveBlock8SWSH, ITrainerStatRecord, IS
     public Party8 PartyInfo => Blocks.PartyInfo;
     public MyItem8 Items => Blocks.Items;
     public MyStatus8 MyStatus => Blocks.MyStatus;
+    public Coordinates8 Coordinates => Blocks.Coordinates;
     public Misc8 Misc => Blocks.Misc;
     public Zukan8 Zukan => Blocks.Zukan;
     public BoxLayout8 BoxLayout => Blocks.BoxLayout;

--- a/PKHeX.Core/Saves/SAV9SV.cs
+++ b/PKHeX.Core/Saves/SAV9SV.cs
@@ -276,6 +276,11 @@ public sealed class SAV9SV : SaveFile, ISaveBlock9Main, ISCBlockArray, ISaveFile
     public float X { get => ReadSingleLittleEndian(Coordinates); set => WriteSingleLittleEndian(Coordinates, value); }
     public float Y { get => ReadSingleLittleEndian(Coordinates[4..]); set => WriteSingleLittleEndian(Coordinates[4..], value); }
     public float Z { get => ReadSingleLittleEndian(Coordinates[8..]); set => WriteSingleLittleEndian(Coordinates[8..], value); }
+    public Span<byte> PlayerRotation => Blocks.GetBlock(SaveBlockAccessor9SV.KPlayerRotation).Data;
+    public float RX { get => ReadSingleLittleEndian(PlayerRotation); set => WriteSingleLittleEndian(PlayerRotation, value); }
+    public float RY { get => ReadSingleLittleEndian(PlayerRotation[4..]); set => WriteSingleLittleEndian(PlayerRotation[4..], value); }
+    public float RZ { get => ReadSingleLittleEndian(PlayerRotation[8..]); set => WriteSingleLittleEndian(PlayerRotation[8..], value); }
+    public float RW { get => ReadSingleLittleEndian(PlayerRotation[12..]); set => WriteSingleLittleEndian(PlayerRotation[12..], value); }
 
     public void SetCoordinates(float x, float y, float z)
     {
@@ -286,6 +291,18 @@ public sealed class SAV9SV : SaveFile, ISaveBlock9Main, ISCBlockArray, ISaveFile
         X = x;
         Y = y;
         Z = z;
+    }
+
+    public void SetPlayerRotation(float rx, float ry, float rz, float rw)
+    {
+        // Only set coordinates if epsilon is different enough
+        const float epsilon = 0.0001f;
+        if (Math.Abs(RX - rx) < epsilon && Math.Abs(RY - ry) < epsilon && Math.Abs(RZ - rz) < epsilon && Math.Abs(RW - rw) < epsilon)
+            return;
+        RX = rx;
+        RY = ry;
+        RZ = rz;
+        RW = rw;
     }
 
     public override int GetBoxWallpaper(int box)

--- a/PKHeX.Core/Saves/Substructures/Gen6/Situation6.cs
+++ b/PKHeX.Core/Saves/Substructures/Gen6/Situation6.cs
@@ -31,34 +31,34 @@ public sealed class Situation6 : SaveBlock<SAV6>
 
     public float X
     {
-        get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x10)) / 18;
+        get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x10));
         set
         {
             var span = Data.AsSpan(Offset + 0x10);
-            WriteSingleLittleEndian(span, value * 18);
-            WriteSingleLittleEndian(span[0xF4..], value * 18);
+            WriteSingleLittleEndian(span, value);
+            WriteSingleLittleEndian(span[0xF4..], value);
         }
     }
 
     public float Z
     {
-        get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x14)) / 18;
+        get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x14));
         set
         {
             var span = Data.AsSpan(Offset + 0x14);
-            WriteSingleLittleEndian(span, value * 18);
-            WriteSingleLittleEndian(span[0xF4..], value * 18);
+            WriteSingleLittleEndian(span, value);
+            WriteSingleLittleEndian(span[0xF4..], value);
         }
     }
 
     public float Y
     {
-        get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x18)) / 18;
+        get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x18));
         set
         {
             var span = Data.AsSpan(Offset + 0x18);
-            WriteSingleLittleEndian(span, value * 18);
-            WriteSingleLittleEndian(span[0xF4..], value * 18);
+            WriteSingleLittleEndian(span, value);
+            WriteSingleLittleEndian(span[0xF4..], value);
         }
     }
 

--- a/PKHeX.Core/Saves/Substructures/Gen6/Situation6.cs
+++ b/PKHeX.Core/Saves/Substructures/Gen6/Situation6.cs
@@ -14,7 +14,18 @@ public sealed class Situation6 : SaveBlock<SAV6>
         {
             var span = Data.AsSpan(Offset + 0x02);
             WriteUInt16LittleEndian(span, (ushort)value);
-            WriteUInt16LittleEndian(span[0xF4..], (ushort)value);
+            WriteUInt16LittleEndian(span[0xF2..], (ushort)value);
+        }
+    }
+
+    public int R
+    {
+        get => ReadUInt16LittleEndian(Data.AsSpan(Offset + 0x06));
+        set
+        {
+            var span = Data.AsSpan(Offset + 0x06);
+            WriteUInt16LittleEndian(span, (ushort)value);
+            WriteUInt16LittleEndian(span[0xF0..], (ushort)value);
         }
     }
 

--- a/PKHeX.Core/Saves/Substructures/Gen7/LGPE/BelugaBlockIndex.cs
+++ b/PKHeX.Core/Saves/Substructures/Gen7/LGPE/BelugaBlockIndex.cs
@@ -16,7 +16,7 @@ public enum BelugaBlockIndex
     /* 11 @ 0x45600, len = 0x00E90 */ WB7Record,
     /* 12 @ 0x46600, len = 0x010A4 */ CaptureRecord,
     /* 13 @ 0x47800, len = 0x000F0 */ Daycare,
-    /* 14 @ 0x47A00, len = 0x06010 */ _14,
+    /* 14 @ 0x47A00, len = 0x06010 */ Coordinates,
     /* 15 @ 0x4DC00, len = 0x00200 */ _15, // stuff containing data about recent captures?
     /* 16 @ 0x4DE00, len = 0x00098 */ FashionPlayer,
     /* 17 @ 0x4E000, len = 0x00068 */ FashionStarter,

--- a/PKHeX.Core/Saves/Substructures/Gen7/LGPE/Coordinates7b.cs
+++ b/PKHeX.Core/Saves/Substructures/Gen7/LGPE/Coordinates7b.cs
@@ -1,0 +1,31 @@
+using System;
+using static System.Buffers.Binary.BinaryPrimitives;
+
+namespace PKHeX.Core;
+
+/// <summary>
+/// Stores the position of the player.
+/// </summary>
+public sealed class Coordinates7b : SaveBlock<SAV7b>
+{
+    public Coordinates7b(SAV7b sav, int offset) : base(sav) => Offset = offset;
+
+    // Position
+    public float X { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x10)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x10), value); }
+    public float Z { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x14)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x14), value); }
+    public float Y { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x18)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x18), value); }
+
+    // Scale
+    public float SX { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x20)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x20), value); }
+    public float SZ { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x24)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x24), value); }
+    public float SY { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x28)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x28), value); }
+
+    // Rotation
+    public float RX { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x30)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x30), value); }
+    public float RZ { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x34)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x34), value); }
+    public float RY { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x38)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x38), value); }
+    public float RW { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x3C)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x3C), value); }
+
+    // Map
+    public ulong M { get => ReadUInt64LittleEndian(Data.AsSpan(Offset + 0x6000)); set => WriteUInt64LittleEndian(Data.AsSpan(Offset + 0x6000), value); }
+}

--- a/PKHeX.Core/Saves/Substructures/Gen8/LA/Coordinates8a.cs
+++ b/PKHeX.Core/Saves/Substructures/Gen8/LA/Coordinates8a.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel;
+using System.Text;
 using static System.Buffers.Binary.BinaryPrimitives;
 
 namespace PKHeX.Core;
@@ -11,7 +12,26 @@ namespace PKHeX.Core;
 public sealed class Coordinates8a : SaveBlock<SAV8LA>
 {
     public Coordinates8a(SAV8LA sav, SCBlock block) : base(sav, block.Data) { }
+
+    // Map
+    public string M
+    {
+        get => Util.TrimFromZero(Encoding.ASCII.GetString(Data, 0x08, 0x48));
+        set
+        {
+            for (int i = 0; i < 0x48; i++)
+                Data[0x08 + i] = (byte)(value.Length > i ? value[i] : '\0');
+        }
+    }
+
+    // Position
     public float X { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x50)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x50), value); }
     public float Z { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x54)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x54), value); }
     public float Y { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x58)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x58), value); }
+
+    // Rotation
+    public float RX { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x60)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x60), value); }
+    public float RZ { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x64)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x64), value); }
+    public float RY { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x68)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x68), value); }
+    public float RW { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x6C)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x6C), value); }
 }

--- a/PKHeX.Core/Saves/Substructures/Gen8/SWSH/Coordinates8.cs
+++ b/PKHeX.Core/Saves/Substructures/Gen8/SWSH/Coordinates8.cs
@@ -1,0 +1,31 @@
+using System;
+using static System.Buffers.Binary.BinaryPrimitives;
+
+namespace PKHeX.Core;
+
+/// <summary>
+/// Stores the position of the player.
+/// </summary>
+public sealed class Coordinates8 : SaveBlock<SAV8SWSH>
+{
+    public Coordinates8(SAV8SWSH sav, SCBlock block) : base(sav, block.Data) { }
+
+    // Position
+    public float X { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x10)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x10), value); }
+    public float Z { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x14)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x14), value); }
+    public float Y { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x18)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x18), value); }
+
+    // Scale
+    public float SX { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x20)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x20), value); }
+    public float SZ { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x24)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x24), value); }
+    public float SY { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x28)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x28), value); }
+
+    // Rotation
+    public float RX { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x30)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x30), value); }
+    public float RZ { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x34)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x34), value); }
+    public float RY { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x38)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x38), value); }
+    public float RW { get => ReadSingleLittleEndian(Data.AsSpan(Offset + 0x3C)); set => WriteSingleLittleEndian(Data.AsSpan(Offset + 0x3C), value); }
+
+    // Map
+    public ulong M { get => ReadUInt64LittleEndian(Data.AsSpan(Offset + 0x6000)); set => WriteUInt64LittleEndian(Data.AsSpan(Offset + 0x6000), value); }
+}

--- a/PKHeX.WinForms/Resources/text/lang_de.txt
+++ b/PKHeX.WinForms/Resources/text/lang_de.txt
@@ -1506,6 +1506,7 @@ SAV_Trainer.L_NormalB=Normal
 SAV_Trainer.L_NormalC=Normal
 SAV_Trainer.L_Offset=(offset)
 SAV_Trainer.L_PM=Pokémeilen:
+SAV_Trainer.L_R=Rotation:
 SAV_Trainer.L_Region=Region:
 SAV_Trainer.L_RotationB=Rotation:
 SAV_Trainer.L_RotationC=Rotation:

--- a/PKHeX.WinForms/Resources/text/lang_en.txt
+++ b/PKHeX.WinForms/Resources/text/lang_en.txt
@@ -1506,6 +1506,7 @@ SAV_Trainer.L_NormalB=Normal
 SAV_Trainer.L_NormalC=Normal
 SAV_Trainer.L_Offset=(offset)
 SAV_Trainer.L_PM=PokéMiles:
+SAV_Trainer.L_R=Rotation:
 SAV_Trainer.L_Region=Region:
 SAV_Trainer.L_RotationB=Rotation:
 SAV_Trainer.L_RotationC=Rotation:

--- a/PKHeX.WinForms/Resources/text/lang_es.txt
+++ b/PKHeX.WinForms/Resources/text/lang_es.txt
@@ -1506,6 +1506,7 @@ SAV_Trainer.L_NormalB=Normal
 SAV_Trainer.L_NormalC=Normal
 SAV_Trainer.L_Offset=(offset)
 SAV_Trainer.L_PM=PokéMillas:
+SAV_Trainer.L_R=Rotación:
 SAV_Trainer.L_Region=Subregión:
 SAV_Trainer.L_RotationB=Rotación:
 SAV_Trainer.L_RotationC=Rotación:

--- a/PKHeX.WinForms/Resources/text/lang_fr.txt
+++ b/PKHeX.WinForms/Resources/text/lang_fr.txt
@@ -1506,6 +1506,7 @@ SAV_Trainer.L_NormalB=Normal
 SAV_Trainer.L_NormalC=Normal
 SAV_Trainer.L_Offset=(offset)
 SAV_Trainer.L_PM=PokéMiles:
+SAV_Trainer.L_R=Rotation:
 SAV_Trainer.L_Region=Region:
 SAV_Trainer.L_RotationB=Rotation:
 SAV_Trainer.L_RotationC=Rotation:

--- a/PKHeX.WinForms/Resources/text/lang_it.txt
+++ b/PKHeX.WinForms/Resources/text/lang_it.txt
@@ -1506,6 +1506,7 @@ SAV_Trainer.L_NormalB=Normale
 SAV_Trainer.L_NormalC=Normale
 SAV_Trainer.L_Offset=(offset)
 SAV_Trainer.L_PM=Pokémiglia:
+SAV_Trainer.L_R=Rotazione:
 SAV_Trainer.L_Region=Regione:
 SAV_Trainer.L_RotationB=Rotazione:
 SAV_Trainer.L_RotationC=Rotazione:

--- a/PKHeX.WinForms/Resources/text/lang_ja.txt
+++ b/PKHeX.WinForms/Resources/text/lang_ja.txt
@@ -1506,6 +1506,7 @@ SAV_Trainer.L_NormalB=ノーマル
 SAV_Trainer.L_NormalC=ノーマル
 SAV_Trainer.L_Offset=(offset)
 SAV_Trainer.L_PM=ポケマイル
+SAV_Trainer.L_R=回転座標
 SAV_Trainer.L_Region=地域
 SAV_Trainer.L_RotationB=ﾛｰﾃｰｼｮﾝ
 SAV_Trainer.L_RotationC=ﾛｰﾃｰｼｮﾝ

--- a/PKHeX.WinForms/Resources/text/lang_ko.txt
+++ b/PKHeX.WinForms/Resources/text/lang_ko.txt
@@ -1506,6 +1506,7 @@ SAV_Trainer.L_NormalB=노말
 SAV_Trainer.L_NormalC=노말
 SAV_Trainer.L_Offset=(오프셋)
 SAV_Trainer.L_PM=포켓마일:
+SAV_Trainer.L_R=회전:
 SAV_Trainer.L_Region=지역:
 SAV_Trainer.L_RotationB=로테이션:
 SAV_Trainer.L_RotationC=로테이션:

--- a/PKHeX.WinForms/Resources/text/lang_zh.txt
+++ b/PKHeX.WinForms/Resources/text/lang_zh.txt
@@ -1507,6 +1507,7 @@ SAV_Trainer.L_NormalB=普通
 SAV_Trainer.L_NormalC=普通
 SAV_Trainer.L_Offset=(偏移)
 SAV_Trainer.L_PM=宝可里程:
+SAV_Trainer.L_R=轮盘:
 SAV_Trainer.L_Region=区域:
 SAV_Trainer.L_RotationB=轮盘:
 SAV_Trainer.L_RotationC=轮盘:

--- a/PKHeX.WinForms/Resources/text/lang_zh2.txt
+++ b/PKHeX.WinForms/Resources/text/lang_zh2.txt
@@ -1506,6 +1506,7 @@ SAV_Trainer.L_NormalB=普通
 SAV_Trainer.L_NormalC=普通
 SAV_Trainer.L_Offset=(偏移)
 SAV_Trainer.L_PM=寶可里程:
+SAV_Trainer.L_R=輪盤:
 SAV_Trainer.L_Region=區域:
 SAV_Trainer.L_RotationB=輪盤:
 SAV_Trainer.L_RotationC=輪盤:

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen6/SAV_Trainer.Designer.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen6/SAV_Trainer.Designer.cs
@@ -1488,12 +1488,13 @@ namespace PKHeX.WinForms
             // 
             // NUD_Z
             // 
+            NUD_Z.DecimalPlaces = 6;
             NUD_Z.Location = new System.Drawing.Point(108, 78);
             NUD_Z.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             NUD_Z.Maximum = new decimal(new int[] { 65535, 0, 0, 0 });
             NUD_Z.Minimum = new decimal(new int[] { 65535, 0, 0, int.MinValue });
             NUD_Z.Name = "NUD_Z";
-            NUD_Z.Size = new System.Drawing.Size(58, 23);
+            NUD_Z.Size = new System.Drawing.Size(112, 23);
             NUD_Z.TabIndex = 53;
             NUD_Z.ValueChanged += ChangeMapValue;
             // 
@@ -1509,23 +1510,23 @@ namespace PKHeX.WinForms
             // 
             // NUD_Y
             // 
-            NUD_Y.DecimalPlaces = 1;
+            NUD_Y.DecimalPlaces = 6;
             NUD_Y.Location = new System.Drawing.Point(108, 108);
             NUD_Y.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             NUD_Y.Maximum = new decimal(new int[] { 65535, 0, 0, 0 });
             NUD_Y.Name = "NUD_Y";
-            NUD_Y.Size = new System.Drawing.Size(58, 23);
+            NUD_Y.Size = new System.Drawing.Size(112, 23);
             NUD_Y.TabIndex = 51;
             NUD_Y.ValueChanged += ChangeMapValue;
             // 
             // NUD_X
             // 
-            NUD_X.DecimalPlaces = 1;
+            NUD_X.DecimalPlaces = 6;
             NUD_X.Location = new System.Drawing.Point(108, 48);
             NUD_X.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             NUD_X.Maximum = new decimal(new int[] { 65535, 0, 0, 0 });
             NUD_X.Name = "NUD_X";
-            NUD_X.Size = new System.Drawing.Size(58, 23);
+            NUD_X.Size = new System.Drawing.Size(112, 23);
             NUD_X.TabIndex = 50;
             NUD_X.ValueChanged += ChangeMapValue;
             // 

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen6/SAV_Trainer.Designer.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen6/SAV_Trainer.Designer.cs
@@ -138,6 +138,8 @@ namespace PKHeX.WinForms
             CAL_LastSavedTime = new System.Windows.Forms.DateTimePicker();
             Tab_BadgeMap = new System.Windows.Forms.TabPage();
             GB_Map = new System.Windows.Forms.GroupBox();
+            NUD_R = new System.Windows.Forms.NumericUpDown();
+            L_R = new System.Windows.Forms.Label();
             NUD_Z = new System.Windows.Forms.NumericUpDown();
             NUD_M = new System.Windows.Forms.NumericUpDown();
             NUD_Y = new System.Windows.Forms.NumericUpDown();
@@ -167,6 +169,7 @@ namespace PKHeX.WinForms
             GB_Adventure.SuspendLayout();
             Tab_BadgeMap.SuspendLayout();
             GB_Map.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)NUD_R).BeginInit();
             ((System.ComponentModel.ISupportInitialize)NUD_Z).BeginInit();
             ((System.ComponentModel.ISupportInitialize)NUD_M).BeginInit();
             ((System.ComponentModel.ISupportInitialize)NUD_Y).BeginInit();
@@ -287,7 +290,7 @@ namespace PKHeX.WinForms
             // CHK_Badge1
             // 
             CHK_Badge1.AutoSize = true;
-            CHK_Badge1.Location = new System.Drawing.Point(197, 23);
+            CHK_Badge1.Location = new System.Drawing.Point(307, 23);
             CHK_Badge1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             CHK_Badge1.Name = "CHK_Badge1";
             CHK_Badge1.Size = new System.Drawing.Size(32, 19);
@@ -298,7 +301,7 @@ namespace PKHeX.WinForms
             // CHK_Badge2
             // 
             CHK_Badge2.AutoSize = true;
-            CHK_Badge2.Location = new System.Drawing.Point(197, 50);
+            CHK_Badge2.Location = new System.Drawing.Point(307, 50);
             CHK_Badge2.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             CHK_Badge2.Name = "CHK_Badge2";
             CHK_Badge2.Size = new System.Drawing.Size(32, 19);
@@ -309,7 +312,7 @@ namespace PKHeX.WinForms
             // CHK_Badge3
             // 
             CHK_Badge3.AutoSize = true;
-            CHK_Badge3.Location = new System.Drawing.Point(197, 76);
+            CHK_Badge3.Location = new System.Drawing.Point(307, 76);
             CHK_Badge3.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             CHK_Badge3.Name = "CHK_Badge3";
             CHK_Badge3.Size = new System.Drawing.Size(32, 19);
@@ -320,7 +323,7 @@ namespace PKHeX.WinForms
             // CHK_Badge4
             // 
             CHK_Badge4.AutoSize = true;
-            CHK_Badge4.Location = new System.Drawing.Point(197, 103);
+            CHK_Badge4.Location = new System.Drawing.Point(307, 103);
             CHK_Badge4.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             CHK_Badge4.Name = "CHK_Badge4";
             CHK_Badge4.Size = new System.Drawing.Size(32, 19);
@@ -331,7 +334,7 @@ namespace PKHeX.WinForms
             // CHK_Badge5
             // 
             CHK_Badge5.AutoSize = true;
-            CHK_Badge5.Location = new System.Drawing.Point(241, 23);
+            CHK_Badge5.Location = new System.Drawing.Point(351, 23);
             CHK_Badge5.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             CHK_Badge5.Name = "CHK_Badge5";
             CHK_Badge5.Size = new System.Drawing.Size(32, 19);
@@ -342,7 +345,7 @@ namespace PKHeX.WinForms
             // CHK_Badge7
             // 
             CHK_Badge7.AutoSize = true;
-            CHK_Badge7.Location = new System.Drawing.Point(241, 76);
+            CHK_Badge7.Location = new System.Drawing.Point(351, 76);
             CHK_Badge7.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             CHK_Badge7.Name = "CHK_Badge7";
             CHK_Badge7.Size = new System.Drawing.Size(32, 19);
@@ -353,7 +356,7 @@ namespace PKHeX.WinForms
             // CHK_Badge8
             // 
             CHK_Badge8.AutoSize = true;
-            CHK_Badge8.Location = new System.Drawing.Point(241, 103);
+            CHK_Badge8.Location = new System.Drawing.Point(351, 103);
             CHK_Badge8.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             CHK_Badge8.Name = "CHK_Badge8";
             CHK_Badge8.Size = new System.Drawing.Size(32, 19);
@@ -1444,6 +1447,8 @@ namespace PKHeX.WinForms
             // 
             // GB_Map
             // 
+            GB_Map.Controls.Add(NUD_R);
+            GB_Map.Controls.Add(L_R);
             GB_Map.Controls.Add(NUD_Z);
             GB_Map.Controls.Add(NUD_M);
             GB_Map.Controls.Add(NUD_Y);
@@ -1452,14 +1457,34 @@ namespace PKHeX.WinForms
             GB_Map.Controls.Add(L_CurrentMap);
             GB_Map.Controls.Add(L_Z);
             GB_Map.Controls.Add(L_X);
-            GB_Map.Location = new System.Drawing.Point(134, 136);
+            GB_Map.Location = new System.Drawing.Point(7, 7);
             GB_Map.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             GB_Map.Name = "GB_Map";
             GB_Map.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            GB_Map.Size = new System.Drawing.Size(183, 144);
+            GB_Map.Size = new System.Drawing.Size(237, 180);
             GB_Map.TabIndex = 52;
             GB_Map.TabStop = false;
             GB_Map.Text = "Map Position";
+            // 
+            // NUD_R
+            // 
+            NUD_R.Location = new System.Drawing.Point(108, 138);
+            NUD_R.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            NUD_R.Maximum = new decimal(new int[] { 7, 0, 0, 0 });
+            NUD_R.Name = "NUD_R";
+            NUD_R.Size = new System.Drawing.Size(58, 23);
+            NUD_R.TabIndex = 55;
+            NUD_R.ValueChanged += ChangeMapValue;
+            // 
+            // L_R
+            // 
+            L_R.Location = new System.Drawing.Point(7, 138);
+            L_R.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            L_R.Name = "L_R";
+            L_R.Size = new System.Drawing.Size(93, 23);
+            L_R.TabIndex = 54;
+            L_R.Text = "Rotation:";
+            L_R.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // NUD_Z
             // 
@@ -1547,7 +1572,7 @@ namespace PKHeX.WinForms
             // CHK_Badge6
             // 
             CHK_Badge6.AutoSize = true;
-            CHK_Badge6.Location = new System.Drawing.Point(241, 50);
+            CHK_Badge6.Location = new System.Drawing.Point(351, 50);
             CHK_Badge6.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             CHK_Badge6.Name = "CHK_Badge6";
             CHK_Badge6.Size = new System.Drawing.Size(32, 19);
@@ -1686,6 +1711,7 @@ namespace PKHeX.WinForms
             Tab_BadgeMap.ResumeLayout(false);
             Tab_BadgeMap.PerformLayout();
             GB_Map.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)NUD_R).EndInit();
             ((System.ComponentModel.ISupportInitialize)NUD_Z).EndInit();
             ((System.ComponentModel.ISupportInitialize)NUD_M).EndInit();
             ((System.ComponentModel.ISupportInitialize)NUD_Y).EndInit();
@@ -1828,5 +1854,7 @@ namespace PKHeX.WinForms
         private System.Windows.Forms.CheckBox CHK_MegaRayquazaUnlocked;
         private System.Windows.Forms.ToolTip Tip1;
         private System.Windows.Forms.ToolTip Tip2;
+        private System.Windows.Forms.NumericUpDown NUD_R;
+        private System.Windows.Forms.Label L_R;
     }
 }

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen6/SAV_Trainer.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen6/SAV_Trainer.cs
@@ -138,21 +138,13 @@ public partial class SAV_Trainer : Form
         NUD_M.Value = sit.M;
         NUD_R.Value = sit.R;
         // Sanity Check Map Coordinates
-        if (!GB_Map.Enabled || sit.X % 0.5 != 0 || sit.Z % 0.5 != 0 || sit.Y % 0.5 != 0)
+        try
         {
-            GB_Map.Enabled = false;
+            NUD_X.Value = (decimal)(double)sit.X;
+            NUD_Z.Value = (decimal)(double)sit.Z;
+            NUD_Y.Value = (decimal)(double)sit.Y;
         }
-        else
-        {
-            try
-            {
-                NUD_X.Value = (decimal)sit.X;
-                NUD_Z.Value = (decimal)sit.Z;
-                NUD_Y.Value = (decimal)sit.Y;
-            }
-            // If we can't accurately represent the coordinates, don't allow them to be changed.
-            catch { GB_Map.Enabled = false; }
-        }
+        catch { GB_Map.Enabled = false; }
 
         // Load BP and PokeMiles
         TB_BP.Text = SAV.BP.ToString();

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen6/SAV_Trainer.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen6/SAV_Trainer.cs
@@ -136,6 +136,7 @@ public partial class SAV_Trainer : Form
 
         var sit = SAV.Situation;
         NUD_M.Value = sit.M;
+        NUD_R.Value = sit.R;
         // Sanity Check Map Coordinates
         if (!GB_Map.Enabled || sit.X % 0.5 != 0 || sit.Z % 0.5 != 0 || sit.Y % 0.5 != 0)
         {
@@ -233,6 +234,7 @@ public partial class SAV_Trainer : Form
             sit.X = (float)NUD_X.Value;
             sit.Z = (float)NUD_Z.Value;
             sit.Y = (float)NUD_Y.Value;
+            sit.R = (int)NUD_R.Value;
         }
 
         SAV.BP = ushort.Parse(TB_BP.Text);

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen6/SAV_Trainer.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen6/SAV_Trainer.cs
@@ -140,9 +140,9 @@ public partial class SAV_Trainer : Form
         // Sanity Check Map Coordinates
         try
         {
-            NUD_X.Value = (decimal)(double)sit.X;
-            NUD_Z.Value = (decimal)(double)sit.Z;
-            NUD_Y.Value = (decimal)(double)sit.Y;
+            NUD_X.Value = (decimal)(sit.X / 18.0);
+            NUD_Z.Value = (decimal)(sit.Z / 18.0);
+            NUD_Y.Value = (decimal)(sit.Y / 18.0);
         }
         catch { GB_Map.Enabled = false; }
 
@@ -223,9 +223,9 @@ public partial class SAV_Trainer : Form
         if (GB_Map.Enabled && MapUpdated)
         {
             sit.M = (int)NUD_M.Value;
-            sit.X = (float)NUD_X.Value;
-            sit.Z = (float)NUD_Z.Value;
-            sit.Y = (float)NUD_Y.Value;
+            sit.X = (float)(NUD_X.Value * 18);
+            sit.Z = (float)(NUD_Z.Value * 18);
+            sit.Y = (float)(NUD_Y.Value * 18);
             sit.R = (int)NUD_R.Value;
         }
 

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen7/SAV_Trainer7.Designer.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen7/SAV_Trainer7.Designer.cs
@@ -1196,7 +1196,7 @@ namespace PKHeX.WinForms
             // NUD_R
             // 
             NUD_R.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
-            NUD_R.DecimalPlaces = 5;
+            NUD_R.DecimalPlaces = 6;
             NUD_R.Location = new System.Drawing.Point(108, 138);
             NUD_R.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             NUD_R.Maximum = new decimal(new int[] { 99999999, 0, 0, 0 });
@@ -1219,7 +1219,7 @@ namespace PKHeX.WinForms
             // NUD_Z
             // 
             NUD_Z.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
-            NUD_Z.DecimalPlaces = 5;
+            NUD_Z.DecimalPlaces = 6;
             NUD_Z.Location = new System.Drawing.Point(108, 78);
             NUD_Z.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             NUD_Z.Maximum = new decimal(new int[] { 99999999, 0, 0, 0 });
@@ -1242,7 +1242,7 @@ namespace PKHeX.WinForms
             // NUD_Y
             // 
             NUD_Y.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
-            NUD_Y.DecimalPlaces = 5;
+            NUD_Y.DecimalPlaces = 6;
             NUD_Y.Location = new System.Drawing.Point(108, 108);
             NUD_Y.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             NUD_Y.Maximum = new decimal(new int[] { 99999999, 0, 0, 0 });
@@ -1255,7 +1255,7 @@ namespace PKHeX.WinForms
             // NUD_X
             // 
             NUD_X.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
-            NUD_X.DecimalPlaces = 5;
+            NUD_X.DecimalPlaces = 6;
             NUD_X.Location = new System.Drawing.Point(108, 48);
             NUD_X.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             NUD_X.Maximum = new decimal(new int[] { 99999999, 0, 0, 0 });

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen7/SAV_Trainer7.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen7/SAV_Trainer7.cs
@@ -126,9 +126,9 @@ public partial class SAV_Trainer7 : Form
         // Sanity Check Map Coordinates
         try
         {
-            NUD_X.Value = (decimal)(double)SAV.Situation.X;
-            NUD_Z.Value = (decimal)(double)SAV.Situation.Z;
-            NUD_Y.Value = (decimal)(double)SAV.Situation.Y;
+            NUD_X.Value = (decimal)(SAV.Situation.X / 60.0);
+            NUD_Z.Value = (decimal)(SAV.Situation.Z / 60.0);
+            NUD_Y.Value = (decimal)(SAV.Situation.Y / 60.0);
             NUD_R.Value = (decimal)(Math.Atan2(SAV.Situation.RZ, SAV.Situation.RW) * 360.0 / Math.PI);
         }
         catch { GB_Map.Enabled = false; }
@@ -339,11 +339,13 @@ public partial class SAV_Trainer7 : Form
         if (GB_Map.Enabled && MapUpdated)
         {
             SAV.Situation.M = (int)NUD_M.Value;
-            SAV.Situation.X = (float)NUD_X.Value;
-            SAV.Situation.Z = (float)NUD_Z.Value;
-            SAV.Situation.Y = (float)NUD_Y.Value;
+            SAV.Situation.X = (float)(NUD_X.Value * 60);
+            SAV.Situation.Z = (float)(NUD_Z.Value * 60);
+            SAV.Situation.Y = (float)(NUD_Y.Value * 60);
             var angle = (double)NUD_R.Value * Math.PI / 360.0;
+            SAV.Situation.RX = 0;
             SAV.Situation.RZ = (float)Math.Sin(angle);
+            SAV.Situation.RY = 0;
             SAV.Situation.RW = (float)Math.Cos(angle);
             SAV.Situation.UpdateOverworldCoordinates();
         }

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen7/SAV_Trainer7.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen7/SAV_Trainer7.cs
@@ -126,12 +126,11 @@ public partial class SAV_Trainer7 : Form
         // Sanity Check Map Coordinates
         try
         {
-            NUD_X.Value = (decimal)SAV.Situation.X;
-            NUD_Z.Value = (decimal)SAV.Situation.Z;
-            NUD_Y.Value = (decimal)SAV.Situation.Y;
+            NUD_X.Value = (decimal)(double)SAV.Situation.X;
+            NUD_Z.Value = (decimal)(double)SAV.Situation.Z;
+            NUD_Y.Value = (decimal)(double)SAV.Situation.Y;
             NUD_R.Value = (decimal)(Math.Atan2(SAV.Situation.RZ, SAV.Situation.RW) * 360.0 / Math.PI);
         }
-        // Sometimes the coordinates aren't really decimal/float coordinates?
         catch { GB_Map.Enabled = false; }
 
         // Load Play Time

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen7/SAV_Trainer7GG.Designer.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen7/SAV_Trainer7GG.Designer.cs
@@ -74,11 +74,39 @@ namespace PKHeX.WinForms
             L_GoSlot = new System.Windows.Forms.Label();
             NUD_GoIndex = new System.Windows.Forms.NumericUpDown();
             B_ExportGoSummary = new System.Windows.Forms.Button();
+            Tab_BadgeMap = new System.Windows.Forms.TabPage();
+            GB_Map = new System.Windows.Forms.GroupBox();
+            NUD_SZ = new System.Windows.Forms.NumericUpDown();
+            NUD_SY = new System.Windows.Forms.NumericUpDown();
+            NUD_SX = new System.Windows.Forms.NumericUpDown();
+            L_SY = new System.Windows.Forms.Label();
+            L_SZ = new System.Windows.Forms.Label();
+            L_SX = new System.Windows.Forms.Label();
+            NUD_R = new System.Windows.Forms.NumericUpDown();
+            L_R = new System.Windows.Forms.Label();
+            NUD_Z = new System.Windows.Forms.NumericUpDown();
+            NUD_M = new System.Windows.Forms.NumericUpDown();
+            NUD_Y = new System.Windows.Forms.NumericUpDown();
+            NUD_X = new System.Windows.Forms.NumericUpDown();
+            L_Y = new System.Windows.Forms.Label();
+            L_CurrentMap = new System.Windows.Forms.Label();
+            L_Z = new System.Windows.Forms.Label();
+            L_X = new System.Windows.Forms.Label();
             TC_Editor.SuspendLayout();
             Tab_Overview.SuspendLayout();
             GB_Adventure.SuspendLayout();
             Tab_Complex.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)NUD_GoIndex).BeginInit();
+            Tab_BadgeMap.SuspendLayout();
+            GB_Map.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)NUD_SZ).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)NUD_SY).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)NUD_SX).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)NUD_R).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)NUD_Z).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)NUD_M).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)NUD_Y).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)NUD_X).BeginInit();
             SuspendLayout();
             // 
             // B_Cancel
@@ -333,6 +361,7 @@ namespace PKHeX.WinForms
             // TC_Editor
             // 
             TC_Editor.Controls.Add(Tab_Overview);
+            TC_Editor.Controls.Add(Tab_BadgeMap);
             TC_Editor.Controls.Add(Tab_Complex);
             TC_Editor.Location = new System.Drawing.Point(14, 14);
             TC_Editor.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
@@ -568,6 +597,224 @@ namespace PKHeX.WinForms
             B_ExportGoSummary.UseVisualStyleBackColor = true;
             B_ExportGoSummary.Click += B_ExportGoSummary_Click;
             // 
+            // Tab_BadgeMap
+            // 
+            Tab_BadgeMap.Controls.Add(GB_Map);
+            Tab_BadgeMap.Location = new System.Drawing.Point(4, 24);
+            Tab_BadgeMap.Name = "Tab_BadgeMap";
+            Tab_BadgeMap.Size = new System.Drawing.Size(452, 337);
+            Tab_BadgeMap.TabIndex = 5;
+            Tab_BadgeMap.Text = "Map";
+            Tab_BadgeMap.UseVisualStyleBackColor = true;
+            // 
+            // GB_Map
+            // 
+            GB_Map.Controls.Add(NUD_SZ);
+            GB_Map.Controls.Add(NUD_SY);
+            GB_Map.Controls.Add(NUD_SX);
+            GB_Map.Controls.Add(L_SY);
+            GB_Map.Controls.Add(L_SZ);
+            GB_Map.Controls.Add(L_SX);
+            GB_Map.Controls.Add(NUD_R);
+            GB_Map.Controls.Add(L_R);
+            GB_Map.Controls.Add(NUD_Z);
+            GB_Map.Controls.Add(NUD_M);
+            GB_Map.Controls.Add(NUD_Y);
+            GB_Map.Controls.Add(NUD_X);
+            GB_Map.Controls.Add(L_Y);
+            GB_Map.Controls.Add(L_CurrentMap);
+            GB_Map.Controls.Add(L_Z);
+            GB_Map.Controls.Add(L_X);
+            GB_Map.Location = new System.Drawing.Point(7, 7);
+            GB_Map.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            GB_Map.Name = "GB_Map";
+            GB_Map.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            GB_Map.Size = new System.Drawing.Size(237, 270);
+            GB_Map.TabIndex = 59;
+            GB_Map.TabStop = false;
+            GB_Map.Text = "Map Position";
+            // 
+            // NUD_SZ
+            // 
+            NUD_SZ.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            NUD_SZ.DecimalPlaces = 6;
+            NUD_SZ.Location = new System.Drawing.Point(108, 168);
+            NUD_SZ.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            NUD_SZ.Maximum = new decimal(new int[] { 99999999, 0, 0, 0 });
+            NUD_SZ.Minimum = new decimal(new int[] { 99999999, 0, 0, int.MinValue });
+            NUD_SZ.Name = "NUD_SZ";
+            NUD_SZ.Size = new System.Drawing.Size(112, 23);
+            NUD_SZ.TabIndex = 59;
+            NUD_SZ.ValueChanged += ChangeMapValue;
+            // 
+            // NUD_SY
+            // 
+            NUD_SY.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            NUD_SY.DecimalPlaces = 6;
+            NUD_SY.Location = new System.Drawing.Point(108, 198);
+            NUD_SY.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            NUD_SY.Maximum = new decimal(new int[] { 99999999, 0, 0, 0 });
+            NUD_SY.Minimum = new decimal(new int[] { 99999999, 0, 0, int.MinValue });
+            NUD_SY.Name = "NUD_SY";
+            NUD_SY.Size = new System.Drawing.Size(112, 23);
+            NUD_SY.TabIndex = 60;
+            NUD_SY.ValueChanged += ChangeMapValue;
+            // 
+            // NUD_SX
+            // 
+            NUD_SX.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            NUD_SX.DecimalPlaces = 6;
+            NUD_SX.Location = new System.Drawing.Point(108, 138);
+            NUD_SX.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            NUD_SX.Maximum = new decimal(new int[] { 99999999, 0, 0, 0 });
+            NUD_SX.Minimum = new decimal(new int[] { 99999999, 0, 0, int.MinValue });
+            NUD_SX.Name = "NUD_SX";
+            NUD_SX.Size = new System.Drawing.Size(112, 23);
+            NUD_SX.TabIndex = 58;
+            NUD_SX.ValueChanged += ChangeMapValue;
+            // 
+            // L_SY
+            // 
+            L_SY.Location = new System.Drawing.Point(7, 198);
+            L_SY.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            L_SY.Name = "L_SY";
+            L_SY.Size = new System.Drawing.Size(93, 23);
+            L_SY.TabIndex = 52;
+            L_SY.Text = "Y Scale:";
+            L_SY.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // L_SZ
+            // 
+            L_SZ.Location = new System.Drawing.Point(7, 168);
+            L_SZ.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            L_SZ.Name = "L_SZ";
+            L_SZ.Size = new System.Drawing.Size(93, 23);
+            L_SZ.TabIndex = 51;
+            L_SZ.Text = "Z Scale:";
+            L_SZ.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // L_SX
+            // 
+            L_SX.Location = new System.Drawing.Point(7, 138);
+            L_SX.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            L_SX.Name = "L_SX";
+            L_SX.Size = new System.Drawing.Size(93, 23);
+            L_SX.TabIndex = 50;
+            L_SX.Text = "X Scale:";
+            L_SX.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // NUD_R
+            // 
+            NUD_R.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            NUD_R.DecimalPlaces = 6;
+            NUD_R.Location = new System.Drawing.Point(108, 228);
+            NUD_R.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            NUD_R.Maximum = new decimal(new int[] { 99999999, 0, 0, 0 });
+            NUD_R.Minimum = new decimal(new int[] { 99999999, 0, 0, int.MinValue });
+            NUD_R.Name = "NUD_R";
+            NUD_R.Size = new System.Drawing.Size(112, 23);
+            NUD_R.TabIndex = 61;
+            NUD_R.ValueChanged += ChangeMapValue;
+            // 
+            // L_R
+            // 
+            L_R.Location = new System.Drawing.Point(7, 228);
+            L_R.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            L_R.Name = "L_R";
+            L_R.Size = new System.Drawing.Size(93, 23);
+            L_R.TabIndex = 53;
+            L_R.Text = "Rotation:";
+            L_R.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // NUD_Z
+            // 
+            NUD_Z.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            NUD_Z.DecimalPlaces = 6;
+            NUD_Z.Location = new System.Drawing.Point(108, 78);
+            NUD_Z.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            NUD_Z.Maximum = new decimal(new int[] { 99999999, 0, 0, 0 });
+            NUD_Z.Minimum = new decimal(new int[] { 99999999, 0, 0, int.MinValue });
+            NUD_Z.Name = "NUD_Z";
+            NUD_Z.Size = new System.Drawing.Size(112, 23);
+            NUD_Z.TabIndex = 56;
+            NUD_Z.ValueChanged += ChangeMapValue;
+            // 
+            // NUD_M
+            // 
+            NUD_M.Location = new System.Drawing.Point(108, 18);
+            NUD_M.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            NUD_M.Maximum = new decimal(new int[] { -1, -1, 0, 0 });
+            NUD_M.Name = "NUD_M";
+            NUD_M.Size = new System.Drawing.Size(112, 23);
+            NUD_M.TabIndex = 54;
+            NUD_M.ValueChanged += ChangeMapValue;
+            // 
+            // NUD_Y
+            // 
+            NUD_Y.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            NUD_Y.DecimalPlaces = 6;
+            NUD_Y.Location = new System.Drawing.Point(108, 108);
+            NUD_Y.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            NUD_Y.Maximum = new decimal(new int[] { 99999999, 0, 0, 0 });
+            NUD_Y.Minimum = new decimal(new int[] { 99999999, 0, 0, int.MinValue });
+            NUD_Y.Name = "NUD_Y";
+            NUD_Y.Size = new System.Drawing.Size(112, 23);
+            NUD_Y.TabIndex = 57;
+            NUD_Y.ValueChanged += ChangeMapValue;
+            // 
+            // NUD_X
+            // 
+            NUD_X.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            NUD_X.DecimalPlaces = 6;
+            NUD_X.Location = new System.Drawing.Point(108, 48);
+            NUD_X.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            NUD_X.Maximum = new decimal(new int[] { 99999999, 0, 0, 0 });
+            NUD_X.Minimum = new decimal(new int[] { 99999999, 0, 0, int.MinValue });
+            NUD_X.Name = "NUD_X";
+            NUD_X.Size = new System.Drawing.Size(112, 23);
+            NUD_X.TabIndex = 55;
+            NUD_X.ValueChanged += ChangeMapValue;
+            // 
+            // L_Y
+            // 
+            L_Y.Location = new System.Drawing.Point(7, 108);
+            L_Y.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            L_Y.Name = "L_Y";
+            L_Y.Size = new System.Drawing.Size(93, 23);
+            L_Y.TabIndex = 49;
+            L_Y.Text = "Y Coordinate:";
+            L_Y.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // L_CurrentMap
+            // 
+            L_CurrentMap.Location = new System.Drawing.Point(7, 18);
+            L_CurrentMap.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            L_CurrentMap.Name = "L_CurrentMap";
+            L_CurrentMap.Size = new System.Drawing.Size(93, 23);
+            L_CurrentMap.TabIndex = 46;
+            L_CurrentMap.Text = "Current Map:";
+            L_CurrentMap.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // L_Z
+            // 
+            L_Z.Location = new System.Drawing.Point(7, 78);
+            L_Z.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            L_Z.Name = "L_Z";
+            L_Z.Size = new System.Drawing.Size(93, 23);
+            L_Z.TabIndex = 48;
+            L_Z.Text = "Z Coordinate:";
+            L_Z.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // L_X
+            // 
+            L_X.Location = new System.Drawing.Point(7, 48);
+            L_X.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            L_X.Name = "L_X";
+            L_X.Size = new System.Drawing.Size(93, 23);
+            L_X.TabIndex = 47;
+            L_X.Text = "X Coordinate:";
+            L_X.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
             // SAV_Trainer7GG
             // 
             AllowDrop = true;
@@ -593,6 +840,16 @@ namespace PKHeX.WinForms
             GB_Adventure.PerformLayout();
             Tab_Complex.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)NUD_GoIndex).EndInit();
+            Tab_BadgeMap.ResumeLayout(false);
+            GB_Map.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)NUD_SZ).EndInit();
+            ((System.ComponentModel.ISupportInitialize)NUD_SY).EndInit();
+            ((System.ComponentModel.ISupportInitialize)NUD_SX).EndInit();
+            ((System.ComponentModel.ISupportInitialize)NUD_R).EndInit();
+            ((System.ComponentModel.ISupportInitialize)NUD_Z).EndInit();
+            ((System.ComponentModel.ISupportInitialize)NUD_M).EndInit();
+            ((System.ComponentModel.ISupportInitialize)NUD_Y).EndInit();
+            ((System.ComponentModel.ISupportInitialize)NUD_X).EndInit();
             ResumeLayout(false);
         }
 
@@ -644,5 +901,23 @@ namespace PKHeX.WinForms
         private System.Windows.Forms.Button B_DeleteGo;
         private System.Windows.Forms.Button B_AllTrainerTitles;
         private System.Windows.Forms.Button B_AllFashionItems;
+        private System.Windows.Forms.TabPage Tab_BadgeMap;
+        private System.Windows.Forms.GroupBox GB_Map;
+        private System.Windows.Forms.NumericUpDown NUD_SZ;
+        private System.Windows.Forms.NumericUpDown NUD_SY;
+        private System.Windows.Forms.NumericUpDown NUD_SX;
+        private System.Windows.Forms.Label L_SY;
+        private System.Windows.Forms.Label L_SZ;
+        private System.Windows.Forms.Label L_SX;
+        private System.Windows.Forms.NumericUpDown NUD_R;
+        private System.Windows.Forms.Label L_R;
+        private System.Windows.Forms.NumericUpDown NUD_Z;
+        private System.Windows.Forms.NumericUpDown NUD_M;
+        private System.Windows.Forms.NumericUpDown NUD_Y;
+        private System.Windows.Forms.NumericUpDown NUD_X;
+        private System.Windows.Forms.Label L_Y;
+        private System.Windows.Forms.Label L_CurrentMap;
+        private System.Windows.Forms.Label L_Z;
+        private System.Windows.Forms.Label L_X;
     }
 }

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen7/SAV_Trainer7GG.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen7/SAV_Trainer7GG.cs
@@ -32,6 +32,8 @@ public partial class SAV_Trainer7GG : Form
         LoadTrainerInfo();
     }
 
+    private bool MapUpdated;
+
     // Drag & Drop Events
     private void Main_DragEnter(object? sender, DragEventArgs? e)
     {
@@ -73,6 +75,20 @@ public partial class SAV_Trainer7GG : Form
         CB_Gender.SelectedIndex = SAV.Gender;
         trainerID1.LoadIDValues(SAV, SAV.Generation);
 
+        NUD_M.Value = SAV.Coordinates.M;
+        // Sanity Check Map Coordinates
+        try
+        {
+            NUD_X.Value = (decimal)(double)SAV.Coordinates.X;
+            NUD_Z.Value = (decimal)(double)SAV.Coordinates.Z;
+            NUD_Y.Value = (decimal)(double)SAV.Coordinates.Y;
+            NUD_SX.Value = (decimal)(double)SAV.Coordinates.SX;
+            NUD_SZ.Value = (decimal)(double)SAV.Coordinates.SZ;
+            NUD_SY.Value = (decimal)(double)SAV.Coordinates.SY;
+            NUD_R.Value = (decimal)(Math.Atan2(SAV.Coordinates.RZ, SAV.Coordinates.RW) * 360.0 / Math.PI);
+        }
+        catch { GB_Map.Enabled = false; }
+
         // Load Play Time
         MT_Hours.Text = SAV.PlayedHours.ToString();
         MT_Minutes.Text = SAV.PlayedMinutes.ToString();
@@ -94,6 +110,23 @@ public partial class SAV_Trainer7GG : Form
 
         SAV.OT = TB_OTName.Text;
         SAV.Blocks.Misc.Rival = TB_RivalName.Text;
+
+        // Copy Position
+        if (GB_Map.Enabled && MapUpdated)
+        {
+            SAV.Coordinates.M = (ulong)NUD_M.Value;
+            SAV.Coordinates.X = (float)NUD_X.Value;
+            SAV.Coordinates.Z = (float)NUD_Z.Value;
+            SAV.Coordinates.Y = (float)NUD_Y.Value;
+            SAV.Coordinates.SX = (float)NUD_SX.Value;
+            SAV.Coordinates.SZ = (float)NUD_SZ.Value;
+            SAV.Coordinates.SY = (float)NUD_SY.Value;
+            var angle = (double)NUD_R.Value * Math.PI / 360.0;
+            SAV.Coordinates.RX = 0;
+            SAV.Coordinates.RZ = (float)Math.Sin(angle);
+            SAV.Coordinates.RY = 0;
+            SAV.Coordinates.RW = (float)Math.Cos(angle);
+        }
 
         // Save PlayTime
         SAV.PlayedHours = ushort.Parse(MT_Hours.Text);
@@ -131,6 +164,11 @@ public partial class SAV_Trainer7GG : Form
         MaskedTextBox box = (MaskedTextBox)sender;
         if (box.Text.Length == 0) box.Text = "0";
         if (Util.ToInt32(box.Text) > 255) box.Text = "255";
+    }
+
+    private void ChangeMapValue(object sender, EventArgs e)
+    {
+        MapUpdated = true;
     }
 
     private void B_ExportGoSummary_Click(object sender, EventArgs e)

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen8/SAV_Trainer8.Designer.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen8/SAV_Trainer8.Designer.cs
@@ -1062,6 +1062,7 @@ namespace PKHeX.WinForms
             NUD_SZ.Name = "NUD_SZ";
             NUD_SZ.Size = new System.Drawing.Size(112, 23);
             NUD_SZ.TabIndex = 59;
+            NUD_SZ.ValueChanged += ChangeMapValue;
             // 
             // NUD_SY
             // 
@@ -1074,6 +1075,7 @@ namespace PKHeX.WinForms
             NUD_SY.Name = "NUD_SY";
             NUD_SY.Size = new System.Drawing.Size(112, 23);
             NUD_SY.TabIndex = 60;
+            NUD_SY.ValueChanged += ChangeMapValue;
             // 
             // NUD_SX
             // 
@@ -1086,6 +1088,7 @@ namespace PKHeX.WinForms
             NUD_SX.Name = "NUD_SX";
             NUD_SX.Size = new System.Drawing.Size(112, 23);
             NUD_SX.TabIndex = 58;
+            NUD_SX.ValueChanged += ChangeMapValue;
             // 
             // L_SY
             // 

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen8/SAV_Trainer8.Designer.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen8/SAV_Trainer8.Designer.cs
@@ -119,6 +119,12 @@ namespace PKHeX.WinForms
             CAL_LastSavedTime = new System.Windows.Forms.DateTimePicker();
             Tab_BadgeMap = new System.Windows.Forms.TabPage();
             GB_Map = new System.Windows.Forms.GroupBox();
+            NUD_SZ = new System.Windows.Forms.NumericUpDown();
+            NUD_SY = new System.Windows.Forms.NumericUpDown();
+            NUD_SX = new System.Windows.Forms.NumericUpDown();
+            L_SY = new System.Windows.Forms.Label();
+            L_SZ = new System.Windows.Forms.Label();
+            L_SX = new System.Windows.Forms.Label();
             NUD_R = new System.Windows.Forms.NumericUpDown();
             L_R = new System.Windows.Forms.Label();
             NUD_Z = new System.Windows.Forms.NumericUpDown();
@@ -156,6 +162,9 @@ namespace PKHeX.WinForms
             GB_Adventure.SuspendLayout();
             Tab_BadgeMap.SuspendLayout();
             GB_Map.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)NUD_SZ).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)NUD_SY).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)NUD_SX).BeginInit();
             ((System.ComponentModel.ISupportInitialize)NUD_R).BeginInit();
             ((System.ComponentModel.ISupportInitialize)NUD_Z).BeginInit();
             ((System.ComponentModel.ISupportInitialize)NUD_M).BeginInit();
@@ -1017,6 +1026,12 @@ namespace PKHeX.WinForms
             // 
             // GB_Map
             // 
+            GB_Map.Controls.Add(NUD_SZ);
+            GB_Map.Controls.Add(NUD_SY);
+            GB_Map.Controls.Add(NUD_SX);
+            GB_Map.Controls.Add(L_SY);
+            GB_Map.Controls.Add(L_SZ);
+            GB_Map.Controls.Add(L_SX);
             GB_Map.Controls.Add(NUD_R);
             GB_Map.Controls.Add(L_R);
             GB_Map.Controls.Add(NUD_Z);
@@ -1027,85 +1042,151 @@ namespace PKHeX.WinForms
             GB_Map.Controls.Add(L_CurrentMap);
             GB_Map.Controls.Add(L_Z);
             GB_Map.Controls.Add(L_X);
-            GB_Map.Location = new System.Drawing.Point(138, 103);
+            GB_Map.Location = new System.Drawing.Point(7, 7);
             GB_Map.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             GB_Map.Name = "GB_Map";
             GB_Map.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            GB_Map.Size = new System.Drawing.Size(237, 180);
+            GB_Map.Size = new System.Drawing.Size(237, 270);
             GB_Map.TabIndex = 58;
             GB_Map.TabStop = false;
             GB_Map.Text = "Map Position";
             // 
+            // NUD_SZ
+            // 
+            NUD_SZ.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            NUD_SZ.DecimalPlaces = 6;
+            NUD_SZ.Location = new System.Drawing.Point(108, 168);
+            NUD_SZ.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            NUD_SZ.Maximum = new decimal(new int[] { 99999999, 0, 0, 0 });
+            NUD_SZ.Minimum = new decimal(new int[] { 99999999, 0, 0, int.MinValue });
+            NUD_SZ.Name = "NUD_SZ";
+            NUD_SZ.Size = new System.Drawing.Size(112, 23);
+            NUD_SZ.TabIndex = 59;
+            // 
+            // NUD_SY
+            // 
+            NUD_SY.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            NUD_SY.DecimalPlaces = 6;
+            NUD_SY.Location = new System.Drawing.Point(108, 198);
+            NUD_SY.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            NUD_SY.Maximum = new decimal(new int[] { 99999999, 0, 0, 0 });
+            NUD_SY.Minimum = new decimal(new int[] { 99999999, 0, 0, int.MinValue });
+            NUD_SY.Name = "NUD_SY";
+            NUD_SY.Size = new System.Drawing.Size(112, 23);
+            NUD_SY.TabIndex = 60;
+            // 
+            // NUD_SX
+            // 
+            NUD_SX.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            NUD_SX.DecimalPlaces = 6;
+            NUD_SX.Location = new System.Drawing.Point(108, 138);
+            NUD_SX.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            NUD_SX.Maximum = new decimal(new int[] { 99999999, 0, 0, 0 });
+            NUD_SX.Minimum = new decimal(new int[] { 99999999, 0, 0, int.MinValue });
+            NUD_SX.Name = "NUD_SX";
+            NUD_SX.Size = new System.Drawing.Size(112, 23);
+            NUD_SX.TabIndex = 58;
+            // 
+            // L_SY
+            // 
+            L_SY.Location = new System.Drawing.Point(7, 198);
+            L_SY.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            L_SY.Name = "L_SY";
+            L_SY.Size = new System.Drawing.Size(93, 23);
+            L_SY.TabIndex = 52;
+            L_SY.Text = "Y Scale:";
+            L_SY.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // L_SZ
+            // 
+            L_SZ.Location = new System.Drawing.Point(7, 168);
+            L_SZ.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            L_SZ.Name = "L_SZ";
+            L_SZ.Size = new System.Drawing.Size(93, 23);
+            L_SZ.TabIndex = 51;
+            L_SZ.Text = "Z Scale:";
+            L_SZ.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // L_SX
+            // 
+            L_SX.Location = new System.Drawing.Point(7, 138);
+            L_SX.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            L_SX.Name = "L_SX";
+            L_SX.Size = new System.Drawing.Size(93, 23);
+            L_SX.TabIndex = 50;
+            L_SX.Text = "X Scale:";
+            L_SX.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
             // NUD_R
             // 
             NUD_R.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
-            NUD_R.DecimalPlaces = 5;
-            NUD_R.Location = new System.Drawing.Point(108, 138);
+            NUD_R.DecimalPlaces = 6;
+            NUD_R.Location = new System.Drawing.Point(108, 228);
             NUD_R.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             NUD_R.Maximum = new decimal(new int[] { 99999999, 0, 0, 0 });
             NUD_R.Minimum = new decimal(new int[] { 99999999, 0, 0, int.MinValue });
             NUD_R.Name = "NUD_R";
             NUD_R.Size = new System.Drawing.Size(112, 23);
-            NUD_R.TabIndex = 55;
+            NUD_R.TabIndex = 61;
             NUD_R.ValueChanged += ChangeMapValue;
             // 
             // L_R
             // 
-            L_R.Location = new System.Drawing.Point(7, 138);
+            L_R.Location = new System.Drawing.Point(7, 228);
             L_R.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             L_R.Name = "L_R";
             L_R.Size = new System.Drawing.Size(93, 23);
-            L_R.TabIndex = 54;
+            L_R.TabIndex = 53;
             L_R.Text = "Rotation:";
             L_R.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // NUD_Z
             // 
             NUD_Z.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
-            NUD_Z.DecimalPlaces = 5;
+            NUD_Z.DecimalPlaces = 6;
             NUD_Z.Location = new System.Drawing.Point(108, 78);
             NUD_Z.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             NUD_Z.Maximum = new decimal(new int[] { 99999999, 0, 0, 0 });
             NUD_Z.Minimum = new decimal(new int[] { 99999999, 0, 0, int.MinValue });
             NUD_Z.Name = "NUD_Z";
             NUD_Z.Size = new System.Drawing.Size(112, 23);
-            NUD_Z.TabIndex = 53;
+            NUD_Z.TabIndex = 56;
             NUD_Z.ValueChanged += ChangeMapValue;
             // 
             // NUD_M
             // 
             NUD_M.Location = new System.Drawing.Point(108, 18);
             NUD_M.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            NUD_M.Maximum = new decimal(new int[] { 1000, 0, 0, 0 });
+            NUD_M.Maximum = new decimal(new int[] { -1, -1, 0, 0 });
             NUD_M.Name = "NUD_M";
-            NUD_M.Size = new System.Drawing.Size(58, 23);
-            NUD_M.TabIndex = 52;
+            NUD_M.Size = new System.Drawing.Size(112, 23);
+            NUD_M.TabIndex = 54;
             NUD_M.ValueChanged += ChangeMapValue;
             // 
             // NUD_Y
             // 
             NUD_Y.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
-            NUD_Y.DecimalPlaces = 5;
+            NUD_Y.DecimalPlaces = 6;
             NUD_Y.Location = new System.Drawing.Point(108, 108);
             NUD_Y.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             NUD_Y.Maximum = new decimal(new int[] { 99999999, 0, 0, 0 });
             NUD_Y.Minimum = new decimal(new int[] { 99999999, 0, 0, int.MinValue });
             NUD_Y.Name = "NUD_Y";
             NUD_Y.Size = new System.Drawing.Size(112, 23);
-            NUD_Y.TabIndex = 51;
+            NUD_Y.TabIndex = 57;
             NUD_Y.ValueChanged += ChangeMapValue;
             // 
             // NUD_X
             // 
             NUD_X.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
-            NUD_X.DecimalPlaces = 5;
+            NUD_X.DecimalPlaces = 6;
             NUD_X.Location = new System.Drawing.Point(108, 48);
             NUD_X.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             NUD_X.Maximum = new decimal(new int[] { 99999999, 0, 0, 0 });
             NUD_X.Minimum = new decimal(new int[] { 99999999, 0, 0, int.MinValue });
             NUD_X.Name = "NUD_X";
             NUD_X.Size = new System.Drawing.Size(112, 23);
-            NUD_X.TabIndex = 50;
+            NUD_X.TabIndex = 55;
             NUD_X.ValueChanged += ChangeMapValue;
             // 
             // L_Y
@@ -1400,6 +1481,9 @@ namespace PKHeX.WinForms
             GB_Adventure.PerformLayout();
             Tab_BadgeMap.ResumeLayout(false);
             GB_Map.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)NUD_SZ).EndInit();
+            ((System.ComponentModel.ISupportInitialize)NUD_SY).EndInit();
+            ((System.ComponentModel.ISupportInitialize)NUD_SX).EndInit();
             ((System.ComponentModel.ISupportInitialize)NUD_R).EndInit();
             ((System.ComponentModel.ISupportInitialize)NUD_Z).EndInit();
             ((System.ComponentModel.ISupportInitialize)NUD_M).EndInit();
@@ -1538,5 +1622,11 @@ namespace PKHeX.WinForms
         private System.Windows.Forms.Button B_CopyFromPartyToTrainerCard;
         private System.Windows.Forms.Button B_CopyFromPartyToTitleScreen;
         private System.Windows.Forms.Button B_CollectDiglett;
+        private System.Windows.Forms.NumericUpDown NUD_SZ;
+        private System.Windows.Forms.NumericUpDown NUD_SY;
+        private System.Windows.Forms.NumericUpDown NUD_SX;
+        private System.Windows.Forms.Label L_SY;
+        private System.Windows.Forms.Label L_SZ;
+        private System.Windows.Forms.Label L_SX;
     }
 }

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen8/SAV_Trainer8.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen8/SAV_Trainer8.cs
@@ -34,8 +34,6 @@ public partial class SAV_Trainer8 : Form
         GetTextBoxes();
         GetMiscValues();
 
-        TC_Editor.TabPages.Remove(Tab_BadgeMap); // needs more work
-
         ChangeTitleScreenIndex(this, EventArgs.Empty);
         ChangeTrainerCardIndex(this, EventArgs.Empty);
 
@@ -46,7 +44,7 @@ public partial class SAV_Trainer8 : Form
     }
 
     // private readonly bool Loading;
-    // private bool MapUpdated;
+    private bool MapUpdated;
 
     private void GetComboBoxes()
     {
@@ -71,16 +69,19 @@ public partial class SAV_Trainer8 : Form
         MT_Watt.Text = SAV.MyStatus.Watt.ToString();
         CB_Language.SelectedValue = SAV.Language;
 
-        //NUD_M.Value = SAV.Situation.M;
-        //// Sanity Check Map Coordinates
-        //try
-        //{
-        //    NUD_X.Value = (decimal)SAV.Situation.X;
-        //    NUD_Z.Value = (decimal)SAV.Situation.Z;
-        //    NUD_Y.Value = (decimal)SAV.Situation.Y;
-        //    NUD_R.Value = (decimal)SAV.Situation.R;
-        //}
-        //catch { GB_Map.Enabled = false; }
+        NUD_M.Value = SAV.Coordinates.M;
+        // Sanity Check Map Coordinates
+        try
+        {
+            NUD_X.Value = (decimal)(double)SAV.Coordinates.X;
+            NUD_Z.Value = (decimal)(double)SAV.Coordinates.Z;
+            NUD_Y.Value = (decimal)(double)SAV.Coordinates.Y;
+            NUD_SX.Value = (decimal)(double)SAV.Coordinates.SX;
+            NUD_SZ.Value = (decimal)(double)SAV.Coordinates.SZ;
+            NUD_SY.Value = (decimal)(double)SAV.Coordinates.SY;
+            NUD_R.Value = (decimal)(Math.Atan2(SAV.Coordinates.RZ, SAV.Coordinates.RW) * 360.0 / Math.PI);
+        }
+        catch { GB_Map.Enabled = false; }
 
         // Load Play Time
         MT_Hours.Text = SAV.PlayedHours.ToString();
@@ -154,15 +155,21 @@ public partial class SAV_Trainer8 : Form
         SAV.Misc.BP = (int)NUD_BP.Value;
 
         // Copy Position
-        //if (GB_Map.Enabled && MapUpdated)
-        //{
-        //    SAV.Situation.M = (int)NUD_M.Value;
-        //    SAV.Situation.X = (float)NUD_X.Value;
-        //    SAV.Situation.Z = (float)NUD_Z.Value;
-        //    SAV.Situation.Y = (float)NUD_Y.Value;
-        //    SAV.Situation.R = (float)NUD_R.Value;
-        //    SAV.Situation.UpdateOverworldCoordinates();
-        //}
+        if (GB_Map.Enabled && MapUpdated)
+        {
+            SAV.Coordinates.M = (ulong)NUD_M.Value;
+            SAV.Coordinates.X = (float)NUD_X.Value;
+            SAV.Coordinates.Z = (float)NUD_Z.Value;
+            SAV.Coordinates.Y = (float)NUD_Y.Value;
+            SAV.Coordinates.SX = (float)NUD_SX.Value;
+            SAV.Coordinates.SZ = (float)NUD_SZ.Value;
+            SAV.Coordinates.SY = (float)NUD_SY.Value;
+            var angle = (double)NUD_R.Value * Math.PI / 360.0;
+            SAV.Coordinates.RX = 0;
+            SAV.Coordinates.RZ = (float)Math.Sin(angle);
+            SAV.Coordinates.RY = 0;
+            SAV.Coordinates.RW = (float)Math.Cos(angle);
+        }
 
         // Save PlayTime
         SAV.PlayedHours = ushort.Parse(MT_Hours.Text);
@@ -213,7 +220,7 @@ public partial class SAV_Trainer8 : Form
     private void ChangeMapValue(object sender, EventArgs e)
     {
         //if (!Loading)
-        //    MapUpdated = true;
+        MapUpdated = true;
     }
 
     private void ChangeTrainerCardIndex(object sender, EventArgs e)

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen8/SAV_Trainer8a.Designer.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen8/SAV_Trainer8a.Designer.cs
@@ -107,6 +107,18 @@ namespace PKHeX.WinForms
             CAL_AdventureStartDate = new System.Windows.Forms.DateTimePicker();
             CAL_AdventureStartTime = new System.Windows.Forms.DateTimePicker();
             CAL_LastSavedTime = new System.Windows.Forms.DateTimePicker();
+            Tab_BadgeMap = new System.Windows.Forms.TabPage();
+            GB_Map = new System.Windows.Forms.GroupBox();
+            TB_M = new System.Windows.Forms.TextBox();
+            NUD_R = new System.Windows.Forms.NumericUpDown();
+            L_R = new System.Windows.Forms.Label();
+            NUD_Z = new System.Windows.Forms.NumericUpDown();
+            NUD_Y = new System.Windows.Forms.NumericUpDown();
+            NUD_X = new System.Windows.Forms.NumericUpDown();
+            L_Y = new System.Windows.Forms.Label();
+            L_CurrentMap = new System.Windows.Forms.Label();
+            L_Z = new System.Windows.Forms.Label();
+            L_X = new System.Windows.Forms.Label();
             TC_Editor.SuspendLayout();
             Tab_Overview.SuspendLayout();
             GB_Stats.SuspendLayout();
@@ -115,6 +127,12 @@ namespace PKHeX.WinForms
             ((System.ComponentModel.ISupportInitialize)NUD_MeritEarned).BeginInit();
             ((System.ComponentModel.ISupportInitialize)NUD_MeritCurrent).BeginInit();
             GB_Adventure.SuspendLayout();
+            Tab_BadgeMap.SuspendLayout();
+            GB_Map.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)NUD_R).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)NUD_Z).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)NUD_Y).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)NUD_X).BeginInit();
             SuspendLayout();
             // 
             // B_Cancel
@@ -621,6 +639,7 @@ namespace PKHeX.WinForms
             // 
             TC_Editor.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
             TC_Editor.Controls.Add(Tab_Overview);
+            TC_Editor.Controls.Add(Tab_BadgeMap);
             TC_Editor.Location = new System.Drawing.Point(14, 14);
             TC_Editor.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             TC_Editor.Name = "TC_Editor";
@@ -830,6 +849,148 @@ namespace PKHeX.WinForms
             CAL_LastSavedTime.TabIndex = 37;
             CAL_LastSavedTime.Value = new System.DateTime(2000, 1, 1, 0, 0, 0, 0);
             // 
+            // Tab_BadgeMap
+            // 
+            Tab_BadgeMap.Controls.Add(GB_Map);
+            Tab_BadgeMap.Location = new System.Drawing.Point(4, 24);
+            Tab_BadgeMap.Name = "Tab_BadgeMap";
+            Tab_BadgeMap.Size = new System.Drawing.Size(503, 333);
+            Tab_BadgeMap.TabIndex = 1;
+            Tab_BadgeMap.Text = "Map";
+            Tab_BadgeMap.UseVisualStyleBackColor = true;
+            // 
+            // GB_Map
+            // 
+            GB_Map.Controls.Add(TB_M);
+            GB_Map.Controls.Add(NUD_R);
+            GB_Map.Controls.Add(L_R);
+            GB_Map.Controls.Add(NUD_Z);
+            GB_Map.Controls.Add(NUD_Y);
+            GB_Map.Controls.Add(NUD_X);
+            GB_Map.Controls.Add(L_Y);
+            GB_Map.Controls.Add(L_CurrentMap);
+            GB_Map.Controls.Add(L_Z);
+            GB_Map.Controls.Add(L_X);
+            GB_Map.Location = new System.Drawing.Point(7, 7);
+            GB_Map.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            GB_Map.Name = "GB_Map";
+            GB_Map.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            GB_Map.Size = new System.Drawing.Size(237, 180);
+            GB_Map.TabIndex = 59;
+            GB_Map.TabStop = false;
+            GB_Map.Text = "Map Position";
+            // 
+            // TB_M
+            // 
+            TB_M.Location = new System.Drawing.Point(109, 18);
+            TB_M.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            TB_M.MaxLength = 48;
+            TB_M.Name = "TB_M";
+            TB_M.Size = new System.Drawing.Size(112, 23);
+            TB_M.TabIndex = 51;
+            // 
+            // NUD_R
+            // 
+            NUD_R.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            NUD_R.DecimalPlaces = 6;
+            NUD_R.Location = new System.Drawing.Point(109, 138);
+            NUD_R.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            NUD_R.Maximum = new decimal(new int[] { 99999999, 0, 0, 0 });
+            NUD_R.Minimum = new decimal(new int[] { 99999999, 0, 0, int.MinValue });
+            NUD_R.Name = "NUD_R";
+            NUD_R.Size = new System.Drawing.Size(112, 23);
+            NUD_R.TabIndex = 55;
+            NUD_R.ValueChanged += ChangeMapValue;
+            // 
+            // L_R
+            // 
+            L_R.Location = new System.Drawing.Point(7, 138);
+            L_R.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            L_R.Name = "L_R";
+            L_R.Size = new System.Drawing.Size(93, 23);
+            L_R.TabIndex = 50;
+            L_R.Text = "Rotation:";
+            L_R.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // NUD_Z
+            // 
+            NUD_Z.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            NUD_Z.DecimalPlaces = 6;
+            NUD_Z.Location = new System.Drawing.Point(109, 78);
+            NUD_Z.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            NUD_Z.Maximum = new decimal(new int[] { 99999999, 0, 0, 0 });
+            NUD_Z.Minimum = new decimal(new int[] { 99999999, 0, 0, int.MinValue });
+            NUD_Z.Name = "NUD_Z";
+            NUD_Z.Size = new System.Drawing.Size(112, 23);
+            NUD_Z.TabIndex = 53;
+            NUD_Z.ValueChanged += ChangeMapValue;
+            // 
+            // NUD_Y
+            // 
+            NUD_Y.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            NUD_Y.DecimalPlaces = 6;
+            NUD_Y.Location = new System.Drawing.Point(109, 108);
+            NUD_Y.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            NUD_Y.Maximum = new decimal(new int[] { 99999999, 0, 0, 0 });
+            NUD_Y.Minimum = new decimal(new int[] { 99999999, 0, 0, int.MinValue });
+            NUD_Y.Name = "NUD_Y";
+            NUD_Y.Size = new System.Drawing.Size(112, 23);
+            NUD_Y.TabIndex = 54;
+            NUD_Y.ValueChanged += ChangeMapValue;
+            // 
+            // NUD_X
+            // 
+            NUD_X.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            NUD_X.DecimalPlaces = 6;
+            NUD_X.Location = new System.Drawing.Point(109, 48);
+            NUD_X.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            NUD_X.Maximum = new decimal(new int[] { 99999999, 0, 0, 0 });
+            NUD_X.Minimum = new decimal(new int[] { 99999999, 0, 0, int.MinValue });
+            NUD_X.Name = "NUD_X";
+            NUD_X.Size = new System.Drawing.Size(112, 23);
+            NUD_X.TabIndex = 52;
+            NUD_X.ValueChanged += ChangeMapValue;
+            // 
+            // L_Y
+            // 
+            L_Y.Location = new System.Drawing.Point(7, 108);
+            L_Y.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            L_Y.Name = "L_Y";
+            L_Y.Size = new System.Drawing.Size(93, 23);
+            L_Y.TabIndex = 49;
+            L_Y.Text = "Y Coordinate:";
+            L_Y.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // L_CurrentMap
+            // 
+            L_CurrentMap.Location = new System.Drawing.Point(7, 18);
+            L_CurrentMap.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            L_CurrentMap.Name = "L_CurrentMap";
+            L_CurrentMap.Size = new System.Drawing.Size(93, 23);
+            L_CurrentMap.TabIndex = 46;
+            L_CurrentMap.Text = "Current Map:";
+            L_CurrentMap.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // L_Z
+            // 
+            L_Z.Location = new System.Drawing.Point(7, 78);
+            L_Z.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            L_Z.Name = "L_Z";
+            L_Z.Size = new System.Drawing.Size(93, 23);
+            L_Z.TabIndex = 48;
+            L_Z.Text = "Z Coordinate:";
+            L_Z.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
+            // L_X
+            // 
+            L_X.Location = new System.Drawing.Point(7, 48);
+            L_X.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            L_X.Name = "L_X";
+            L_X.Size = new System.Drawing.Size(93, 23);
+            L_X.TabIndex = 47;
+            L_X.Text = "X Coordinate:";
+            L_X.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
             // SAV_Trainer8a
             // 
             AutoScaleMode = System.Windows.Forms.AutoScaleMode.Inherit;
@@ -855,6 +1016,13 @@ namespace PKHeX.WinForms
             ((System.ComponentModel.ISupportInitialize)NUD_MeritCurrent).EndInit();
             GB_Adventure.ResumeLayout(false);
             GB_Adventure.PerformLayout();
+            Tab_BadgeMap.ResumeLayout(false);
+            GB_Map.ResumeLayout(false);
+            GB_Map.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)NUD_R).EndInit();
+            ((System.ComponentModel.ISupportInitialize)NUD_Z).EndInit();
+            ((System.ComponentModel.ISupportInitialize)NUD_Y).EndInit();
+            ((System.ComponentModel.ISupportInitialize)NUD_X).EndInit();
             ResumeLayout(false);
         }
 
@@ -939,5 +1107,17 @@ namespace PKHeX.WinForms
         private System.Windows.Forms.Label L_SatchelUpgrades;
         private System.Windows.Forms.NumericUpDown NUD_Rank;
         private System.Windows.Forms.Label L_GalaxyRank;
+        private System.Windows.Forms.GroupBox GB_Map;
+        private System.Windows.Forms.NumericUpDown NUD_R;
+        private System.Windows.Forms.Label L_R;
+        private System.Windows.Forms.NumericUpDown NUD_Z;
+        private System.Windows.Forms.NumericUpDown NUD_Y;
+        private System.Windows.Forms.NumericUpDown NUD_X;
+        private System.Windows.Forms.Label L_Y;
+        private System.Windows.Forms.Label L_CurrentMap;
+        private System.Windows.Forms.Label L_Z;
+        private System.Windows.Forms.Label L_X;
+        private System.Windows.Forms.TabPage Tab_BadgeMap;
+        private System.Windows.Forms.TextBox TB_M;
     }
 }

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen8/SAV_Trainer8a.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen8/SAV_Trainer8a.cs
@@ -27,6 +27,8 @@ public partial class SAV_Trainer8a : Form
         GetTextBoxes();
     }
 
+    private bool MapUpdated;
+
     private void GetComboBoxes()
     {
         CB_Language.InitializeBinding();
@@ -43,6 +45,17 @@ public partial class SAV_Trainer8a : Form
         trainerID1.LoadIDValues(SAV, SAV.Generation);
         MT_Money.Text = SAV.Money.ToString();
         CB_Language.SelectedValue = SAV.Language;
+
+        TB_M.Text = SAV.Coordinates.M;
+        // Sanity Check Map Coordinates
+        try
+        {
+            NUD_X.Value = (decimal)(double)SAV.Coordinates.X;
+            NUD_Z.Value = (decimal)(double)SAV.Coordinates.Z;
+            NUD_Y.Value = (decimal)(double)SAV.Coordinates.Y;
+            NUD_R.Value = (decimal)(Math.Atan2(SAV.Coordinates.RZ, SAV.Coordinates.RW) * 360.0 / Math.PI);
+        }
+        catch { GB_Map.Enabled = false; }
 
         // Load Play Time
         MT_Hours.Text = SAV.PlayedHours.ToString();
@@ -80,6 +93,20 @@ public partial class SAV_Trainer8a : Form
         SAV.Money = Util.ToUInt32(MT_Money.Text);
         SAV.Language = WinFormsUtil.GetIndex(CB_Language);
         SAV.OT = TB_OTName.Text;
+
+        // Copy Position
+        if (GB_Map.Enabled && MapUpdated)
+        {
+            SAV.Coordinates.M = TB_M.Text;
+            SAV.Coordinates.X = (float)NUD_X.Value;
+            SAV.Coordinates.Z = (float)NUD_Z.Value;
+            SAV.Coordinates.Y = (float)NUD_Y.Value;
+            var angle = (double)NUD_R.Value * Math.PI / 360.0;
+            SAV.Coordinates.RX = 0;
+            SAV.Coordinates.RZ = (float)Math.Sin(angle);
+            SAV.Coordinates.RY = 0;
+            SAV.Coordinates.RW = (float)Math.Cos(angle);
+        }
 
         // Save PlayTime
         SAV.PlayedHours = ushort.Parse(MT_Hours.Text);
@@ -126,5 +153,10 @@ public partial class SAV_Trainer8a : Form
         MaskedTextBox box = (MaskedTextBox)sender;
         if (box.Text.Length == 0) box.Text = "0";
         if (Util.ToInt32(box.Text) > 255) box.Text = "255";
+    }
+
+    private void ChangeMapValue(object sender, EventArgs e)
+    {
+        MapUpdated = true;
     }
 }

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen9/SAV_Trainer9.Designer.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen9/SAV_Trainer9.Designer.cs
@@ -114,6 +114,8 @@ namespace PKHeX.WinForms
             P_InitialIcon = new System.Windows.Forms.PictureBox();
             P_CurrIcon = new System.Windows.Forms.PictureBox();
             P_CurrPhoto = new System.Windows.Forms.PictureBox();
+            NUD_R = new System.Windows.Forms.NumericUpDown();
+            L_R = new System.Windows.Forms.Label();
             TC_Editor.SuspendLayout();
             Tab_Overview.SuspendLayout();
             Tab_MiscValues.SuspendLayout();
@@ -125,6 +127,7 @@ namespace PKHeX.WinForms
             ((System.ComponentModel.ISupportInitialize)P_InitialIcon).BeginInit();
             ((System.ComponentModel.ISupportInitialize)P_CurrIcon).BeginInit();
             ((System.ComponentModel.ISupportInitialize)P_CurrPhoto).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)NUD_R).BeginInit();
             SuspendLayout();
             // 
             // B_Cancel
@@ -418,7 +421,7 @@ namespace PKHeX.WinForms
             // 
             TB_MBTN.Location = new System.Drawing.Point(0, 0);
             TB_MBTN.Name = "TB_MBTN";
-            TB_MBTN.Size = new System.Drawing.Size(100, 27);
+            TB_MBTN.Size = new System.Drawing.Size(100, 23);
             TB_MBTN.TabIndex = 0;
             // 
             // TB_MBDS
@@ -741,7 +744,7 @@ namespace PKHeX.WinForms
             // 
             // B_UnlockClothing
             // 
-            B_UnlockClothing.Location = new System.Drawing.Point(15, 151);
+            B_UnlockClothing.Location = new System.Drawing.Point(15, 182);
             B_UnlockClothing.Margin = new System.Windows.Forms.Padding(0);
             B_UnlockClothing.Name = "B_UnlockClothing";
             B_UnlockClothing.Size = new System.Drawing.Size(260, 45);
@@ -796,6 +799,8 @@ namespace PKHeX.WinForms
             // 
             // GB_Map
             // 
+            GB_Map.Controls.Add(NUD_R);
+            GB_Map.Controls.Add(L_R);
             GB_Map.Controls.Add(NUD_Z);
             GB_Map.Controls.Add(NUD_Y);
             GB_Map.Controls.Add(NUD_X);
@@ -806,7 +811,7 @@ namespace PKHeX.WinForms
             GB_Map.Margin = new System.Windows.Forms.Padding(5, 4, 5, 4);
             GB_Map.Name = "GB_Map";
             GB_Map.Padding = new System.Windows.Forms.Padding(5, 4, 5, 4);
-            GB_Map.Size = new System.Drawing.Size(260, 129);
+            GB_Map.Size = new System.Drawing.Size(260, 160);
             GB_Map.TabIndex = 59;
             GB_Map.TabStop = false;
             GB_Map.Text = "Map Position";
@@ -814,13 +819,13 @@ namespace PKHeX.WinForms
             // NUD_Z
             // 
             NUD_Z.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
-            NUD_Z.DecimalPlaces = 5;
+            NUD_Z.DecimalPlaces = 6;
             NUD_Z.Location = new System.Drawing.Point(95, 56);
             NUD_Z.Margin = new System.Windows.Forms.Padding(0);
             NUD_Z.Maximum = new decimal(new int[] { 99999999, 0, 0, 0 });
             NUD_Z.Minimum = new decimal(new int[] { 99999999, 0, 0, int.MinValue });
             NUD_Z.Name = "NUD_Z";
-            NUD_Z.Size = new System.Drawing.Size(148, 27);
+            NUD_Z.Size = new System.Drawing.Size(148, 23);
             NUD_Z.TabIndex = 53;
             NUD_Z.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
             NUD_Z.ValueChanged += ChangeMapValue;
@@ -828,13 +833,13 @@ namespace PKHeX.WinForms
             // NUD_Y
             // 
             NUD_Y.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
-            NUD_Y.DecimalPlaces = 5;
+            NUD_Y.DecimalPlaces = 6;
             NUD_Y.Location = new System.Drawing.Point(95, 92);
             NUD_Y.Margin = new System.Windows.Forms.Padding(0);
             NUD_Y.Maximum = new decimal(new int[] { 99999999, 0, 0, 0 });
             NUD_Y.Minimum = new decimal(new int[] { 99999999, 0, 0, int.MinValue });
             NUD_Y.Name = "NUD_Y";
-            NUD_Y.Size = new System.Drawing.Size(148, 27);
+            NUD_Y.Size = new System.Drawing.Size(148, 23);
             NUD_Y.TabIndex = 51;
             NUD_Y.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
             NUD_Y.ValueChanged += ChangeMapValue;
@@ -842,13 +847,13 @@ namespace PKHeX.WinForms
             // NUD_X
             // 
             NUD_X.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
-            NUD_X.DecimalPlaces = 5;
+            NUD_X.DecimalPlaces = 6;
             NUD_X.Location = new System.Drawing.Point(95, 21);
             NUD_X.Margin = new System.Windows.Forms.Padding(0);
             NUD_X.Maximum = new decimal(new int[] { 99999999, 0, 0, 0 });
             NUD_X.Minimum = new decimal(new int[] { 99999999, 0, 0, int.MinValue });
             NUD_X.Name = "NUD_X";
-            NUD_X.Size = new System.Drawing.Size(148, 27);
+            NUD_X.Size = new System.Drawing.Size(148, 23);
             NUD_X.TabIndex = 50;
             NUD_X.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
             NUD_X.ValueChanged += ChangeMapValue;
@@ -931,6 +936,29 @@ namespace PKHeX.WinForms
             P_CurrPhoto.TabStop = false;
             P_CurrPhoto.Click += P_CurrPhoto_Click;
             // 
+            // NUD_R
+            // 
+            NUD_R.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            NUD_R.DecimalPlaces = 6;
+            NUD_R.Location = new System.Drawing.Point(95, 128);
+            NUD_R.Margin = new System.Windows.Forms.Padding(0);
+            NUD_R.Maximum = new decimal(new int[] { 99999999, 0, 0, 0 });
+            NUD_R.Minimum = new decimal(new int[] { 99999999, 0, 0, int.MinValue });
+            NUD_R.Name = "NUD_R";
+            NUD_R.Size = new System.Drawing.Size(148, 23);
+            NUD_R.TabIndex = 55;
+            NUD_R.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
+            // 
+            // L_R
+            // 
+            L_R.Location = new System.Drawing.Point(-15, 125);
+            L_R.Margin = new System.Windows.Forms.Padding(0);
+            L_R.Name = "L_R";
+            L_R.Size = new System.Drawing.Size(110, 31);
+            L_R.TabIndex = 54;
+            L_R.Text = "Rotation:";
+            L_R.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
+            // 
             // SAV_Trainer9
             // 
             AutoScaleMode = System.Windows.Forms.AutoScaleMode.Inherit;
@@ -958,6 +986,7 @@ namespace PKHeX.WinForms
             ((System.ComponentModel.ISupportInitialize)P_InitialIcon).EndInit();
             ((System.ComponentModel.ISupportInitialize)P_CurrIcon).EndInit();
             ((System.ComponentModel.ISupportInitialize)P_CurrPhoto).EndInit();
+            ((System.ComponentModel.ISupportInitialize)NUD_R).EndInit();
             ResumeLayout(false);
         }
 
@@ -1049,5 +1078,7 @@ namespace PKHeX.WinForms
         private System.Windows.Forms.PictureBox P_CurrIcon;
         private System.Windows.Forms.PictureBox P_CurrPhoto;
         private System.Windows.Forms.Button B_UnlockClothing;
+        private System.Windows.Forms.NumericUpDown NUD_R;
+        private System.Windows.Forms.Label L_R;
     }
 }

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen9/SAV_Trainer9.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen9/SAV_Trainer9.cs
@@ -3,6 +3,7 @@ using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
 using System.Linq;
+using System.Reflection.Metadata;
 using System.Windows.Forms;
 using PKHeX.Core;
 using PKHeX.Drawing;
@@ -70,9 +71,10 @@ public partial class SAV_Trainer9 : Form
     {
         try
         {
-            NUD_X.Value = (decimal)SAV.X;
-            NUD_Y.Value = (decimal)SAV.Y;
-            NUD_Z.Value = (decimal)SAV.Z;
+            NUD_X.Value = (decimal)(double)SAV.X;
+            NUD_Y.Value = (decimal)(double)SAV.Y;
+            NUD_Z.Value = (decimal)(double)SAV.Z;
+            NUD_R.Value = (decimal)(Math.Atan2(SAV.RZ, SAV.RW) * 360.0 / Math.PI);
         }
         // If we can't accurately represent the coordinates, don't allow them to be changed.
         catch { GB_Map.Enabled = false; }
@@ -116,6 +118,8 @@ public partial class SAV_Trainer9 : Form
         if (!MapUpdated)
             return;
         SAV.SetCoordinates((float)NUD_X.Value, (float)NUD_Y.Value, (float)NUD_Z.Value);
+        var angle = (double)NUD_R.Value * Math.PI / 360.0;
+        SAV.SetPlayerRotation(0, (float)Math.Sin(angle), 0, (float)Math.Cos(angle));
     }
 
     private void SaveTrainerInfo()


### PR DESCRIPTION
## Gen 6/7 map position
In Gen 6, the player's rotation is stored as an uint16 at offsets 0x06 and 0xF6 with the following values. If the player is off-grid (roller skating/sneaking) on save, their angle will be rounded to one of these values on save.
- 0: Up
- 1: Down
- 2: Left
- 3: Right
- 4: Up/Left
- 5: Up/Right
- 6: Down/Left
- 7: Down/Right

Values 0x0008 to 0xFFFF appear to be treated the same way as 1 on load. Also, I fixed the offset for the second copy of M (0x02/0xF4 is 0x02/0x02 + 0xF2).

For the purposes of things like Egg hatching, a single step in Gen 6 is 18 units long and single step in Gen 7 is 60 units long. To make it so that this behavior is consistent for all of the 3DS games, I made it so that the raw values can be modified directly/precisely using the Save Block Editor/accessors, but the Trainer Data Editor uses the scaled values instead. Also, since floats have about 7 decimal digits of precision, I increased the number of displayed decimal places to 6, so something like 1.000001 will be displayed correctly.


## LGPE/SwSh map position
LGPE/SwSh store the position, scale, and rotation of up to 128 different objects, including the player. The player's is stored in the first spot from 0x0000 to 0x00C0. Scale is stored as three floats for each of the X/Y/Z axes, and rotation is stored as a quaternion like SMUSUM. The current map is stored as a 8-byte value at offset 0x6000 after all of the objects.

![scale](https://github.com/kwsch/PKHeX/assets/16735361/550bd990-bc95-46cc-8fa4-680b08429127)


## LA map position
The current map is stored as a null-terminated string beginning at offset 0x08. The length of the buffer is at most 0x48 since that's where the coordinates start, but I haven't verified that it isn't shorter. Rotation is stored as a quaternion at offset 0x60.


## SV map position
Rotation is stored as a quaternion in PlayerSave_StartRotation.