### PR TITLE
Add Korea(KOR) Operation Get Mythical Keldeo, Zarude & Deoxys's date

### DIFF
--- a/PKHeX.Core/Legality/Encounters/Data/Live/EncounterServerDate.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Live/EncounterServerDate.cs
@@ -210,7 +210,10 @@ public static class EncounterServerDate
         {0512, (new(2024, 08, 16), new(2024, 08, 20))}, // Tomoya's Sylveon
         {0062, (new(2024, 10, 31), new(2026, 02, 01))}, // PokéCenter Birthday Tandemaus
         {0513, (new(2024, 11, 15), new(2024, 11, 23))}, // Patrick's Pelipper
-        
+        {0054, (new(2024, 11, 21), new(2025, 06, 01))}, // Operation Get Mythical's JPN Keldeo
+        {0055, (new(2024, 11, 21), new(2025, 06, 01))}, // Operation Get Mythical's JPN Zarude
+        {0056, (new(2024, 11, 21), new(2025, 06, 01))}, // Operation Get Mythical's JPN Deoxys
+       
         {9021, HOME3_ML}, // Hidden Ability Sprigatito
         {9022, HOME3_ML}, // Hidden Ability Fuecoco
         {9023, HOME3_ML}, // Hidden Ability Quaxly

--- a/PKHeX.Core/Legality/Encounters/Data/Live/EncounterServerDate.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Live/EncounterServerDate.cs
@@ -213,6 +213,10 @@ public static class EncounterServerDate
         {0054, (new(2024, 11, 21), new(2025, 06, 01))}, // Operation Get Mythical's JPN Keldeo
         {0055, (new(2024, 11, 21), new(2025, 06, 01))}, // Operation Get Mythical's JPN Zarude
         {0056, (new(2024, 11, 21), new(2025, 06, 01))}, // Operation Get Mythical's JPN Deoxys
+        {1011, (new(2024, 11, 21), new(2025, 06, 01))}, // Operation Get Mythical's KOR Keldeo
+        {1012, (new(2024, 11, 21), new(2025, 06, 01))}, // Operation Get Mythical's KOR Zarude
+        {1013, (new(2024, 11, 21), new(2025, 06, 01))}, // Operation Get Mythical's KOR Deoxys
+
        
         {9021, HOME3_ML}, // Hidden Ability Sprigatito
         {9022, HOME3_ML}, // Hidden Ability Fuecoco


### PR DESCRIPTION
- Korea's release and end date in-line with Japan.


![Screenshot 2024-11-25 173105](https://github.com/user-attachments/assets/30d4a656-a897-4d8f-986b-26d33acaf100)
