### PR TITLE
Fix 3DS country/region names

### DIFF
--- a/PKHeX.Core/Resources/text/locale3DS/subregions/sr_001.txt
+++ b/PKHeX.Core/Resources/text/locale3DS/subregions/sr_001.txt
@@ -2,15 +2,15 @@
 002	東京都	Tokyo	Tokyo	Tokio	Tokyo	Tokio	东京都	도쿄 도	東京都
 003	北海道	Hokkaido	Hokkaido	Hokkaido	Hokkaido	Hokaido	北海道	홋카이도	北海道
 004	青森県	Aomori	Aomori	Aomori	Aomori	Aomori	青森县	아오모리 현	青森縣
-005	岩手県	Iwate	Iwate	Iwate	Iwate	Iwate	岩手县	이와테 현	巖手縣
+005	岩手県	Iwate	Iwate	Iwate	Iwate	Iwate	岩手县	이와테 현	岩手縣
 006	宮城県	Miyagi	Miyagi	Miyagi	Miyagi	Miyagi	宫城县	미야기 현	宮城縣
 007	秋田県	Akita	Akita	Akita	Akita	Akita	秋田县	아키타 현	秋田縣
 008	山形県	Yamagata	Yamagata	Yamagata	Yamagata	Yamagata	山形县	야마가타 현	山形縣
 009	福島県	Fukushima	Fukushima	Fukushima	Fukushima	Fukushima	福岛县	후쿠시마 현	福島縣
 010	茨城県	Ibaraki	Ibaraki	Ibaraki	Ibaraki	Ibaraki	茨城县	이바라키 현	茨城縣
-011	栃木県	Tochigi	Tochigi	Tochigi	Tochigi	Tochigi	枥木县	도치기 현	櫪木縣
-012	群馬県	Gunma	Gunma	Gunma	Gunma	Gunma	群马县	군마 현	羣馬縣
-013	埼玉県	Saitama	Saitama	Saitama	Saitama	Saitama	琦玉县	사이타마 현	琦玉縣
+011	栃木県	Tochigi	Tochigi	Tochigi	Tochigi	Tochigi	枥木县	도치기 현	枋木縣
+012	群馬県	Gunma	Gunma	Gunma	Gunma	Gunma	群马县	군마 현	群馬縣
+013	埼玉県	Saitama	Saitama	Saitama	Saitama	Saitama	琦玉县	사이타마 현	埼玉縣
 014	千葉県	Chiba	Chiba	Chiba	Chiba	Chiba	千叶县	지바 현	千葉縣
 015	神奈川県	Kanagawa	Kanagawa	Kanagawa	Kanagawa	Kanagawa	神奈川县	가나가와 현	神奈川縣
 016	富山県	Toyama	Toyama	Toyama	Toyama	Toyama	富山县	도야마 현	富山縣
@@ -18,8 +18,8 @@
 018	福井県	Fukui	Fukui	Fukui	Fukui	Fukui	福井县	후쿠이 현	福井縣
 019	山梨県	Yamanashi	Yamanashi	Yamanashi	Yamanashi	Yamanashi	山梨县	야마나시 현	山梨縣
 020	長野県	Nagano	Nagano	Nagano	Nagano	Nagano	长野县	나가노 현	長野縣
-021	新潟県	Niigata	Niigata	Niigata	Niigata	Niigata	新泻县	니가타 현	新瀉縣
-022	岐阜県	Gifu	Gifu	Gifu	Gifu	Gifu	歧阜县	기후 현	歧阜縣
+021	新潟県	Niigata	Niigata	Niigata	Niigata	Niigata	新泻县	니가타 현	新潟縣
+022	岐阜県	Gifu	Gifu	Gifu	Gifu	Gifu	歧阜县	기후 현	岐阜縣
 023	静岡県	Shizuoka	Shizuoka	Shizuoka	Shizuoka	Shizuoka	静冈县	시즈오카 현	靜岡縣
 024	愛知県	Aichi	Aichi	Aichi	Aichi	Aichi	爱知县	아이치 현	愛知縣
 025	三重県	Mie	Mie	Mie	Mie	Mie	三重县	미에 현	三重縣
@@ -45,4 +45,4 @@
 045	大分県	Oita	Oita	Oita	Oita	Oita	大分县	오이타 현	大分縣
 046	宮崎県	Miyazaki	Miyazaki	Miyazaki	Miyazaki	Miyazaki	宫崎县	미야자키 현	宮崎縣
 047	鹿児島県	Kagoshima	Kagoshima	Kagoshima	Kagoshima	Kagoshima	鹿儿岛县	가고시마 현	鹿兒島縣
-048	沖縄県	Okinawa	Okinawa	Okinawa	Okinawa	Okinawa	冲绳县	오키나와 현	衝繩縣
+048	沖縄県	Okinawa	Okinawa	Okinawa	Okinawa	Okinawa	冲绳县	오키나와 현	沖繩縣

--- a/PKHeX.Core/Resources/text/locale3DS/subregions/sr_039.txt
+++ b/PKHeX.Core/Resources/text/locale3DS/subregions/sr_039.txt
@@ -7,7 +7,7 @@
 007	エステリ	Estelí	Estelí	Estelí	Estelí	Estelí	埃斯特利省	에스텔리	埃斯特利省
 008	グラナダ	Granada	Granada	Granada	Granada	Granada	格拉纳达省	그라나다	格拉納達省
 009	ヒノテガ	Jinotega	Jinotega	Jinotega	Jinotega	Jinotega	希诺特加省	히노테가	希諾特加省
-010	レオン	León	León	León	León	León	莱昂省	레온 주	萊昂省
+010	レオン	León	León	León	León	León	莱昂省	레온	萊昂省
 011	マドリス	Madriz	Madriz	Madriz	Madriz	Madriz	马德里斯省	마드리스	馬德裏斯省
 012	マサヤ	Masaya	Masaya	Masaya	Masaya	Masaya	马萨亚省	마사야	馬薩亞省
 013	マタガルパ	Matagalpa	Matagalpa	Matagalpa	Matagalpa	Matagalpa	马塔加尔帕省	마타갈파	馬塔加爾帕省

--- a/PKHeX.Core/Resources/text/locale3DS/subregions/sr_043.txt
+++ b/PKHeX.Core/Resources/text/locale3DS/subregions/sr_043.txt
@@ -9,7 +9,7 @@
 009	セント・メリー・ケーヨン	Saint Mary Cayon	Saint Mary Cayon	Saint Mary Cayon	Saint Mary Cayon	Saint Mary Cayon	圣玛丽卡永区	세인트메리케이언	聖瑪麗卡永區
 010	セント・ポール・カピステール	Saint Paul Capesterre	Saint Paul Capesterre	Saint Paul Capisterre	Saint Paul Capisterre	Saint Paul Capesterre	圣保罗卡皮斯特尔区	세인트폴카페스테르	聖保羅卡皮斯特爾區
 011	セント・ポール・チャールズタウン	Saint Paul Charlestown	Saint Paul Charlestown	Saint Paul Charlestown	Saint Paul Charlestown	Saint Paul Charlestown	圣保罗查尔斯敦区	세인트폴찰스타운	聖保羅查爾斯敦區
-012	セント・ピーター・バセテール	Saint Peter Basseterre	Saint Peter Basseterre	Saint Peter Basseterre	Saint Peter Basseterre	Saint Peter Basseterre	圣彼得巴斯特尔区	세인트폴바스테르	聖彼得巴斯特爾區
+012	セント・ピーター・バセテール	Saint Peter Basseterre	Saint Peter Basseterre	Saint Peter Basseterre	Saint Peter Basseterre	Saint Peter Basseterre	圣彼得巴斯特尔区	세인트피터바스테르	聖彼得巴斯特爾區
 013	セント・トーマス・ロウランド	Saint Thomas Lowland	Saint Thomas Lowland	Saint Thomas Lowland	Saint Thomas Lowland	Saint Thomas Lowland	圣托马斯洛兰区	세인트토머스롤랜드	聖託馬斯洛蘭區
 014	セント・トーマス・ミドルアイランド	Saint Thomas Middle Island	Saint Thomas Middle Island	Saint Thomas Middle Island	Saint Thomas Middle Island	Saint Thomas Middle Island	圣托马斯米德尔艾兰区	세인트토머스미들아일랜드	聖託馬斯米德爾艾蘭區
 015	トリニティ・パルメット・ポイント	Trinity Palmetto Point	Trinity Palmetto Point	Trinity Palmetto Point	Trinity Palmetto Point	Trinity Palmetto Point	特里尼蒂帕尔梅托波因特区	트리니티팰머토포인트	特裏尼蒂帕爾梅託波因特區

--- a/PKHeX.Core/Resources/text/locale3DS/subregions/sr_047.txt
+++ b/PKHeX.Core/Resources/text/locale3DS/subregions/sr_047.txt
@@ -9,6 +9,6 @@
 009	セント・ジョージ州	Saint George	Saint George	Saint George	Saint George	Saint George	圣乔治郡	세인트조지 주	聖佐治郡
 010	セント・パトリック州	Saint Patrick	Saint Patrick	Saint Patrick	Saint Patrick	Saint Patrick	圣帕特里克郡	세인트패트릭 주	聖帕特裏克郡
 011	サン・フェルナンド	San Fernando	San Fernando	San Fernando	San Fernando	San Fernando	圣费尔南多市	산페르난도	聖費爾南多市
-012	トバゴ島	Tobago	Tobago	Tobago	Tobago	Tobago	多巴哥岛	토바고	多巴哥島
+012	トバゴ島	Tobago	Tobago	Tobago	Tobago	Tobago	多巴哥岛	토바고 섬	多巴哥島
 013	ビクトリア州	Victoria	Victoria	Victoria	Victoria	Victoria	维多利亚郡	빅토리아 주	維多利亞郡
 014	ポイントフォーティン	Point Fortin	Point Fortin	Point Fortin	Point Fortin	Point Fortin	福廷岬市	포인트포르틴	福廷岬市

--- a/PKHeX.Core/Resources/text/locale3DS/subregions/sr_049.txt
+++ b/PKHeX.Core/Resources/text/locale3DS/subregions/sr_049.txt
@@ -50,4 +50,4 @@
 050	ウィスコンシン州	Wisconsin	Wisconsin	Wisconsin	Wisconsin	Wisconsin	威斯康星州	위스콘신 주	威斯康星州
 051	ウェストバージニア州	West Virginia	Virginie Occidentale	West Virginia	Virginia Occidentale	Virginia Occidental	西弗吉尼亚州	웨스트버지니아 주	西弗吉尼亞州
 052	ワイオミング州	Wyoming	Wyoming	Wyoming	Wyoming	Wyoming	怀俄明州	와이오밍 주	懷俄明州
-053	プエルトリコ	Puerto Rico	Porto Rico	Puerto Rico	Porto Rico	Puerto Rico	波多黎各	푸에르토리코 주	波多黎各
+053	プエルトリコ	Puerto Rico	Porto Rico	Puerto Rico	Porto Rico	Puerto Rico	波多黎各	푸에르토리코	波多黎各

--- a/PKHeX.Core/Resources/text/locale3DS/subregions/sr_074.txt
+++ b/PKHeX.Core/Resources/text/locale3DS/subregions/sr_074.txt
@@ -4,5 +4,5 @@
 020	中央ユラン地域	Central Denmark Region	Jutland-Central	Mitteljütland	Jutland Centrale	Jutlandia Central	中日德兰大区	중부 덴마크 지역	中日德蘭大區
 021	北ユラン地域	North Denmark Region	Jutland-du-Nord	Nordjütland	Jutland Settentrionale	Jutlandia Septentrional	北日德兰大区	북부 덴마크 지역	北日德蘭大區
 022	シェラン地域	Region Zealand	Zélande-du-Nord	Seeland	Sjælland	Selandia	西兰大区	셸란 지역	西蘭大區
-023	南デンマーク地域	Region of Southern Denmark	Danemark-du-Sud	Süddänemark	Syddanmark	Dinamarca del Sur	南丹麦大区	남부 덴마크 지역	南丹麥大區
+023	南デンマーク地域	Region of Southern Denmark	Danemark-du-Sud	Süddänemark	Syddanmark	Dinamarca Meridional	南丹麦大区	남부 덴마크 지역	南丹麥大區
 024	フェロー諸島	Faroe Islands	Îles Féroé	Färöer	Isole Fær Øer	Islas Feroe	法罗群岛	페로 제도	法羅羣島

--- a/PKHeX.Core/Resources/text/locale3DS/subregions/sr_077.txt
+++ b/PKHeX.Core/Resources/text/locale3DS/subregions/sr_077.txt
@@ -24,4 +24,4 @@
 024	グアドループ	Guadeloupe	Guadeloupe	Guadeloupe	Guadalupa	Guadalupe	瓜德罗普省	과들루프	瓜德羅普省
 025	マルチニーク	Martinique	Martinique	Martinique	Martinica	Martinica	马提尼克省	마르티니크	馬提尼克省
 026	フランス領ギアナ	French Guiana	Guyane	Französisch-Guayana	Guyana Francese	Guayana Francesa	法属圭亚那省	프랑스령 기아나	法屬圭亞那省
-027	レユニオン	Réunion	Réunion	Réunion	Riunione	La Reunión	留尼汪省	레위니옹	留尼汪省
+027	レユニオン	Réunion	Réunion	Réunion	Riunione	Reunión	留尼汪省	레위니옹	留尼汪省

--- a/PKHeX.Core/Resources/text/locale3DS/subregions/sr_097.txt
+++ b/PKHeX.Core/Resources/text/locale3DS/subregions/sr_097.txt
@@ -7,7 +7,7 @@
 007	ルブシュ	Lubusz	Lubusz	Lebus	Lebus	Lubus	鲁布斯卡省	루부쉬	魯布斯卡省
 008	マウォポルスカ	Lesser Poland	Petite-Pologne	Kleinpolen	Piccola Polonia	Pequeña Polonia	小波兰省	소폴란드	小波蘭省
 009	オポーレ	Opole	Opole	Oppeln	Opole	Opole	奥波莱省	오폴레	奧波萊省
-010	ポトカルパチェ	Subcarpathia	Basses-Carpates	Karpatenvorland	Precarpazi	Subcarpacia	喀尔巴阡山省	카르파티아	喀爾巴阡山省
+010	ポトカルパチェ	Subcarpathia	Basses-Carpates	Karpatenvorland	Precarpazia	Subcarpacia	喀尔巴阡山省	카르파티아	喀爾巴阡山省
 011	ポドラシェ	Podlachia	Podlachie	Podlachien	Podlachia	Podlaquia	波德拉斯省	포들라셰	波德拉斯省
 012	ポモージェ	Pomerania	Poméranie	Pommern	Pomerania	Pomerania	滨海省	포메라니아	濱海省
 013	シュレジエン	Silesia	Silésie	Schlesien	Slesia	Silesia	西里西亚省	슐레지엔	西裏西亞省

--- a/PKHeX.Core/Resources/text/locale3DS/subregions/sr_100.txt
+++ b/PKHeX.Core/Resources/text/locale3DS/subregions/sr_100.txt
@@ -1,6 +1,6 @@
 ﻿000	—	—	—	—	—	—	—	—	—
 009	モスクワ市	Moscow City	Moscou (ville)	Moskau (Stadt)	Mosca	Ciudad de Moscú	莫斯科市	모스크바	莫斯科市
-010	アディゲ共和国	Adygey	Adyguée	Republik Adygeja	Repubblica di Adigezia	República de Adigueya	阿迪格共和国	아디게야 공화국	阿迪格共和國
+010	アディゲ共和国	Adygey	Adyguée	Republik Adygeja	Repubblica di Adighezia	República de Adigueya	阿迪格共和国	아디게야 공화국	阿迪格共和國
 011	アルタイ共和国	Gorno-Altay	Altaï (république)	Republik Altai	Repubblica dell'Altaj	República de Altái	阿尔泰共和国	고르노알타이 공화국	阿爾泰共和國
 012	アルタイ地方	Altay	Altaï (kraï)	Region Altai	Territorio dell'Altaj	Territorio de Altái	阿尔泰边疆区	알타이 지방	阿爾泰邊疆區
 013	アムール州	Amur	Amour	Oblast Amur	Regione dell'Amur	Región de Amur	阿穆尔州	아무르 주	阿穆爾州

--- a/PKHeX.Core/Resources/text/locale3DS/subregions/sr_128.txt
+++ b/PKHeX.Core/Resources/text/locale3DS/subregions/sr_128.txt
@@ -1,23 +1,23 @@
 ﻿000	—	—	—	—	—	—	—	—	—
-002	台北市	Taipei City	Taipei	Taipeh	Taipei	Taipéi	-	타이베이	-
-003	高雄市	Kaohsiung City	Kaohsiung	Kaohsiung	Kaohsiung	Condado de Kaohsiung	-	가오슝	-
-004	基隆市	Keelung City	Keelung	Keelung	Keelung	Keelung	-	지룽	-
-005	新竹市	Hsinchu City	Hsinchu	Hsinchu	Hsinchu	Hsinchu	-	신주	-
-006	台中市	Taichung City	Taichung	Taichung	Taichung	Taichung	-	타이중	-
-007	嘉義市	Chiayi City	Chiayi	Chiayi	Chiayi	Chiayi	-	자이	-
-008	台南市	Tainan City	Tainan	Tainan	Tainan	Tainan	-	타이난	-
-009	新北市	New Taipei City	Nouveau Taipei	Xinbei	New Taipei	Nuevo Taipéi	-	신베이	-
-010	桃園県	Taoyuan County	Taoyuan (comté de)	Kreis Taoyuan	Contea di Taoyuan	Condado de Taoyuan	-	타오위안 현	-
-011	新竹県	HsinChu County	Hsinchu (comté de)	Kreis Hsinchu	Contea di HsinChu	Condado de Hsinchu	-	신주 현	-
-012	苗栗県	Miaoli County	Miaoli (comté de)	Kreis Miaoli	Contea di Miaoli	Distrito de Miaoli	-	먀오리 현	-
-014	彰化県	Changhua County	Changhua (comté de)	Kreis Changhua	Contea di Changhua	Condado de Changhua	-	장화 현	-
-015	南投県	Nantou County	Nantou (comté de)	Kreis Nantou	Contea di Nantou	Condado de Nantou	-	난터우 현	-
-016	雲林県	Yunlin County	Yunlin (comté de)	Kreis Yunlin	Contea di Yunlin	Condado de Yunlin	-	윈린 현	-
-017	嘉義県	Chiayi County	Chiayi (comté de)	Kreis Chiayi	Contea di Chiayi	Condado de Chiayi	-	자이 현	-
-020	屏東県	Pingtung County	Pingtung (comté de)	Kreis Pingtung	Contea di Pingtung	Condado de Pingtung	-	핑둥 현	-
-021	宜蘭県	Yilan County	Ilan (comté de)	Kreis Yilan	Contea di Yilan	Condado de Yilan	-	이란 현	-
-022	花蓮県	Hualien County	Hualien (comté de)	Kreis Hualien	Contea di Hualien	Condado de Hualien	-	화롄 현	-
-023	台東県	Taitung County	Taitung (comté de)	Kreis Taitung	Contea di Taitung	Condado de Taitung	-	타이둥 현	-
-024	澎湖県	Penghu County	Penghu (comté de)	Kreis Penghu	Contea di Penghu	Islas Pescadores	-	펑후 현	-
-025	金門県	Kinmen County	Kinmen (comté de)	Kreis Kinmen	Contea di Kinmen	Condado de Kinmen	-	진먼 현	-
-026	連江県	Lienchiang County	Lienchiang (comté de)	Kreis Lienchiang	Contea di Lienchiang	Condado de Lienchiang	-	롄장 현	-
+002	台北市	Taipei City	Taipei	Taipeh	Taipei	Taipéi	台北市	타이베이	臺北市
+003	高雄市	Kaohsiung City	Kaohsiung	Kaohsiung	Kaohsiung	Condado de Kaohsiung	高雄市	가오슝	高雄市
+004	基隆市	Keelung City	Keelung	Keelung	Keelung	Keelung	基隆市	지룽	基隆市
+005	新竹市	Hsinchu City	Hsinchu	Hsinchu	Hsinchu	Hsinchu	新竹市	신주	新竹市
+006	台中市	Taichung City	Taichung	Taichung	Taichung	Taichung	台中市	타이중	臺中市
+007	嘉義市	Chiayi City	Chiayi	Chiayi	Chiayi	Chiayi	嘉义市	자이	嘉義市
+008	台南市	Tainan City	Tainan	Tainan	Tainan	Tainan	台南市	타이난	臺南市
+009	新北市	New Taipei City	Nouveau Taipei	Xinbei	New Taipei	Nuevo Taipéi	新北市	신베이	新北市
+010	桃園市	Taoyuan City	Taoyuan	Taoyuan	Taoyuan	Ciudad de Taoyuan	桃园市	타오위안	桃園市
+011	新竹県	HsinChu County	Hsinchu (comté de)	Kreis Hsinchu	Contea di HsinChu	Condado de Hsinchu	新竹县	신주 현	新竹縣
+012	苗栗県	Miaoli County	Miaoli (comté de)	Kreis Miaoli	Contea di Miaoli	Distrito de Miaoli	苗栗县	먀오리 현	苗栗縣
+014	彰化県	Changhua County	Changhua (comté de)	Kreis Changhua	Contea di Changhua	Condado de Changhua	彰化县	장화 현	彰化縣
+015	南投県	Nantou County	Nantou (comté de)	Kreis Nantou	Contea di Nantou	Condado de Nantou	南投县	난터우 현	南投縣
+016	雲林県	Yunlin County	Yunlin (comté de)	Kreis Yunlin	Contea di Yunlin	Condado de Yunlin	云林县	윈린 현	雲林縣
+017	嘉義県	Chiayi County	Chiayi (comté de)	Kreis Chiayi	Contea di Chiayi	Condado de Chiayi	嘉义县	자이 현	嘉義縣
+020	屏東県	Pingtung County	Pingtung (comté de)	Kreis Pingtung	Contea di Pingtung	Condado de Pingtung	屏东县	핑둥 현	屏東縣
+021	宜蘭県	Yilan County	Ilan (comté de)	Kreis Yilan	Contea di Yilan	Condado de Yilan	宜兰县	이란 현	宜蘭縣
+022	花蓮県	Hualien County	Hualien (comté de)	Kreis Hualien	Contea di Hualien	Condado de Hualien	花莲县	화롄 현	花蓮縣
+023	台東県	Taitung County	Taitung (comté de)	Kreis Taitung	Contea di Taitung	Condado de Taitung	台东县	타이둥 현	臺東縣
+024	澎湖県	Penghu County	Penghu (comté de)	Kreis Penghu	Contea di Penghu	Islas Pescadores	澎湖县	펑후 현	澎湖縣
+025	金門県	Kinmen County	Kinmen (comté de)	Kreis Kinmen	Contea di Kinmen	Condado de Kinmen	金门县	진먼 현	金門縣
+026	連江県	Lienchiang County	Lienchiang (comté de)	Kreis Lienchiang	Contea di Lienchiang	Condado de Lienchiang	连江县	롄장 현	連江縣

--- a/PKHeX.Core/Resources/text/locale3DS/subregions/sr_144.txt
+++ b/PKHeX.Core/Resources/text/locale3DS/subregions/sr_144.txt
@@ -1,2 +1,2 @@
 ﻿000	—	—	—	—	—	—	—	—	—
-001	ホンコン	Hong Kong	Hong Kong	Hongkong	Hong Kong	Hong Kong	中国 香港	홍콩	中國 香港
+001	ホンコン	Hong Kong	Hong Kong	Hongkong	Hong Kong	Hong Kong	中国 香港	홍콩	香港


### PR DESCRIPTION
Fixes some typos by grabbing the names from region manifest v5122, the last version for 3DS.

TW has all of its subregions censored as a dash in CHS, so they're instead translated from CHT.