### PR TITLE
Make Raid Editors Edit Copies Rather Than Origin Save's Data

### DIFF
--- a/PKHeX.Core/Saves/Substructures/Gen8/SWSH/RaidSpawnList8.cs
+++ b/PKHeX.Core/Saves/Substructures/Gen8/SWSH/RaidSpawnList8.cs
@@ -214,3 +214,10 @@ public enum RaidType : byte
     Event = 5,
     DynamaxCrystal = 6,
 }
+
+public enum MaxRaidOrigin: uint
+{
+    Galar,
+    IsleOfArmor,
+    CrownTundra
+}

--- a/PKHeX.Core/Saves/Substructures/Gen9/RaidSpawnList9.cs
+++ b/PKHeX.Core/Saves/Substructures/Gen9/RaidSpawnList9.cs
@@ -151,3 +151,10 @@ public enum TeraRaidContentType : uint
     Distribution,
     Might7,
 }
+
+public enum TeraRaidOrigin : uint
+{
+    Paldea,
+    Kitakami,
+    BlueberryAcademy
+}

--- a/PKHeX.WinForms/Controls/SAV Editor/SAVEditor.cs
+++ b/PKHeX.WinForms/Controls/SAV Editor/SAVEditor.cs
@@ -566,22 +566,22 @@ public partial class SAVEditor : UserControl, ISlotViewer<PictureBox>, ISaveFile
         if (SAV is SAV9SV sv)
         {
             if (sender == B_Raids)
-                OpenDialog(new SAV_Raid9(sv, sv.RaidPaldea));
+                OpenDialog(new SAV_Raid9(sv, TeraRaidOrigin.Paldea));
             else if (sender == B_RaidDLC1)
-                OpenDialog(new SAV_Raid9(sv, sv.RaidKitakami));
+                OpenDialog(new SAV_Raid9(sv, TeraRaidOrigin.Kitakami));
             else if (sender == B_RaidDLC2)
-                OpenDialog(new SAV_Raid9(sv, sv.RaidBlueberry));
+                OpenDialog(new SAV_Raid9(sv, TeraRaidOrigin.BlueberryAcademy));
             else if (sender == B_RaidsSevenStar)
-                OpenDialog(new SAV_RaidSevenStar9(sv, sv.RaidSevenStar));
+                OpenDialog(new SAV_RaidSevenStar9(sv));
         }
         else if (SAV is SAV8SWSH swsh)
         {
             if (sender == B_Raids)
-                OpenDialog(new SAV_Raid8(swsh, swsh.Raid));
+                OpenDialog(new SAV_Raid8(swsh, MaxRaidOrigin.Galar));
             else if (sender == B_RaidDLC1)
-                OpenDialog(new SAV_Raid8(swsh, swsh.RaidArmor));
+                OpenDialog(new SAV_Raid8(swsh, MaxRaidOrigin.IsleOfArmor));
             else if(sender == B_RaidDLC2)
-                OpenDialog(new SAV_Raid8(swsh, swsh.RaidCrown));
+                OpenDialog(new SAV_Raid8(swsh, MaxRaidOrigin.CrownTundra));
         }
     }
 

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen8/SAV_Raid8.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen8/SAV_Raid8.cs
@@ -11,27 +11,29 @@ public partial class SAV_Raid8 : Form
     private readonly SAV8SWSH SAV;
     private readonly RaidSpawnList8 Raids;
 
-    public SAV_Raid8(SAV8SWSH sav, RaidSpawnList8 raid)
+    public SAV_Raid8(SAV8SWSH sav, MaxRaidOrigin raidOrigin)
     {
         InitializeComponent();
         WinFormsUtil.TranslateInterface(this, Main.CurrentLanguage);
         SAV = (SAV8SWSH)(Origin = sav).Clone();
-        Raids = raid;
-        CB_Den.Items.AddRange(Enumerable.Range(1, raid.CountUsed).Select(z => (object)$"Den {z:000}").ToArray());
+        Raids = raidOrigin switch
+        {
+            MaxRaidOrigin.Galar => SAV.Raid,
+            MaxRaidOrigin.IsleOfArmor => SAV.RaidArmor,
+            MaxRaidOrigin.CrownTundra => SAV.RaidCrown,
+            _ => throw new ArgumentOutOfRangeException($"Raid Origin {raidOrigin} is not valid for Sword and Shield")
+        };
+        CB_Den.Items.AddRange(Enumerable.Range(1, Raids.CountUsed).Select(z => (object)$"Den {z:000}").ToArray());
         CB_Den.SelectedIndex = 0;
     }
 
     private void LoadDen(int index) => PG_Den.SelectedObject = Raids.GetRaid(index);
 
-    private void B_Cancel_Click(object sender, EventArgs e)
-    {
-        // We've been editing the original save file blocks. Restore the clone's data.
-        Origin.CopyChangesFrom(SAV);
-        Close();
-    }
+    private void B_Cancel_Click(object sender, EventArgs e) => Close();
 
     private void B_Save_Click(object sender, EventArgs e)
     {
+        Origin.CopyChangesFrom(SAV);
         Close();
     }
 

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen9/SAV_Raid9.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen9/SAV_Raid9.cs
@@ -12,20 +12,26 @@ public partial class SAV_Raid9 : Form
     private readonly SAV9SV SAV;
     private readonly RaidSpawnList9 Raids;
 
-    public SAV_Raid9(SAV9SV sav, RaidSpawnList9 raid)
+    public SAV_Raid9(SAV9SV sav, TeraRaidOrigin raidOrigin)
     {
         InitializeComponent();
         WinFormsUtil.TranslateInterface(this, Main.CurrentLanguage);
         SAV = (SAV9SV)(Origin = sav).Clone();
-        Raids = raid;
-        CB_Raid.Items.AddRange(Enumerable.Range(1, raid.CountUsed).Select(z => (object)$"Raid {z:000}").ToArray());
+        Raids = raidOrigin switch
+        {
+            TeraRaidOrigin.Paldea => SAV.RaidPaldea,
+            TeraRaidOrigin.Kitakami => SAV.RaidKitakami,
+            TeraRaidOrigin.BlueberryAcademy => SAV.RaidBlueberry,
+            _ => throw new ArgumentOutOfRangeException($"Raid Origin {raidOrigin} is not valid for Scarlet and Violet")
+        };
+        CB_Raid.Items.AddRange(Enumerable.Range(1, Raids.CountUsed).Select(z => (object)$"Raid {z:000}").ToArray());
         CB_Raid.SelectedIndex = 0;
-        LoadSeeds(raid);
+        LoadSeeds();
     }
 
-    private void LoadSeeds(RaidSpawnList9 raid)
+    private void LoadSeeds()
     {
-        if (raid.HasSeeds)
+        if (Raids.HasSeeds)
         {
             TB_SeedToday.Text = Raids.CurrentSeed.ToString("X16");
             TB_SeedTomorrow.Text = Raids.TomorrowSeed.ToString("X16");
@@ -44,15 +50,11 @@ public partial class SAV_Raid9 : Form
 
     private void LoadRaid(int index) => PG_Raid.SelectedObject = Raids.GetRaid(index);
 
-    private void B_Cancel_Click(object sender, EventArgs e)
-    {
-        // We've been editing the original save file blocks. Restore the clone's data.
-        Origin.CopyChangesFrom(SAV);
-        Close();
-    }
+    private void B_Cancel_Click(object sender, EventArgs e) => Close();
 
     private void B_Save_Click(object sender, EventArgs e)
     {
+        Origin.CopyChangesFrom(SAV);
         ValidateChildren();
         Validate();
         Close();

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen9/SAV_RaidSevenStar9.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen9/SAV_RaidSevenStar9.cs
@@ -11,27 +11,24 @@ public partial class SAV_RaidSevenStar9 : Form
     private readonly SAV9SV SAV;
     private readonly RaidSevenStar9 Raids;
 
-    public SAV_RaidSevenStar9(SAV9SV sav, RaidSevenStar9 raid)
+
+    public SAV_RaidSevenStar9(SAV9SV sav)
     {
         InitializeComponent();
         WinFormsUtil.TranslateInterface(this, Main.CurrentLanguage);
         SAV = (SAV9SV)(Origin = sav).Clone();
-        Raids = raid;
-        CB_Raid.Items.AddRange(Enumerable.Range(1, raid.CountAll).Select(z => (object)$"Raid {z:0000}").ToArray());
+        Raids = SAV.RaidSevenStar;
+        CB_Raid.Items.AddRange(Enumerable.Range(1, Raids.CountAll).Select(z => (object)$"Raid {z:0000}").ToArray());
         CB_Raid.SelectedIndex = 0;
     }
 
     private void LoadRaid(int index) => PG_Raid.SelectedObject = Raids.GetRaid(index);
 
-    private void B_Cancel_Click(object sender, EventArgs e)
-    {
-        // We've been editing the original save file blocks. Restore the clone's data.
-        Origin.CopyChangesFrom(SAV);
-        Close();
-    }
+    private void B_Cancel_Click(object sender, EventArgs e) => Close();
 
     private void B_Save_Click(object sender, EventArgs e)
     {
+        Origin.CopyChangesFrom(SAV);
         ValidateChildren();
         Validate();
         Close();


### PR DESCRIPTION
Use an enum to know which raids to use rather than passing the specific raids so that the save changes copy back operation only happens when a user saves modifications and thus won't flag the save as modified if nothing was changed.