### PR TITLE
Expose Gen 2 Palette to Block Editor

### DIFF
--- a/PKHeX.Core/Saves/SAV2.cs
+++ b/PKHeX.Core/Saves/SAV2.cs
@@ -359,6 +359,12 @@ public sealed class SAV2 : SaveFile, ILangDeviantSave, IEventFlagArray, IEventWo
         }
     }
 
+    public byte Palette
+    {
+        get => Data[Offsets.Palette];
+        set => Data[Offsets.Palette] = value;
+    }
+
     public override uint ID32
     {
         get => TID16;


### PR DESCRIPTION
So you can actually set the players palette to another color.