### PR TITLE
Add Pokémon Day 2025 Flying Tera Type Eevee's date

### DIFF
--- a/PKHeX.Core/Legality/Encounters/Data/Live/DistributionWindow.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Live/DistributionWindow.cs
@@ -1,0 +1,42 @@
+using System;
+
+namespace PKHeX.Core;
+
+/// <summary>
+/// Record to store the date range availability for a distribution.
+/// </summary>
+/// <param name="Start">Absolute earliest date the distribution can be received.</param>
+/// <param name="End">Absolute latest date the distribution can be received.</param>
+/// <param name="GenerateDaysAfterStart">Days after the earliest start date that a distribution would normally be generated with.</param>
+public readonly record struct DistributionWindow(DateOnly Start, DateOnly? End = null, byte GenerateDaysAfterStart = 0)
+{
+    public DistributionWindow(int startYear, int startMonth, int startDay, byte generateDaysAfterStart = 0)
+        : this(new DateOnly(startYear, startMonth, startDay), null, generateDaysAfterStart) { }
+
+    public DistributionWindow(int startYear, int startMonth, int startDay, int endYear, int endMonth, int endDay, byte generateDaysAfterStart = 0)
+        : this(new DateOnly(startYear, startMonth, startDay), new DateOnly(endYear, endMonth, endDay), generateDaysAfterStart) { }
+
+    /// <summary>
+    /// Checks if the date obtained is within the date of availability for the given range.
+    /// </summary>
+    /// <param name="obtained">Date obtained.</param>
+    /// <returns>True if the date obtained is within the date of availability for the given range.</returns>
+    public bool Contains(DateOnly obtained) => Start <= obtained && End is null || obtained <= End;
+
+    /// <summary>
+    /// Get a valid date within the generation range.
+    /// </summary>
+    public DateOnly GetGenerateDate() => Start.AddDays(GenerateDaysAfterStart);
+
+    /// <summary>
+    /// Checks if the distribution was acquired earlier than generally available.
+    /// </summary>
+    /// <param name="obtained">Date obtained.</param>
+    /// <remarks>Only relevant when <see cref="GenerateDaysAfterStart"/> is non-zero.</remarks>
+    public bool IsEarlyAcquisition(DateOnly obtained) => obtained < Start.AddDays(GenerateDaysAfterStart);
+
+    /// <summary>
+    /// Checks if the distribution can be acquired earlier than generally available.
+    /// </summary>
+    public bool CanAcquireEarly => GenerateDaysAfterStart > 0;
+}

--- a/PKHeX.Core/Legality/Encounters/Data/Live/EncounterServerDate.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Live/EncounterServerDate.cs
@@ -219,6 +219,7 @@ public static class EncounterServerDate
         {1012, (new(2024, 11, 21), new(2025, 06, 01))}, // Operation Get Mythical's KOR Zarude
         {1013, (new(2024, 11, 21), new(2025, 06, 01))}, // Operation Get Mythical's KOR Deoxys
         {1010, (new(2025, 01, 21), new(2025, 04, 01))}, // Pokémon Lucario & The Mystery of Mew Movie Gift KOR 아론's Lucario
+        {0514, (new(2025, 02, 05), new(2025, 07, 01))}, // Pokémon Day 2025 Flying Tera Type Eevee
 
         {9021, HOME3_ML}, // Hidden Ability Sprigatito
         {9022, HOME3_ML}, // Hidden Ability Fuecoco

--- a/PKHeX.Core/Legality/Encounters/Data/Live/EncounterServerDate.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Live/EncounterServerDate.cs
@@ -9,85 +9,65 @@ namespace PKHeX.Core;
 /// </summary>
 public static class EncounterServerDate
 {
-    private static bool IsValidDate(DateOnly obtained, DateOnly start) => obtained >= start && obtained <= DateOnly.FromDateTime(DateTime.UtcNow);
-
-    private static bool IsValidDate(DateOnly obtained, DateOnly start, DateOnly end) => obtained >= start && obtained <= end;
-
-    /// <summary>
-    /// Checks if the date obtained is within the date of availability for the given <see cref="value"/>.
-    /// </summary>
-    /// <param name="obtained">Date obtained.</param>
-    /// <param name="value">Date of availability. End date is inclusive.</param>
-    /// <returns>True if the date obtained is within the date of availability for the given <see cref="value"/>.</returns>
-    private static bool IsValidDate(DateOnly obtained, (DateOnly Start, DateOnly? End) value)
-    {
-        var (start, end) = value;
-        if (end is not { } x)
-            return IsValidDate(obtained, start);
-        return IsValidDate(obtained, start, x);
-    }
-
     private static EncounterServerDateCheck Result(bool result) => result ? Valid : Invalid;
 
-    /// <inheritdoc cref="IsValidDateWC8(WC8, DateOnly)"/>
-    public static EncounterServerDateCheck IsValidDate(this IEncounterServerDate enc, DateOnly obtained) => enc switch
+    /// <summary>
+    /// Checks if the date obtained is within the date of availability for the given <see cref="enc"/>.
+    /// </summary>
+    /// <param name="enc">Encounter to check.</param>
+    /// <param name="obtained">Date obtained.</param>
+    /// <returns>True if the date obtained is within the date of availability for the given <see cref="enc"/>.</returns>
+    public static EncounterServerDateCheck IsWithinDistributionWindow(this IEncounterServerDate enc, DateOnly obtained) => enc switch
     {
-        WC8 wc8 => Result(IsValidDateWC8(wc8, obtained)),
-        WA8 wa8 => Result(IsValidDateWA8(wa8, obtained)),
-        WB8 wb8 => Result(IsValidDateWB8(wb8, obtained)),
-        WC9 wc9 => Result(IsValidDateWC9(wc9, obtained)),
+        WC8 wc8 => Result(wc8.IsWithinDistributionWindow(obtained)),
+        WA8 wa8 => Result(wa8.IsWithinDistributionWindow(obtained)),
+        WB8 wb8 => Result(wb8.IsWithinDistributionWindow(obtained)),
+        WC9 wc9 => Result(wc9.IsWithinDistributionWindow(obtained)),
         EncounterSlot8GO g8 => Result(g8.IsWithinDistributionWindow(obtained)),
         _ => throw new ArgumentOutOfRangeException(nameof(enc)),
     };
 
-    /// <summary>
-    /// Checks if the date obtained is within the date of availability for the given <see cref="card"/>.
-    /// </summary>
-    /// <param name="card">Gift card to check.</param>
-    /// <param name="obtained">Date obtained.</param>
-    /// <returns>True if the date obtained is within the date of availability for the given <see cref="card"/>.</returns>
-    public static bool IsValidDateWC8(WC8 card, DateOnly obtained) => (WC8Gifts.TryGetValue(card.CardID, out var time)
-                                                                      || WC8GiftsChk.TryGetValue(card.Checksum, out time)) && IsValidDate(obtained, time);
+    /// <inheritdoc cref="IsWithinDistributionWindow(IEncounterServerDate,DateOnly)"/>
+    public static bool IsWithinDistributionWindow(this WC8 card, DateOnly obtained) => card.GetDistributionWindow(out var window) && window.Contains(obtained);
 
-    /// <inheritdoc cref="IsValidDateWC8(WC8, DateOnly)"/>
-    public static bool IsValidDateWA8(WA8 card, DateOnly obtained) => WA8Gifts.TryGetValue(card.CardID, out var time) && IsValidDate(obtained, time);
+    /// <inheritdoc cref="IsWithinDistributionWindow(IEncounterServerDate,DateOnly)"/>
+    public static bool IsWithinDistributionWindow(this WA8 card, DateOnly obtained) => card.GetDistributionWindow(out var window) && window.Contains(obtained);
 
-    /// <inheritdoc cref="IsValidDateWC8(WC8, DateOnly)"/>
-    public static bool IsValidDateWB8(WB8 card, DateOnly obtained) => WB8Gifts.TryGetValue(card.CardID, out var time) && IsValidDate(obtained, time);
+    /// <inheritdoc cref="IsWithinDistributionWindow(IEncounterServerDate,DateOnly)"/>
+    public static bool IsWithinDistributionWindow(this WB8 card, DateOnly obtained) => card.GetDistributionWindow(out var window) && window.Contains(obtained);
 
-    /// <inheritdoc cref="IsValidDateWC8(WC8, DateOnly)"/>
-    public static bool IsValidDateWC9(WC9 card, DateOnly obtained) => (WC9Gifts.TryGetValue(card.CardID, out var time)
-                                                                      || WC9GiftsChk.TryGetValue(card.Checksum, out time)) && IsValidDate(obtained, time);
+    /// <inheritdoc cref="IsWithinDistributionWindow(IEncounterServerDate,DateOnly)"/>
+    public static bool IsWithinDistributionWindow(this WC9 card, DateOnly obtained) => card.GetDistributionWindow(out var window) && window.Contains(obtained);
 
-    /// <summary>
-    /// Used to signify an unbounded end date.
-    /// </summary>
-    private static readonly DateOnly? Never = null;
+    public static bool GetDistributionWindow(this WC8 card, out DistributionWindow window) => WC8Gifts.TryGetValue(card.CardID, out window) || WC8GiftsChk.TryGetValue(card.Checksum, out window);
+    public static bool GetDistributionWindow(this WA8 card, out DistributionWindow window) => WA8Gifts.TryGetValue(card.CardID, out window);
+    public static bool GetDistributionWindow(this WB8 card, out DistributionWindow window) => WB8Gifts.TryGetValue(card.CardID, out window);
+    public static bool GetDistributionWindow(this WC9 card, out DistributionWindow window) => WC9Gifts.TryGetValue(card.CardID, out window) || WC9GiftsChk.TryGetValue(card.Checksum, out window);
 
     /// <summary>
     /// Initial introduction of HOME support for SW/SH; gift availability (generating) was revised in 3.0.0.
     /// </summary>
-    private static readonly (DateOnly Start, DateOnly  End) HOME1 = (new(2020, 02, 12), new(2023, 05, 29));
+    private static readonly DistributionWindow HOME1 = new(2020, 02, 12, 2023, 05, 29);
 
     /// <summary>
     /// Revision of HOME support for SW/SH; gift availability (generating) was revised in 3.0.0.
     /// </summary>
-    private static readonly (DateOnly Start, DateOnly? End) HOME3 = (new(2023, 05, 30), Never);
+    private static readonly DistributionWindow HOME3 = new(2023, 05, 30);
 
     /// <summary>
     /// Introduction of BD/SP and PLA support; gift availability time window for these games.
     /// </summary>
-    private static readonly (DateOnly Start, DateOnly? End) HOME2_AB = (new(2022, 05, 18), Never);
+    private static readonly DistributionWindow HOME2_AB = new(2022, 05, 18);
 
     /// <summary>
     /// Introduction of S/V support; gift availability time window for these games.
     /// </summary>
-    private static readonly (DateOnly Start, DateOnly? End) HOME3_ML = (new(2023, 05, 30), Never);
+    private static readonly DistributionWindow HOME3_ML = new(2023, 05, 30);
 
     /// <summary>
     /// Minimum date the gift can be received.
     /// </summary>
-    public static readonly Dictionary<int, (DateOnly Start, DateOnly? End)> WC8GiftsChk = new()
+    private static readonly Dictionary<int, DistributionWindow> WC8GiftsChk = new()
     {
         // HOME 1.0.0 to 2.0.2 - PID, EC, Height, Weight = 0 (rev 1)
         {0xFBBE, HOME1}, // Bulbasaur
@@ -113,118 +93,118 @@ public static class EncounterServerDate
     /// <summary>
     /// Minimum date the gift can be received.
     /// </summary>
-    public static readonly Dictionary<int, (DateOnly Start, DateOnly? End)> WC8Gifts = new()
+    private static readonly Dictionary<int, DistributionWindow> WC8Gifts = new()
     {
-        {9008, (new(2020, 06, 02), Never)}, // Hidden Ability Grookey
-        {9009, (new(2020, 06, 02), Never)}, // Hidden Ability Scorbunny
-        {9010, (new(2020, 06, 02), Never)}, // Hidden Ability Sobble
-        {9011, (new(2020, 06, 30), Never)}, // Shiny Zeraora
-        {9012, (new(2020, 11, 10), Never)}, // Gigantamax Melmetal
-        {9013, (new(2021, 06, 17), Never)}, // Gigantamax Bulbasaur
-        {9014, (new(2021, 06, 17), Never)}, // Gigantamax Squirtle
+        {9008, new(2020, 06, 02)}, // Hidden Ability Grookey
+        {9009, new(2020, 06, 02)}, // Hidden Ability Scorbunny
+        {9010, new(2020, 06, 02)}, // Hidden Ability Sobble
+        {9011, new(2020, 06, 30)}, // Shiny Zeraora
+        {9012, new(2020, 11, 10)}, // Gigantamax Melmetal
+        {9013, new(2021, 06, 17)}, // Gigantamax Bulbasaur
+        {9014, new(2021, 06, 17)}, // Gigantamax Squirtle
     };
 
     /// <summary>
     /// Minimum date the gift can be received.
     /// </summary>
-    public static readonly Dictionary<int, (DateOnly Start, DateOnly? End)> WA8Gifts = new()
+    private static readonly Dictionary<int, DistributionWindow> WA8Gifts = new()
     {
-        {0138, (new(2022, 01, 27), new(2023, 02, 01))}, // Poké Center Happiny
-        {0301, (new(2022, 02, 04), new(2023, 03, 01))}, // プロポチャ Piplup
-        {0801, (new(2022, 02, 25), new(2022, 06, 01))}, // Teresa Roca Hisuian Growlithe
-        {1201, (new(2022, 05, 31), new(2022, 08, 01))}, // 전이마을 Regigigas
-        {1202, (new(2022, 05, 31), new(2022, 08, 01))}, // 빛나's Piplup
-        {1203, (new(2022, 08, 18), new(2022, 11, 01))}, // Arceus Chronicles Hisuian Growlithe
-        {0151, (new(2022, 09, 03), new(2022, 10, 01))}, // Otsukimi Festival 2022 Clefairy
+        {0138, new(2022, 01, 27, 2023, 02, 01)}, // Poké Center Happiny
+        {0301, new(2022, 02, 04, 2023, 03, 01)}, // プロポチャ Piplup
+        {0801, new(2022, 02, 25, 2022, 06, 01)}, // Teresa Roca Hisuian Growlithe
+        {1201, new(2022, 05, 31, 2022, 08, 01)}, // 전이마을 Regigigas
+        {1202, new(2022, 05, 31, 2022, 08, 01)}, // 빛나's Piplup
+        {1203, new(2022, 08, 18, 2022, 11, 01)}, // Arceus Chronicles Hisuian Growlithe
+        {0151, new(2022, 09, 03, 2022, 10, 01)}, // Otsukimi Festival 2022 Clefairy
 
         {9018, HOME2_AB}, // Hidden Ability Rowlet
         {9019, HOME2_AB}, // Hidden Ability Cyndaquil
         {9020, HOME2_AB}, // Hidden Ability Oshawott
-        {9027, (new(2025, 01, 28), Never)}, // Shiny Enamorus
+        {9027, new(2025, 01, 28)}, // Shiny Enamorus
     };
 
     /// <summary>
     /// Minimum date the gift can be received.
     /// </summary>
-    public static readonly Dictionary<int, (DateOnly Start, DateOnly? End)> WB8Gifts = new()
+    private static readonly Dictionary<int, DistributionWindow> WB8Gifts = new()
     {
         {9015, HOME2_AB}, // Hidden Ability Turtwig
         {9016, HOME2_AB}, // Hidden Ability Chimchar
         {9017, HOME2_AB}, // Hidden Ability Piplup
-        {9026, (new(2025, 01, 28), Never)}, // Shiny Manaphy
+        {9026, new(2025, 01, 28)}, // Shiny Manaphy
     };
 
     /// <summary>
     /// Minimum date the gift can be received.
     /// </summary>
-    public static readonly Dictionary<int, (DateOnly Start, DateOnly? End)> WC9GiftsChk = new()
+    private static readonly Dictionary<int, DistributionWindow> WC9GiftsChk = new()
     {
-        {0xE5EB, (new(2022, 11, 17), new(2023, 02, 03))}, // Fly Pikachu - rev 1 (male 128 height/weight)
-        {0x908B, (new(2023, 02, 02), new(2023, 03, 01))}, // Fly Pikachu - rev 2 (both 0 height/weight)
+        {0xE5EB, new(2022, 11, 17, 2023, 02, 03)}, // Fly Pikachu - rev 1 (male 128 height/weight)
+        {0x908B, new(2023, 02, 02, 2023, 03, 01)}, // Fly Pikachu - rev 2 (both 0 height/weight)
     };
 
     /// <summary>
     /// Minimum date the gift can be received.
     /// </summary>
-    public static readonly Dictionary<int, (DateOnly Start, DateOnly? End)> WC9Gifts = new()
+    private static readonly Dictionary<int, DistributionWindow> WC9Gifts = new()
     {
-        {0001, (new(2022, 11, 17), Never)}, // PokéCenter Birthday Flabébé
-        {0006, (new(2022, 12, 16), new(2023, 02, 01))}, // Jump Festa Gyarados
-        {0501, (new(2023, 02, 16), new(2023, 02, 21))}, // Jiseok's Garganacl
-        {1513, (new(2023, 02, 27), new(2024, 03, 01))}, // Hisuian Zoroark DLC Purchase Gift
-        {0502, (new(2023, 03, 31), new(2023, 07, 01))}, // TCG Flying Lechonk
-        {0503, (new(2023, 04, 13), new(2023, 04, 18))}, // Gavin's Palafin (-1 start date tolerance for GMT-10 regions)
-        {0025, (new(2023, 04, 21), new(2023, 08, 01))}, // Pokémon Center Pikachu (Mini & Jumbo)
-        {1003, (new(2023, 05, 29), new(2023, 08, 01))}, // Arceus and the Jewel of Life Distribution - Pokémon Store Tie-In Bronzong
-        {1002, (new(2023, 05, 31), new(2023, 08, 01))}, // Arceus and the Jewel of Life Distribution Pichu
-        {0028, (new(2023, 06, 09), new(2023, 06, 12))}, // そらみつ's Bronzong (-1 start date tolerance for GMT-10 regions)
-        {1005, (new(2023, 06, 16), new(2023, 06, 20))}, // 정원석's Gastrodon (-1 start date tolerance for GMT-10 regions)
-        {0504, (new(2023, 06, 30), new(2023, 07, 04))}, // Paul's Shiny Arcanine
-        {1522, (new(2023, 07, 21), new(2023, 09, 01))}, // Dark Tera Type Charizard
-        {0024, (new(2023, 07, 26), new(2023, 08, 19))}, // Nontaro's Shiny Grimmsnarl
-        {0505, (new(2023, 08, 07), new(2023, 09, 01))}, // WCS 2023 Stretchy Form Tatsugiri
-        {1521, (new(2023, 08, 08), new(2023, 09, 19))}, // My Very Own Mew
-        {0506, (new(2023, 08, 10), new(2023, 08, 15))}, // Eduardo Gastrodon
-        {1524, (new(2023, 09, 06), new(2024, 09, 01))}, // Glaseado Cetitan
-        {0507, (new(2023, 10, 13), new(2024, 01, 01))}, // Trixie Mimikyu
-        {0031, (new(2023, 11, 01), new(2025, 02, 01))}, // PokéCenter Birthday Charcadet and Pawmi
-        {1006, (new(2023, 11, 02), new(2024, 01, 01))}, // Korea Bundle Fidough
-        {0508, (new(2023, 11, 17), new(2023, 11, 21))}, // Alex's Dragapult
-        {1526, (new(2023, 11, 22), new(2024, 11, 01))}, // Team Star Revavroom
-        {1529, (new(2023, 12, 07), new(2023, 12, 22))}, // New Moon Darkrai
-        {1530, (new(2023, 12, 07), new(2024, 01, 04))}, // Shiny Buddy Lucario
-        {1527, (new(2023, 12, 13), new(2024, 12, 01))}, // Paldea Gimmighoul
-        {0036, (new(2023, 12, 14), new(2024, 02, 14))}, // コロコロ Roaring Moon and Iron Valiant
-        {1007, (new(2023, 12, 29), new(2024, 02, 11))}, // 윈터페스타 Baxcalibur
-        {0038, (new(2024, 01, 14), new(2024, 03, 14))}, // コロコロ Scream Tail, Brute Bonnet, Flutter Mane, Iron Hands, Iron Jugulis, and Iron Thorns
-        {0048, (new(2024, 02, 22), new(2024, 04, 01))}, // Project Snorlax Campaign Gift
-        {1534, (new(2024, 03, 12), new(2025, 03, 01))}, // YOASOBI Pawmot
-        {1535, (new(2024, 03, 14), new(2024, 10, 01))}, // Liko's Sprigatito
-        {0509, (new(2024, 04, 04), new(2024, 04, 09))}, // Marco's Iron Hands
-        {1008, (new(2024, 05, 04), new(2024, 05, 08))}, // 신여명's Flutter Mane
-        {0052, (new(2024, 05, 11), new(2024, 07, 01))}, // Sophia's Gyarados
-        {1536, (new(2024, 05, 18), new(2024, 12, 01))}, // Dot's Quaxly
-        {0049, (new(2024, 05, 31), new(2024, 06, 03))}, // ナーク's Talonflame
-        {0510, (new(2024, 06, 07), new(2024, 06, 11))}, // Nils's Porygon2
-        {0050, (new(2024, 07, 13), new(2024, 10, 01))}, // Japan's Pokéss Summer Festival Eevee
-        {1537, (new(2024, 07, 24), new(2025, 02, 01))}, // Roy's Fuecoco
-        {0511, (new(2024, 08, 15), new(2024, 08, 31))}, // WCS 2024 Steenee
-        {0512, (new(2024, 08, 16), new(2024, 08, 20))}, // Tomoya's Sylveon
-        {0062, (new(2024, 10, 31), new(2026, 02, 01))}, // PokéCenter Birthday Tandemaus
-        {0513, (new(2024, 11, 15), new(2024, 11, 23))}, // Patrick's Pelipper
-        {0054, (new(2024, 11, 21), new(2025, 06, 01))}, // Operation Get Mythical's JPN Keldeo
-        {0055, (new(2024, 11, 21), new(2025, 06, 01))}, // Operation Get Mythical's JPN Zarude
-        {0056, (new(2024, 11, 21), new(2025, 06, 01))}, // Operation Get Mythical's JPN Deoxys
-        {1011, (new(2024, 11, 21), new(2025, 06, 01))}, // Operation Get Mythical's KOR Keldeo
-        {1012, (new(2024, 11, 21), new(2025, 06, 01))}, // Operation Get Mythical's KOR Zarude
-        {1013, (new(2024, 11, 21), new(2025, 06, 01))}, // Operation Get Mythical's KOR Deoxys
-        {1010, (new(2025, 01, 21), new(2025, 04, 01))}, // Pokémon Lucario & The Mystery of Mew Movie Gift KOR 아론's Lucario
-        {0514, (new(2025, 02, 05), new(2025, 07, 01))}, // Pokémon Day 2025 Flying Tera Type Eevee
+        {0001, new(2022, 11, 17)}, // PokéCenter Birthday Flabébé
+        {0006, new(2022, 12, 16, 2023, 02, 01)}, // Jump Festa Gyarados
+        {0501, new(2023, 02, 16, 2023, 02, 21)}, // Jiseok's Garganacl
+        {1513, new(2023, 02, 27, 2024, 03, 01)}, // Hisuian Zoroark DLC Purchase Gift
+        {0502, new(2023, 03, 31, 2023, 07, 01)}, // TCG Flying Lechonk
+        {0503, new(2023, 04, 13, 2023, 04, 18)}, // Gavin's Palafin (-1 start date tolerance for GMT-10 regions)
+        {0025, new(2023, 04, 21, 2023, 08, 01)}, // Pokémon Center Pikachu (Mini & Jumbo)
+        {1003, new(2023, 05, 29, 2023, 08, 01)}, // Arceus and the Jewel of Life Distribution - Pokémon Store Tie-In Bronzong
+        {1002, new(2023, 05, 31, 2023, 08, 01)}, // Arceus and the Jewel of Life Distribution Pichu
+        {0028, new(2023, 06, 09, 2023, 06, 12)}, // そらみつ's Bronzong (-1 start date tolerance for GMT-10 regions)
+        {1005, new(2023, 06, 16, 2023, 06, 20)}, // 정원석's Gastrodon (-1 start date tolerance for GMT-10 regions)
+        {0504, new(2023, 06, 30, 2023, 07, 04)}, // Paul's Shiny Arcanine
+        {1522, new(2023, 07, 21, 2023, 09, 01)}, // Dark Tera Type Charizard
+        {0024, new(2023, 07, 26, 2023, 08, 19)}, // Nontaro's Shiny Grimmsnarl
+        {0505, new(2023, 08, 07, 2023, 09, 01)}, // WCS 2023 Stretchy Form Tatsugiri
+        {1521, new(2023, 08, 08, 2023, 09, 19)}, // My Very Own Mew
+        {0506, new(2023, 08, 10, 2023, 08, 15)}, // Eduardo Gastrodon
+        {1524, new(2023, 09, 06, 2024, 09, 01)}, // Glaseado Cetitan
+        {0507, new(2023, 10, 13, 2024, 01, 01)}, // Trixie Mimikyu
+        {0031, new(2023, 11, 01, 2025, 02, 01)}, // PokéCenter Birthday Charcadet and Pawmi
+        {1006, new(2023, 11, 02, 2024, 01, 01)}, // Korea Bundle Fidough
+        {0508, new(2023, 11, 17, 2023, 11, 21)}, // Alex's Dragapult
+        {1526, new(2023, 11, 22, 2024, 11, 01)}, // Team Star Revavroom
+        {1529, new(2023, 12, 07, 2023, 12, 22)}, // New Moon Darkrai
+        {1530, new(2023, 12, 07, 2024, 01, 04)}, // Shiny Buddy Lucario
+        {1527, new(2023, 12, 13, 2024, 12, 01)}, // Paldea Gimmighoul
+        {0036, new(2023, 12, 14, 2024, 02, 14)}, // コロコロ Roaring Moon and Iron Valiant
+        {1007, new(2023, 12, 29, 2024, 02, 11)}, // 윈터페스타 Baxcalibur
+        {0038, new(2024, 01, 14, 2024, 03, 14)}, // コロコロ Scream Tail, Brute Bonnet, Flutter Mane, Iron Hands, Iron Jugulis, and Iron Thorns
+        {0048, new(2024, 02, 22, 2024, 04, 01)}, // Project Snorlax Campaign Gift
+        {1534, new(2024, 03, 12, 2025, 03, 01)}, // YOASOBI Pawmot
+        {1535, new(2024, 03, 14, 2024, 10, 01)}, // Liko's Sprigatito
+        {0509, new(2024, 04, 04, 2024, 04, 09)}, // Marco's Iron Hands
+        {1008, new(2024, 05, 04, 2024, 05, 08)}, // 신여명's Flutter Mane
+        {0052, new(2024, 05, 11, 2024, 07, 01)}, // Sophia's Gyarados
+        {1536, new(2024, 05, 18, 2024, 12, 01)}, // Dot's Quaxly
+        {0049, new(2024, 05, 31, 2024, 06, 03)}, // ナーク's Talonflame
+        {0510, new(2024, 06, 07, 2024, 06, 11)}, // Nils's Porygon2
+        {0050, new(2024, 07, 13, 2024, 10, 01)}, // Japan's Pokéss Summer Festival Eevee
+        {1537, new(2024, 07, 24, 2025, 02, 01)}, // Roy's Fuecoco
+        {0511, new(2024, 08, 15, 2024, 08, 31)}, // WCS 2024 Steenee
+        {0512, new(2024, 08, 16, 2024, 08, 20)}, // Tomoya's Sylveon
+        {0062, new(2024, 10, 31, 2026, 02, 01)}, // PokéCenter Birthday Tandemaus
+        {0513, new(2024, 11, 15, 2024, 11, 23)}, // Patrick's Pelipper
+        {0054, new(2024, 11, 21, 2025, 06, 01)}, // Operation Get Mythical's JPN Keldeo
+        {0055, new(2024, 11, 21, 2025, 06, 01)}, // Operation Get Mythical's JPN Zarude
+        {0056, new(2024, 11, 21, 2025, 06, 01)}, // Operation Get Mythical's JPN Deoxys
+        {1011, new(2024, 11, 21, 2025, 06, 01)}, // Operation Get Mythical's KOR Keldeo
+        {1012, new(2024, 11, 21, 2025, 06, 01)}, // Operation Get Mythical's KOR Zarude
+        {1013, new(2024, 11, 21, 2025, 06, 01)}, // Operation Get Mythical's KOR Deoxys
+        {1010, new(2025, 01, 21, 2025, 04, 01)}, // Pokémon Lucario & The Mystery of Mew Movie Gift KOR 아론's Lucario
+        {0514, new(2025, 02, 05, 2025, 07, 01, +2)}, // Pokémon Day 2025 Flying Tera Type Eevee
 
         {9021, HOME3_ML}, // Hidden Ability Sprigatito
         {9022, HOME3_ML}, // Hidden Ability Fuecoco
         {9023, HOME3_ML}, // Hidden Ability Quaxly
-        {9024, (new(2024, 10, 16), Never)}, // Shiny Meloetta
-        {9025, (new(2024, 11, 01), Never)}, // PokéCenter Birthday Tandemaus
+        {9024, new(2024, 10, 16)}, // Shiny Meloetta
+        {9025, new(2024, 11, 01)}, // PokéCenter Birthday Tandemaus
     };
 }

--- a/PKHeX.Core/Legality/Verifiers/MiscVerifier.cs
+++ b/PKHeX.Core/Legality/Verifiers/MiscVerifier.cs
@@ -84,7 +84,7 @@ public sealed class MiscVerifier : Verifier
                     data.AddLine(GetInvalid(LDateOutsideDistributionWindow));
             }
 
-            var result = serverGift.IsValidDate(date);
+            var result = serverGift.IsWithinDistributionWindow(date);
             if (result == EncounterServerDateCheck.Invalid)
                 data.AddLine(GetInvalid(LDateOutsideDistributionWindow));
         }

--- a/PKHeX.Core/MysteryGifts/WA8.cs
+++ b/PKHeX.Core/MysteryGifts/WA8.cs
@@ -486,7 +486,7 @@ public sealed class WA8(byte[] Data) : DataMysteryGift(Data), ILangNick, INature
             pk.SID16 = tr.SID16;
         }
 
-        var date = IsDateRestricted && EncounterServerDate.WA8Gifts.TryGetValue(CardID, out var dt) ? dt.Start : EncounterDate.GetDateSwitch();
+        var date = IsDateRestricted && this.GetDistributionWindow(out var dt) ? dt.GetGenerateDate() : EncounterDate.GetDateSwitch();
         if (IsDateLockJapanese && language != (int)LanguageID.Japanese && date < new DateOnly(2022, 5, 20)) // 2022/05/18
             date = new DateOnly(2022, 5, 20); // Pick a better Start date that can be the language we're generating for.
         pk.MetDate = date;

--- a/PKHeX.Core/MysteryGifts/WB8.cs
+++ b/PKHeX.Core/MysteryGifts/WB8.cs
@@ -484,7 +484,7 @@ public sealed class WB8(byte[] Data) : DataMysteryGift(Data),
             pk.SID16 = tr.SID16;
         }
 
-        var date = IsDateRestricted && EncounterServerDate.WB8Gifts.TryGetValue(CardID, out var dt) ? dt.Start : EncounterDate.GetDateSwitch();
+        var date = IsDateRestricted && this.GetDistributionWindow(out var dt) ? dt.GetGenerateDate() : EncounterDate.GetDateSwitch();
         if (IsDateLockJapanese && language != (int)LanguageID.Japanese && date < new DateOnly(2022, 5, 20)) // 2022/05/18
             date = new DateOnly(2022, 5, 20); // Pick a better Start date that can be the language we're generating for.
         pk.MetDate = date;

--- a/PKHeX.Core/MysteryGifts/WC8.cs
+++ b/PKHeX.Core/MysteryGifts/WC8.cs
@@ -535,10 +535,8 @@ public sealed class WC8(byte[] Data) : DataMysteryGift(Data), ILangNick, INature
     {
         if (!IsDateRestricted)
             return EncounterDate.GetDateSwitch();
-        if (EncounterServerDate.WC8GiftsChk.TryGetValue(Checksum, out var range))
-            return range.Start;
-        if (EncounterServerDate.WC8Gifts.TryGetValue(CardID, out range))
-            return range.Start;
+        if (this.GetDistributionWindow(out var window))
+            return window.GetGenerateDate();
         return EncounterDate.GetDateSwitch();
     }
 

--- a/PKHeX.Core/MysteryGifts/WC9.cs
+++ b/PKHeX.Core/MysteryGifts/WC9.cs
@@ -560,10 +560,8 @@ public sealed class WC9(byte[] Data) : DataMysteryGift(Data), ILangNick, INature
     {
         if (!IsDateRestricted)
             return EncounterDate.GetDateSwitch();
-        if (EncounterServerDate.WC9GiftsChk.TryGetValue(Checksum, out var range))
-            return range.Start;
-        if (EncounterServerDate.WC9Gifts.TryGetValue(CardID, out range))
-            return range.Start;
+        if (this.GetDistributionWindow(out var window))
+            return window.GetGenerateDate();
         return EncounterDate.GetDateSwitch();
     }
 

--- a/PKHeX.WinForms/Controls/SAV Editor/SlotChangeManager.cs
+++ b/PKHeX.WinForms/Controls/SAV Editor/SlotChangeManager.cs
@@ -245,7 +245,7 @@ public sealed class SlotChangeManager(SAVEditor se) : IDisposable
 
         if (Directory.Exists(files[0])) // folder
         {
-            SE.LoadBoxes(out string _, files[0]);
+            SE.LoadBoxes(out _, files[0]);
             Drag.Reset();
             return;
         }


### PR DESCRIPTION
Official redemption would be made possible on 7 Feb onward (if we uses NZDT +13 would mean 6 Feb for =＜ UTC+3 Time zone). Considering only a niche of users that would have access to a redemption code before 7 Feb( Kurt mentioned on 5 Feb (UTC+8) that redemption could be made at least possible on the 4 Feb but probably better to have a reasonable start date), making 5 Feb as a start date for those with access to the code early would be fair and within an acceptable tolerance. Redemption code for the distribution must be made by 30 June 2359 (PDT hence UTC+12 time zone would still be able to redeem it on the 1 Jul 2025.
