### PR TITLE
Update SaveHandlerFooterRTC.cs

### DIFF
--- a/PKHeX.Core/Saves/Util/Recognition/SaveHandlerFooterRTC.cs
+++ b/PKHeX.Core/Saves/Util/Recognition/SaveHandlerFooterRTC.cs
@@ -23,6 +23,8 @@ public sealed class SaveHandlerFooterRTC : ISaveHandler
 
     private static bool IsPlausibleFooterSize(long size)
     {
+        if (size == 0x07) // exception for lesserkuma/FlashGBX >v2.0
+            return true;
         if ((size & 1) != 0) // must be even
             return false;
         return size is not (> MaxFooter or < MinFooter);


### PR DESCRIPTION
saves with 0x7 RTC footer generated by [FlashGBX](https://github.com/lesserkuma/FlashGBX) were rejected as too large.
change tested to work on latest release (24.07.03).