### PR TITLE
Handle generation and legality for HOME Manaphy and Enamorus

### DIFF
--- a/PKHeX.Core/Legality/Verifiers/Ball/BallVerifier.cs
+++ b/PKHeX.Core/Legality/Verifiers/Ball/BallVerifier.cs
@@ -23,7 +23,8 @@ public sealed class BallVerifier : Verifier
     private static Ball IsReplacedBall(IVersion enc, PKM pk) => pk switch
     {
         // Trading from PLA origin -> SW/SH will replace the Legends: Arceus ball with a regular Poké Ball
-        PK8 when enc.Version == GameVersion.PLA => Poke,
+        // Enamorus is a special case where the ball is not replaced with a Poké Ball (it's a Cherish Ball)
+        PK8 when enc.Version == GameVersion.PLA && enc is not IFixedBall { FixedBall: (>0 and < Strange) } => Poke,
 
         // No replacement done.
         _ => NoBallReplace,

--- a/PKHeX.Core/MysteryGifts/WA8.cs
+++ b/PKHeX.Core/MysteryGifts/WA8.cs
@@ -509,8 +509,8 @@ public sealed class WA8(byte[] Data) : DataMysteryGift(Data), ILangNick, INature
             SetEggMetData(pk);
         pk.CurrentFriendship = pk.IsEgg ? pi.HatchCycles : pi.BaseFriendship;
 
-        pk.HeightScalar = PokeSizeUtil.GetRandomScalar(rnd);
-        pk.WeightScalar = PokeSizeUtil.GetRandomScalar(rnd);
+        pk.HeightScalar = GetScalar(rnd);
+        pk.WeightScalar = GetScalar(rnd);
         pk.Scale = pk.HeightScalar;
         pk.ResetHeight();
         pk.ResetWeight();
@@ -626,6 +626,14 @@ public sealed class WA8(byte[] Data) : DataMysteryGift(Data), ILangNick, INature
         pk.SetIVs(finalIVs);
     }
 
+    private byte GetScalar(Random rnd)
+    {
+        if (CardID is 9027) // HOME Enamorus is a special case where height/weight is fixed.
+            return 127;
+
+        return PokeSizeUtil.GetRandomScalar(rnd);
+    }
+
     public override bool IsMatchExact(PKM pk, EvoCriteria evo)
     {
         if (!IsEgg)
@@ -694,6 +702,15 @@ public sealed class WA8(byte[] Data) : DataMysteryGift(Data), ILangNick, INature
 
         if (pk is IGanbaru b && b.IsGanbaruValuesBelow(this))
             return false;
+
+        // HOME Enamorus has fixed Height/Weight/Scale.
+        if (CardID is 9027)
+        {
+            if (pk is IScaledSize ht && (ht.HeightScalar != 127 || ht.WeightScalar != 127))
+                return false;
+            if (pk is IScaledSize3 s && s.Scale != 127)
+                return false;
+        }
 
         // PID Types 0 and 1 do not use the fixed PID value.
         // Values 2,3 are specific shiny states, and 4 is fixed value.

--- a/PKHeX.Core/MysteryGifts/WA8.cs
+++ b/PKHeX.Core/MysteryGifts/WA8.cs
@@ -682,7 +682,7 @@ public sealed class WA8(byte[] Data) : DataMysteryGift(Data), ILangNick, INature
 
         const int poke = (int)Core.Ball.LAPoke;
         var expectedBall = Ball == 0 ? poke : Ball;
-        if (expectedBall < poke) // Not even Cherish balls are safe! They get set to the proto-Poké ball.
+        if (expectedBall < poke && !IsHOMEGift) // Not even Cherish balls are safe! They get set to the proto-Poké ball. HOME gifts may still use Cherish.
             expectedBall = poke;
         if (pk is PK8)
             expectedBall = (int)Core.Ball.Poke; // Transferred to SW/SH -> Regular Poké ball

--- a/PKHeX.Core/MysteryGifts/WA8.cs
+++ b/PKHeX.Core/MysteryGifts/WA8.cs
@@ -509,9 +509,15 @@ public sealed class WA8(byte[] Data) : DataMysteryGift(Data), ILangNick, INature
             SetEggMetData(pk);
         pk.CurrentFriendship = pk.IsEgg ? pi.HatchCycles : pi.BaseFriendship;
 
-        pk.HeightScalar = IsScalarFixed ? GetHomeScalar() : PokeSizeUtil.GetRandomScalar(rnd);
-        pk.WeightScalar = IsScalarFixed ? GetHomeScalar() : PokeSizeUtil.GetRandomScalar(rnd);
-        pk.Scale = pk.HeightScalar;
+        if (IsScalarFixed)
+        {
+            pk.Scale = pk.HeightScalar = pk.WeightScalar = GetHomeScalar();
+        }
+        else
+        {
+            pk.Scale = pk.HeightScalar = PokeSizeUtil.GetRandomScalar(rnd);
+            pk.WeightScalar = PokeSizeUtil.GetRandomScalar(rnd);
+        }
         pk.ResetHeight();
         pk.ResetWeight();
 
@@ -529,6 +535,12 @@ public sealed class WA8(byte[] Data) : DataMysteryGift(Data), ILangNick, INature
     ///  HOME Gift Enamorus is a special case where height/weight is fixed.
     /// </summary>
     public bool IsScalarFixed => CardID is 9027;
+
+    private byte GetHomeScalar() => CardID switch
+    {
+        9027 => 127,
+        _ => throw new ArgumentException(),
+    };
 
     private void SetEggMetData(PA8 pk)
     {
@@ -631,12 +643,6 @@ public sealed class WA8(byte[] Data) : DataMysteryGift(Data), ILangNick, INature
         pk.SetIVs(finalIVs);
     }
 
-    private byte GetHomeScalar() => CardID switch
-    {
-        9027 => 127,
-        _ => throw new ArgumentException(),
-    };
-
     public override bool IsMatchExact(PKM pk, EvoCriteria evo)
     {
         if (!IsEgg)
@@ -695,7 +701,7 @@ public sealed class WA8(byte[] Data) : DataMysteryGift(Data), ILangNick, INature
         var expectedBall = Ball == 0 ? poke : Ball;
         if (expectedBall < poke && !IsHOMEGift) // Not even Cherish balls are safe! They get set to the proto-Poké ball. HOME gifts may still use Cherish.
             expectedBall = poke;
-        if (pk is PK8)
+        if (pk is PK8 && expectedBall >= (int)Core.Ball.Strange)
             expectedBall = (int)Core.Ball.Poke; // Transferred to SW/SH -> Regular Poké ball
         if (expectedBall != pk.Ball)
             return false;

--- a/PKHeX.Core/MysteryGifts/WB8.cs
+++ b/PKHeX.Core/MysteryGifts/WB8.cs
@@ -507,8 +507,15 @@ public sealed class WB8(byte[] Data) : DataMysteryGift(Data),
             SetEggMetData(pk);
         pk.CurrentFriendship = pk.IsEgg ? pi.HatchCycles : pi.BaseFriendship;
 
-        pk.HeightScalar = IsScalarFixed ? GetHomeScalar() : PokeSizeUtil.GetRandomScalar(rnd);
-        pk.WeightScalar = IsScalarFixed ? GetHomeScalar() : PokeSizeUtil.GetRandomScalar(rnd);
+        if (IsScalarFixed)
+        {
+            pk.HeightScalar = pk.WeightScalar = GetHomeScalar();
+        }
+        else
+        {
+            pk.HeightScalar = PokeSizeUtil.GetRandomScalar(rnd);
+            pk.WeightScalar = PokeSizeUtil.GetRandomScalar(rnd);
+        }
 
         pk.ResetPartyStats();
         pk.RefreshChecksum();
@@ -524,6 +531,12 @@ public sealed class WB8(byte[] Data) : DataMysteryGift(Data),
     ///  HOME Gift Manaphy is a special case where height/weight is fixed.
     /// </summary>
     public bool IsScalarFixed => CardID is 9026;
+
+    private byte GetHomeScalar() => CardID switch
+    {
+        9026 => 128,
+        _ => throw new ArgumentException(),
+    };
 
     private void SetEggMetData(PB8 pk)
     {
@@ -626,12 +639,6 @@ public sealed class WB8(byte[] Data) : DataMysteryGift(Data),
         }
         pk.SetIVs(finalIVs);
     }
-
-    private byte GetHomeScalar() => CardID switch
-    {
-        9026 => 128,
-        _ => throw new ArgumentException(),
-    };
 
     public override bool IsMatchExact(PKM pk, EvoCriteria evo)
     {

--- a/PKHeX.Core/MysteryGifts/WB8.cs
+++ b/PKHeX.Core/MysteryGifts/WB8.cs
@@ -507,8 +507,8 @@ public sealed class WB8(byte[] Data) : DataMysteryGift(Data),
             SetEggMetData(pk);
         pk.CurrentFriendship = pk.IsEgg ? pi.HatchCycles : pi.BaseFriendship;
 
-        pk.HeightScalar = PokeSizeUtil.GetRandomScalar(rnd);
-        pk.WeightScalar = PokeSizeUtil.GetRandomScalar(rnd);
+        pk.HeightScalar = GetScalar(rnd);
+        pk.WeightScalar = GetScalar(rnd);
 
         pk.ResetPartyStats();
         pk.RefreshChecksum();
@@ -622,6 +622,14 @@ public sealed class WB8(byte[] Data) : DataMysteryGift(Data),
         pk.SetIVs(finalIVs);
     }
 
+    private byte GetScalar(Random rnd)
+    {
+        if (CardID is 9026) // HOME Manaphy is a special case where height/weight is fixed.
+            return 180;
+
+        return PokeSizeUtil.GetRandomScalar(rnd);
+    }
+
     public override bool IsMatchExact(PKM pk, EvoCriteria evo)
     {
         if (!IsEgg)
@@ -685,6 +693,15 @@ public sealed class WB8(byte[] Data) : DataMysteryGift(Data),
         if (OTGender < 2 && OTGender != pk.OriginalTrainerGender) return false;
         if ((sbyte)Nature != -1 && pk.Nature != Nature) return false;
         if (Gender != 3 && Gender != pk.Gender) return false;
+
+        // HOME Manaphy has fixed Height/Weight/Scale.
+        if (CardID is 9026)
+        {
+            if (pk is IScaledSize ht && (ht.HeightScalar != 128 || ht.WeightScalar != 128))
+                return false;
+            if (pk is IScaledSize3 s && s.Scale != 128)
+                return false;
+        }
 
         // PID Types 0 and 1 do not use the fixed PID value.
         // Values 2,3 are specific shiny states, and 4 is fixed value.


### PR DESCRIPTION
The WB8 and WA8 classes do not have properties for HeightScalar and WeightScalar, so a quirk in the code is needed to ensure correct entity generation and legality checks.

Additionally, Enamorus comes with a Cherish Ball rather than an LA-specific/proto ball, which also needs to be accounted for.