### PR TITLE
Fixed Pokedex National Unlock Magic for FRLG

### DIFF
--- a/PKHeX.Core/Saves/SAV3.cs
+++ b/PKHeX.Core/Saves/SAV3.cs
@@ -588,7 +588,7 @@ public abstract class SAV3 : SaveFile, ILangDeviantSave, IEventFlag37
     }
 
     protected const byte PokedexNationalUnlockRSE = 0xDA;
-    protected const byte PokedexNationalUnlockFRLG = 0xDA;
+    protected const byte PokedexNationalUnlockFRLG = 0xB9;
     protected const ushort PokedexNationalUnlockWorkRSE = 0x0302;
     protected const ushort PokedexNationalUnlockWorkFRLG = 0x6258;
 


### PR DESCRIPTION
It's 0xB9 in FRLG: https://github.com/pret/pokefirered/blob/master/src/event_data.c#L102