### PR TITLE
Enhanced Slot Hover Preview

### DIFF
--- a/PKHeX.Core/Editing/Showdown/ShowdownSet.cs
+++ b/PKHeX.Core/Editing/Showdown/ShowdownSet.cs
@@ -425,7 +425,7 @@ public sealed class ShowdownSet : IBattleTemplate
         return $"{Nickname} ({specForm})";
     }
 
-    private static string[] GetStringStats(ReadOnlySpan<int> stats, int ignoreValue)
+    public static string[] GetStringStats<T>(ReadOnlySpan<T> stats, T ignoreValue) where T : IEquatable<T>
     {
         var count = stats.Length - stats.Count(ignoreValue);
         if (count == 0)
@@ -437,7 +437,7 @@ public sealed class ShowdownSet : IBattleTemplate
         {
             var statIndex = GetStatIndexStored(i);
             var statValue = stats[statIndex];
-            if (statValue == ignoreValue)
+            if (statValue.Equals(ignoreValue))
                 continue; // ignore unused stats
             var statName = StatNames[statIndex];
             result[ctr++] = $"{statValue} {statName}";

--- a/PKHeX.Core/PKM/Interfaces/IGanbaru.cs
+++ b/PKHeX.Core/PKM/Interfaces/IGanbaru.cs
@@ -138,6 +138,23 @@ public static class GanbaruExtensions
     };
 
     /// <summary>
+    /// Loads the <see cref="IGanbaru"/> values and stores them in the provided <see cref="Span{T}"/>.
+    /// </summary>
+    /// <param name="pk">Pokémon to check.</param>
+    /// <param name="value">Span to store values in.</param>
+    public static void GetGVs(this IGanbaru pk, Span<byte> value)
+    {
+        if (value.Length != 6)
+            return;
+        value[0] = pk.GV_HP;
+        value[1] = pk.GV_ATK;
+        value[2] = pk.GV_DEF;
+        value[3] = pk.GV_SPE;
+        value[4] = pk.GV_SPA;
+        value[5] = pk.GV_SPD;
+    }
+
+    /// <summary>
     /// Checks if any of the <see cref="IGanbaru"/> values are below a reference's minimum value.
     /// </summary>
     /// <param name="pk">Pokémon to check.</param>

--- a/PKHeX.WinForms/Controls/PKM Editor/MoveChoice.cs
+++ b/PKHeX.WinForms/Controls/PKM Editor/MoveChoice.cs
@@ -51,7 +51,7 @@ public partial class MoveChoice : UserControl
             return;
         }
         PB_Triangle.Visible = true;
-        PB_Triangle.Image = MoveDisplay.GetMoveImage(!move.Valid, entity, i);
+        PB_Triangle.Image = MoveDisplayState.GetMoveImage(!move.Valid, entity, i);
     }
 
     public void HealPP(PKM pk)

--- a/PKHeX.WinForms/Controls/PKM Editor/MoveDisplay.Designer.cs
+++ b/PKHeX.WinForms/Controls/PKM Editor/MoveDisplay.Designer.cs
@@ -37,9 +37,9 @@ namespace PKHeX.WinForms.Controls
             // 
             // FLP_Move
             // 
+            FLP_Move.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
             FLP_Move.Controls.Add(PB_Type);
             FLP_Move.Controls.Add(L_Move);
-            FLP_Move.Dock = System.Windows.Forms.DockStyle.Fill;
             FLP_Move.Location = new System.Drawing.Point(0, 0);
             FLP_Move.Name = "FLP_Move";
             FLP_Move.Size = new System.Drawing.Size(138, 24);
@@ -57,11 +57,11 @@ namespace PKHeX.WinForms.Controls
             // 
             // L_Move
             // 
-            L_Move.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            L_Move.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
             L_Move.Location = new System.Drawing.Point(26, 0);
             L_Move.Margin = new System.Windows.Forms.Padding(0);
             L_Move.Name = "L_Move";
-            L_Move.Size = new System.Drawing.Size(100, 24);
+            L_Move.Size = new System.Drawing.Size(112, 24);
             L_Move.TabIndex = 79;
             L_Move.Text = "Name";
             L_Move.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;

--- a/PKHeX.WinForms/Controls/PKM Editor/MoveDisplay.Designer.cs
+++ b/PKHeX.WinForms/Controls/PKM Editor/MoveDisplay.Designer.cs
@@ -1,0 +1,85 @@
+namespace PKHeX.WinForms.Controls
+{
+    partial class MoveDisplay
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            FLP_Move = new System.Windows.Forms.FlowLayoutPanel();
+            PB_Type = new System.Windows.Forms.PictureBox();
+            L_Move = new System.Windows.Forms.Label();
+            FLP_Move.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)PB_Type).BeginInit();
+            SuspendLayout();
+            // 
+            // FLP_Move
+            // 
+            FLP_Move.Controls.Add(PB_Type);
+            FLP_Move.Controls.Add(L_Move);
+            FLP_Move.Dock = System.Windows.Forms.DockStyle.Fill;
+            FLP_Move.Location = new System.Drawing.Point(0, 0);
+            FLP_Move.Name = "FLP_Move";
+            FLP_Move.Size = new System.Drawing.Size(138, 24);
+            FLP_Move.TabIndex = 18;
+            // 
+            // PB_Type
+            // 
+            PB_Type.Location = new System.Drawing.Point(0, 0);
+            PB_Type.Margin = new System.Windows.Forms.Padding(0, 0, 2, 0);
+            PB_Type.Name = "PB_Type";
+            PB_Type.Size = new System.Drawing.Size(24, 24);
+            PB_Type.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
+            PB_Type.TabIndex = 4;
+            PB_Type.TabStop = false;
+            // 
+            // L_Move
+            // 
+            L_Move.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            L_Move.Location = new System.Drawing.Point(26, 0);
+            L_Move.Margin = new System.Windows.Forms.Padding(0);
+            L_Move.Name = "L_Move";
+            L_Move.Size = new System.Drawing.Size(100, 24);
+            L_Move.TabIndex = 79;
+            L_Move.Text = "Name";
+            L_Move.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // MoveDisplay
+            // 
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Inherit;
+            Controls.Add(FLP_Move);
+            Name = "MoveDisplay";
+            Size = new System.Drawing.Size(138, 24);
+            FLP_Move.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)PB_Type).EndInit();
+            ResumeLayout(false);
+        }
+
+        #endregion
+        private System.Windows.Forms.FlowLayoutPanel FLP_Move;
+        private System.Windows.Forms.PictureBox PB_Type;
+        private System.Windows.Forms.Label L_Move;
+    }
+}

--- a/PKHeX.WinForms/Controls/PKM Editor/MoveDisplay.Designer.cs
+++ b/PKHeX.WinForms/Controls/PKM Editor/MoveDisplay.Designer.cs
@@ -69,6 +69,8 @@ namespace PKHeX.WinForms.Controls
             // MoveDisplay
             // 
             AutoScaleMode = System.Windows.Forms.AutoScaleMode.Inherit;
+            AutoSize = true;
+            AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             Controls.Add(FLP_Move);
             Name = "MoveDisplay";
             Size = new System.Drawing.Size(138, 24);

--- a/PKHeX.WinForms/Controls/PKM Editor/MoveDisplay.cs
+++ b/PKHeX.WinForms/Controls/PKM Editor/MoveDisplay.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Drawing;
 using System.Windows.Forms;
 using PKHeX.Core;
 using PKHeX.Drawing.Misc;
@@ -9,7 +10,7 @@ public partial class MoveDisplay : UserControl
 {
     public MoveDisplay() => InitializeComponent();
 
-    public void Populate(ushort move, EntityContext context, ReadOnlySpan<string> moves)
+    public void Populate(ushort move, EntityContext context, ReadOnlySpan<string> moves, bool valid = true)
     {
         if (move == 0 || move >= moves.Length)
         {
@@ -21,5 +22,9 @@ public partial class MoveDisplay : UserControl
         L_Move.Text = moves[move];
         var type = MoveInfo.GetType(move, context);
         PB_Type.Image = TypeSpriteUtil.GetTypeSpriteIcon(type);
+        if (valid)
+            L_Move.ResetForeColor();
+        else
+            L_Move.ForeColor = Color.Red;
     }
 }

--- a/PKHeX.WinForms/Controls/PKM Editor/MoveDisplay.cs
+++ b/PKHeX.WinForms/Controls/PKM Editor/MoveDisplay.cs
@@ -10,12 +10,12 @@ public partial class MoveDisplay : UserControl
 {
     public MoveDisplay() => InitializeComponent();
 
-    public void Populate(PKM pk, ushort move, EntityContext context, ReadOnlySpan<string> moves, bool valid = true)
+    public int Populate(PKM pk, ushort move, EntityContext context, ReadOnlySpan<string> moves, bool valid = true)
     {
         if (move == 0 || move >= moves.Length)
         {
             Visible = false;
-            return;
+            return 0;
         }
         Visible = true;
 
@@ -24,8 +24,11 @@ public partial class MoveDisplay : UserControl
         if (move == (int)Core.Move.HiddenPower && pk.Format < 8)
         {
             type = (byte)pk.HPType;
-            name = $"{name} {pk.HPPower}";
+            name = $"{name} ({GameInfo.Strings.types[type]}) [{pk.HPPower}]";
         }
+
+        var size = PokePreview.MeasureSize(name, L_Move.Font);
+        var ctrlWidth = PB_Type.Width + PB_Type.Margin.Horizontal + size.Width + L_Move.Margin.Horizontal;
 
         PB_Type.Image = TypeSpriteUtil.GetTypeSpriteIcon(type);
         L_Move.Text = name;
@@ -33,5 +36,9 @@ public partial class MoveDisplay : UserControl
             L_Move.ResetForeColor();
         else
             L_Move.ForeColor = Color.Red;
+        L_Move.Width = size.Width;
+        Width = ctrlWidth;
+
+        return ctrlWidth;
     }
 }

--- a/PKHeX.WinForms/Controls/PKM Editor/MoveDisplay.cs
+++ b/PKHeX.WinForms/Controls/PKM Editor/MoveDisplay.cs
@@ -21,7 +21,7 @@ public partial class MoveDisplay : UserControl
 
         byte type = MoveInfo.GetType(move, context);
         var name = moves[move];
-        if (move == (int)Core.Move.HiddenPower && pk.Format < 8)
+        if (move == (int)Core.Move.HiddenPower && pk.Context is not EntityContext.Gen8a)
         {
             type = (byte)pk.HPType;
             name = $"{name} ({GameInfo.Strings.types[type]}) [{pk.HPPower}]";

--- a/PKHeX.WinForms/Controls/PKM Editor/MoveDisplay.cs
+++ b/PKHeX.WinForms/Controls/PKM Editor/MoveDisplay.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Windows.Forms;
+using PKHeX.Core;
+using PKHeX.Drawing.Misc;
+
+namespace PKHeX.WinForms.Controls;
+
+public partial class MoveDisplay : UserControl
+{
+    public MoveDisplay() => InitializeComponent();
+
+    public void Populate(ushort move, EntityContext context, ReadOnlySpan<string> moves)
+    {
+        if (move == 0 || move >= moves.Length)
+        {
+            Visible = false;
+            return;
+        }
+        Visible = true;
+
+        L_Move.Text = moves[move];
+        var type = MoveInfo.GetType(move, context);
+        PB_Type.Image = TypeSpriteUtil.GetTypeSpriteIcon(type);
+    }
+}

--- a/PKHeX.WinForms/Controls/PKM Editor/MoveDisplay.cs
+++ b/PKHeX.WinForms/Controls/PKM Editor/MoveDisplay.cs
@@ -10,7 +10,7 @@ public partial class MoveDisplay : UserControl
 {
     public MoveDisplay() => InitializeComponent();
 
-    public void Populate(ushort move, EntityContext context, ReadOnlySpan<string> moves, bool valid = true)
+    public void Populate(PKM pk, ushort move, EntityContext context, ReadOnlySpan<string> moves, bool valid = true)
     {
         if (move == 0 || move >= moves.Length)
         {
@@ -19,9 +19,16 @@ public partial class MoveDisplay : UserControl
         }
         Visible = true;
 
-        L_Move.Text = moves[move];
-        var type = MoveInfo.GetType(move, context);
+        byte type = MoveInfo.GetType(move, context);
+        var name = moves[move];
+        if (move == (int)Core.Move.HiddenPower && pk.Format < 8)
+        {
+            type = (byte)pk.HPType;
+            name = $"{name} {pk.HPPower}";
+        }
+
         PB_Type.Image = TypeSpriteUtil.GetTypeSpriteIcon(type);
+        L_Move.Text = name;
         if (valid)
             L_Move.ResetForeColor();
         else

--- a/PKHeX.WinForms/Controls/PKM Editor/PKMEditor.cs
+++ b/PKHeX.WinForms/Controls/PKM Editor/PKMEditor.cs
@@ -2238,7 +2238,7 @@ public sealed partial class PKMEditor : UserControl, IMainEditor
     }
 }
 
-public static class MoveDisplay
+public static class MoveDisplayState
 {
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Bitmap? GetMoveImage(bool isIllegal, PKM pk, int index)

--- a/PKHeX.WinForms/Controls/SAV Editor/SlotChangeManager.cs
+++ b/PKHeX.WinForms/Controls/SAV Editor/SlotChangeManager.cs
@@ -111,7 +111,10 @@ public sealed class SlotChangeManager : IDisposable
     public void MouseMove(object? sender, MouseEventArgs e)
     {
         if (!Drag.CanStartDrag)
+        {
+            Hover.UpdateMousePosition(e.Location);
             return;
+        }
         if (sender is not PictureBox pb)
             return;
 

--- a/PKHeX.WinForms/Controls/Slots/PokePreview.Designer.cs
+++ b/PKHeX.WinForms/Controls/Slots/PokePreview.Designer.cs
@@ -29,57 +29,84 @@ namespace PKHeX.WinForms.Controls
         private void InitializeComponent()
         {
             panel1 = new System.Windows.Forms.Panel();
+            splitContainer1 = new System.Windows.Forms.SplitContainer();
             PB_Other = new System.Windows.Forms.PictureBox();
-            L_Stats = new System.Windows.Forms.Label();
             PB_Gender = new System.Windows.Forms.PictureBox();
             PB_Type2 = new System.Windows.Forms.PictureBox();
             PB_Type1 = new System.Windows.Forms.PictureBox();
+            L_Name = new System.Windows.Forms.Label();
+            PB_Ball = new System.Windows.Forms.PictureBox();
+            L_Stats = new System.Windows.Forms.Label();
             L_Move4 = new System.Windows.Forms.Label();
             L_Move3 = new System.Windows.Forms.Label();
             L_Move2 = new System.Windows.Forms.Label();
             L_Move1 = new System.Windows.Forms.Label();
-            L_Name = new System.Windows.Forms.Label();
             PB_Move4 = new System.Windows.Forms.PictureBox();
             PB_Move3 = new System.Windows.Forms.PictureBox();
             PB_Move2 = new System.Windows.Forms.PictureBox();
             PB_Move1 = new System.Windows.Forms.PictureBox();
-            PB_Ball = new System.Windows.Forms.PictureBox();
             panel1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)splitContainer1).BeginInit();
+            splitContainer1.Panel1.SuspendLayout();
+            splitContainer1.Panel2.SuspendLayout();
+            splitContainer1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)PB_Other).BeginInit();
             ((System.ComponentModel.ISupportInitialize)PB_Gender).BeginInit();
             ((System.ComponentModel.ISupportInitialize)PB_Type2).BeginInit();
             ((System.ComponentModel.ISupportInitialize)PB_Type1).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)PB_Ball).BeginInit();
             ((System.ComponentModel.ISupportInitialize)PB_Move4).BeginInit();
             ((System.ComponentModel.ISupportInitialize)PB_Move3).BeginInit();
             ((System.ComponentModel.ISupportInitialize)PB_Move2).BeginInit();
             ((System.ComponentModel.ISupportInitialize)PB_Move1).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)PB_Ball).BeginInit();
             SuspendLayout();
             // 
             // panel1
             // 
             panel1.BackColor = System.Drawing.SystemColors.Window;
-            panel1.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
-            panel1.Controls.Add(PB_Other);
-            panel1.Controls.Add(L_Stats);
-            panel1.Controls.Add(PB_Gender);
-            panel1.Controls.Add(PB_Type2);
-            panel1.Controls.Add(PB_Type1);
-            panel1.Controls.Add(L_Move4);
-            panel1.Controls.Add(L_Move3);
-            panel1.Controls.Add(L_Move2);
-            panel1.Controls.Add(L_Move1);
-            panel1.Controls.Add(L_Name);
-            panel1.Controls.Add(PB_Move4);
-            panel1.Controls.Add(PB_Move3);
-            panel1.Controls.Add(PB_Move2);
-            panel1.Controls.Add(PB_Move1);
-            panel1.Controls.Add(PB_Ball);
+            panel1.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            panel1.Controls.Add(splitContainer1);
             panel1.Dock = System.Windows.Forms.DockStyle.Fill;
             panel1.Location = new System.Drawing.Point(0, 0);
+            panel1.Margin = new System.Windows.Forms.Padding(0);
             panel1.Name = "panel1";
-            panel1.Size = new System.Drawing.Size(280, 156);
+            panel1.Size = new System.Drawing.Size(276, 152);
             panel1.TabIndex = 19;
+            // 
+            // splitContainer1
+            // 
+            splitContainer1.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            splitContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
+            splitContainer1.IsSplitterFixed = true;
+            splitContainer1.Location = new System.Drawing.Point(0, 0);
+            splitContainer1.Margin = new System.Windows.Forms.Padding(0);
+            splitContainer1.Name = "splitContainer1";
+            splitContainer1.Orientation = System.Windows.Forms.Orientation.Horizontal;
+            // 
+            // splitContainer1.Panel1
+            // 
+            splitContainer1.Panel1.Controls.Add(PB_Other);
+            splitContainer1.Panel1.Controls.Add(PB_Gender);
+            splitContainer1.Panel1.Controls.Add(PB_Type2);
+            splitContainer1.Panel1.Controls.Add(PB_Type1);
+            splitContainer1.Panel1.Controls.Add(L_Name);
+            splitContainer1.Panel1.Controls.Add(PB_Ball);
+            // 
+            // splitContainer1.Panel2
+            // 
+            splitContainer1.Panel2.Controls.Add(L_Stats);
+            splitContainer1.Panel2.Controls.Add(L_Move4);
+            splitContainer1.Panel2.Controls.Add(L_Move3);
+            splitContainer1.Panel2.Controls.Add(L_Move2);
+            splitContainer1.Panel2.Controls.Add(L_Move1);
+            splitContainer1.Panel2.Controls.Add(PB_Move4);
+            splitContainer1.Panel2.Controls.Add(PB_Move3);
+            splitContainer1.Panel2.Controls.Add(PB_Move2);
+            splitContainer1.Panel2.Controls.Add(PB_Move1);
+            splitContainer1.Size = new System.Drawing.Size(274, 150);
+            splitContainer1.SplitterDistance = 40;
+            splitContainer1.SplitterWidth = 1;
+            splitContainer1.TabIndex = 52;
             // 
             // PB_Other
             // 
@@ -89,18 +116,8 @@ namespace PKHeX.WinForms.Controls
             PB_Other.Name = "PB_Other";
             PB_Other.Size = new System.Drawing.Size(24, 24);
             PB_Other.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
-            PB_Other.TabIndex = 33;
+            PB_Other.TabIndex = 45;
             PB_Other.TabStop = false;
-            // 
-            // L_Stats
-            // 
-            L_Stats.Font = new System.Drawing.Font("Courier New", 8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
-            L_Stats.Location = new System.Drawing.Point(168, 44);
-            L_Stats.Name = "L_Stats";
-            L_Stats.Size = new System.Drawing.Size(100, 96);
-            L_Stats.TabIndex = 32;
-            L_Stats.Text = "Stats";
-            L_Stats.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // PB_Gender
             // 
@@ -110,7 +127,7 @@ namespace PKHeX.WinForms.Controls
             PB_Gender.Name = "PB_Gender";
             PB_Gender.Size = new System.Drawing.Size(24, 24);
             PB_Gender.SizeMode = System.Windows.Forms.PictureBoxSizeMode.CenterImage;
-            PB_Gender.TabIndex = 31;
+            PB_Gender.TabIndex = 44;
             PB_Gender.TabStop = false;
             // 
             // PB_Type2
@@ -121,7 +138,7 @@ namespace PKHeX.WinForms.Controls
             PB_Type2.Name = "PB_Type2";
             PB_Type2.Size = new System.Drawing.Size(24, 24);
             PB_Type2.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
-            PB_Type2.TabIndex = 30;
+            PB_Type2.TabIndex = 43;
             PB_Type2.TabStop = false;
             // 
             // PB_Type1
@@ -132,93 +149,17 @@ namespace PKHeX.WinForms.Controls
             PB_Type1.Name = "PB_Type1";
             PB_Type1.Size = new System.Drawing.Size(24, 24);
             PB_Type1.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
-            PB_Type1.TabIndex = 29;
+            PB_Type1.TabIndex = 42;
             PB_Type1.TabStop = false;
-            // 
-            // L_Move4
-            // 
-            L_Move4.Location = new System.Drawing.Point(40, 116);
-            L_Move4.Name = "L_Move4";
-            L_Move4.Size = new System.Drawing.Size(100, 24);
-            L_Move4.TabIndex = 28;
-            L_Move4.Text = "Move4";
-            L_Move4.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
-            // L_Move3
-            // 
-            L_Move3.Location = new System.Drawing.Point(40, 92);
-            L_Move3.Name = "L_Move3";
-            L_Move3.Size = new System.Drawing.Size(100, 24);
-            L_Move3.TabIndex = 27;
-            L_Move3.Text = "Move3";
-            L_Move3.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
-            // L_Move2
-            // 
-            L_Move2.Location = new System.Drawing.Point(40, 68);
-            L_Move2.Name = "L_Move2";
-            L_Move2.Size = new System.Drawing.Size(100, 24);
-            L_Move2.TabIndex = 26;
-            L_Move2.Text = "Move2";
-            L_Move2.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
-            // L_Move1
-            // 
-            L_Move1.Location = new System.Drawing.Point(40, 44);
-            L_Move1.Name = "L_Move1";
-            L_Move1.Size = new System.Drawing.Size(100, 24);
-            L_Move1.TabIndex = 25;
-            L_Move1.Text = "Move1";
-            L_Move1.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // L_Name
             // 
             L_Name.Location = new System.Drawing.Point(40, 8);
             L_Name.Name = "L_Name";
             L_Name.Size = new System.Drawing.Size(100, 24);
-            L_Name.TabIndex = 24;
+            L_Name.TabIndex = 41;
             L_Name.Text = "Species";
             L_Name.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
-            // PB_Move4
-            // 
-            PB_Move4.Location = new System.Drawing.Point(8, 116);
-            PB_Move4.Margin = new System.Windows.Forms.Padding(0, 0, 8, 0);
-            PB_Move4.Name = "PB_Move4";
-            PB_Move4.Size = new System.Drawing.Size(24, 24);
-            PB_Move4.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
-            PB_Move4.TabIndex = 23;
-            PB_Move4.TabStop = false;
-            // 
-            // PB_Move3
-            // 
-            PB_Move3.Location = new System.Drawing.Point(8, 92);
-            PB_Move3.Margin = new System.Windows.Forms.Padding(0, 0, 8, 0);
-            PB_Move3.Name = "PB_Move3";
-            PB_Move3.Size = new System.Drawing.Size(24, 24);
-            PB_Move3.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
-            PB_Move3.TabIndex = 22;
-            PB_Move3.TabStop = false;
-            // 
-            // PB_Move2
-            // 
-            PB_Move2.Location = new System.Drawing.Point(8, 68);
-            PB_Move2.Margin = new System.Windows.Forms.Padding(0, 0, 8, 0);
-            PB_Move2.Name = "PB_Move2";
-            PB_Move2.Size = new System.Drawing.Size(24, 24);
-            PB_Move2.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
-            PB_Move2.TabIndex = 21;
-            PB_Move2.TabStop = false;
-            // 
-            // PB_Move1
-            // 
-            PB_Move1.Location = new System.Drawing.Point(8, 44);
-            PB_Move1.Margin = new System.Windows.Forms.Padding(0, 0, 8, 0);
-            PB_Move1.Name = "PB_Move1";
-            PB_Move1.Size = new System.Drawing.Size(24, 24);
-            PB_Move1.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
-            PB_Move1.TabIndex = 20;
-            PB_Move1.TabStop = false;
             // 
             // PB_Ball
             // 
@@ -228,14 +169,99 @@ namespace PKHeX.WinForms.Controls
             PB_Ball.Name = "PB_Ball";
             PB_Ball.Size = new System.Drawing.Size(24, 24);
             PB_Ball.SizeMode = System.Windows.Forms.PictureBoxSizeMode.CenterImage;
-            PB_Ball.TabIndex = 19;
+            PB_Ball.TabIndex = 40;
             PB_Ball.TabStop = false;
+            // 
+            // L_Stats
+            // 
+            L_Stats.Location = new System.Drawing.Point(162, 4);
+            L_Stats.Name = "L_Stats";
+            L_Stats.Size = new System.Drawing.Size(100, 96);
+            L_Stats.TabIndex = 58;
+            L_Stats.Text = "Stats";
+            L_Stats.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // L_Move4
+            // 
+            L_Move4.Location = new System.Drawing.Point(40, 78);
+            L_Move4.Name = "L_Move4";
+            L_Move4.Size = new System.Drawing.Size(100, 24);
+            L_Move4.TabIndex = 57;
+            L_Move4.Text = "Move4";
+            L_Move4.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // L_Move3
+            // 
+            L_Move3.Location = new System.Drawing.Point(40, 54);
+            L_Move3.Name = "L_Move3";
+            L_Move3.Size = new System.Drawing.Size(100, 24);
+            L_Move3.TabIndex = 56;
+            L_Move3.Text = "Move3";
+            L_Move3.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // L_Move2
+            // 
+            L_Move2.Location = new System.Drawing.Point(40, 30);
+            L_Move2.Name = "L_Move2";
+            L_Move2.Size = new System.Drawing.Size(100, 24);
+            L_Move2.TabIndex = 55;
+            L_Move2.Text = "Move2";
+            L_Move2.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // L_Move1
+            // 
+            L_Move1.Location = new System.Drawing.Point(40, 6);
+            L_Move1.Name = "L_Move1";
+            L_Move1.Size = new System.Drawing.Size(100, 24);
+            L_Move1.TabIndex = 54;
+            L_Move1.Text = "Move1";
+            L_Move1.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // PB_Move4
+            // 
+            PB_Move4.Location = new System.Drawing.Point(8, 78);
+            PB_Move4.Margin = new System.Windows.Forms.Padding(0, 0, 8, 0);
+            PB_Move4.Name = "PB_Move4";
+            PB_Move4.Size = new System.Drawing.Size(24, 24);
+            PB_Move4.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
+            PB_Move4.TabIndex = 53;
+            PB_Move4.TabStop = false;
+            // 
+            // PB_Move3
+            // 
+            PB_Move3.Location = new System.Drawing.Point(8, 54);
+            PB_Move3.Margin = new System.Windows.Forms.Padding(0, 0, 8, 0);
+            PB_Move3.Name = "PB_Move3";
+            PB_Move3.Size = new System.Drawing.Size(24, 24);
+            PB_Move3.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
+            PB_Move3.TabIndex = 52;
+            PB_Move3.TabStop = false;
+            // 
+            // PB_Move2
+            // 
+            PB_Move2.Location = new System.Drawing.Point(8, 30);
+            PB_Move2.Margin = new System.Windows.Forms.Padding(0, 0, 8, 0);
+            PB_Move2.Name = "PB_Move2";
+            PB_Move2.Size = new System.Drawing.Size(24, 24);
+            PB_Move2.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
+            PB_Move2.TabIndex = 51;
+            PB_Move2.TabStop = false;
+            // 
+            // PB_Move1
+            // 
+            PB_Move1.Location = new System.Drawing.Point(8, 6);
+            PB_Move1.Margin = new System.Windows.Forms.Padding(0, 0, 8, 0);
+            PB_Move1.Name = "PB_Move1";
+            PB_Move1.Size = new System.Drawing.Size(24, 24);
+            PB_Move1.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
+            PB_Move1.TabIndex = 50;
+            PB_Move1.TabStop = false;
             // 
             // PokePreview
             // 
             AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            ClientSize = new System.Drawing.Size(280, 156);
+            ClientSize = new System.Drawing.Size(276, 152);
             Controls.Add(panel1);
             FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
             MaximizeBox = false;
@@ -245,35 +271,40 @@ namespace PKHeX.WinForms.Controls
             ShowInTaskbar = false;
             Text = "PokePreview";
             panel1.ResumeLayout(false);
+            splitContainer1.Panel1.ResumeLayout(false);
+            splitContainer1.Panel2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)splitContainer1).EndInit();
+            splitContainer1.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)PB_Other).EndInit();
             ((System.ComponentModel.ISupportInitialize)PB_Gender).EndInit();
             ((System.ComponentModel.ISupportInitialize)PB_Type2).EndInit();
             ((System.ComponentModel.ISupportInitialize)PB_Type1).EndInit();
+            ((System.ComponentModel.ISupportInitialize)PB_Ball).EndInit();
             ((System.ComponentModel.ISupportInitialize)PB_Move4).EndInit();
             ((System.ComponentModel.ISupportInitialize)PB_Move3).EndInit();
             ((System.ComponentModel.ISupportInitialize)PB_Move2).EndInit();
             ((System.ComponentModel.ISupportInitialize)PB_Move1).EndInit();
-            ((System.ComponentModel.ISupportInitialize)PB_Ball).EndInit();
             ResumeLayout(false);
         }
 
         #endregion
 
         private System.Windows.Forms.Panel panel1;
+        private System.Windows.Forms.SplitContainer splitContainer1;
         private System.Windows.Forms.PictureBox PB_Other;
-        private System.Windows.Forms.Label L_Stats;
         private System.Windows.Forms.PictureBox PB_Gender;
         private System.Windows.Forms.PictureBox PB_Type2;
         private System.Windows.Forms.PictureBox PB_Type1;
+        private System.Windows.Forms.Label L_Name;
+        private System.Windows.Forms.PictureBox PB_Ball;
+        private System.Windows.Forms.Label L_Stats;
         private System.Windows.Forms.Label L_Move4;
         private System.Windows.Forms.Label L_Move3;
         private System.Windows.Forms.Label L_Move2;
         private System.Windows.Forms.Label L_Move1;
-        private System.Windows.Forms.Label L_Name;
         private System.Windows.Forms.PictureBox PB_Move4;
         private System.Windows.Forms.PictureBox PB_Move3;
         private System.Windows.Forms.PictureBox PB_Move2;
         private System.Windows.Forms.PictureBox PB_Move1;
-        private System.Windows.Forms.PictureBox PB_Ball;
     }
 }

--- a/PKHeX.WinForms/Controls/Slots/PokePreview.Designer.cs
+++ b/PKHeX.WinForms/Controls/Slots/PokePreview.Designer.cs
@@ -59,7 +59,7 @@ namespace PKHeX.WinForms.Controls
             PAN_All.Location = new System.Drawing.Point(0, 0);
             PAN_All.Margin = new System.Windows.Forms.Padding(0);
             PAN_All.Name = "PAN_All";
-            PAN_All.Size = new System.Drawing.Size(148, 348);
+            PAN_All.Size = new System.Drawing.Size(148, 180);
             PAN_All.TabIndex = 19;
             // 
             // FLP_List
@@ -71,7 +71,7 @@ namespace PKHeX.WinForms.Controls
             FLP_List.Controls.Add(L_Etc);
             FLP_List.Location = new System.Drawing.Point(0, 34);
             FLP_List.Name = "FLP_List";
-            FLP_List.Size = new System.Drawing.Size(146, 312);
+            FLP_List.Size = new System.Drawing.Size(146, 144);
             FLP_List.TabIndex = 1;
             // 
             // L_Stats
@@ -190,7 +190,7 @@ namespace PKHeX.WinForms.Controls
             // 
             AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            ClientSize = new System.Drawing.Size(148, 348);
+            ClientSize = new System.Drawing.Size(148, 180);
             Controls.Add(PAN_All);
             FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
             MaximizeBox = false;
@@ -199,7 +199,6 @@ namespace PKHeX.WinForms.Controls
             ShowIcon = false;
             ShowInTaskbar = false;
             Text = "PokePreview";
-            TopMost = true;
             PAN_All.ResumeLayout(false);
             FLP_List.ResumeLayout(false);
             FLP_List.PerformLayout();

--- a/PKHeX.WinForms/Controls/Slots/PokePreview.Designer.cs
+++ b/PKHeX.WinForms/Controls/Slots/PokePreview.Designer.cs
@@ -38,13 +38,15 @@ namespace PKHeX.WinForms.Controls
             Move4 = new MoveDisplay();
             L_Etc = new System.Windows.Forms.Label();
             PAN_Top = new System.Windows.Forms.Panel();
-            L_Name = new System.Windows.Forms.Label();
+            FLP_Top = new System.Windows.Forms.FlowLayoutPanel();
             PB_Ball = new System.Windows.Forms.PictureBox();
+            L_Name = new System.Windows.Forms.Label();
             PB_Gender = new System.Windows.Forms.PictureBox();
             PAN_All.SuspendLayout();
             FLP_List.SuspendLayout();
             FLP_Moves.SuspendLayout();
             PAN_Top.SuspendLayout();
+            FLP_Top.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)PB_Ball).BeginInit();
             ((System.ComponentModel.ISupportInitialize)PB_Gender).BeginInit();
             SuspendLayout();
@@ -86,40 +88,44 @@ namespace PKHeX.WinForms.Controls
             // 
             // FLP_Moves
             // 
+            FLP_Moves.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
             FLP_Moves.AutoSize = true;
             FLP_Moves.Controls.Add(Move1);
             FLP_Moves.Controls.Add(Move2);
             FLP_Moves.Controls.Add(Move3);
             FLP_Moves.Controls.Add(Move4);
-            FLP_Moves.Location = new System.Drawing.Point(4, 23);
-            FLP_Moves.Margin = new System.Windows.Forms.Padding(4);
+            FLP_Moves.Location = new System.Drawing.Point(0, 23);
+            FLP_Moves.Margin = new System.Windows.Forms.Padding(0, 4, 0, 4);
             FLP_Moves.Name = "FLP_Moves";
-            FLP_Moves.Size = new System.Drawing.Size(138, 96);
+            FLP_Moves.Size = new System.Drawing.Size(142, 96);
             FLP_Moves.TabIndex = 7;
             // 
             // Move1
             // 
+            Move1.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
             FLP_Moves.SetFlowBreak(Move1, true);
-            Move1.Location = new System.Drawing.Point(0, 0);
-            Move1.Margin = new System.Windows.Forms.Padding(0);
+            Move1.Location = new System.Drawing.Point(4, 0);
+            Move1.Margin = new System.Windows.Forms.Padding(4, 0, 0, 0);
             Move1.Name = "Move1";
             Move1.Size = new System.Drawing.Size(138, 24);
             Move1.TabIndex = 1;
             // 
             // Move2
             // 
+            Move2.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
             FLP_Moves.SetFlowBreak(Move2, true);
-            Move2.Location = new System.Drawing.Point(0, 24);
-            Move2.Margin = new System.Windows.Forms.Padding(0);
+            Move2.Location = new System.Drawing.Point(4, 24);
+            Move2.Margin = new System.Windows.Forms.Padding(4, 0, 0, 0);
             Move2.Name = "Move2";
             Move2.Size = new System.Drawing.Size(138, 24);
             Move2.TabIndex = 2;
             // 
             // Move3
             // 
+            Move3.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
             FLP_Moves.SetFlowBreak(Move3, true);
-            Move3.Location = new System.Drawing.Point(0, 48);
-            Move3.Margin = new System.Windows.Forms.Padding(0);
+            Move3.Location = new System.Drawing.Point(4, 48);
+            Move3.Margin = new System.Windows.Forms.Padding(4, 0, 0, 0);
             Move3.Name = "Move3";
             Move3.Size = new System.Drawing.Size(138, 24);
             Move3.TabIndex = 3;
@@ -127,8 +133,8 @@ namespace PKHeX.WinForms.Controls
             // Move4
             // 
             FLP_Moves.SetFlowBreak(Move4, true);
-            Move4.Location = new System.Drawing.Point(0, 72);
-            Move4.Margin = new System.Windows.Forms.Padding(0);
+            Move4.Location = new System.Drawing.Point(4, 72);
+            Move4.Margin = new System.Windows.Forms.Padding(4, 0, 0, 0);
             Move4.Name = "Move4";
             Move4.Size = new System.Drawing.Size(138, 24);
             Move4.TabIndex = 4;
@@ -146,40 +152,50 @@ namespace PKHeX.WinForms.Controls
             // PAN_Top
             // 
             PAN_Top.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            PAN_Top.Controls.Add(L_Name);
-            PAN_Top.Controls.Add(PB_Ball);
-            PAN_Top.Controls.Add(PB_Gender);
+            PAN_Top.Controls.Add(FLP_Top);
             PAN_Top.Dock = System.Windows.Forms.DockStyle.Top;
             PAN_Top.Location = new System.Drawing.Point(0, 0);
             PAN_Top.Name = "PAN_Top";
             PAN_Top.Size = new System.Drawing.Size(146, 34);
             PAN_Top.TabIndex = 0;
             // 
-            // L_Name
+            // FLP_Top
             // 
-            L_Name.Location = new System.Drawing.Point(30, 4);
-            L_Name.Name = "L_Name";
-            L_Name.Size = new System.Drawing.Size(80, 24);
-            L_Name.TabIndex = 0;
-            L_Name.Text = "Species";
-            L_Name.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            FLP_Top.Controls.Add(PB_Ball);
+            FLP_Top.Controls.Add(L_Name);
+            FLP_Top.Controls.Add(PB_Gender);
+            FLP_Top.Dock = System.Windows.Forms.DockStyle.Fill;
+            FLP_Top.Location = new System.Drawing.Point(0, 0);
+            FLP_Top.Name = "FLP_Top";
+            FLP_Top.Size = new System.Drawing.Size(144, 32);
+            FLP_Top.TabIndex = 71;
             // 
             // PB_Ball
             // 
             PB_Ball.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
             PB_Ball.Location = new System.Drawing.Point(4, 4);
-            PB_Ball.Margin = new System.Windows.Forms.Padding(0);
+            PB_Ball.Margin = new System.Windows.Forms.Padding(4, 4, 0, 0);
             PB_Ball.Name = "PB_Ball";
             PB_Ball.Size = new System.Drawing.Size(24, 24);
             PB_Ball.SizeMode = System.Windows.Forms.PictureBoxSizeMode.CenterImage;
             PB_Ball.TabIndex = 68;
             PB_Ball.TabStop = false;
             // 
+            // L_Name
+            // 
+            L_Name.Location = new System.Drawing.Point(28, 4);
+            L_Name.Margin = new System.Windows.Forms.Padding(0, 4, 0, 0);
+            L_Name.Name = "L_Name";
+            L_Name.Size = new System.Drawing.Size(88, 24);
+            L_Name.TabIndex = 0;
+            L_Name.Text = "Species";
+            L_Name.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
             // PB_Gender
             // 
             PB_Gender.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
-            PB_Gender.Location = new System.Drawing.Point(115, 4);
-            PB_Gender.Margin = new System.Windows.Forms.Padding(0);
+            PB_Gender.Location = new System.Drawing.Point(116, 4);
+            PB_Gender.Margin = new System.Windows.Forms.Padding(0, 4, 4, 0);
             PB_Gender.Name = "PB_Gender";
             PB_Gender.Size = new System.Drawing.Size(24, 24);
             PB_Gender.SizeMode = System.Windows.Forms.PictureBoxSizeMode.CenterImage;
@@ -204,6 +220,7 @@ namespace PKHeX.WinForms.Controls
             FLP_List.PerformLayout();
             FLP_Moves.ResumeLayout(false);
             PAN_Top.ResumeLayout(false);
+            FLP_Top.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)PB_Ball).EndInit();
             ((System.ComponentModel.ISupportInitialize)PB_Gender).EndInit();
             ResumeLayout(false);
@@ -224,5 +241,6 @@ namespace PKHeX.WinForms.Controls
         private MoveDisplay Move4;
         private System.Windows.Forms.Label L_Etc;
         private System.Windows.Forms.FlowLayoutPanel FLP_Moves;
+        private System.Windows.Forms.FlowLayoutPanel FLP_Top;
     }
 }

--- a/PKHeX.WinForms/Controls/Slots/PokePreview.Designer.cs
+++ b/PKHeX.WinForms/Controls/Slots/PokePreview.Designer.cs
@@ -31,6 +31,7 @@ namespace PKHeX.WinForms.Controls
             PAN_All = new System.Windows.Forms.Panel();
             FLP_List = new System.Windows.Forms.FlowLayoutPanel();
             L_Stats = new System.Windows.Forms.Label();
+            FLP_Moves = new System.Windows.Forms.FlowLayoutPanel();
             Move1 = new MoveDisplay();
             Move2 = new MoveDisplay();
             Move3 = new MoveDisplay();
@@ -42,6 +43,7 @@ namespace PKHeX.WinForms.Controls
             PB_Gender = new System.Windows.Forms.PictureBox();
             PAN_All.SuspendLayout();
             FLP_List.SuspendLayout();
+            FLP_Moves.SuspendLayout();
             PAN_Top.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)PB_Ball).BeginInit();
             ((System.ComponentModel.ISupportInitialize)PB_Gender).BeginInit();
@@ -57,7 +59,7 @@ namespace PKHeX.WinForms.Controls
             PAN_All.Location = new System.Drawing.Point(0, 0);
             PAN_All.Margin = new System.Windows.Forms.Padding(0);
             PAN_All.Name = "PAN_All";
-            PAN_All.Size = new System.Drawing.Size(148, 180);
+            PAN_All.Size = new System.Drawing.Size(148, 348);
             PAN_All.TabIndex = 19;
             // 
             // FLP_List
@@ -65,58 +67,68 @@ namespace PKHeX.WinForms.Controls
             FLP_List.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
             FLP_List.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             FLP_List.Controls.Add(L_Stats);
-            FLP_List.Controls.Add(Move1);
-            FLP_List.Controls.Add(Move2);
-            FLP_List.Controls.Add(Move3);
-            FLP_List.Controls.Add(Move4);
+            FLP_List.Controls.Add(FLP_Moves);
             FLP_List.Controls.Add(L_Etc);
             FLP_List.Location = new System.Drawing.Point(0, 34);
             FLP_List.Name = "FLP_List";
-            FLP_List.Size = new System.Drawing.Size(146, 144);
+            FLP_List.Size = new System.Drawing.Size(146, 312);
             FLP_List.TabIndex = 1;
             // 
             // L_Stats
             // 
             FLP_List.SetFlowBreak(L_Stats, true);
-            L_Stats.Location = new System.Drawing.Point(2, 2);
-            L_Stats.Margin = new System.Windows.Forms.Padding(2, 2, 0, 0);
+            L_Stats.Location = new System.Drawing.Point(2, 4);
+            L_Stats.Margin = new System.Windows.Forms.Padding(2, 4, 0, 0);
             L_Stats.Name = "L_Stats";
             L_Stats.Size = new System.Drawing.Size(32, 15);
             L_Stats.TabIndex = 5;
             L_Stats.Text = "Stats";
             // 
+            // FLP_Moves
+            // 
+            FLP_Moves.AutoSize = true;
+            FLP_Moves.Controls.Add(Move1);
+            FLP_Moves.Controls.Add(Move2);
+            FLP_Moves.Controls.Add(Move3);
+            FLP_Moves.Controls.Add(Move4);
+            FLP_Moves.Location = new System.Drawing.Point(4, 23);
+            FLP_Moves.Margin = new System.Windows.Forms.Padding(4);
+            FLP_Moves.Name = "FLP_Moves";
+            FLP_Moves.Size = new System.Drawing.Size(138, 96);
+            FLP_Moves.TabIndex = 7;
+            // 
             // Move1
             // 
-            FLP_List.SetFlowBreak(Move1, true);
-            Move1.Location = new System.Drawing.Point(4, 17);
-            Move1.Margin = new System.Windows.Forms.Padding(4, 0, 0, 0);
+            FLP_Moves.SetFlowBreak(Move1, true);
+            Move1.Location = new System.Drawing.Point(0, 0);
+            Move1.Margin = new System.Windows.Forms.Padding(0);
             Move1.Name = "Move1";
             Move1.Size = new System.Drawing.Size(138, 24);
             Move1.TabIndex = 1;
             // 
             // Move2
             // 
-            FLP_List.SetFlowBreak(Move2, true);
-            Move2.Location = new System.Drawing.Point(4, 41);
-            Move2.Margin = new System.Windows.Forms.Padding(4, 0, 0, 0);
+            FLP_Moves.SetFlowBreak(Move2, true);
+            Move2.Location = new System.Drawing.Point(0, 24);
+            Move2.Margin = new System.Windows.Forms.Padding(0);
             Move2.Name = "Move2";
             Move2.Size = new System.Drawing.Size(138, 24);
             Move2.TabIndex = 2;
             // 
             // Move3
             // 
-            FLP_List.SetFlowBreak(Move3, true);
-            Move3.Location = new System.Drawing.Point(4, 65);
-            Move3.Margin = new System.Windows.Forms.Padding(4, 0, 0, 0);
+            FLP_Moves.SetFlowBreak(Move3, true);
+            Move3.Location = new System.Drawing.Point(0, 48);
+            Move3.Margin = new System.Windows.Forms.Padding(0);
             Move3.Name = "Move3";
             Move3.Size = new System.Drawing.Size(138, 24);
             Move3.TabIndex = 3;
             // 
             // Move4
             // 
-            FLP_List.SetFlowBreak(Move4, true);
-            Move4.Location = new System.Drawing.Point(4, 89);
-            Move4.Margin = new System.Windows.Forms.Padding(4, 0, 0, 0);
+            FLP_Moves.SetFlowBreak(Move4, true);
+            Move4.Location = new System.Drawing.Point(0, 72);
+            Move4.Margin = new System.Windows.Forms.Padding(0);
             Move4.Name = "Move4";
             Move4.Size = new System.Drawing.Size(138, 24);
             Move4.TabIndex = 4;
@@ -124,8 +136,8 @@ namespace PKHeX.WinForms.Controls
             // L_Etc
             // 
             FLP_List.SetFlowBreak(L_Etc, true);
-            L_Etc.Location = new System.Drawing.Point(2, 115);
-            L_Etc.Margin = new System.Windows.Forms.Padding(2, 2, 0, 0);
+            L_Etc.Location = new System.Drawing.Point(2, 123);
+            L_Etc.Margin = new System.Windows.Forms.Padding(2, 0, 0, 4);
             L_Etc.Name = "L_Etc";
             L_Etc.Size = new System.Drawing.Size(28, 15);
             L_Etc.TabIndex = 6;
@@ -178,7 +190,7 @@ namespace PKHeX.WinForms.Controls
             // 
             AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            ClientSize = new System.Drawing.Size(148, 180);
+            ClientSize = new System.Drawing.Size(148, 348);
             Controls.Add(PAN_All);
             FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
             MaximizeBox = false;
@@ -190,6 +202,8 @@ namespace PKHeX.WinForms.Controls
             TopMost = true;
             PAN_All.ResumeLayout(false);
             FLP_List.ResumeLayout(false);
+            FLP_List.PerformLayout();
+            FLP_Moves.ResumeLayout(false);
             PAN_Top.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)PB_Ball).EndInit();
             ((System.ComponentModel.ISupportInitialize)PB_Gender).EndInit();
@@ -210,5 +224,6 @@ namespace PKHeX.WinForms.Controls
         private MoveDisplay Move3;
         private MoveDisplay Move4;
         private System.Windows.Forms.Label L_Etc;
+        private System.Windows.Forms.FlowLayoutPanel FLP_Moves;
     }
 }

--- a/PKHeX.WinForms/Controls/Slots/PokePreview.Designer.cs
+++ b/PKHeX.WinForms/Controls/Slots/PokePreview.Designer.cs
@@ -71,14 +71,17 @@ namespace PKHeX.WinForms.Controls
             FLP_List.Controls.Add(L_Stats);
             FLP_List.Controls.Add(FLP_Moves);
             FLP_List.Controls.Add(L_Etc);
+            FLP_List.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
             FLP_List.Location = new System.Drawing.Point(0, 34);
+            FLP_List.Margin = new System.Windows.Forms.Padding(0);
             FLP_List.Name = "FLP_List";
             FLP_List.Size = new System.Drawing.Size(146, 144);
             FLP_List.TabIndex = 1;
+            FLP_List.WrapContents = false;
             // 
             // L_Stats
             // 
-            FLP_List.SetFlowBreak(L_Stats, true);
+            L_Stats.AutoSize = true;
             L_Stats.Location = new System.Drawing.Point(2, 4);
             L_Stats.Margin = new System.Windows.Forms.Padding(2, 4, 0, 0);
             L_Stats.Name = "L_Stats";
@@ -90,20 +93,25 @@ namespace PKHeX.WinForms.Controls
             // 
             FLP_Moves.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
             FLP_Moves.AutoSize = true;
+            FLP_Moves.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             FLP_Moves.Controls.Add(Move1);
             FLP_Moves.Controls.Add(Move2);
             FLP_Moves.Controls.Add(Move3);
             FLP_Moves.Controls.Add(Move4);
+            FLP_List.SetFlowBreak(FLP_Moves, true);
+            FLP_Moves.FlowDirection = System.Windows.Forms.FlowDirection.TopDown;
             FLP_Moves.Location = new System.Drawing.Point(0, 23);
             FLP_Moves.Margin = new System.Windows.Forms.Padding(0, 4, 0, 4);
             FLP_Moves.Name = "FLP_Moves";
             FLP_Moves.Size = new System.Drawing.Size(142, 96);
             FLP_Moves.TabIndex = 7;
+            FLP_Moves.WrapContents = false;
             // 
             // Move1
             // 
             Move1.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
-            FLP_Moves.SetFlowBreak(Move1, true);
+            Move1.AutoSize = true;
+            Move1.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             Move1.Location = new System.Drawing.Point(4, 0);
             Move1.Margin = new System.Windows.Forms.Padding(4, 0, 0, 0);
             Move1.Name = "Move1";
@@ -113,7 +121,8 @@ namespace PKHeX.WinForms.Controls
             // Move2
             // 
             Move2.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
-            FLP_Moves.SetFlowBreak(Move2, true);
+            Move2.AutoSize = true;
+            Move2.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             Move2.Location = new System.Drawing.Point(4, 24);
             Move2.Margin = new System.Windows.Forms.Padding(4, 0, 0, 0);
             Move2.Name = "Move2";
@@ -123,7 +132,8 @@ namespace PKHeX.WinForms.Controls
             // Move3
             // 
             Move3.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
-            FLP_Moves.SetFlowBreak(Move3, true);
+            Move3.AutoSize = true;
+            Move3.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             Move3.Location = new System.Drawing.Point(4, 48);
             Move3.Margin = new System.Windows.Forms.Padding(4, 0, 0, 0);
             Move3.Name = "Move3";
@@ -132,7 +142,8 @@ namespace PKHeX.WinForms.Controls
             // 
             // Move4
             // 
-            FLP_Moves.SetFlowBreak(Move4, true);
+            Move4.AutoSize = true;
+            Move4.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             Move4.Location = new System.Drawing.Point(4, 72);
             Move4.Margin = new System.Windows.Forms.Padding(4, 0, 0, 0);
             Move4.Name = "Move4";
@@ -141,7 +152,7 @@ namespace PKHeX.WinForms.Controls
             // 
             // L_Etc
             // 
-            FLP_List.SetFlowBreak(L_Etc, true);
+            L_Etc.AutoSize = true;
             L_Etc.Location = new System.Drawing.Point(2, 123);
             L_Etc.Margin = new System.Windows.Forms.Padding(2, 0, 0, 4);
             L_Etc.Name = "L_Etc";
@@ -155,6 +166,7 @@ namespace PKHeX.WinForms.Controls
             PAN_Top.Controls.Add(FLP_Top);
             PAN_Top.Dock = System.Windows.Forms.DockStyle.Top;
             PAN_Top.Location = new System.Drawing.Point(0, 0);
+            PAN_Top.Margin = new System.Windows.Forms.Padding(0);
             PAN_Top.Name = "PAN_Top";
             PAN_Top.Size = new System.Drawing.Size(146, 34);
             PAN_Top.TabIndex = 0;
@@ -166,6 +178,7 @@ namespace PKHeX.WinForms.Controls
             FLP_Top.Controls.Add(PB_Gender);
             FLP_Top.Dock = System.Windows.Forms.DockStyle.Fill;
             FLP_Top.Location = new System.Drawing.Point(0, 0);
+            FLP_Top.Margin = new System.Windows.Forms.Padding(0);
             FLP_Top.Name = "FLP_Top";
             FLP_Top.Size = new System.Drawing.Size(144, 32);
             FLP_Top.TabIndex = 71;
@@ -219,6 +232,7 @@ namespace PKHeX.WinForms.Controls
             FLP_List.ResumeLayout(false);
             FLP_List.PerformLayout();
             FLP_Moves.ResumeLayout(false);
+            FLP_Moves.PerformLayout();
             PAN_Top.ResumeLayout(false);
             FLP_Top.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)PB_Ball).EndInit();

--- a/PKHeX.WinForms/Controls/Slots/PokePreview.Designer.cs
+++ b/PKHeX.WinForms/Controls/Slots/PokePreview.Designer.cs
@@ -187,6 +187,7 @@ namespace PKHeX.WinForms.Controls
             ShowIcon = false;
             ShowInTaskbar = false;
             Text = "PokePreview";
+            TopMost = true;
             PAN_All.ResumeLayout(false);
             FLP_List.ResumeLayout(false);
             PAN_Top.ResumeLayout(false);

--- a/PKHeX.WinForms/Controls/Slots/PokePreview.Designer.cs
+++ b/PKHeX.WinForms/Controls/Slots/PokePreview.Designer.cs
@@ -28,241 +28,158 @@ namespace PKHeX.WinForms.Controls
         /// </summary>
         private void InitializeComponent()
         {
-            panel1 = new System.Windows.Forms.Panel();
-            splitContainer1 = new System.Windows.Forms.SplitContainer();
-            PB_Other = new System.Windows.Forms.PictureBox();
-            PB_Gender = new System.Windows.Forms.PictureBox();
-            PB_Type2 = new System.Windows.Forms.PictureBox();
-            PB_Type1 = new System.Windows.Forms.PictureBox();
+            PAN_All = new System.Windows.Forms.Panel();
+            FLP_List = new System.Windows.Forms.FlowLayoutPanel();
+            L_Stats = new System.Windows.Forms.Label();
+            Move1 = new MoveDisplay();
+            Move2 = new MoveDisplay();
+            Move3 = new MoveDisplay();
+            Move4 = new MoveDisplay();
+            L_Etc = new System.Windows.Forms.Label();
+            PAN_Top = new System.Windows.Forms.Panel();
             L_Name = new System.Windows.Forms.Label();
             PB_Ball = new System.Windows.Forms.PictureBox();
-            L_Stats = new System.Windows.Forms.Label();
-            L_Move4 = new System.Windows.Forms.Label();
-            L_Move3 = new System.Windows.Forms.Label();
-            L_Move2 = new System.Windows.Forms.Label();
-            L_Move1 = new System.Windows.Forms.Label();
-            PB_Move4 = new System.Windows.Forms.PictureBox();
-            PB_Move3 = new System.Windows.Forms.PictureBox();
-            PB_Move2 = new System.Windows.Forms.PictureBox();
-            PB_Move1 = new System.Windows.Forms.PictureBox();
-            panel1.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)splitContainer1).BeginInit();
-            splitContainer1.Panel1.SuspendLayout();
-            splitContainer1.Panel2.SuspendLayout();
-            splitContainer1.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)PB_Other).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)PB_Gender).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)PB_Type2).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)PB_Type1).BeginInit();
+            PB_Gender = new System.Windows.Forms.PictureBox();
+            PAN_All.SuspendLayout();
+            FLP_List.SuspendLayout();
+            PAN_Top.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)PB_Ball).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)PB_Move4).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)PB_Move3).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)PB_Move2).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)PB_Move1).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)PB_Gender).BeginInit();
             SuspendLayout();
             // 
-            // panel1
+            // PAN_All
             // 
-            panel1.BackColor = System.Drawing.SystemColors.Window;
-            panel1.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            panel1.Controls.Add(splitContainer1);
-            panel1.Dock = System.Windows.Forms.DockStyle.Fill;
-            panel1.Location = new System.Drawing.Point(0, 0);
-            panel1.Margin = new System.Windows.Forms.Padding(0);
-            panel1.Name = "panel1";
-            panel1.Size = new System.Drawing.Size(276, 152);
-            panel1.TabIndex = 19;
+            PAN_All.BackColor = System.Drawing.SystemColors.Window;
+            PAN_All.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            PAN_All.Controls.Add(FLP_List);
+            PAN_All.Controls.Add(PAN_Top);
+            PAN_All.Dock = System.Windows.Forms.DockStyle.Fill;
+            PAN_All.Location = new System.Drawing.Point(0, 0);
+            PAN_All.Margin = new System.Windows.Forms.Padding(0);
+            PAN_All.Name = "PAN_All";
+            PAN_All.Size = new System.Drawing.Size(148, 180);
+            PAN_All.TabIndex = 19;
             // 
-            // splitContainer1
+            // FLP_List
             // 
-            splitContainer1.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            splitContainer1.Dock = System.Windows.Forms.DockStyle.Fill;
-            splitContainer1.IsSplitterFixed = true;
-            splitContainer1.Location = new System.Drawing.Point(0, 0);
-            splitContainer1.Margin = new System.Windows.Forms.Padding(0);
-            splitContainer1.Name = "splitContainer1";
-            splitContainer1.Orientation = System.Windows.Forms.Orientation.Horizontal;
+            FLP_List.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            FLP_List.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            FLP_List.Controls.Add(L_Stats);
+            FLP_List.Controls.Add(Move1);
+            FLP_List.Controls.Add(Move2);
+            FLP_List.Controls.Add(Move3);
+            FLP_List.Controls.Add(Move4);
+            FLP_List.Controls.Add(L_Etc);
+            FLP_List.Location = new System.Drawing.Point(0, 34);
+            FLP_List.Name = "FLP_List";
+            FLP_List.Size = new System.Drawing.Size(146, 144);
+            FLP_List.TabIndex = 1;
             // 
-            // splitContainer1.Panel1
+            // L_Stats
             // 
-            splitContainer1.Panel1.Controls.Add(PB_Other);
-            splitContainer1.Panel1.Controls.Add(PB_Gender);
-            splitContainer1.Panel1.Controls.Add(PB_Type2);
-            splitContainer1.Panel1.Controls.Add(PB_Type1);
-            splitContainer1.Panel1.Controls.Add(L_Name);
-            splitContainer1.Panel1.Controls.Add(PB_Ball);
+            FLP_List.SetFlowBreak(L_Stats, true);
+            L_Stats.Location = new System.Drawing.Point(2, 2);
+            L_Stats.Margin = new System.Windows.Forms.Padding(2, 2, 0, 0);
+            L_Stats.Name = "L_Stats";
+            L_Stats.Size = new System.Drawing.Size(32, 15);
+            L_Stats.TabIndex = 5;
+            L_Stats.Text = "Stats";
             // 
-            // splitContainer1.Panel2
+            // Move1
             // 
-            splitContainer1.Panel2.Controls.Add(L_Stats);
-            splitContainer1.Panel2.Controls.Add(L_Move4);
-            splitContainer1.Panel2.Controls.Add(L_Move3);
-            splitContainer1.Panel2.Controls.Add(L_Move2);
-            splitContainer1.Panel2.Controls.Add(L_Move1);
-            splitContainer1.Panel2.Controls.Add(PB_Move4);
-            splitContainer1.Panel2.Controls.Add(PB_Move3);
-            splitContainer1.Panel2.Controls.Add(PB_Move2);
-            splitContainer1.Panel2.Controls.Add(PB_Move1);
-            splitContainer1.Size = new System.Drawing.Size(274, 150);
-            splitContainer1.SplitterDistance = 40;
-            splitContainer1.SplitterWidth = 1;
-            splitContainer1.TabIndex = 52;
+            FLP_List.SetFlowBreak(Move1, true);
+            Move1.Location = new System.Drawing.Point(4, 17);
+            Move1.Margin = new System.Windows.Forms.Padding(4, 0, 0, 0);
+            Move1.Name = "Move1";
+            Move1.Size = new System.Drawing.Size(138, 24);
+            Move1.TabIndex = 1;
             // 
-            // PB_Other
+            // Move2
             // 
-            PB_Other.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
-            PB_Other.Location = new System.Drawing.Point(232, 8);
-            PB_Other.Margin = new System.Windows.Forms.Padding(0);
-            PB_Other.Name = "PB_Other";
-            PB_Other.Size = new System.Drawing.Size(24, 24);
-            PB_Other.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
-            PB_Other.TabIndex = 45;
-            PB_Other.TabStop = false;
+            FLP_List.SetFlowBreak(Move2, true);
+            Move2.Location = new System.Drawing.Point(4, 41);
+            Move2.Margin = new System.Windows.Forms.Padding(4, 0, 0, 0);
+            Move2.Name = "Move2";
+            Move2.Size = new System.Drawing.Size(138, 24);
+            Move2.TabIndex = 2;
             // 
-            // PB_Gender
+            // Move3
             // 
-            PB_Gender.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
-            PB_Gender.Location = new System.Drawing.Point(128, 8);
-            PB_Gender.Margin = new System.Windows.Forms.Padding(0);
-            PB_Gender.Name = "PB_Gender";
-            PB_Gender.Size = new System.Drawing.Size(24, 24);
-            PB_Gender.SizeMode = System.Windows.Forms.PictureBoxSizeMode.CenterImage;
-            PB_Gender.TabIndex = 44;
-            PB_Gender.TabStop = false;
+            FLP_List.SetFlowBreak(Move3, true);
+            Move3.Location = new System.Drawing.Point(4, 65);
+            Move3.Margin = new System.Windows.Forms.Padding(4, 0, 0, 0);
+            Move3.Name = "Move3";
+            Move3.Size = new System.Drawing.Size(138, 24);
+            Move3.TabIndex = 3;
             // 
-            // PB_Type2
+            // Move4
             // 
-            PB_Type2.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
-            PB_Type2.Location = new System.Drawing.Point(192, 8);
-            PB_Type2.Margin = new System.Windows.Forms.Padding(0);
-            PB_Type2.Name = "PB_Type2";
-            PB_Type2.Size = new System.Drawing.Size(24, 24);
-            PB_Type2.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
-            PB_Type2.TabIndex = 43;
-            PB_Type2.TabStop = false;
+            FLP_List.SetFlowBreak(Move4, true);
+            Move4.Location = new System.Drawing.Point(4, 89);
+            Move4.Margin = new System.Windows.Forms.Padding(4, 0, 0, 0);
+            Move4.Name = "Move4";
+            Move4.Size = new System.Drawing.Size(138, 24);
+            Move4.TabIndex = 4;
             // 
-            // PB_Type1
+            // L_Etc
             // 
-            PB_Type1.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
-            PB_Type1.Location = new System.Drawing.Point(168, 8);
-            PB_Type1.Margin = new System.Windows.Forms.Padding(0);
-            PB_Type1.Name = "PB_Type1";
-            PB_Type1.Size = new System.Drawing.Size(24, 24);
-            PB_Type1.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
-            PB_Type1.TabIndex = 42;
-            PB_Type1.TabStop = false;
+            FLP_List.SetFlowBreak(L_Etc, true);
+            L_Etc.Location = new System.Drawing.Point(2, 115);
+            L_Etc.Margin = new System.Windows.Forms.Padding(2, 2, 0, 0);
+            L_Etc.Name = "L_Etc";
+            L_Etc.Size = new System.Drawing.Size(28, 15);
+            L_Etc.TabIndex = 6;
+            L_Etc.Text = "Info";
+            // 
+            // PAN_Top
+            // 
+            PAN_Top.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            PAN_Top.Controls.Add(L_Name);
+            PAN_Top.Controls.Add(PB_Ball);
+            PAN_Top.Controls.Add(PB_Gender);
+            PAN_Top.Dock = System.Windows.Forms.DockStyle.Top;
+            PAN_Top.Location = new System.Drawing.Point(0, 0);
+            PAN_Top.Name = "PAN_Top";
+            PAN_Top.Size = new System.Drawing.Size(146, 34);
+            PAN_Top.TabIndex = 0;
             // 
             // L_Name
             // 
-            L_Name.Location = new System.Drawing.Point(40, 8);
+            L_Name.Location = new System.Drawing.Point(30, 4);
             L_Name.Name = "L_Name";
-            L_Name.Size = new System.Drawing.Size(100, 24);
-            L_Name.TabIndex = 41;
+            L_Name.Size = new System.Drawing.Size(80, 24);
+            L_Name.TabIndex = 0;
             L_Name.Text = "Species";
             L_Name.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // PB_Ball
             // 
             PB_Ball.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
-            PB_Ball.Location = new System.Drawing.Point(8, 8);
+            PB_Ball.Location = new System.Drawing.Point(4, 4);
             PB_Ball.Margin = new System.Windows.Forms.Padding(0);
             PB_Ball.Name = "PB_Ball";
             PB_Ball.Size = new System.Drawing.Size(24, 24);
             PB_Ball.SizeMode = System.Windows.Forms.PictureBoxSizeMode.CenterImage;
-            PB_Ball.TabIndex = 40;
+            PB_Ball.TabIndex = 68;
             PB_Ball.TabStop = false;
             // 
-            // L_Stats
+            // PB_Gender
             // 
-            L_Stats.Location = new System.Drawing.Point(162, 4);
-            L_Stats.Name = "L_Stats";
-            L_Stats.Size = new System.Drawing.Size(100, 96);
-            L_Stats.TabIndex = 58;
-            L_Stats.Text = "Stats";
-            L_Stats.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
-            // L_Move4
-            // 
-            L_Move4.Location = new System.Drawing.Point(40, 78);
-            L_Move4.Name = "L_Move4";
-            L_Move4.Size = new System.Drawing.Size(100, 24);
-            L_Move4.TabIndex = 57;
-            L_Move4.Text = "Move4";
-            L_Move4.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
-            // L_Move3
-            // 
-            L_Move3.Location = new System.Drawing.Point(40, 54);
-            L_Move3.Name = "L_Move3";
-            L_Move3.Size = new System.Drawing.Size(100, 24);
-            L_Move3.TabIndex = 56;
-            L_Move3.Text = "Move3";
-            L_Move3.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
-            // L_Move2
-            // 
-            L_Move2.Location = new System.Drawing.Point(40, 30);
-            L_Move2.Name = "L_Move2";
-            L_Move2.Size = new System.Drawing.Size(100, 24);
-            L_Move2.TabIndex = 55;
-            L_Move2.Text = "Move2";
-            L_Move2.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
-            // L_Move1
-            // 
-            L_Move1.Location = new System.Drawing.Point(40, 6);
-            L_Move1.Name = "L_Move1";
-            L_Move1.Size = new System.Drawing.Size(100, 24);
-            L_Move1.TabIndex = 54;
-            L_Move1.Text = "Move1";
-            L_Move1.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            // 
-            // PB_Move4
-            // 
-            PB_Move4.Location = new System.Drawing.Point(8, 78);
-            PB_Move4.Margin = new System.Windows.Forms.Padding(0, 0, 8, 0);
-            PB_Move4.Name = "PB_Move4";
-            PB_Move4.Size = new System.Drawing.Size(24, 24);
-            PB_Move4.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
-            PB_Move4.TabIndex = 53;
-            PB_Move4.TabStop = false;
-            // 
-            // PB_Move3
-            // 
-            PB_Move3.Location = new System.Drawing.Point(8, 54);
-            PB_Move3.Margin = new System.Windows.Forms.Padding(0, 0, 8, 0);
-            PB_Move3.Name = "PB_Move3";
-            PB_Move3.Size = new System.Drawing.Size(24, 24);
-            PB_Move3.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
-            PB_Move3.TabIndex = 52;
-            PB_Move3.TabStop = false;
-            // 
-            // PB_Move2
-            // 
-            PB_Move2.Location = new System.Drawing.Point(8, 30);
-            PB_Move2.Margin = new System.Windows.Forms.Padding(0, 0, 8, 0);
-            PB_Move2.Name = "PB_Move2";
-            PB_Move2.Size = new System.Drawing.Size(24, 24);
-            PB_Move2.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
-            PB_Move2.TabIndex = 51;
-            PB_Move2.TabStop = false;
-            // 
-            // PB_Move1
-            // 
-            PB_Move1.Location = new System.Drawing.Point(8, 6);
-            PB_Move1.Margin = new System.Windows.Forms.Padding(0, 0, 8, 0);
-            PB_Move1.Name = "PB_Move1";
-            PB_Move1.Size = new System.Drawing.Size(24, 24);
-            PB_Move1.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
-            PB_Move1.TabIndex = 50;
-            PB_Move1.TabStop = false;
+            PB_Gender.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
+            PB_Gender.Location = new System.Drawing.Point(115, 4);
+            PB_Gender.Margin = new System.Windows.Forms.Padding(0);
+            PB_Gender.Name = "PB_Gender";
+            PB_Gender.Size = new System.Drawing.Size(24, 24);
+            PB_Gender.SizeMode = System.Windows.Forms.PictureBoxSizeMode.CenterImage;
+            PB_Gender.TabIndex = 70;
+            PB_Gender.TabStop = false;
             // 
             // PokePreview
             // 
             AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            ClientSize = new System.Drawing.Size(276, 152);
-            Controls.Add(panel1);
+            ClientSize = new System.Drawing.Size(148, 180);
+            Controls.Add(PAN_All);
             FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
             MaximizeBox = false;
             MinimizeBox = false;
@@ -270,41 +187,27 @@ namespace PKHeX.WinForms.Controls
             ShowIcon = false;
             ShowInTaskbar = false;
             Text = "PokePreview";
-            panel1.ResumeLayout(false);
-            splitContainer1.Panel1.ResumeLayout(false);
-            splitContainer1.Panel2.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)splitContainer1).EndInit();
-            splitContainer1.ResumeLayout(false);
-            ((System.ComponentModel.ISupportInitialize)PB_Other).EndInit();
-            ((System.ComponentModel.ISupportInitialize)PB_Gender).EndInit();
-            ((System.ComponentModel.ISupportInitialize)PB_Type2).EndInit();
-            ((System.ComponentModel.ISupportInitialize)PB_Type1).EndInit();
+            PAN_All.ResumeLayout(false);
+            FLP_List.ResumeLayout(false);
+            PAN_Top.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)PB_Ball).EndInit();
-            ((System.ComponentModel.ISupportInitialize)PB_Move4).EndInit();
-            ((System.ComponentModel.ISupportInitialize)PB_Move3).EndInit();
-            ((System.ComponentModel.ISupportInitialize)PB_Move2).EndInit();
-            ((System.ComponentModel.ISupportInitialize)PB_Move1).EndInit();
+            ((System.ComponentModel.ISupportInitialize)PB_Gender).EndInit();
             ResumeLayout(false);
         }
 
         #endregion
 
-        private System.Windows.Forms.Panel panel1;
-        private System.Windows.Forms.SplitContainer splitContainer1;
-        private System.Windows.Forms.PictureBox PB_Other;
-        private System.Windows.Forms.PictureBox PB_Gender;
-        private System.Windows.Forms.PictureBox PB_Type2;
-        private System.Windows.Forms.PictureBox PB_Type1;
+        private System.Windows.Forms.Panel PAN_All;
+        private System.Windows.Forms.FlowLayoutPanel FLP_List;
+        private System.Windows.Forms.Label L_Stats;
+        private System.Windows.Forms.Panel PAN_Top;
         private System.Windows.Forms.Label L_Name;
         private System.Windows.Forms.PictureBox PB_Ball;
-        private System.Windows.Forms.Label L_Stats;
-        private System.Windows.Forms.Label L_Move4;
-        private System.Windows.Forms.Label L_Move3;
-        private System.Windows.Forms.Label L_Move2;
-        private System.Windows.Forms.Label L_Move1;
-        private System.Windows.Forms.PictureBox PB_Move4;
-        private System.Windows.Forms.PictureBox PB_Move3;
-        private System.Windows.Forms.PictureBox PB_Move2;
-        private System.Windows.Forms.PictureBox PB_Move1;
+        private System.Windows.Forms.PictureBox PB_Gender;
+        private MoveDisplay Move1;
+        private MoveDisplay Move2;
+        private MoveDisplay Move3;
+        private MoveDisplay Move4;
+        private System.Windows.Forms.Label L_Etc;
     }
 }

--- a/PKHeX.WinForms/Controls/Slots/PokePreview.Designer.cs
+++ b/PKHeX.WinForms/Controls/Slots/PokePreview.Designer.cs
@@ -1,0 +1,279 @@
+namespace PKHeX.WinForms.Controls
+{
+    partial class PokePreview
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            panel1 = new System.Windows.Forms.Panel();
+            PB_Other = new System.Windows.Forms.PictureBox();
+            L_Stats = new System.Windows.Forms.Label();
+            PB_Gender = new System.Windows.Forms.PictureBox();
+            PB_Type2 = new System.Windows.Forms.PictureBox();
+            PB_Type1 = new System.Windows.Forms.PictureBox();
+            L_Move4 = new System.Windows.Forms.Label();
+            L_Move3 = new System.Windows.Forms.Label();
+            L_Move2 = new System.Windows.Forms.Label();
+            L_Move1 = new System.Windows.Forms.Label();
+            L_Name = new System.Windows.Forms.Label();
+            PB_Move4 = new System.Windows.Forms.PictureBox();
+            PB_Move3 = new System.Windows.Forms.PictureBox();
+            PB_Move2 = new System.Windows.Forms.PictureBox();
+            PB_Move1 = new System.Windows.Forms.PictureBox();
+            PB_Ball = new System.Windows.Forms.PictureBox();
+            panel1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)PB_Other).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)PB_Gender).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)PB_Type2).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)PB_Type1).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)PB_Move4).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)PB_Move3).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)PB_Move2).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)PB_Move1).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)PB_Ball).BeginInit();
+            SuspendLayout();
+            // 
+            // panel1
+            // 
+            panel1.BackColor = System.Drawing.SystemColors.Window;
+            panel1.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
+            panel1.Controls.Add(PB_Other);
+            panel1.Controls.Add(L_Stats);
+            panel1.Controls.Add(PB_Gender);
+            panel1.Controls.Add(PB_Type2);
+            panel1.Controls.Add(PB_Type1);
+            panel1.Controls.Add(L_Move4);
+            panel1.Controls.Add(L_Move3);
+            panel1.Controls.Add(L_Move2);
+            panel1.Controls.Add(L_Move1);
+            panel1.Controls.Add(L_Name);
+            panel1.Controls.Add(PB_Move4);
+            panel1.Controls.Add(PB_Move3);
+            panel1.Controls.Add(PB_Move2);
+            panel1.Controls.Add(PB_Move1);
+            panel1.Controls.Add(PB_Ball);
+            panel1.Dock = System.Windows.Forms.DockStyle.Fill;
+            panel1.Location = new System.Drawing.Point(0, 0);
+            panel1.Name = "panel1";
+            panel1.Size = new System.Drawing.Size(280, 156);
+            panel1.TabIndex = 19;
+            // 
+            // PB_Other
+            // 
+            PB_Other.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
+            PB_Other.Location = new System.Drawing.Point(232, 8);
+            PB_Other.Margin = new System.Windows.Forms.Padding(0);
+            PB_Other.Name = "PB_Other";
+            PB_Other.Size = new System.Drawing.Size(24, 24);
+            PB_Other.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
+            PB_Other.TabIndex = 33;
+            PB_Other.TabStop = false;
+            // 
+            // L_Stats
+            // 
+            L_Stats.Font = new System.Drawing.Font("Courier New", 8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+            L_Stats.Location = new System.Drawing.Point(168, 44);
+            L_Stats.Name = "L_Stats";
+            L_Stats.Size = new System.Drawing.Size(100, 96);
+            L_Stats.TabIndex = 32;
+            L_Stats.Text = "Stats";
+            L_Stats.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // PB_Gender
+            // 
+            PB_Gender.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
+            PB_Gender.Location = new System.Drawing.Point(128, 8);
+            PB_Gender.Margin = new System.Windows.Forms.Padding(0);
+            PB_Gender.Name = "PB_Gender";
+            PB_Gender.Size = new System.Drawing.Size(24, 24);
+            PB_Gender.SizeMode = System.Windows.Forms.PictureBoxSizeMode.CenterImage;
+            PB_Gender.TabIndex = 31;
+            PB_Gender.TabStop = false;
+            // 
+            // PB_Type2
+            // 
+            PB_Type2.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
+            PB_Type2.Location = new System.Drawing.Point(192, 8);
+            PB_Type2.Margin = new System.Windows.Forms.Padding(0);
+            PB_Type2.Name = "PB_Type2";
+            PB_Type2.Size = new System.Drawing.Size(24, 24);
+            PB_Type2.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
+            PB_Type2.TabIndex = 30;
+            PB_Type2.TabStop = false;
+            // 
+            // PB_Type1
+            // 
+            PB_Type1.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
+            PB_Type1.Location = new System.Drawing.Point(168, 8);
+            PB_Type1.Margin = new System.Windows.Forms.Padding(0);
+            PB_Type1.Name = "PB_Type1";
+            PB_Type1.Size = new System.Drawing.Size(24, 24);
+            PB_Type1.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
+            PB_Type1.TabIndex = 29;
+            PB_Type1.TabStop = false;
+            // 
+            // L_Move4
+            // 
+            L_Move4.Location = new System.Drawing.Point(40, 116);
+            L_Move4.Name = "L_Move4";
+            L_Move4.Size = new System.Drawing.Size(100, 24);
+            L_Move4.TabIndex = 28;
+            L_Move4.Text = "Move4";
+            L_Move4.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // L_Move3
+            // 
+            L_Move3.Location = new System.Drawing.Point(40, 92);
+            L_Move3.Name = "L_Move3";
+            L_Move3.Size = new System.Drawing.Size(100, 24);
+            L_Move3.TabIndex = 27;
+            L_Move3.Text = "Move3";
+            L_Move3.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // L_Move2
+            // 
+            L_Move2.Location = new System.Drawing.Point(40, 68);
+            L_Move2.Name = "L_Move2";
+            L_Move2.Size = new System.Drawing.Size(100, 24);
+            L_Move2.TabIndex = 26;
+            L_Move2.Text = "Move2";
+            L_Move2.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // L_Move1
+            // 
+            L_Move1.Location = new System.Drawing.Point(40, 44);
+            L_Move1.Name = "L_Move1";
+            L_Move1.Size = new System.Drawing.Size(100, 24);
+            L_Move1.TabIndex = 25;
+            L_Move1.Text = "Move1";
+            L_Move1.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // L_Name
+            // 
+            L_Name.Location = new System.Drawing.Point(40, 8);
+            L_Name.Name = "L_Name";
+            L_Name.Size = new System.Drawing.Size(100, 24);
+            L_Name.TabIndex = 24;
+            L_Name.Text = "Species";
+            L_Name.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
+            // PB_Move4
+            // 
+            PB_Move4.Location = new System.Drawing.Point(8, 116);
+            PB_Move4.Margin = new System.Windows.Forms.Padding(0, 0, 8, 0);
+            PB_Move4.Name = "PB_Move4";
+            PB_Move4.Size = new System.Drawing.Size(24, 24);
+            PB_Move4.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
+            PB_Move4.TabIndex = 23;
+            PB_Move4.TabStop = false;
+            // 
+            // PB_Move3
+            // 
+            PB_Move3.Location = new System.Drawing.Point(8, 92);
+            PB_Move3.Margin = new System.Windows.Forms.Padding(0, 0, 8, 0);
+            PB_Move3.Name = "PB_Move3";
+            PB_Move3.Size = new System.Drawing.Size(24, 24);
+            PB_Move3.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
+            PB_Move3.TabIndex = 22;
+            PB_Move3.TabStop = false;
+            // 
+            // PB_Move2
+            // 
+            PB_Move2.Location = new System.Drawing.Point(8, 68);
+            PB_Move2.Margin = new System.Windows.Forms.Padding(0, 0, 8, 0);
+            PB_Move2.Name = "PB_Move2";
+            PB_Move2.Size = new System.Drawing.Size(24, 24);
+            PB_Move2.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
+            PB_Move2.TabIndex = 21;
+            PB_Move2.TabStop = false;
+            // 
+            // PB_Move1
+            // 
+            PB_Move1.Location = new System.Drawing.Point(8, 44);
+            PB_Move1.Margin = new System.Windows.Forms.Padding(0, 0, 8, 0);
+            PB_Move1.Name = "PB_Move1";
+            PB_Move1.Size = new System.Drawing.Size(24, 24);
+            PB_Move1.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
+            PB_Move1.TabIndex = 20;
+            PB_Move1.TabStop = false;
+            // 
+            // PB_Ball
+            // 
+            PB_Ball.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
+            PB_Ball.Location = new System.Drawing.Point(8, 8);
+            PB_Ball.Margin = new System.Windows.Forms.Padding(0);
+            PB_Ball.Name = "PB_Ball";
+            PB_Ball.Size = new System.Drawing.Size(24, 24);
+            PB_Ball.SizeMode = System.Windows.Forms.PictureBoxSizeMode.CenterImage;
+            PB_Ball.TabIndex = 19;
+            PB_Ball.TabStop = false;
+            // 
+            // PokePreview
+            // 
+            AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            ClientSize = new System.Drawing.Size(280, 156);
+            Controls.Add(panel1);
+            FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
+            MaximizeBox = false;
+            MinimizeBox = false;
+            Name = "PokePreview";
+            ShowIcon = false;
+            ShowInTaskbar = false;
+            Text = "PokePreview";
+            panel1.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)PB_Other).EndInit();
+            ((System.ComponentModel.ISupportInitialize)PB_Gender).EndInit();
+            ((System.ComponentModel.ISupportInitialize)PB_Type2).EndInit();
+            ((System.ComponentModel.ISupportInitialize)PB_Type1).EndInit();
+            ((System.ComponentModel.ISupportInitialize)PB_Move4).EndInit();
+            ((System.ComponentModel.ISupportInitialize)PB_Move3).EndInit();
+            ((System.ComponentModel.ISupportInitialize)PB_Move2).EndInit();
+            ((System.ComponentModel.ISupportInitialize)PB_Move1).EndInit();
+            ((System.ComponentModel.ISupportInitialize)PB_Ball).EndInit();
+            ResumeLayout(false);
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Panel panel1;
+        private System.Windows.Forms.PictureBox PB_Other;
+        private System.Windows.Forms.Label L_Stats;
+        private System.Windows.Forms.PictureBox PB_Gender;
+        private System.Windows.Forms.PictureBox PB_Type2;
+        private System.Windows.Forms.PictureBox PB_Type1;
+        private System.Windows.Forms.Label L_Move4;
+        private System.Windows.Forms.Label L_Move3;
+        private System.Windows.Forms.Label L_Move2;
+        private System.Windows.Forms.Label L_Move1;
+        private System.Windows.Forms.Label L_Name;
+        private System.Windows.Forms.PictureBox PB_Move4;
+        private System.Windows.Forms.PictureBox PB_Move3;
+        private System.Windows.Forms.PictureBox PB_Move2;
+        private System.Windows.Forms.PictureBox PB_Move1;
+        private System.Windows.Forms.PictureBox PB_Ball;
+    }
+}

--- a/PKHeX.WinForms/Controls/Slots/PokePreview.cs
+++ b/PKHeX.WinForms/Controls/Slots/PokePreview.cs
@@ -25,9 +25,10 @@ public partial class PokePreview : Form
 
     public void Populate(PKM pk)
     {
+        var la = new LegalityAnalysis(pk);
         PopulateHeader(pk);
-        PopulateMoves(pk);
-        PopulateText(pk);
+        PopulateMoves(pk, la);
+        PopulateText(pk, la);
     }
 
     private void PopulateHeader(PKM pk)
@@ -59,19 +60,19 @@ public partial class PokePreview : Form
         PB_Gender.Image = GenderImages[gender];
     }
 
-    private void PopulateMoves(PKM pk)
+    private void PopulateMoves(PKM pk, LegalityAnalysis la)
     {
         var context = pk.Context;
         var names = GameInfo.Strings.movelist;
-        Move1.Populate(pk.Move1, context, names);
-        Move2.Populate(pk.Move2, context, names);
-        Move3.Populate(pk.Move3, context, names);
-        Move4.Populate(pk.Move4, context, names);
+        Move1.Populate(pk.Move1, context, names, la.Info.Moves[0].Valid);
+        Move2.Populate(pk.Move2, context, names, la.Info.Moves[1].Valid);
+        Move3.Populate(pk.Move3, context, names, la.Info.Moves[2].Valid);
+        Move4.Populate(pk.Move4, context, names, la.Info.Moves[3].Valid);
     }
 
-    private void PopulateText(PKM pk)
+    private void PopulateText(PKM pk, LegalityAnalysis la)
     {
-        var (stats, enc) = GetStatsString(pk);
+        var (stats, enc) = GetStatsString(pk, la);
         var settings = Main.Settings.Hover;
         var height = FLP_List.Top + (pk.MoveCount * Move1.Height) + 4;
         var width = InitialWidth;
@@ -99,9 +100,9 @@ public partial class PokePreview : Form
         display.Visible = true;
     }
 
-    private static (string Detail, string Encounter) GetStatsString(PKM pk)
+    private static (string Detail, string Encounter) GetStatsString(PKM pk, LegalityAnalysis la)
     {
-        var setText = SummaryPreviewer.GetPreviewText(pk);
+        var setText = SummaryPreviewer.GetPreviewText(pk, la);
         var sb = new StringBuilder();
         var lines = setText.AsSpan().EnumerateLines();
         if (!lines.MoveNext())

--- a/PKHeX.WinForms/Controls/Slots/PokePreview.cs
+++ b/PKHeX.WinForms/Controls/Slots/PokePreview.cs
@@ -87,12 +87,16 @@ public partial class PokePreview : Form
         width = Math.Max(width, maxWidth + Move1.Margin.Horizontal + interiorMargin);
     }
 
-    private void PopulateText(PKM pk, LegalityAnalysis la, int minWidth)
+    private void PopulateText(PKM pk, LegalityAnalysis la, int width)
     {
         var (stats, enc) = GetStatsString(pk, la);
         var settings = Main.Settings.Hover;
-        var height = FLP_List.Top + FLP_Moves.Height + FLP_Moves.Margin.Vertical + interiorMargin;
-        var width = minWidth;
+
+        bool hasMoves = pk.MoveCount != 0;
+        FLP_Moves.Visible = hasMoves;
+        var height = FLP_List.Top + interiorMargin;
+        if (hasMoves)
+            height += FLP_Moves.Height + FLP_Moves.Margin.Vertical;
         ToggleLabel(L_Stats, stats, settings.PreviewShowPaste, ref width, ref height);
         ToggleLabel(L_Etc, enc, settings.HoverSlotShowEncounter, ref width, ref height);
         Size = new Size(width, height);
@@ -108,10 +112,7 @@ public partial class PokePreview : Form
 
         var size = MeasureSize(text, display.Font);
         width = Math.Max(width, display.Margin.Horizontal + size.Width);
-        var actHeight = size.Height;
-        height += actHeight + display.Margin.Vertical;
-        display.Width = size.Width;
-        display.Height = actHeight;
+        height += size.Height + display.Margin.Vertical;
         display.Text = text;
         display.Visible = true;
     }

--- a/PKHeX.WinForms/Controls/Slots/PokePreview.cs
+++ b/PKHeX.WinForms/Controls/Slots/PokePreview.cs
@@ -77,7 +77,7 @@ public partial class PokePreview : Form
         var settings = Main.Settings.Hover;
         var height = FLP_List.Top + FLP_Moves.Height + FLP_Moves.Margin.Vertical + 4; // 1px border * 4
         var width = InitialWidth;
-        ToggleLabel(L_Stats, stats, settings.HoverSlotShowPaste, ref width, ref height);
+        ToggleLabel(L_Stats, stats, settings.PreviewShowPaste, ref width, ref height);
         ToggleLabel(L_Etc, enc, settings.HoverSlotShowEncounter, ref width, ref height);
         Size = new Size(width, height);
     }

--- a/PKHeX.WinForms/Controls/Slots/PokePreview.cs
+++ b/PKHeX.WinForms/Controls/Slots/PokePreview.cs
@@ -64,10 +64,10 @@ public partial class PokePreview : Form
     {
         var context = pk.Context;
         var names = GameInfo.Strings.movelist;
-        Move1.Populate(pk.Move1, context, names, la.Info.Moves[0].Valid);
-        Move2.Populate(pk.Move2, context, names, la.Info.Moves[1].Valid);
-        Move3.Populate(pk.Move3, context, names, la.Info.Moves[2].Valid);
-        Move4.Populate(pk.Move4, context, names, la.Info.Moves[3].Valid);
+        Move1.Populate(pk, pk.Move1, context, names, la.Info.Moves[0].Valid);
+        Move2.Populate(pk, pk.Move2, context, names, la.Info.Moves[1].Valid);
+        Move3.Populate(pk, pk.Move3, context, names, la.Info.Moves[2].Valid);
+        Move4.Populate(pk, pk.Move4, context, names, la.Info.Moves[3].Valid);
     }
 
     private void PopulateText(PKM pk, LegalityAnalysis la)

--- a/PKHeX.WinForms/Controls/Slots/PokePreview.cs
+++ b/PKHeX.WinForms/Controls/Slots/PokePreview.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Drawing;
+using System.Text;
+using System.Windows.Forms;
+using PKHeX.Core;
+using PKHeX.Drawing.Misc;
+
+namespace PKHeX.WinForms.Controls;
+
+public partial class PokePreview : Form
+{
+    public PokePreview() => InitializeComponent();
+
+    private static readonly Image[] GenderImages =
+    {
+        Properties.Resources.gender_0,
+        Properties.Resources.gender_1,
+        Properties.Resources.gender_2,
+    };
+
+    public void Populate(PKM pk)
+    {
+        var pi = pk.PersonalInfo;
+        PopulateHeader(pk, pi);
+        PopulateMoves(pk);
+        PopulateStats(pk, pi);
+    }
+
+    private void PopulateHeader(PKM pk, IPersonalType pi)
+    {
+        L_Name.Text = pk.Nickname;
+        PopulateBall(pk);
+        PopulateGender(pk);
+        PopulateExtra(pk);
+
+        var type1 = pi.Type1;
+        var type2 = pi.Type2;
+        PB_Type1.Image = TypeSpriteUtil.GetTypeSpriteIcon(type1);
+        PB_Type2.Image = type1 == type2 ? null : TypeSpriteUtil.GetTypeSpriteIcon(type2);
+    }
+
+    private void PopulateBall(PKM pk)
+    {
+        int ball = (int)Ball.Poke;
+        if (pk.Format >= 3)
+            ball = pk.Ball;
+        PB_Ball.Image = Drawing.PokeSprite.SpriteUtil.GetBallSprite(ball);
+    }
+
+    private void PopulateExtra(PKM pk)
+    {
+        if (pk is IGigantamaxReadOnly { CanGigantamax: true })
+            PB_Other.Image = Drawing.PokeSprite.Properties.Resources.dyna;
+        else if (pk is ITeraTypeReadOnly tera)
+            PB_Other.Image = TypeSpriteUtil.GetTypeSpriteGem((byte)tera.TeraType);
+        else
+            PB_Other.Image = null;
+    }
+
+    private void PopulateGender(PKM pk)
+    {
+        if (pk.Format == 1)
+        {
+            PB_Gender.Image = null;
+            return;
+        }
+
+        var gender = pk.Gender;
+        if (gender > GenderImages.Length)
+            gender = 2;
+        PB_Gender.Image = GenderImages[gender];
+    }
+
+    private void PopulateMoves(PKM pk)
+    {
+        var context = pk.Context;
+        var names = GameInfo.Strings.movelist;
+        ToggleMove(PB_Move1, L_Move1, pk.Move1, names, context);
+        ToggleMove(PB_Move2, L_Move2, pk.Move2, names, context);
+        ToggleMove(PB_Move3, L_Move3, pk.Move3, names, context);
+        ToggleMove(PB_Move4, L_Move4, pk.Move4, names, context);
+    }
+
+    private static void ToggleMove(PictureBox type, Control text, ushort move, ReadOnlySpan<string> moves, EntityContext context)
+    {
+        if (move == 0 || move >= moves.Length)
+        {
+            type.Visible = text.Visible = false;
+            return;
+        }
+
+        var moveType = MoveInfo.GetType(move, context);
+        type.Image = TypeSpriteUtil.GetTypeSpriteIcon(moveType);
+        type.Visible = text.Visible = true;
+        text.Text = moves[move];
+    }
+
+    private void PopulateStats(PKM pk, PersonalInfo pi)
+    {
+        var sb = new StringBuilder(128);
+        sb.AppendLine("* Base IV EV");
+        sb.AppendLine($"H {pi.HP:000}  {pk.IV_HP:00} {pk.EV_HP,-3}");
+        sb.AppendLine($"A {pi.ATK:000}  {pk.IV_ATK:00} {pk.EV_ATK,-3}");
+        sb.AppendLine($"B {pi.DEF:000}  {pk.IV_DEF:00} {pk.EV_DEF,-3}");
+        sb.AppendLine($"C {pi.SPA:000}  {pk.IV_SPA:00} {pk.EV_SPA,-3}");
+        sb.AppendLine($"D {pi.SPD:000}  {pk.IV_SPD:00} {pk.EV_SPD,-3}");
+        sb.AppendLine($"S {pi.SPE:000}  {pk.IV_SPE:00} {pk.EV_SPE,-3}");
+        L_Stats.Text = sb.ToString();
+    }
+}

--- a/PKHeX.WinForms/Controls/Slots/PokePreview.cs
+++ b/PKHeX.WinForms/Controls/Slots/PokePreview.cs
@@ -8,13 +8,14 @@ namespace PKHeX.WinForms.Controls;
 
 public partial class PokePreview : Form
 {
+    /// <summary> Minimum width to display the form. </summary>
+    private readonly int InitialWidth;
+
     public PokePreview()
     {
         InitializeComponent();
         InitialWidth = Width;
     }
-
-    private readonly int InitialWidth;
 
     private static readonly Image[] GenderImages =
     {
@@ -146,5 +147,19 @@ public partial class PokePreview : Form
         return (detail.TrimEnd(), enc.TrimEnd());
 
         static bool IsMoveLine(ReadOnlySpan<char> line) => line.Length != 0 && line[0] == '-';
+    }
+
+    /// <summary> Prevent stealing focus from the form that shows this. </summary>
+    protected override bool ShowWithoutActivation => true;
+
+    private const int WS_EX_TOPMOST = 0x00000008;
+    protected override CreateParams CreateParams
+    {
+        get
+        {
+            CreateParams createParams = base.CreateParams;
+            createParams.ExStyle |= WS_EX_TOPMOST;
+            return createParams;
+        }
     }
 }

--- a/PKHeX.WinForms/Controls/Slots/PokePreview.cs
+++ b/PKHeX.WinForms/Controls/Slots/PokePreview.cs
@@ -74,7 +74,7 @@ public partial class PokePreview : Form
     {
         var (stats, enc) = GetStatsString(pk, la);
         var settings = Main.Settings.Hover;
-        var height = FLP_List.Top + (pk.MoveCount * Move1.Height) + 4;
+        var height = FLP_List.Top + FLP_Moves.Height + FLP_Moves.Margin.Vertical + 4; // 1px border * 4
         var width = InitialWidth;
         ToggleLabel(L_Stats, stats, settings.HoverSlotShowPaste, ref width, ref height);
         ToggleLabel(L_Etc, enc, settings.HoverSlotShowEncounter, ref width, ref height);
@@ -89,12 +89,13 @@ public partial class PokePreview : Form
             return;
         }
 
-        const int factor = 8;
-        var size = TextRenderer.MeasureText(text, Font);
-        width = Math.Max(width, display.Left + size.Width + factor);
-        var actHeight = (int)Math.Round((size.Height + factor) / (double)factor, MidpointRounding.AwayFromZero) * factor;
-        height += actHeight + display.Margin.Top;
-        display.Width = size.Width + factor - display.Left;
+        const TextFormatFlags flags = TextFormatFlags.LeftAndRightPadding | TextFormatFlags.VerticalCenter;
+
+        var size = TextRenderer.MeasureText(text, Font, new Size(), flags);
+        width = Math.Max(width, display.Margin.Horizontal + size.Width);
+        var actHeight = size.Height;
+        height += actHeight + display.Margin.Vertical;
+        display.Width = size.Width;
         display.Height = actHeight;
         display.Text = text;
         display.Visible = true;

--- a/PKHeX.WinForms/Controls/Slots/SlotHoverHandler.cs
+++ b/PKHeX.WinForms/Controls/Slots/SlotHoverHandler.cs
@@ -15,8 +15,7 @@ public sealed class SlotHoverHandler : IDisposable
     public DrawConfig Draw { private get; set; } = new();
     public bool GlowHover { private get; set; } = true;
 
-    public static readonly CryPlayer CryPlayer = new();
-    public static readonly SummaryPreviewer Preview = new();
+    private readonly SummaryPreviewer Preview = new();
     private static Bitmap Hover => SpriteUtil.Spriter.Hover;
 
     private readonly BitmapAnimator HoverWorker = new();
@@ -79,5 +78,10 @@ public sealed class SlotHoverHandler : IDisposable
         HoverWorker.Dispose();
         Slot = null;
         Draw.Dispose();
+    }
+
+    public void UpdateMousePosition(Point location)
+    {
+        Preview.UpdatePreviewPosition(location);
     }
 }

--- a/PKHeX.WinForms/Controls/Slots/SummaryPreviewer.cs
+++ b/PKHeX.WinForms/Controls/Slots/SummaryPreviewer.cs
@@ -14,6 +14,7 @@ public sealed class SummaryPreviewer
     private readonly CryPlayer Cry = new();
     private readonly PokePreview Previewer = new();
     private CancellationTokenSource _source = new();
+    private static HoverSettings Settings => Main.Settings.Hover;
 
     public void Show(Control pb, PKM pk)
     {
@@ -23,11 +24,11 @@ public sealed class SummaryPreviewer
             return;
         }
 
-        if (Main.Settings.Hover.HoverSlotShowPreview && Control.ModifierKeys != Keys.Alt)
+        if (Settings.HoverSlotShowPreview && Control.ModifierKeys != Keys.Alt)
             UpdatePreview(pb, pk);
-        else if (Main.Settings.Hover.HoverSlotShowText)
+        else if (Settings.HoverSlotShowText)
             ShowSet.SetToolTip(pb, GetPreviewText(pk, new LegalityAnalysis(pk)));
-        if (Main.Settings.Hover.HoverSlotPlayCry)
+        if (Settings.HoverSlotPlayCry)
             Cry.PlayCry(pk, pk.Context);
     }
 
@@ -43,8 +44,8 @@ public sealed class SummaryPreviewer
     public void UpdatePreviewPosition(Point location)
     {
         var cLoc = Cursor.Position;
-        var cSize = Cursor.Current?.Size ?? new Size(16, 8);
-        Previewer.Location = cLoc with { X = cLoc.X + (cSize.Width / 2), Y = cLoc.Y + (cSize.Height / 4)};
+        var shift = Settings.PreviewCursorShift;
+        Previewer.Location = cLoc with { X = cLoc.X + shift.X, Y = cLoc.Y + shift.Y };
     }
 
     public void Show(Control pb, IEncounterInfo enc)
@@ -55,9 +56,9 @@ public sealed class SummaryPreviewer
             return;
         }
 
-        if (Main.Settings.Hover.HoverSlotShowText)
+        if (Settings.HoverSlotShowText)
             ShowSet.SetToolTip(pb, GetPreviewText(enc));
-        if (Main.Settings.Hover.HoverSlotPlayCry)
+        if (Settings.HoverSlotPlayCry)
             Cry.PlayCry(enc, enc.Context);
     }
 

--- a/PKHeX.WinForms/Controls/Slots/SummaryPreviewer.cs
+++ b/PKHeX.WinForms/Controls/Slots/SummaryPreviewer.cs
@@ -42,8 +42,9 @@ public sealed class SummaryPreviewer
 
     public void UpdatePreviewPosition(Point location)
     {
-        var pt = Cursor.Position;
-        Previewer.Location = pt with { X = pt.X + 12, Y = pt.Y + 8 };
+        var cLoc = Cursor.Position;
+        var cSize = Cursor.Current?.Size ?? new Size(16, 8);
+        Previewer.Location = cLoc with { X = cLoc.X + (cSize.Width / 2), Y = cLoc.Y + (cSize.Height / 4)};
     }
 
     public void Show(Control pb, IEncounterInfo enc)

--- a/PKHeX.WinForms/Controls/Slots/SummaryPreviewer.cs
+++ b/PKHeX.WinForms/Controls/Slots/SummaryPreviewer.cs
@@ -77,6 +77,8 @@ public sealed class SummaryPreviewer
     public static string GetPreviewText(PKM pk, LegalityAnalysis la)
     {
         var text = ShowdownParsing.GetLocalizedPreviewText(pk, Main.Settings.Startup.Language);
+        if (!Main.Settings.Hover.HoverSlotShowEncounter)
+            return text;
         var result = new List<string> { text, string.Empty };
         LegalityFormatting.AddEncounterInfo(la, result);
         return string.Join(Environment.NewLine, result);

--- a/PKHeX.WinForms/Controls/Slots/SummaryPreviewer.cs
+++ b/PKHeX.WinForms/Controls/Slots/SummaryPreviewer.cs
@@ -45,7 +45,8 @@ public sealed class SummaryPreviewer
     {
         var cLoc = Cursor.Position;
         var shift = Settings.PreviewCursorShift;
-        Previewer.Location = cLoc with { X = cLoc.X + shift.X, Y = cLoc.Y + shift.Y };
+        cLoc.Offset(shift);
+        Previewer.Location = cLoc;
     }
 
     public void Show(Control pb, IEncounterInfo enc)

--- a/PKHeX.WinForms/Controls/Slots/SummaryPreviewer.cs
+++ b/PKHeX.WinForms/Controls/Slots/SummaryPreviewer.cs
@@ -26,7 +26,7 @@ public sealed class SummaryPreviewer
         if (Main.Settings.Hover.HoverSlotShowPreview && Control.ModifierKeys != Keys.Alt)
             UpdatePreview(pb, pk);
         else if (Main.Settings.Hover.HoverSlotShowText)
-            ShowSet.SetToolTip(pb, GetPreviewText(pk));
+            ShowSet.SetToolTip(pb, GetPreviewText(pk, new LegalityAnalysis(pk)));
         if (Main.Settings.Hover.HoverSlotPlayCry)
             Cry.PlayCry(pk, pk.Context);
     }
@@ -73,10 +73,9 @@ public sealed class SummaryPreviewer
         Cry.Stop();
     }
 
-    public static string GetPreviewText(PKM pk)
+    public static string GetPreviewText(PKM pk, LegalityAnalysis la)
     {
         var text = ShowdownParsing.GetLocalizedPreviewText(pk, Main.Settings.Startup.Language);
-        var la = new LegalityAnalysis(pk);
         var result = new List<string> { text, string.Empty };
         LegalityFormatting.AddEncounterInfo(la, result);
         return string.Join(Environment.NewLine, result);

--- a/PKHeX.WinForms/Controls/Slots/SummaryPreviewer.cs
+++ b/PKHeX.WinForms/Controls/Slots/SummaryPreviewer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Windows.Forms;
 using PKHeX.Core;
 
@@ -9,6 +10,7 @@ public sealed class SummaryPreviewer
 {
     private readonly ToolTip ShowSet = new() { InitialDelay = 200, IsBalloon = false, AutoPopDelay = 32_767 };
     private readonly CryPlayer Cry = new();
+    private readonly PokePreview Previewer = new();
 
     public void Show(Control pb, PKM pk)
     {
@@ -18,17 +20,25 @@ public sealed class SummaryPreviewer
             return;
         }
 
-        if (Main.Settings.Hover.HoverSlotShowText)
-        {
-            var text = ShowdownParsing.GetLocalizedPreviewText(pk, Main.Settings.Startup.Language);
-            var la = new LegalityAnalysis(pk);
-            var result = new List<string> { text, string.Empty };
-            LegalityFormatting.AddEncounterInfo(la, result);
-            ShowSet.SetToolTip(pb, string.Join(Environment.NewLine, result));
-        }
-
+        if (Main.Settings.Hover.HoverSlotShowPreview && Control.ModifierKeys != Keys.Alt)
+            UpdatePreview(pb, pk);
+        else if (Main.Settings.Hover.HoverSlotShowText)
+            ShowSet.SetToolTip(pb, GetPreviewText(pk));
         if (Main.Settings.Hover.HoverSlotPlayCry)
             Cry.PlayCry(pk, pk.Context);
+    }
+
+    private void UpdatePreview(Control pb, PKM pk)
+    {
+        UpdatePreviewPosition(new());
+        Previewer.Populate(pk);
+        Previewer.Show();
+    }
+
+    public void UpdatePreviewPosition(Point location)
+    {
+        var pt = Cursor.Position;
+        Previewer.Location = pt with { X = pt.X + 12, Y = pt.Y + 8 };
     }
 
     public void Show(Control pb, IEncounterInfo enc)
@@ -40,19 +50,30 @@ public sealed class SummaryPreviewer
         }
 
         if (Main.Settings.Hover.HoverSlotShowText)
-        {
-            var lines = enc.GetTextLines(GameInfo.Strings);
-            var text = string.Join(Environment.NewLine, lines);
-            ShowSet.SetToolTip(pb, text);
-        }
-
+            ShowSet.SetToolTip(pb, GetPreviewText(enc));
         if (Main.Settings.Hover.HoverSlotPlayCry)
             Cry.PlayCry(enc, enc.Context);
     }
 
     public void Clear()
     {
+        Previewer.Hide();
         ShowSet.RemoveAll();
         Cry.Stop();
+    }
+
+    private static string GetPreviewText(PKM pk)
+    {
+        var text = ShowdownParsing.GetLocalizedPreviewText(pk, Main.Settings.Startup.Language);
+        var la = new LegalityAnalysis(pk);
+        var result = new List<string> { text, string.Empty };
+        LegalityFormatting.AddEncounterInfo(la, result);
+        return string.Join(Environment.NewLine, result);
+    }
+
+    private static string GetPreviewText(IEncounterInfo enc)
+    {
+        var lines = enc.GetTextLines(GameInfo.Strings);
+        return string.Join(Environment.NewLine, lines);
     }
 }

--- a/PKHeX.WinForms/Controls/Slots/SummaryPreviewer.cs
+++ b/PKHeX.WinForms/Controls/Slots/SummaryPreviewer.cs
@@ -62,7 +62,7 @@ public sealed class SummaryPreviewer
         Cry.Stop();
     }
 
-    private static string GetPreviewText(PKM pk)
+    public static string GetPreviewText(PKM pk)
     {
         var text = ShowdownParsing.GetLocalizedPreviewText(pk, Main.Settings.Startup.Language);
         var la = new LegalityAnalysis(pk);

--- a/PKHeX.WinForms/MainWindow/Main.cs
+++ b/PKHeX.WinForms/MainWindow/Main.cs
@@ -380,7 +380,7 @@ public partial class Main : Form
         }
     }
 
-    private static bool IsPopupFormType(Form z) => z is not (Main or SplashScreen or SAV_FolderList);
+    private static bool IsPopupFormType(Form z) => z is not (Main or SplashScreen or SAV_FolderList or PokePreview);
 
     private void MainMenuSettings(object sender, EventArgs e)
     {

--- a/PKHeX.WinForms/Properties/PKHeXSettings.cs
+++ b/PKHeX.WinForms/Properties/PKHeXSettings.cs
@@ -317,6 +317,9 @@ public sealed class MysteryGiftDatabaseSettings
 [Serializable]
 public sealed class HoverSettings
 {
+    [LocalizedDescription("Show PKM Slot Preview on Hover")]
+    public bool HoverSlotShowPreview { get; set; } = true;
+
     [LocalizedDescription("Show PKM Slot ToolTip on Hover")]
     public bool HoverSlotShowText { get; set; } = true;
 

--- a/PKHeX.WinForms/Properties/PKHeXSettings.cs
+++ b/PKHeX.WinForms/Properties/PKHeXSettings.cs
@@ -320,6 +320,12 @@ public sealed class HoverSettings
     [LocalizedDescription("Show PKM Slot Preview on Hover")]
     public bool HoverSlotShowPreview { get; set; } = true;
 
+    [LocalizedDescription("Show Showdown Paste in special Preview on Hover")]
+    public bool HoverSlotShowPaste { get; set; } = true;
+
+    [LocalizedDescription("Show Encounter Info in special Preview on Hover")]
+    public bool HoverSlotShowEncounter { get; set; } = true;
+
     [LocalizedDescription("Show PKM Slot ToolTip on Hover")]
     public bool HoverSlotShowText { get; set; } = true;
 

--- a/PKHeX.WinForms/Properties/PKHeXSettings.cs
+++ b/PKHeX.WinForms/Properties/PKHeXSettings.cs
@@ -320,10 +320,7 @@ public sealed class HoverSettings
     [LocalizedDescription("Show PKM Slot Preview on Hover")]
     public bool HoverSlotShowPreview { get; set; } = true;
 
-    [LocalizedDescription("Show Showdown Paste in special Preview on Hover")]
-    public bool HoverSlotShowPaste { get; set; } = true;
-
-    [LocalizedDescription("Show Encounter Info in special Preview on Hover")]
+    [LocalizedDescription("Show Encounter Info in on Hover")]
     public bool HoverSlotShowEncounter { get; set; } = true;
 
     [LocalizedDescription("Show PKM Slot ToolTip on Hover")]
@@ -334,6 +331,12 @@ public sealed class HoverSettings
 
     [LocalizedDescription("Show a Glow effect around the PKM on Hover")]
     public bool HoverSlotGlowEdges { get; set; } = true;
+
+    [LocalizedDescription("Show Showdown Paste in special Preview on Hover")]
+    public bool PreviewShowPaste { get; set; } = true;
+
+    [LocalizedDescription("Show a Glow effect around the PKM on Hover")]
+    public Point PreviewCursorShift { get; set; } = new(16, 8);
 }
 
 [Serializable]

--- a/PKHeX.WinForms/Subforms/SAV_Database.cs
+++ b/PKHeX.WinForms/Subforms/SAV_Database.cs
@@ -77,7 +77,11 @@ public partial class SAV_Database : Form
 
             slot.ContextMenuStrip = mnu;
             if (Main.Settings.Hover.HoverSlotShowText)
+            {
+                slot.MouseMove += (o, args) => ShowSet.UpdatePreviewPosition(args.Location);
                 slot.MouseEnter += (o, args) => ShowHoverTextForSlot(slot, args);
+                slot.MouseLeave += (o, args) => ShowSet.Clear();
+            }
             slot.Enter += (sender, e) =>
             {
                 if (sender is not PictureBox pb)
@@ -121,6 +125,7 @@ public partial class SAV_Database : Form
         };
         CB_Format.Items[0] = MsgAny;
         CenterToParent();
+        Closing += (sender, e) => ShowSet.Clear();
     }
 
     private readonly PictureBox[] PKXBOXES;

--- a/PKHeX.WinForms/Subforms/SAV_Database.cs
+++ b/PKHeX.WinForms/Subforms/SAV_Database.cs
@@ -620,8 +620,10 @@ public partial class SAV_Database : Form
 
     private void UpdateScroll(object sender, ScrollEventArgs e)
     {
-        if (e.OldValue != e.NewValue)
-            FillPKXBoxes(e.NewValue);
+        if (e.OldValue == e.NewValue)
+            return;
+        FillPKXBoxes(e.NewValue);
+        ShowSet.Clear();
     }
 
     private void SetResults(List<SlotCache> res)
@@ -693,8 +695,10 @@ public partial class SAV_Database : Form
             return;
         int oldval = SCR_Box.Value;
         int newval = oldval + (e.Delta < 0 ? 1 : -1);
-        if (newval >= SCR_Box.Minimum && SCR_Box.Maximum >= newval)
-            FillPKXBoxes(SCR_Box.Value = newval);
+        if (newval < SCR_Box.Minimum || SCR_Box.Maximum < newval)
+            return;
+        FillPKXBoxes(SCR_Box.Value = newval);
+        ShowSet.Clear();
     }
 
     private void ChangeFormatFilter(object sender, EventArgs e)

--- a/PKHeX.WinForms/Subforms/SAV_MysteryGiftDB.cs
+++ b/PKHeX.WinForms/Subforms/SAV_MysteryGiftDB.cs
@@ -359,8 +359,10 @@ public partial class SAV_MysteryGiftDB : Form
 
     private void UpdateScroll(object sender, ScrollEventArgs e)
     {
-        if (e.OldValue != e.NewValue)
-            FillPKXBoxes(e.NewValue);
+        if (e.OldValue == e.NewValue)
+            return;
+        FillPKXBoxes(e.NewValue);
+        ShowSet.Clear();
     }
 
     private void SetResults(List<MysteryGift> res)
@@ -369,7 +371,8 @@ public partial class SAV_MysteryGiftDB : Form
         ShowSet.Clear();
 
         SCR_Box.Maximum = (int)Math.Ceiling((decimal)Results.Count / RES_MIN);
-        if (SCR_Box.Maximum > 0) SCR_Box.Maximum--;
+        if (SCR_Box.Maximum > 0)
+            SCR_Box.Maximum--;
 
         SCR_Box.Value = 0;
         FillPKXBoxes(0);
@@ -428,8 +431,10 @@ public partial class SAV_MysteryGiftDB : Form
             return;
         int oldval = SCR_Box.Value;
         int newval = oldval + (e.Delta < 0 ? 1 : -1);
-        if (newval >= SCR_Box.Minimum && SCR_Box.Maximum >= newval)
-            FillPKXBoxes(SCR_Box.Value = newval);
+        if (newval < SCR_Box.Minimum || SCR_Box.Maximum < newval)
+            return;
+        FillPKXBoxes(SCR_Box.Value = newval);
+        ShowSet.Clear();
     }
 
     private void ChangeFormatFilter(object sender, EventArgs e)

--- a/PKHeX.WinForms/Subforms/Save Editors/SAV_GroupViewer.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/SAV_GroupViewer.cs
@@ -37,9 +37,12 @@ public sealed partial class SAV_GroupViewer : Form
         foreach (PictureBox pb in Box.Entries)
         {
             pb.Click += (o, args) => OmniClick(pb, args);
-            pb.MouseHover += (o, args) => HoverSlot(pb, args);
             pb.ContextMenuStrip = mnu;
+            pb.MouseMove += (o, args) => Preview.UpdatePreviewPosition(args.Location);
+            pb.MouseEnter += (o, args) => HoverSlot(pb, args);
+            pb.MouseLeave += (o, args) => Preview.Clear();
         }
+        Closing += (s, e) => Preview.Clear();
     }
 
     private void HoverSlot(object sender, EventArgs e)


### PR DESCRIPTION
When the user hovers over a slot in their Box / Party, PKHeX displays a tooltip indicating details about the Pokémon. This text tooltip shows the `Showdown` text (with some localization based on program setting), and includes details about the encounter the legality check matched it to.

Example:
![image](https://github.com/kwsch/PKHeX/assets/6393368/48b96f31-9568-4caf-8266-38d1a6ad914c)

The tooltip functionality is slightly clunky and isn't feasible to customize; instead, we can create a popup form and stylize it as we wish. This pull request adds a replacement to the existing behavior.

New behavior can...
* be reverted by the user via program settings, to instead use the old tooltip.
* turn off extra details (encounter details, and paste too).
* adjust the positioning the form appears at, relative to the user's cursor.

Additional behaviors implemented:
* Moves are shown with type icons instead of bland `-` prefix.
* Held Item is displayed beneath the header instead of in the header (like Showdown paste)
* Form will follow the user's cursor as they move it. If moving outside of a slot, there's a small (50ms) delay in the form closing. If the user hovers over another slot, the form will instead stay open and display details for the new slot.
* Form will auto-expand/contract between slots.
* Nicknames that are long will expand the preview's header.
* Move names that are long (other languages) will expand the preview's width.
* Hidden Power in Gen2-7 will show the effective typing and base power.
* Illegal moves are shown with Red text instead of Black.

Examples:
- Encounter Details Hidden:
![image](https://github.com/kwsch/PKHeX/assets/6393368/869b21bd-a7dd-4e86-982f-7e5b44aacfb4)
- Encounter & Paste Hidden:
![image](https://github.com/kwsch/PKHeX/assets/6393368/c64a7e17-dc43-4cd2-8b89-4b2ddf63bf6d)
- Hidden Power (Gen5):
![image](https://github.com/kwsch/PKHeX/assets/6393368/78d71a56-a38a-4329-93dc-9ef4cd0e174f)

Slot movement (positioning of labels has been improved since the gif was recorded)
![newhover](https://github.com/kwsch/PKHeX/assets/6393368/6dafa04b-6bab-49d0-b492-bd938f8b9113)
