### PR TITLE
Support G6/7 player gender editing

### DIFF
--- a/PKHeX.Core/Saves/Access/ISaveBlock6Core.cs
+++ b/PKHeX.Core/Saves/Access/ISaveBlock6Core.cs
@@ -11,6 +11,7 @@ public interface ISaveBlock6Core
     GameTime6 GameTime { get; }
     Situation6 Situation { get; }
     PlayTime6 Played { get; }
+    FieldMoveModelSave6 Overworld { get; }
     MyStatus6 Status { get; }
     RecordBlock6 Records { get; }
 }

--- a/PKHeX.Core/Saves/Access/SaveBlockAccessor6AO.cs
+++ b/PKHeX.Core/Saves/Access/SaveBlockAccessor6AO.cs
@@ -80,6 +80,7 @@ public sealed class SaveBlockAccessor6AO(SAV6AO sav) : ISaveBlockAccessor<BlockI
     public GameTime6 GameTime { get; } = new(sav, Block(sav, 3));
     public Situation6 Situation { get; } = new(sav, Block(sav, 4));
     public PlayTime6 Played { get; } = new(sav, Block(sav, 6));
+    public FieldMoveModelSave6 Overworld { get; } = new(sav, Block(sav, 10));
     public Misc6AO Misc { get; } = new(sav, Block(sav, 11));
     public BoxLayout6 BoxLayout { get; } = new(sav, Block(sav, 12));
     public BattleBox6 BattleBox { get; } = new(sav, Block(sav, 13));

--- a/PKHeX.Core/Saves/Access/SaveBlockAccessor6AODemo.cs
+++ b/PKHeX.Core/Saves/Access/SaveBlockAccessor6AODemo.cs
@@ -37,6 +37,7 @@ public sealed class SaveBlockAccessor6AODemo(SAV6AODemo sav) : ISaveBlockAccesso
     public GameTime6 GameTime { get; } = new(sav, Block(sav, 2));
     public Situation6 Situation { get; } = new(sav, Block(sav, 3));
     public PlayTime6 Played { get; } = new(sav, Block(sav, 5));
+    public FieldMoveModelSave6 Overworld { get; } = new(sav, Block(sav, 7));
     public Misc6AO Misc { get; } = new(sav, Block(sav, 8));
     public MyStatus6 Status { get; } = new(sav, Block(sav, 9));
     public EventWork6 EventWork { get; } = new(sav, Block(sav, 11));

--- a/PKHeX.Core/Saves/Access/SaveBlockAccessor6XY.cs
+++ b/PKHeX.Core/Saves/Access/SaveBlockAccessor6XY.cs
@@ -78,6 +78,7 @@ public sealed class SaveBlockAccessor6XY(SAV6XY sav) : ISaveBlockAccessor<BlockI
     public Situation6 Situation { get; } = new(sav, Block(sav, 4));
     public PlayTime6 Played { get; } = new(sav, Block(sav, 6));
     public Fashion6XY Fashion { get; } = new(sav, Block(sav, 7));
+    public FieldMoveModelSave6 Overworld { get; } = new(sav, Block(sav, 10));
     public Misc6XY Misc { get; } = new(sav, Block(sav, 11));
     public BoxLayout6 BoxLayout { get; } = new(sav, Block(sav, 12));
     public BattleBox6 BattleBox { get; } = new(sav, Block(sav, 13));

--- a/PKHeX.Core/Saves/SAV6.cs
+++ b/PKHeX.Core/Saves/SAV6.cs
@@ -155,6 +155,7 @@ public abstract class SAV6 : SAV_BEEF, ITrainerStatRecord, ISaveBlock6Core, IReg
     public abstract GameTime6 GameTime { get; }
     public abstract Situation6 Situation { get; }
     public abstract PlayTime6 Played { get; }
+    public abstract FieldMoveModelSave6 Overworld { get; }
     public abstract MyStatus6 Status { get; }
     public abstract RecordBlock6 Records { get; }
     public abstract EventWork6 EventWork { get; }

--- a/PKHeX.Core/Saves/SAV6AO.cs
+++ b/PKHeX.Core/Saves/SAV6AO.cs
@@ -48,6 +48,7 @@ public sealed class SAV6AO : SAV6, ISaveBlock6AO, IMultiplayerSprite, IBoxDetail
     public override GameTime6 GameTime => Blocks.GameTime;
     public override Situation6 Situation => Blocks.Situation;
     public override PlayTime6 Played => Blocks.Played;
+    public override FieldMoveModelSave6 Overworld => Blocks.Overworld;
     public override MyStatus6 Status => Blocks.Status;
     public override RecordBlock6AO Records => Blocks.Records;
     public override EventWork6 EventWork => Blocks.EventWork;

--- a/PKHeX.Core/Saves/SAV6AODemo.cs
+++ b/PKHeX.Core/Saves/SAV6AODemo.cs
@@ -45,6 +45,7 @@ public sealed class SAV6AODemo : SAV6, ISaveBlock6Core
     public override GameTime6 GameTime => Blocks.GameTime;
     public override Situation6 Situation => Blocks.Situation;
     public override PlayTime6 Played => Blocks.Played;
+    public override FieldMoveModelSave6 Overworld => Blocks.Overworld;
     public override MyStatus6 Status => Blocks.Status;
     public override RecordBlock6 Records => Blocks.Records;
     public override EventWork6 EventWork => Blocks.EventWork;

--- a/PKHeX.Core/Saves/SAV6XY.cs
+++ b/PKHeX.Core/Saves/SAV6XY.cs
@@ -50,6 +50,7 @@ public sealed class SAV6XY : SAV6, ISaveBlock6XY, IMultiplayerSprite, IBoxDetail
     public override GameTime6 GameTime => Blocks.GameTime;
     public override Situation6 Situation => Blocks.Situation;
     public override PlayTime6 Played => Blocks.Played;
+    public override FieldMoveModelSave6 Overworld => Blocks.Overworld;
     public override MyStatus6 Status => Blocks.Status;
     public override RecordBlock6 Records => Blocks.Records;
     public override EventWork6 EventWork => Blocks.EventWork;

--- a/PKHeX.Core/Saves/Substructures/Gen6/FieldMoveModelSave6.cs
+++ b/PKHeX.Core/Saves/Substructures/Gen6/FieldMoveModelSave6.cs
@@ -1,0 +1,51 @@
+using System;
+using static System.Buffers.Binary.BinaryPrimitives;
+
+namespace PKHeX.Core;
+
+public sealed class FieldMoveModelSave6(SAV6 sav, Memory<byte> raw) : SaveBlock<SAV6>(sav, raw)
+{
+    private const int SIZE = 0x108;
+    private const int PLAYER_MAGIC = 0x43;
+    private const int OFS_MODEL = 0x8;
+
+    private int GetPlayerModelOffset()
+    {
+        for (int i = 0; i < Data.Length; i += SIZE)
+        {
+            if (Data[i] == PLAYER_MAGIC)
+                return i;
+        }
+        return -1;
+    }
+
+    /// <summary>
+    /// Model used for the player when the save is loaded.
+    /// </summary>
+    /// <remarks>
+    /// 1: Serena, 2: Calem, 3: Shauna, 4: Tierno, 5: Trevor, ..., 171: May, 172: Brendan
+    /// </remarks>
+    public int PlayerModel
+    {
+        get
+        {
+            var ofs = GetPlayerModelOffset();
+            if (ofs == -1)
+                return -1;
+            return ReadUInt16LittleEndian(Data[(ofs + OFS_MODEL)..]);
+        }
+
+        set
+        {
+            var ofs = GetPlayerModelOffset();
+            if (ofs == -1)
+                return;
+            WriteUInt16LittleEndian(Data[(ofs + OFS_MODEL)..], (ushort)value);
+        }
+    }
+
+    /// <summary>
+    /// Resets the player's model to the expected value based on version and gender.
+    /// </summary>
+    public void ResetPlayerModel() => PlayerModel = (SAV.Gender == 0 ? 2 : 1) + (SAV is SAV6AO or SAV6AODemo ? 170 : 0);
+}

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen6/SAV_Trainer.Designer.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen6/SAV_Trainer.Designer.cs
@@ -725,7 +725,6 @@ namespace PKHeX.WinForms
             // CB_Gender
             // 
             CB_Gender.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            CB_Gender.Enabled = false;
             CB_Gender.FormattingEnabled = true;
             CB_Gender.Items.AddRange(new object[] { "♂", "♀" });
             CB_Gender.Location = new System.Drawing.Point(115, 59);

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen6/SAV_Trainer.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen6/SAV_Trainer.cs
@@ -192,6 +192,7 @@ public partial class SAV_Trainer : Form
     {
         SAV.Version = (GameVersion)(CB_Game.SelectedIndex + 0x18);
         SAV.Gender = (byte)CB_Gender.SelectedIndex;
+        SAV.Overworld.ResetPlayerModel();
 
         SAV.TID16 = (ushort)Util.ToUInt32(MT_TID.Text);
         SAV.SID16 = (ushort)Util.ToUInt32(MT_SID.Text);

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen7/SAV_Trainer7.Designer.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen7/SAV_Trainer7.Designer.cs
@@ -573,7 +573,6 @@ namespace PKHeX.WinForms
             // CB_Gender
             // 
             CB_Gender.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            CB_Gender.Enabled = false;
             CB_Gender.FormattingEnabled = true;
             CB_Gender.Items.AddRange(new object[] { "♂", "♀" });
             CB_Gender.Location = new System.Drawing.Point(115, 59);
@@ -581,6 +580,7 @@ namespace PKHeX.WinForms
             CB_Gender.Name = "CB_Gender";
             CB_Gender.Size = new System.Drawing.Size(46, 23);
             CB_Gender.TabIndex = 22;
+            CB_Gender.SelectedIndexChanged += UpdateSkinColor;
             // 
             // TB_MBMS
             // 

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen7/SAV_Trainer7.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen7/SAV_Trainer7.cs
@@ -601,6 +601,13 @@ public partial class SAV_Trainer7 : Form
         }
     }
 
+    private void UpdateSkinColor(object sender, EventArgs e)
+    {
+        if (Loading)
+            return;
+        CB_SkinColor.SelectedIndex = (CB_SkinColor.SelectedIndex & ~0x1) | (CB_Gender.SelectedIndex & 1);
+    }
+
     private void B_AllFlyDest_Click(object sender, EventArgs e)
     {
         for (int i = 0; i < CLB_FlyDest.Items.Count; i++)

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen7/SAV_Trainer7GG.Designer.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen7/SAV_Trainer7GG.Designer.cs
@@ -355,7 +355,6 @@ namespace PKHeX.WinForms
             // CB_Gender
             // 
             CB_Gender.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-            CB_Gender.Enabled = false;
             CB_Gender.FormattingEnabled = true;
             CB_Gender.Items.AddRange(new object[] { "♂", "♀" });
             CB_Gender.Location = new System.Drawing.Point(226, 90);


### PR DESCRIPTION
## Add G6 player gender editing
Basic support for editing the player's gender in Gen 6 without causing the game to hang on a black screen.
Note that the game seems to reset the player's appearance to the default if the saved appearance is for the other gender.

- In the FieldMoveModelSave block, the game writes an entry for the player tagged with 0x43 as the first byte.
- Within this entry at offset 0x8, there's a u16 that stores the model to display; this corresponds to the player's model.
- At least on maps where the corresponding model is present, some other values will actually load that model without a freeze (such as Shauna, Tierno, and Trevor in Vaniville/Route 1/Aquacorde).
- The game will regenerate this entry if it's missing, which is presumably why Gen 7 and later don't have this issue.

----

## Enable G7 player gender editing
Since the existing functionality for SM/USUM/LGPE already changes the player's appearance/pronouns used in dialogue without any glaring issues, I've enabled the option to change the player's gender in those games as well. If needed, maybe a warning that event flags and fashion items are not changed and must be edited separately would be good to have? PLA/SV already have it enabled.