### PR TITLE
Fixing StatusCondition to report sleep correctly

### DIFF
--- a/PKHeX.Core/PKM/Enums/StatusCondition.cs
+++ b/PKHeX.Core/PKM/Enums/StatusCondition.cs
@@ -36,7 +36,7 @@ public static class StatusConditionUtil
         if (value == StatusCondition.None)
             return StatusType.None;
         if (value <= StatusCondition.Sleep7)
-            return (StatusType)value;
+            return StatusType.Sleep;
 
         if ((value & StatusCondition.Paralysis) != 0)
             return StatusType.Paralysis;


### PR DESCRIPTION
Before this patch StatusConditionUtil.GetStatusType can return 7 different status conditions depending on the stage of sleep

For example:

Sleep1 would return Sleep
Sleep2 would return Poison
Sleep3 would return Burn
Sleep4 would return Freeze
Sleep5 would return Paralysis