### PR TITLE
Rename Obedience_Level To Match C# Naming Standard

### DIFF
--- a/PKHeX.Core/Legality/Encounters/Templates/GO/EncounterSlot8GO.cs
+++ b/PKHeX.Core/Legality/Encounters/Templates/GO/EncounterSlot8GO.cs
@@ -158,7 +158,7 @@ public sealed record EncounterSlot8GO(int StartDate, int EndDate, ushort Species
         {
             var pi = pk9.PersonalInfo;
             pk9.TeraTypeOriginal = pk9.TeraTypeOverride = TeraTypeUtil.GetTeraTypeImport(pi.Type1, pi.Type2);
-            pk9.Obedience_Level = pk9.MetLevel;
+            pk9.ObedienceLevel = pk9.MetLevel;
         }
         pk.ResetPartyStats();
         return pk;

--- a/PKHeX.Core/Legality/Encounters/Templates/Gen9/EncounterDist9.cs
+++ b/PKHeX.Core/Legality/Encounters/Templates/Gen9/EncounterDist9.cs
@@ -257,7 +257,7 @@ public sealed record EncounterDist9
             Ball = (byte)Ball.Poke,
 
             Nickname = SpeciesName.GetSpeciesNameGeneration(Species, lang, Generation),
-            Obedience_Level = LevelMin,
+            ObedienceLevel = LevelMin,
             OriginalTrainerName = tr.OT,
             OriginalTrainerGender = tr.Gender,
             ID32 = tr.ID32,

--- a/PKHeX.Core/Legality/Encounters/Templates/Gen9/EncounterFixed9.cs
+++ b/PKHeX.Core/Legality/Encounters/Templates/Gen9/EncounterFixed9.cs
@@ -94,7 +94,7 @@ public sealed record EncounterFixed9
             Ball = (byte)Ball.Poke,
 
             Nickname = SpeciesName.GetSpeciesNameGeneration(Species, lang, Generation),
-            Obedience_Level = LevelMin,
+            ObedienceLevel = LevelMin,
             OriginalTrainerName = tr.OT,
             OriginalTrainerGender = tr.Gender,
             ID32 = tr.ID32,

--- a/PKHeX.Core/Legality/Encounters/Templates/Gen9/EncounterMight9.cs
+++ b/PKHeX.Core/Legality/Encounters/Templates/Gen9/EncounterMight9.cs
@@ -271,7 +271,7 @@ public sealed record EncounterMight9
             Ball = (byte)Ball.Poke,
 
             Nickname = SpeciesName.GetSpeciesNameGeneration(Species, lang, Generation),
-            Obedience_Level = LevelMin,
+            ObedienceLevel = LevelMin,
             RibbonMarkMightiest = true,
             AffixedRibbon = (sbyte)RibbonIndex.MarkMightiest,
             OriginalTrainerName = tr.OT,

--- a/PKHeX.Core/Legality/Encounters/Templates/Gen9/EncounterOutbreak9.cs
+++ b/PKHeX.Core/Legality/Encounters/Templates/Gen9/EncounterOutbreak9.cs
@@ -91,7 +91,7 @@ public sealed record EncounterOutbreak9
             Ball = (byte)Ball.Poke,
 
             Nickname = SpeciesName.GetSpeciesNameGeneration(Species, lang, Generation),
-            Obedience_Level = LevelMin,
+            ObedienceLevel = LevelMin,
             OriginalTrainerName = tr.OT,
             OriginalTrainerGender = tr.Gender,
             ID32 = tr.ID32,

--- a/PKHeX.Core/Legality/Encounters/Templates/Gen9/EncounterSlot9.cs
+++ b/PKHeX.Core/Legality/Encounters/Templates/Gen9/EncounterSlot9.cs
@@ -146,7 +146,7 @@ public sealed record EncounterSlot9(EncounterArea9 Parent, ushort Species, byte 
             OriginalTrainerName = tr.OT,
             OriginalTrainerGender = tr.Gender,
             ID32 = tr.ID32,
-            Obedience_Level = LevelMin,
+            ObedienceLevel = LevelMin,
             OriginalTrainerFriendship = pi.BaseFriendship,
             Nickname = SpeciesName.GetSpeciesNameGeneration(Species, lang, Generation),
         };

--- a/PKHeX.Core/Legality/Encounters/Templates/Gen9/EncounterStatic9.cs
+++ b/PKHeX.Core/Legality/Encounters/Templates/Gen9/EncounterStatic9.cs
@@ -84,7 +84,7 @@ public sealed record EncounterStatic9(GameVersion Version)
             FatefulEncounter = FatefulEncounter,
 
             Nickname = SpeciesName.GetSpeciesNameGeneration(Species, lang, Generation),
-            Obedience_Level = LevelMin,
+            ObedienceLevel = LevelMin,
             OriginalTrainerName = tr.OT,
             OriginalTrainerGender = tr.Gender,
             ID32 = tr.ID32,

--- a/PKHeX.Core/Legality/Encounters/Templates/Gen9/EncounterTera9.cs
+++ b/PKHeX.Core/Legality/Encounters/Templates/Gen9/EncounterTera9.cs
@@ -194,7 +194,7 @@ public sealed record EncounterTera9
             Ball = (byte)Ball.Poke,
 
             Nickname = SpeciesName.GetSpeciesNameGeneration(Species, lang, Generation),
-            Obedience_Level = LevelMin,
+            ObedienceLevel = LevelMin,
             OriginalTrainerName = tr.OT,
             OriginalTrainerGender = tr.Gender,
             ID32 = tr.ID32,

--- a/PKHeX.Core/Legality/Encounters/Templates/Gen9/EncounterTrade9.cs
+++ b/PKHeX.Core/Legality/Encounters/Templates/Gen9/EncounterTrade9.cs
@@ -105,7 +105,7 @@ public sealed record EncounterTrade9
             HandlingTrainerLanguage = (byte)tr.Language,
             CurrentHandler = 1,
             HandlingTrainerFriendship = pi.BaseFriendship,
-            Obedience_Level = Level,
+            ObedienceLevel = Level,
         };
 
         EncounterUtil.SetEncounterMoves(pk, version, Level);

--- a/PKHeX.Core/Legality/Encounters/Templates/Shared/EncounterEgg.cs
+++ b/PKHeX.Core/Legality/Encounters/Templates/Shared/EncounterEgg.cs
@@ -152,7 +152,7 @@ public sealed record EncounterEgg(ushort Species, byte Form, byte Level, byte Ge
         pk.MetLocation = Math.Max((ushort)0, EggStateLegality.GetEggHatchLocation(Version, Generation));
 
         if (pk is IObedienceLevel l)
-            l.Obedience_Level = pk.MetLevel;
+            l.ObedienceLevel = pk.MetLevel;
     }
 
     private void SetEncounterMoves(PKM pk, GameVersion version)

--- a/PKHeX.Core/Legality/Verifiers/MiscVerifier.cs
+++ b/PKHeX.Core/Legality/Verifiers/MiscVerifier.cs
@@ -170,7 +170,7 @@ public sealed class MiscVerifier : Verifier
 
         if (!pk9.IsBattleVersionValid(data.Info.EvoChainsAllGens))
             data.AddLine(GetInvalid(LStatBattleVersionInvalid));
-        if (!IsObedienceLevelValid(pk9, pk9.Obedience_Level, pk9.MetLevel))
+        if (!IsObedienceLevelValid(pk9, pk9.ObedienceLevel, pk9.MetLevel))
             data.AddLine(GetInvalid(LTransferObedienceLevel));
         if (pk9.IsEgg)
         {

--- a/PKHeX.Core/MysteryGifts/WC9.cs
+++ b/PKHeX.Core/MysteryGifts/WC9.cs
@@ -544,7 +544,7 @@ public sealed class WC9(byte[] Data) : DataMysteryGift(Data), ILangNick, INature
         else
             pk.Scale = (byte)Scale;
 
-        pk.Obedience_Level = Level;
+        pk.ObedienceLevel = Level;
         pk.ResetPartyStats();
         pk.RefreshChecksum();
         return pk;

--- a/PKHeX.Core/PKM/HOME/GameDataPK9.cs
+++ b/PKHeX.Core/PKM/HOME/GameDataPK9.cs
@@ -124,7 +124,7 @@ public sealed class GameDataPK9 : HomeOptional1, IGameDataSide<PK9>, IScaledSize
         pk.TeraTypeOverride = TeraTypeOverride;
         RecordFlagsBase.CopyTo(pk.RecordFlagsBase);
         RecordFlagsDLC.CopyTo(pk.RecordFlagsDLC);
-        pk.Obedience_Level = Obedience_Level;
+        pk.ObedienceLevel = Obedience_Level;
         pk.Ability = Ability;
         pk.AbilityNumber = AbilityNumber;
     }
@@ -137,7 +137,7 @@ public sealed class GameDataPK9 : HomeOptional1, IGameDataSide<PK9>, IScaledSize
         TeraTypeOverride = pk.TeraTypeOverride;
         pk.RecordFlagsBase.CopyTo(RecordFlagsBase);
         pk.RecordFlagsDLC.CopyTo(RecordFlagsDLC);
-        Obedience_Level = pk.Obedience_Level;
+        Obedience_Level = pk.ObedienceLevel;
         Ability = (ushort)pk.Ability;
         AbilityNumber = (byte)pk.AbilityNumber;
     }

--- a/PKHeX.Core/PKM/Interfaces/IObedienceLevel.cs
+++ b/PKHeX.Core/PKM/Interfaces/IObedienceLevel.cs
@@ -6,15 +6,15 @@ namespace PKHeX.Core;
 public interface IObedienceLevel : IObedienceLevelReadOnly
 {
     /// <summary>
-    /// <inheritdoc cref="IObedienceLevelReadOnly.Obedience_Level"/>
+    /// <inheritdoc cref="IObedienceLevelReadOnly.ObedienceLevel"/>
     /// </summary>
-    new byte Obedience_Level { get; set; }
+    new byte ObedienceLevel { get; set; }
 }
 
 public static class ObedienceExtensions
 {
     /// <summary>
-    /// Suggests the <see cref="IObedienceLevelReadOnly.Obedience_Level"/> for the entity.
+    /// Suggests the <see cref="IObedienceLevelReadOnly.ObedienceLevel"/> for the entity.
     /// </summary>
     public static byte GetSuggestedObedienceLevel(this IObedienceLevelReadOnly _, PKM entity, int originalMet)
     {

--- a/PKHeX.Core/PKM/Interfaces/Templates/IObedienceLevelReadOnly.cs
+++ b/PKHeX.Core/PKM/Interfaces/Templates/IObedienceLevelReadOnly.cs
@@ -7,5 +7,5 @@ public interface IObedienceLevelReadOnly
     /// <summary>
     /// Indicates the level the Pokémon was obtained by the current handler.
     /// </summary>
-    byte Obedience_Level { get; } // no setter, use for Encounters
+    byte ObedienceLevel { get; } // no setter, use for Encounters
 }

--- a/PKHeX.Core/PKM/PK9.cs
+++ b/PKHeX.Core/PKM/PK9.cs
@@ -422,7 +422,7 @@ public sealed class PK9 : PKM, ISanityChecksum, ITeraType, ITechRecord, IObedien
     public override byte MetYear { get => Data[0x11C]; set => Data[0x11C] = value; }
     public override byte MetMonth { get => Data[0x11D]; set => Data[0x11D] = value; }
     public override byte MetDay { get => Data[0x11E]; set => Data[0x11E] = value; }
-    public byte Obedience_Level { get => Data[0x11F]; set => Data[0x11F] = value; }
+    public byte ObedienceLevel { get => Data[0x11F]; set => Data[0x11F] = value; }
     public override ushort EggLocation { get => ReadUInt16LittleEndian(Data.AsSpan(0x120)); set => WriteUInt16LittleEndian(Data.AsSpan(0x120), value); }
     public override ushort MetLocation { get => ReadUInt16LittleEndian(Data.AsSpan(0x122)); set => WriteUInt16LittleEndian(Data.AsSpan(0x122), value); }
     public override byte Ball { get => Data[0x124]; set => Data[0x124] = value; }

--- a/PKHeX.WinForms/Controls/PKM Editor/LoadSave.cs
+++ b/PKHeX.WinForms/Controls/PKM Editor/LoadSave.cs
@@ -495,7 +495,7 @@ public partial class PKMEditor
         CB_BattleVersion.SelectedValue = (int)pk9.BattleVersion;
         Stats.CB_TeraTypeOriginal.SelectedValue = (int)pk9.TeraTypeOriginal;
         Stats.CB_TeraTypeOverride.SelectedValue = (int)pk9.TeraTypeOverride;
-        TB_ObedienceLevel.Text = pk9.Obedience_Level.ToString();
+        TB_ObedienceLevel.Text = pk9.ObedienceLevel.ToString();
     }
 
     private void SaveMisc9(PK9 pk9)
@@ -505,6 +505,6 @@ public partial class PKMEditor
         pk9.BattleVersion = (GameVersion)WinFormsUtil.GetIndex(CB_BattleVersion);
         pk9.TeraTypeOriginal = (MoveType)WinFormsUtil.GetIndex(Stats.CB_TeraTypeOriginal);
         pk9.TeraTypeOverride = (MoveType)WinFormsUtil.GetIndex(Stats.CB_TeraTypeOverride);
-        pk9.Obedience_Level = (byte)Util.ToInt32(TB_ObedienceLevel.Text);
+        pk9.ObedienceLevel = (byte)Util.ToInt32(TB_ObedienceLevel.Text);
     }
 }


### PR DESCRIPTION
Change from Obedience_Level  to ObedienceLevel since it was missed when other properties we changed to match C# naming standard.