### PR TITLE
Properly detect if G3 Mail is Japanese

### DIFF
--- a/PKHeX.Core/Saves/SAV3.cs
+++ b/PKHeX.Core/Saves/SAV3.cs
@@ -628,7 +628,7 @@ public abstract class SAV3 : SaveFile, ILangDeviantSave, IEventFlag37, IBoxDetai
     {
         var ofs = GetMailOffset(mailIndex);
         var data = Large.AsSpan(ofs, Mail3.SIZE).ToArray();
-        return new Mail3(data, ofs, Japanese);
+        return new Mail3(data, ofs);
     }
 
     #region eBerry

--- a/PKHeX.Core/Saves/Substructures/Mail/Mail3.cs
+++ b/PKHeX.Core/Saves/Substructures/Mail/Mail3.cs
@@ -6,10 +6,10 @@ namespace PKHeX.Core;
 public sealed class Mail3 : MailDetail
 {
     public const int SIZE = 0x24;
-    private readonly bool JP;
+    private bool JP;
 
     public Mail3() : base(new byte[SIZE], -1) => ResetData();
-    public Mail3(byte[] data, int ofs, bool japanese) : base(data, ofs) => JP = japanese;
+    public Mail3(byte[] data, int ofs) : base(data, ofs) => JP = Data[0x12 + 5] == 0xFF; // author name length < 6
 
     private void ResetData()
     {
@@ -28,7 +28,7 @@ public sealed class Mail3 : MailDetail
 
     public override ushort GetMessage(int index1, int index2) => ReadUInt16LittleEndian(Data.AsSpan(((index1 * 3) + index2) * 2));
     public override void SetMessage(int index1, int index2, ushort value) => WriteUInt16LittleEndian(Data.AsSpan(((index1 * 3) + index2) * 2), value);
-    public override void CopyTo(SaveFile sav) => sav.SetData(((SAV3)sav).Large, DataOffset);
+    public override void CopyTo(SaveFile sav) => sav.SetData(((SAV3)sav).Large.AsSpan(DataOffset), Data);
 
     public override string AuthorName
     {
@@ -36,8 +36,25 @@ public sealed class Mail3 : MailDetail
         set
         {
             var span = Data.AsSpan(0x12, 8);
-            StringConverter3.SetString(span, value, 7, JP, StringConverterOption.ClearFF);
+            if (value == string.Empty)
+            {
+                span.Fill(0xFF);
+                return;
+            }
+            int len = JP ? 5 : 7;
+            StringConverter3.SetString(span[..(len + 1)], value, len, JP, StringConverterOption.ClearFF);
+            if (!JP)
+                span[..(len - 1)].Replace<byte>(0xFF, 0x00); // Pad with spaces to at least 6 characters
+            else
+                span[^2] = 0x00; // Last two bytes of OT names should be zeroes
+            span[^1] = 0xFF; // Ensure terminator
         }
+    }
+
+    public override byte AuthorLanguage
+    {
+        get => JP ? (byte)LanguageID.Japanese : (byte)LanguageID.English;
+        set => JP = value == (byte)LanguageID.Japanese;
     }
 
     public override ushort AuthorTID { get => ReadUInt16LittleEndian(Data.AsSpan(0x1A)); set => WriteUInt16LittleEndian(Data.AsSpan(0x1A), value); }

--- a/PKHeX.WinForms/Subforms/Save Editors/SAV_MailBox.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/SAV_MailBox.cs
@@ -53,7 +53,6 @@ public partial class SAV_MailBox : Form
         Messages[0][3].Visible = Messages[1][3].Visible = Messages[2][3].Visible = Generation is 4 or 5;
         NUD_AuthorSID.Visible = Generation != 2;
         Label_OTGender.Visible = CB_AuthorVersion.Visible = Generation is 4 or 5;
-        CB_AuthorLang.Visible = Generation is 2 or 4 or 5;
         L_AppearPKM.Visible = AppearPKMs[0].Visible = Generation != 5;
         AppearPKMs[1].Visible = AppearPKMs[2].Visible = Generation == 4;
         NUD_MessageEnding.Visible = Generation == 5;
@@ -153,12 +152,9 @@ public partial class SAV_MailBox : Form
             CB_AuthorVersion.DataSource = new BindingSource(vers, null);
         }
 
-        if (Generation is 2 or 4 or 5)
-        {
-            CB_AuthorLang.Items.Clear();
-            CB_AuthorLang.InitializeBinding();
-            CB_AuthorLang.DataSource = new BindingSource(GameInfo.LanguageDataSource(SAV.Generation), null);
-        }
+        CB_AuthorLang.Items.Clear();
+        CB_AuthorLang.InitializeBinding();
+        CB_AuthorLang.DataSource = new BindingSource(GameInfo.LanguageDataSource(SAV.Generation), null);
 
         var ItemList = GameInfo.Strings.GetItemStrings(SAV.Context, SAV.Version);
         CB_MailType.Items.Clear();
@@ -275,6 +271,8 @@ public partial class SAV_MailBox : Form
         MailDetail mail = m[entry];
         mail.AuthorName = TB_AuthorName.Text;
         mail.AuthorTID = (ushort)NUD_AuthorTID.Value;
+        // ReSharper disable once ConstantNullCoalescingCondition
+        mail.AuthorLanguage = (byte)((int?)CB_AuthorLang.SelectedValue ?? (int)LanguageID.English);
         mail.MailType = CBIndexToMailType(CB_MailType.SelectedIndex);
         // ReSharper disable once ConstantNullCoalescingCondition
         var species = (ushort)WinFormsUtil.GetIndex(CB_AppearPKM1);
@@ -282,8 +280,6 @@ public partial class SAV_MailBox : Form
         {
             mail.AppearPKM = species;
             mail.SetMessage(TB_MessageBody21.Text, TB_MessageBody22.Text, CHK_UserEntered.Checked);
-            // ReSharper disable once ConstantNullCoalescingCondition
-            mail.AuthorLanguage = (byte)((int?)CB_AuthorLang.SelectedValue ?? (int)LanguageID.English);
             return;
         }
         mail.AuthorSID = (ushort)NUD_AuthorSID.Value;
@@ -300,9 +296,6 @@ public partial class SAV_MailBox : Form
 
         // ReSharper disable once ConstantNullCoalescingCondition
         mail.AuthorVersion = (byte)((int?)CB_AuthorVersion.SelectedValue ?? 0);
-
-        // ReSharper disable once ConstantNullCoalescingCondition
-        mail.AuthorLanguage = (byte)((int?)CB_AuthorLang.SelectedValue ?? 0);
 
         mail.AuthorGender = (byte)((mail.AuthorGender & 0xFE) | (LabelValue_GenderF ? 1 : 0));
         switch (mail)
@@ -517,6 +510,7 @@ public partial class SAV_MailBox : Form
         MailDetail mail = m[entry];
         TB_AuthorName.Text = mail.AuthorName;
         NUD_AuthorTID.Value = mail.AuthorTID;
+        CB_AuthorLang.SelectedValue = (int)mail.AuthorLanguage;
         CB_MailType.SelectedIndex = MailTypeToCBIndex(mail);
         var species = mail.AppearPKM;
         if (Generation == 2)
@@ -524,7 +518,6 @@ public partial class SAV_MailBox : Form
             AppearPKMs[0].SelectedValue = (int)species;
             TB_MessageBody21.Text = mail.GetMessage(false);
             TB_MessageBody22.Text = mail.GetMessage(true);
-            CB_AuthorLang.SelectedValue = (int)mail.AuthorLanguage;
             CB_AuthorLang.Enabled = CB_AuthorLang.SelectedValue is not (int)LanguageID.Japanese and not (int)LanguageID.Korean;
             CHK_UserEntered.Checked = mail.UserEntered;
             editing = false;
@@ -543,7 +536,6 @@ public partial class SAV_MailBox : Form
             return;
         }
         CB_AuthorVersion.SelectedValue = (int)mail.AuthorVersion;
-        CB_AuthorLang.SelectedValue = (int)mail.AuthorLanguage;
         LabelValue_GenderF = (mail.AuthorGender & 1) != 0;
         LoadOTlabel();
         switch (mail)


### PR DESCRIPTION
International author names are padded with spaces to at least 6 characters ([decomp](https://github.com/pret/pokeemerald/blob/473e0623ba69541e6659ab88a5b9f35d94a3a76a/src/mail_data.c#L65)).
This means that the buffer will follow the pattern `[XX 00 00 00 00 00 FF] FF`.
In Japanese games, it's displayed in full using the Japanese font, not truncated like OT names/nicknames.

On display, it's treated as Japanese only if the name is 5 characters or less ([decomp](https://github.com/pret/pokeemerald/blob/473e0623ba69541e6659ab88a5b9f35d94a3a76a/src/international_string_util.c#L149)).
This means that the buffer will follow the pattern `[XX FF FF FF FF] FF 00 FF`.
Byte 6 is zero is due to the last two bytes of Japanese player names being zero, and byte 7 is always overwritten with a terminator.