### PR TITLE
Fix Gen 1/2 VC filtered OT name legality

### DIFF
--- a/PKHeX.Core/Legality/Verifiers/TrainerNameVerifier.cs
+++ b/PKHeX.Core/Legality/Verifiers/TrainerNameVerifier.cs
@@ -120,6 +120,11 @@ public sealed class TrainerNameVerifier : Verifier
     private void VerifyGBOTWithinBounds(LegalityAnalysis data, ReadOnlySpan<char> str)
     {
         var pk = data.Entity;
+
+        // Filtered OT names use unavailable characters and can be too long
+        if (str.SequenceEqual(StringConverter12Transporter.GetFilteredOT(pk.Language, pk.Version)))
+            return;
+
         if (pk.Japanese)
         {
             if (str.Length > 5)

--- a/PKHeX.Core/PKM/Strings/StringConverter12Transporter.cs
+++ b/PKHeX.Core/PKM/Strings/StringConverter12Transporter.cs
@@ -147,6 +147,80 @@ public static class StringConverter12Transporter
         5 => "Trainer",
         7 => "Entrenador",
       //8 => "트레이너",
+      //9 => "训练家",
+      //10 => "訓練家",
+        _ => string.Empty,
+    };
+
+    public static string GetFilteredOT(int language, int version) => version switch
+    {
+        (int)GameVersion.RD => language switch
+        {
+            1 => "レッド．",
+            2 => "Red*",
+            3 => "Rouge*",
+            4 => "Rosso*",
+            5 => "Rot*",
+            7 => "Rojo*",
+            _ => string.Empty,
+        },
+        (int)GameVersion.GN => language switch
+        {
+            1 => "グリーン．",
+            2 => "Blue*",
+            3 => "Bleu*",
+            4 => "Blu*",
+            5 => "Blau*",
+            7 => "Azul*",
+            _ => string.Empty,
+        },
+        (int)GameVersion.BU => language switch
+        {
+            1 => "ブルー．",
+            _ => string.Empty,
+        },
+        (int)GameVersion.YW => language switch
+        {
+            1 => "イエロー．",
+            2 => "Yellow*",
+            3 => "Jaune*",
+            4 => "Giallo*",
+            5 => "Gelb*",
+            7 => "Amarillo*",
+            _ => string.Empty,
+        },
+        (int)GameVersion.GD => language switch
+        {
+            1 => "ゴールド．",
+            2 => "Gold*",
+            3 => "Or*",
+            4 => "Oro*",
+            5 => "Gold*",
+            7 => "Oro*",
+            8 => "금.",
+            _ => string.Empty,
+        },
+        (int)GameVersion.SI => language switch
+        {
+            1 => "シルバー．",
+            2 => "Silver*",
+            3 => "Argent*",
+            4 => "Argento*",
+            5 => "Silber*",
+            7 => "Plata*",
+            8 => "은.",
+            _ => string.Empty,
+        },
+        (int)GameVersion.C => language switch
+        {
+            1 => "クリスタル．",
+            2 => "Crystal*",
+            3 => "Cristal*",
+            4 => "Cristallo*",
+            5 => "Kristall*",
+            7 => "Cristal*",
+            _ => string.Empty,
+        },
         _ => string.Empty,
     };
 }


### PR DESCRIPTION
Poké Transporter replaces OT names from the G1/G2 games with filtered words with a [language- and version-specific string](https://bulbapedia.bulbagarden.net/wiki/Pok%C3%A9_Transporter#Censored_words). Some of these names are too long for G1/G2: `クリスタル．` for JPN Crystal (6 > 5), `Crystal*` for ENG Crystal (8 > 7), etc. These names also all include characters that cannot be entered in G1/G2: `．` in Japanese, `*` in EFIGS, and `.` in Korean (this also applies to G3, but there isn't a legality check for G3 unavailable characters yet). 

This checks the OT name against the appropriate string given the Pokémon's language and version, and if it matches, prevents the `OT Name too long.` and `OT from Generation 1/2 uses unavailable characters.` messages from being displayed.