### PR TITLE
MailBox fix

### DIFF
--- a/PKHeX.WinForms/Subforms/Save Editors/SAV_MailBox.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/SAV_MailBox.cs
@@ -586,6 +586,7 @@ public partial class SAV_MailBox : Form
 
     private void SwapSlots(ListBox lb, bool down)
     {
+        if(lb.SelectedIndex == -1) return;
         int index = lb.SelectedIndex;
         var otherIndex = index + (down ? 1 : -1);
         if ((uint)otherIndex >= lb.Items.Count)

--- a/PKHeX.WinForms/Subforms/Save Editors/SAV_MailBox.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/SAV_MailBox.cs
@@ -586,7 +586,8 @@ public partial class SAV_MailBox : Form
 
     private void SwapSlots(ListBox lb, bool down)
     {
-        if(lb.SelectedIndex == -1) return;
+        if (lb.SelectedIndex == -1)
+            return;
         int index = lb.SelectedIndex;
         var otherIndex = index + (down ? 1 : -1);
         if ((uint)otherIndex >= lb.Items.Count)


### PR DESCRIPTION
Catches Out Of Bounds error on ListBox SelectedIndex for when the B_PartyDown_Click event is triggered and the current Selection is in LB_PCBOX.