### PR TITLE
Fix Gen 8+ WC SetRibbon

### DIFF
--- a/PKHeX.Core/MysteryGifts/WA8.cs
+++ b/PKHeX.Core/MysteryGifts/WA8.cs
@@ -814,9 +814,9 @@ public sealed class WA8(byte[] Data) : DataMysteryGift(Data), ILangNick, INature
         {
             if (GetRibbon(index))
                 return;
-            var openIndex = Array.IndexOf(Data, RibbonByteNone, RibbonBytesOffset, RibbonBytesCount);
+            var openIndex = Array.IndexOf(Data, (byte)RibbonByteNone, RibbonBytesOffset, RibbonBytesCount);
             ArgumentOutOfRangeException.ThrowIfNegative(openIndex, nameof(openIndex)); // Full?
-            SetRibbonAtIndex(openIndex, (byte)index);
+            SetRibbonAtIndex(RibbonBytesOffset - openIndex, (byte)index);
         }
         else
         {

--- a/PKHeX.Core/MysteryGifts/WB8.cs
+++ b/PKHeX.Core/MysteryGifts/WB8.cs
@@ -831,9 +831,9 @@ public sealed class WB8(byte[] Data) : DataMysteryGift(Data),
         {
             if (GetRibbon(index))
                 return;
-            var openIndex = Array.IndexOf(Data, RibbonByteNone, RibbonBytesOffset, RibbonBytesCount);
+            var openIndex = Array.IndexOf(Data, (byte)RibbonByteNone, RibbonBytesOffset, RibbonBytesCount);
             ArgumentOutOfRangeException.ThrowIfNegative(openIndex, nameof(openIndex)); // Full?
-            SetRibbonAtIndex(openIndex, (byte)index);
+            SetRibbonAtIndex(RibbonBytesOffset - openIndex, (byte)index);
         }
         else
         {

--- a/PKHeX.Core/MysteryGifts/WC8.cs
+++ b/PKHeX.Core/MysteryGifts/WC8.cs
@@ -881,9 +881,9 @@ public sealed class WC8(byte[] Data) : DataMysteryGift(Data), ILangNick, INature
         {
             if (GetRibbon(index))
                 return;
-            var openIndex = Array.IndexOf(Data, RibbonByteNone, RibbonBytesOffset, RibbonBytesCount);
+            var openIndex = Array.IndexOf(Data, (byte)RibbonByteNone, RibbonBytesOffset, RibbonBytesCount);
             ArgumentOutOfRangeException.ThrowIfNegative(openIndex, nameof(openIndex)); // Full?
-            SetRibbonAtIndex(openIndex, (byte)index);
+            SetRibbonAtIndex(RibbonBytesOffset - openIndex, (byte)index);
         }
         else
         {

--- a/PKHeX.Core/MysteryGifts/WC9.cs
+++ b/PKHeX.Core/MysteryGifts/WC9.cs
@@ -910,9 +910,9 @@ public sealed class WC9(byte[] Data) : DataMysteryGift(Data), ILangNick, INature
         {
             if (GetRibbon(index))
                 return;
-            var openIndex = Array.IndexOf(Data, RibbonByteNone, RibbonBytesOffset, RibbonBytesCount);
+            var openIndex = Array.IndexOf(Data, (byte)RibbonByteNone, RibbonBytesOffset, RibbonBytesCount);
             ArgumentOutOfRangeException.ThrowIfNegative(openIndex, nameof(openIndex)); // Full?
-            SetRibbonAtIndex(openIndex, (byte)index);
+            SetRibbonAtIndex(RibbonBytesOffset - openIndex, (byte)index);
         }
         else
         {


### PR DESCRIPTION
PKHeX.Core has two issues when attempting to assign a new ribbon to a wondercard. The issues afect the SetRibbon method in WC8, WB8, WA8 and WC9 classes. 
Note that I didn't test the editings of wondercards prior to the Gen 8.

**Issue 1:**
```
var openIndex = Array.IndexOf(Data, RibbonByteNone, RibbonBytesOffset, RibbonBytesCount);
ArgumentOutOfRangeException.ThrowIfNegative(openIndex, nameof(openIndex)); // Full?
```
The exception would always be thrown due to a missing cast of the searched value from int to byte.

**Issue 2:**
The code above would start searching from the wondercard's `Data` array, starting from position 0x248 (which corresponds to `RibbonBytesOffsets`), thus making the `openIndex `value to be >= 0x248 in case of a succesfull search.

The SetRibbon methods proceed as follows:
`SetRibbonAtIndex(openIndex, (byte)index);`

```
public void SetRibbonAtIndex(int byteIndex, byte ribbonIndex)
{
   ArgumentOutOfRangeException.ThrowIfGreaterThanOrEqual<uint>((uint)byteIndex, RibbonBytesCount);
   Data[RibbonBytesOffset + byteIndex] = ribbonIndex;
}
```

The SetRibonAtIndex methods want the parameter value to be <0x20 (which corresponds to `RibbonBytesCount`) ; while the the `openIndex` value passed is always >=0x248 due to the IndexOf methods searching in the whole wc's `Data` array; which triggers the exception.
