### PR TITLE
Added setting to export PKM with box and slot index

### DIFF
--- a/PKHeX.Core/Editing/Saves/Slots/Exporting/BoxExport.cs
+++ b/PKHeX.Core/Editing/Saves/Slots/Exporting/BoxExport.cs
@@ -143,6 +143,7 @@ public static class BoxExport
         BoxExportIndexPrefix.None => string.Empty,
         BoxExportIndexPrefix.InAll => $"{(box * boxSlotCount) + slot:0000} - ",
         BoxExportIndexPrefix.InBox => $"{slot:00} - ",
+        BoxExportIndexPrefix.InBoxAndSlot => $"{box + 1:00}-{slot:00} - ",
         _ => throw new ArgumentOutOfRangeException(nameof(mode), mode, null),
     };
 

--- a/PKHeX.Core/Editing/Saves/Slots/Exporting/BoxExportSettings.cs
+++ b/PKHeX.Core/Editing/Saves/Slots/Exporting/BoxExportSettings.cs
@@ -146,9 +146,14 @@ public enum BoxExportIndexPrefix : byte
     InBox = 1,
 
     /// <summary>
-    /// The file name will be prefixed with the box index and slot index
+    /// The file name will be prefixed with the total storage index
     /// </summary>
     InAll = 2,
+
+    /// <summary>
+    /// The file name will be prefixed with the box index and slot index
+    /// </summary>
+    InBoxAndSlot = 3,
 }
 
 /// <summary>


### PR DESCRIPTION
Added a new setting to the box dumper to dump PKM prefixed with box indexes and slot indexes.