### PR TITLE
Make CSV files UTF-8 w/o BOM

### DIFF
--- a/PKHeX.WinForms/Subforms/ReportGrid.cs
+++ b/PKHeX.WinForms/Subforms/ReportGrid.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using PKHeX.Core;
@@ -116,7 +117,7 @@ public partial class ReportGrid : Form
     private async Task Export_CSV(string path)
     {
         await using var fs = new FileStream(path, FileMode.Create);
-        await using var s = new StreamWriter(fs, System.Text.Encoding.Unicode);
+        await using var s = new StreamWriter(fs, new UTF8Encoding(false));
 
         var headers = dgData.Columns.Cast<DataGridViewColumn>();
         await s.WriteLineAsync(string.Join(",", headers.Skip(1).Select(column => $"\"{column.HeaderText}\""))).ConfigureAwait(false);


### PR DESCRIPTION
Usually CSV files are saved with UTF-16 which is not easy to work with. This makes them UTF-8 without the BOM header by default, allowing them to be used more easily.