### PR TITLE
Encounter to PA8 generation tweak

### DIFF
--- a/PKHeX.Core/Legality/Encounters/Templates/Gen8a/EncounterSlot8a.cs
+++ b/PKHeX.Core/Legality/Encounters/Templates/Gen8a/EncounterSlot8a.cs
@@ -61,7 +61,7 @@ public sealed record EncounterSlot8a(EncounterArea8a Parent, ushort Species, byt
         pk.Scale = pk.HeightScalar;
         pk.ResetHeight();
         pk.ResetWeight();
-        SetEncounterMoves(pk, LevelMin);
+        SetEncounterMoves(pk, pk.CurrentLevel);
         pk.ResetPartyStats();
         return pk;
     }

--- a/PKHeX.Core/Legality/Encounters/Templates/Gen8a/EncounterSlot8a.cs
+++ b/PKHeX.Core/Legality/Encounters/Templates/Gen8a/EncounterSlot8a.cs
@@ -61,7 +61,7 @@ public sealed record EncounterSlot8a(EncounterArea8a Parent, ushort Species, byt
         pk.Scale = pk.HeightScalar;
         pk.ResetHeight();
         pk.ResetWeight();
-        SetEncounterMoves(pk, pk.CurrentLevel);
+        SetEncounterMoves(pk, pk.MetLevel);
         pk.ResetPartyStats();
         return pk;
     }


### PR DESCRIPTION
use pa8's current level for determining Mastered flag for Move Shop Records to ensure all flags are checked on encounters who learn moves close to their level mins