### PR TITLE
Add PokéCenter Birthday Tandemaus date

### DIFF
--- a/PKHeX.Core/Legality/Encounters/Data/Live/EncounterServerDate.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Live/EncounterServerDate.cs
@@ -208,7 +208,8 @@ public static class EncounterServerDate
         {1537, (new(2024, 07, 24), new(2025, 02, 01))}, // Roy's Fuecoco
         {0511, (new(2024, 08, 15), new(2024, 08, 31))}, // WCS 2024 Steenee
         {0512, (new(2024, 08, 16), new(2024, 08, 20))}, // Tomoya's Sylveon
-
+        {0062, (new(2024, 10, 31), new(2026, 02, 01))}, // PokéCenter Birthday Tandemaus
+        
         {9021, HOME3_ML}, // Hidden Ability Sprigatito
         {9022, HOME3_ML}, // Hidden Ability Fuecoco
         {9023, HOME3_ML}, // Hidden Ability Quaxly


### PR DESCRIPTION
submitting the date based on

- hard copy serial code issued out at Pokemon center in japan on 1st Nov 2024 1000hr (JST)(operating hous : 1000hr), hence countries in the UTC-11 would be able to redeem it on 31th oct 2024 1400hr earliest

- Serial code expiry date is from 1st Nov 2024 - 31th Jan 2026 (JST) or 1st Feb 2026 (UTC+11 )