### PR TITLE
Update ShowdownSet.cs

### DIFF
--- a/PKHeX.Core/Editing/Showdown/ShowdownSet.cs
+++ b/PKHeX.Core/Editing/Showdown/ShowdownSet.cs
@@ -10,7 +10,7 @@ namespace PKHeX.Core;
 /// </summary>
 public sealed class ShowdownSet : IBattleTemplate
 {
-    private static readonly string[] StatNames = ["HP", "Atk", "Def", "Spe", "SpA", "SpD"];
+    private static readonly string[] StatNames = ["HP", "Atk", "Def", "SpA", "SpD", "Spe"];
     private const string LineSplit = ": ";
     private const string ItemSplit = " @ ";
     private const int MAX_SPECIES = (int)MAX_COUNT - 1;


### PR DESCRIPTION
Correctly Order StatNames.

Currently if a user were to do:
EVs: 10 SpA / 11 SpD / 12 Spe

It would re-order like so:
EVs: 12 SpA / 10 SpD / 11 Spe

The GetStringStats method would have assigned the values as follows:

1. The GetStatIndexStored method would map the display indices to the stored indices:
- SpA (index 3 in Showdown) would be mapped to index 4 in the StatNames array. 
- SpD (index 4 in Showdown) would be mapped to index 5 in the StatNames array. 
- Spe (index 5 in Showdown) would be mapped to index 3 in the StatNames array.

2. The GetStringStats method would then iterate over the stats array and assign the values to the corresponding stat names based on the mapped indices:
- The value 10 would be assigned to "SpA" (index 4 in the original StatNames array). 
- The value 11 would be assigned to "SpD" (index 5 in the original StatNames array). 
- The value 12 would be assigned to "Spe" (index 3 in the original StatNames array).

So, with the original ordering of the StatNames array, the resulting output would have been: EVs: 12 Spe / 10 SpA / 11 SpD

As you can see, the values are correctly assigned to the corresponding stat names, but the order of the stats in the output is different from the Showdown ordering. The original ordering of the StatNames array would have resulted in the stats being displayed in the order "Spe", "SpA", "SpD" instead of the desired order "SpA", "SpD", "Spe".

By updating the StatNames array to match the Showdown ordering, the output will be correct and in the expected order: EVs: 10 SpA / 11 SpD / 12 Spe