### PR TITLE
Update how symbols are handled for Bank -> HOME transfers

### DIFF
--- a/PKHeX.Core/PKM/HOME/GameDataPK8.cs
+++ b/PKHeX.Core/PKM/HOME/GameDataPK8.cs
@@ -113,10 +113,10 @@ public sealed class GameDataPK8 : HomeOptional1, IGameDataSide<PK8>, IGigantamax
         Ability = (ushort)pk.Ability;
 
         pkh.MarkingValue &= 0b1111_1111_1111;
-        StringConverter8.NormalizeHalfWidth(pkh.OriginalTrainerTrash);
+        StringConverter8.TransferGlyphs78(pkh.OriginalTrainerTrash);
         if (pk.IsNicknamed)
         {
-            StringConverter8.NormalizeHalfWidth(pkh.NicknameTrash);
+            StringConverter8.TransferGlyphs78(pkh.NicknameTrash);
         }
         else
         {


### PR DESCRIPTION
Follow-up on 08ed482 and https://github.com/kwsch/PKHeX/issues/4146#issuecomment-1877769156:

This maps the remaining (legal) symbols in the private use area that are modified on transfer from Bank -> HOME. If any of these replacements are made, any leading or trailing halfwidth spaces are trimmed. This can result in nicknames/OT names that are the empty string or consist entirely of fullwidth spaces, even though these can't normally entered.

I was unable to replicate how Anubis's Sudowoodo named `\uE0A5\uE0A3\uE0A4` (Zz, Right-up arrow, Right-down arrow) had its name changed to ` ` (one halfwidth space). I got an empty string instead--it's possible that behavior changed sometime between when those were transferred in 2021 and when I tested it in 2024.