### PR TITLE
Adjust How Glow Is Handled For Gen 9 Sprites

### DIFF
--- a/PKHeX.Drawing.PokeSprite/Util/SpriteUtil.cs
+++ b/PKHeX.Drawing.PokeSprite/Util/SpriteUtil.cs
@@ -216,7 +216,12 @@ public static class SpriteUtil
     {
         bool egg = pk.IsEgg;
         var formarg = pk is IFormArgument f ? f.FormArgument : 0;
-        baseSprite = GetSprite(pk.Species, pk.Form, pk.Gender, formarg, 0, egg, Shiny.Never, pk.Context);
+        Shiny shiny;
+        if (pk.Context == EntityContext.Gen9)
+            shiny = !pk.IsShiny ? Shiny.Never : (ShinyExtensions.IsSquareShinyExist(pk) ? Shiny.AlwaysSquare : Shiny.AlwaysStar);
+        else
+            shiny = Shiny.Never;
+        baseSprite = GetSprite(pk.Species, pk.Form, pk.Gender, formarg, 0, egg, shiny, pk.Context);
         GetSpriteGlow(baseSprite, blue, green, red, out pixels, forceHollow || egg);
     }
 


### PR DESCRIPTION
Since there are no shiny artwork sprites, for pre-SV Pokémon the sprite that is shown when shiny is the older one but the glow effect uses the artwork sprite which causes a mismatch. Change the glow effect to use the shiny sprite in gen 9 so that the glow effect matches the Pokémon. Unfortunate consequence is that the shiny indicator for a sprite has also gets the glow effect.