### PR TITLE
Add Pokémon Lucario & The Mystery of Mew Movie Gift KOR 아론's Lucario Date

### DIFF
--- a/PKHeX.Core/Legality/Encounters/Data/Live/EncounterServerDate.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Live/EncounterServerDate.cs
@@ -216,6 +216,8 @@ public static class EncounterServerDate
         {1011, (new(2024, 11, 21), new(2025, 06, 01))}, // Operation Get Mythical's KOR Keldeo
         {1012, (new(2024, 11, 21), new(2025, 06, 01))}, // Operation Get Mythical's KOR Zarude
         {1013, (new(2024, 11, 21), new(2025, 06, 01))}, // Operation Get Mythical's KOR Deoxys
+        {1010, (new(2025, 01, 21), new(2025, 04, 01))}, // Pokémon Lucario & The Mystery of Mew Movie Gift KOR 아론's Lucario
+
 
         {9021, HOME3_ML}, // Hidden Ability Sprigatito
         {9022, HOME3_ML}, // Hidden Ability Fuecoco

--- a/PKHeX.Core/Legality/Encounters/Data/Live/EncounterServerDate.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Live/EncounterServerDate.cs
@@ -218,7 +218,6 @@ public static class EncounterServerDate
         {1013, (new(2024, 11, 21), new(2025, 06, 01))}, // Operation Get Mythical's KOR Deoxys
         {1010, (new(2025, 01, 21), new(2025, 04, 01))}, // Pokémon Lucario & The Mystery of Mew Movie Gift KOR 아론's Lucario
 
-
         {9021, HOME3_ML}, // Hidden Ability Sprigatito
         {9022, HOME3_ML}, // Hidden Ability Fuecoco
         {9023, HOME3_ML}, // Hidden Ability Quaxly


### PR DESCRIPTION
- Pokémon Lucario & The Mystery of Mew Movie serial code distributed for those attending the movie's screening in South Korea from 22nd Jan 2025 1000 (UTC +9). Serial code redemption till 31th Mar 2025 2359 (UTC +9) hence date available for (UTC -12 ) regions would start from 21th Jan 2025 and end on 1st Apr 2025 for (UTC +12) regions