### PR TITLE
Fix Max Memory Intensity

### DIFF
--- a/PKHeX.Core/Legality/Restrictions/Memories/MemoryContext6.cs
+++ b/PKHeX.Core/Legality/Restrictions/Memories/MemoryContext6.cs
@@ -122,7 +122,7 @@ public sealed partial class MemoryContext6 : MemoryContext
         return (MemoryFeelings[memory] & (1 << feeling)) != 0;
     }
 
-    public const byte MaxIntensity = 6;
+    public const byte MaxIntensity = 7;
 
     public static bool CanHaveIntensity6(int memory, int intensity)
     {

--- a/PKHeX.Core/Legality/Restrictions/Memories/MemoryContext8.cs
+++ b/PKHeX.Core/Legality/Restrictions/Memories/MemoryContext8.cs
@@ -178,7 +178,7 @@ public sealed partial class MemoryContext8 : MemoryContext
         return (MemoryFeelings[memory] & (1 << --feeling)) != 0;
     }
 
-    public const byte MaxIntensity = 6;
+    public const byte MaxIntensity = 7;
 
     public static bool CanHaveIntensity8(byte memory, byte intensity)
     {


### PR DESCRIPTION
From the saves I have it appears that memory intensity goes from 0 to 7 rather than 0 to 6.