### PR TITLE
Secondary heuristic to distinguish SAV1 save files versions

### DIFF
--- a/PKHeX.Core/Saves/SAV1.cs
+++ b/PKHeX.Core/Saves/SAV1.cs
@@ -55,8 +55,13 @@ public sealed class SAV1 : SaveFile, ILangDeviantSave, IEventFlagArray, IEventWo
     private void Initialize(GameVersion versionOverride)
     {
         // see if RBY can be differentiated
-        if (Starter != 0 && versionOverride is not (GameVersion.RB or GameVersion.YW))
-            Version = Yellow ? GameVersion.YW : GameVersion.RB;
+        if (versionOverride is not (GameVersion.RB or GameVersion.YW))
+        {
+            if (Starter != 0)
+                Version = Yellow ? GameVersion.YW : GameVersion.RB;
+            else
+                Version = Data[Offsets.PikaFriendship] != 0 ? GameVersion.YW : GameVersion.RB;
+        }
 
         Box = Data.Length;
         Array.Resize(ref Data, Data.Length + SIZE_RESERVED);

--- a/PKHeX.Core/Saves/Substructures/Gen12/G1OverworldSpawner.cs
+++ b/PKHeX.Core/Saves/Substructures/Gen12/G1OverworldSpawner.cs
@@ -16,7 +16,7 @@ public sealed class G1OverworldSpawner
         SAV = sav;
         EventFlags = sav.GetEventFlags();
         SpawnFlags = sav.EventSpawnFlags;
-        bool yellow = SAV.Yellow;
+        bool yellow = SAV.Version == GameVersion.YW;
 
         // FlagPairs set for Red/Blue when appropriate.
         FlagEevee = new FlagPairG1(0x45);


### PR DESCRIPTION
This PR adds a secondary heuristic based on PikaFriendship value, that has a fixed value of 90 when save data is initialized in YW, and is always 0 in RB.
This covers the small gap between the time the user can perform the first save game, and when the Starter was received.

As alternative check, it was discovered that an unused Hide-Show flag in YW is kept always set, while in RB this is always unused flag data.
`Version = Data[Offsets.ObjectSpawnFlags + 0x1D] != 0x00 ? GameVersion.Y : GameVersion.RB;`

Also, changes to 'G1OverworldSpawner' so that it checks by Version instead of Starter value that may not be set yet.

Having this distinguished as early as first save point, it allows plugins to behave correctly with known data.