### PR TITLE
Handle Arbok Mainland China wondercard

### DIFF
--- a/PKHeX.Core/MysteryGifts/WB7.cs
+++ b/PKHeX.Core/MysteryGifts/WB7.cs
@@ -319,9 +319,6 @@ public sealed class WB7(byte[] Data)
 
     public int GetLanguage(int redeemLanguage)
     {
-        if (IsMainlandChinaGift)
-            return (int)LanguageID.ChineseS;
-
         var languageOffset = GetLanguageIndex(redeemLanguage);
         var value = Data[0x1D8 + languageOffset];
         if (value != 0) // Fixed receiving language
@@ -366,7 +363,7 @@ public sealed class WB7(byte[] Data)
         var metLevel = MetLevel > 0 ? MetLevel : currentLevel;
         var pi = PersonalTable.GG.GetFormEntry(Species, Form);
 
-        var redeemLanguage = tr.Language;
+        var redeemLanguage = IsMainlandChinaGift ? (int)LanguageID.ChineseS : tr.Language;
         var language = GetLanguage(redeemLanguage);
         bool hasOT = GetHasOT(redeemLanguage);
 

--- a/PKHeX.Core/MysteryGifts/WB7.cs
+++ b/PKHeX.Core/MysteryGifts/WB7.cs
@@ -315,7 +315,7 @@ public sealed class WB7(byte[] Data)
     /// <remarks>
     /// Gifts received can be locally traded to the international release, so there is no need to consider residence or transferability.
     /// </remarks>
-    public bool IsMainlandChinaGift => CardID is (1501);
+    public bool IsMainlandChinaGift => CardID is (1501 or 1503);
 
     public int GetLanguage(int redeemLanguage)
     {


### PR DESCRIPTION
Unlike the previous China Mainland-exclusive wondercard (Meltan), Arbok has preset OT values for all languages. 

![immagine](https://github.com/user-attachments/assets/b986d356-fd7e-47bb-baec-2c0c2e6ffe95)

Although it is not legally possible to redeem this wondercard in any language other than CHS, PKHeX currently sets the `redeemLanguage` based on the active save file. This causes OT and Nickname info to be generated according to the save file’s language instead of CHS.

For Arbok, this results in it being generated with the Nickname flag on any non-CHS save. This can also cause problems for ALM, which fails to pull the correct encounter unless "Language: 9" is manually specified in the set.

Since this wondercard can only be redeemed on CHS save files, the `redeemLanguage` should always be CHS, not just the `language` of the generated entity.

