### PR TITLE
Add B2W2 Volcarona Event Flags

### DIFF
--- a/PKHeX.Core/Resources/text/script/gen5/flags_b2w2_en.txt
+++ b/PKHeX.Core/Resources/text/script/gen5/flags_b2w2_en.txt
@@ -4,6 +4,9 @@
 0329	r	Terrakion (Rematch, Level +20)
 0801	r	Virizion Disappeared
 0300	r	Virizion (Rematch, Level +20)
+0928    r   Volcarona Disappeared
+0403    r   Volcarona Captured (Level 35/65)
+0404    r   Volcarona Defeated (Level 35)
 0667	r	Reshiram/Zekrom Disappeared
 1004	r	Kyurem Disappeared
 0922	r	Regirock Disappeared

--- a/PKHeX.Core/Resources/text/script/gen5/flags_b2w2_es.txt
+++ b/PKHeX.Core/Resources/text/script/gen5/flags_b2w2_es.txt
@@ -4,6 +4,9 @@
 0329	r	Terrakion (Revancha, Nivel +20)
 0801	r	Virizion Desaparecido
 0300	r	Virizion (Revancha, Nivel +20)
+0928    r   Volcarona Disappeared
+0403    r   Volcarona Captured (Level 35/65)
+0404    r   Volcarona Defeated (Level 35)
 0667	r	Reshiram/Zekrom Desaparecido
 1004	r	Kyurem Desaparecido
 0922	r	Regirock Desaparecido

--- a/PKHeX.Core/Resources/text/script/gen5/flags_b2w2_ja.txt
+++ b/PKHeX.Core/Resources/text/script/gen5/flags_b2w2_ja.txt
@@ -4,6 +4,9 @@
 0329	r	テラキオン (再戦・レベル+20)
 0801	r	ビリジオン (戦闘済み)
 0300	r	ビリジオン (再戦・レベル+20)
+0928    r   Volcarona Disappeared
+0403    r   Volcarona Captured (Level 35/65)
+0404    r   Volcarona Defeated (Level 35)
 0667	r	レシラム / ゼクロム (戦闘済み)
 1004	r	キュレム (戦闘済み)
 0922	r	レジロック (戦闘済み)

--- a/PKHeX.Core/Resources/text/script/gen5/flags_b2w2_ko.txt
+++ b/PKHeX.Core/Resources/text/script/gen5/flags_b2w2_ko.txt
@@ -4,6 +4,9 @@
 0329	r	테라키온 (재대결, 레벨 +20)
 0801	r	비리디온 사라짐
 0300	r	비리디온 (재대결, 레벨 +20)
+0928    r   Volcarona Disappeared
+0403    r   Volcarona Captured (Level 35/65)
+0404    r   Volcarona Defeated (Level 35)
 0667	r	레시라무/제크로무 사라짐
 1004	r	큐레무 사라짐
 0922	r	레지락 사라짐

--- a/PKHeX.Core/Resources/text/script/gen5/flags_b2w2_zh.txt
+++ b/PKHeX.Core/Resources/text/script/gen5/flags_b2w2_zh.txt
@@ -4,6 +4,9 @@
 0329	r	代拉基翁 (重战, 等级 +20)
 0801	r	毕力吉翁 已消失
 0300	r	毕力吉翁 (重战, 等级 +20)
+0928    r   Volcarona Disappeared
+0403    r   Volcarona Captured (Level 35/65)
+0404    r   Volcarona Defeated (Level 35)
 0667	r	莱希拉姆/捷克罗姆 已消失
 1004	r	酋雷姆 已消失
 0922	r	雷吉洛克 已消失

--- a/PKHeX.Core/Resources/text/script/gen5/flags_b2w2_zh2.txt
+++ b/PKHeX.Core/Resources/text/script/gen5/flags_b2w2_zh2.txt
@@ -4,6 +4,9 @@
 0329	r	代拉基翁 (重戰, 等級 +20)
 0801	r	畢力吉翁 已消失
 0300	r	畢力吉翁 (重戰, 等級 +20)
+0928    r   Volcarona Disappeared
+0403    r   Volcarona Captured (Level 35/65)
+0404    r   Volcarona Defeated (Level 35)
 0667	r	萊希拉姆/捷克羅姆 已消失
 1004	r	酋雷姆 已消失
 0922	r	雷吉洛克 已消失


### PR DESCRIPTION
Tested myself.

Courtesy from https://projectpokemon.org/home/forums/topic/64099-no-event-flags-for-volcarona-black-2-white-2/