### PR TITLE
Handle HOME Keldeo & Meltan; Revise WB7

### DIFF
--- a/PKHeX.Core/Legality/Verifiers/MiscVerifier.cs
+++ b/PKHeX.Core/Legality/Verifiers/MiscVerifier.cs
@@ -642,15 +642,16 @@ public sealed class MiscVerifier : Verifier
             data.AddLine(GetInvalid(LDateOutsideConsoleWindow, Misc));
     }
 
-    private static void VerifyAbsoluteSizes(LegalityAnalysis data, IScaledSizeValue obj)
+    private static void VerifyAbsoluteSizes<T>(LegalityAnalysis data, T obj) where T : IScaledSizeValue
     {
-        if (data is { Entity: PB7 , EncounterMatch: WB7 { IsHeightWeightFixed: true } enc })
-            VerifyFixedSizes(data, obj, enc);
+        if (obj is PB7 pb7 && data.EncounterMatch is WB7 { IsHeightWeightFixed: true } enc)
+            VerifyFixedSizes(data, pb7, enc);
         else
             VerifyCalculatedSizes(data, obj);
     }
 
-    private static void VerifyFixedSizes(LegalityAnalysis data, IScaledSizeValue obj, WB7 enc)
+    // ReSharper disable 4 CompareOfFloatsByEqualityOperator -- THESE MUST MATCH EXACTLY
+    private static void VerifyFixedSizes<T>(LegalityAnalysis data, T obj, WB7 enc) where T : IScaledSizeValue
     {
         if (obj.HeightAbsolute != enc.GetHomeHeightAbsolute())
             data.AddLine(GetInvalid(LStatIncorrectHeight, Encounter));
@@ -658,13 +659,14 @@ public sealed class MiscVerifier : Verifier
             data.AddLine(GetInvalid(LStatIncorrectWeight, Encounter));
     }
 
-    private static void VerifyCalculatedSizes(LegalityAnalysis data, IScaledSizeValue obj)
+    private static void VerifyCalculatedSizes<T>(LegalityAnalysis data, T obj) where T : IScaledSizeValue
     {
         if (obj.HeightAbsolute != obj.CalcHeightAbsolute)
             data.AddLine(GetInvalid(LStatIncorrectHeight, Encounter));
         if (obj.WeightAbsolute != obj.CalcWeightAbsolute)
             data.AddLine(GetInvalid(LStatIncorrectWeight, Encounter));
     }
+    // ReSharper restore CompareOfFloatsByEqualityOperator
 
     private static bool IsStarterLGPE<T>(T pk) where T : ISpeciesForm => pk switch
     {

--- a/PKHeX.Core/Legality/Verifiers/MiscVerifier.cs
+++ b/PKHeX.Core/Legality/Verifiers/MiscVerifier.cs
@@ -644,10 +644,24 @@ public sealed class MiscVerifier : Verifier
 
     private static void VerifyAbsoluteSizes(LegalityAnalysis data, IScaledSizeValue obj)
     {
-        // ReSharper disable once CompareOfFloatsByEqualityOperator -- THESE MUST MATCH EXACTLY
+        if (data.EncounterMatch is WB7 enc && enc.IsHeightWeightFixed)
+            VerifyFixedSizes(data, obj, enc);
+        else
+            VerifyCalculatedSizes(data, obj);
+    }
+
+    private static void VerifyFixedSizes(LegalityAnalysis data, IScaledSizeValue obj, WB7 enc)
+    {
+        if (obj.HeightAbsolute != enc.GetHomeHeightAbsolute())
+            data.AddLine(GetInvalid(LStatIncorrectHeight, Encounter));
+        if (obj.WeightAbsolute != enc.GetHomeWeightAbsolute())
+            data.AddLine(GetInvalid(LStatIncorrectWeight, Encounter));
+    }
+
+    private static void VerifyCalculatedSizes(LegalityAnalysis data, IScaledSizeValue obj)
+    {
         if (obj.HeightAbsolute != obj.CalcHeightAbsolute)
             data.AddLine(GetInvalid(LStatIncorrectHeight, Encounter));
-        // ReSharper disable once CompareOfFloatsByEqualityOperator -- THESE MUST MATCH EXACTLY
         if (obj.WeightAbsolute != obj.CalcWeightAbsolute)
             data.AddLine(GetInvalid(LStatIncorrectWeight, Encounter));
     }

--- a/PKHeX.Core/Legality/Verifiers/MiscVerifier.cs
+++ b/PKHeX.Core/Legality/Verifiers/MiscVerifier.cs
@@ -644,7 +644,7 @@ public sealed class MiscVerifier : Verifier
 
     private static void VerifyAbsoluteSizes(LegalityAnalysis data, IScaledSizeValue obj)
     {
-        if (data.EncounterMatch is WB7 enc && enc.IsHeightWeightFixed)
+        if (data is { Entity: PB7 , EncounterMatch: WB7 { IsHeightWeightFixed: true } enc })
             VerifyFixedSizes(data, obj, enc);
         else
             VerifyCalculatedSizes(data, obj);

--- a/PKHeX.Core/MysteryGifts/WB7.cs
+++ b/PKHeX.Core/MysteryGifts/WB7.cs
@@ -660,8 +660,6 @@ public sealed class WB7(byte[] Data)
                 return false;
             if (pk is IScaledSize3 sc && sc.Scale != scalar)
                 return false;
-            if (pk is IScaledSizeAbsolute abs && (abs.HeightAbsolute != GetHomeHeightAbsolute() || abs.WeightAbsolute != GetHomeWeightAbsolute()))
-                return false;
         }
 
         if (pk is IAwakened s && s.IsAwakeningBelow(this))

--- a/PKHeX.Core/MysteryGifts/WB7.cs
+++ b/PKHeX.Core/MysteryGifts/WB7.cs
@@ -470,13 +470,13 @@ public sealed class WB7(byte[] Data)
 
     public float GetHomeHeightAbsolute() => CardID switch
     {
-        9028 => (float)18.1490211,
+        9028 => 18.1490211f,
         _ => throw new ArgumentException(),
     };
 
     public float GetHomeWeightAbsolute() => CardID switch
     {
-        9028 => (float)77.09419,
+        9028 => 77.09419f,
         _ => throw new ArgumentException(),
     };
 

--- a/PKHeX.Core/MysteryGifts/WB7.cs
+++ b/PKHeX.Core/MysteryGifts/WB7.cs
@@ -13,6 +13,8 @@ public sealed class WB7(byte[] Data)
 
     public const int Size = 0x310;
     private const int CardStart = 0x208;
+    private Span<byte> Card => Data.AsSpan(CardStart, 0x108);
+
     public override bool FatefulEncounter => true;
 
     public override byte Generation => 7;
@@ -224,7 +226,6 @@ public sealed class WB7(byte[] Data)
     public override bool IsEgg { get => Data[CardStart + 0xD1] == 1; set => Data[CardStart + 0xD1] = value ? (byte)1 : (byte)0; }
     public ushort AdditionalItem { get => ReadUInt16LittleEndian(Data.AsSpan(CardStart + 0xD2)); set => WriteUInt16LittleEndian(Data.AsSpan(CardStart + 0xD2), value); }
 
-    public uint PID { get => ReadUInt32LittleEndian(Data.AsSpan(0xD4)); set => WriteUInt32LittleEndian(Data.AsSpan(0xD4), value); }
     public ushort RelearnMove1 { get => ReadUInt16LittleEndian(Data.AsSpan(CardStart + 0xD8)); set => WriteUInt16LittleEndian(Data.AsSpan(CardStart + 0xD8), value); }
     public ushort RelearnMove2 { get => ReadUInt16LittleEndian(Data.AsSpan(CardStart + 0xDA)); set => WriteUInt16LittleEndian(Data.AsSpan(CardStart + 0xDA), value); }
     public ushort RelearnMove3 { get => ReadUInt16LittleEndian(Data.AsSpan(CardStart + 0xDC)); set => WriteUInt16LittleEndian(Data.AsSpan(CardStart + 0xDC), value); }
@@ -236,6 +237,7 @@ public sealed class WB7(byte[] Data)
     public byte AV_SPE { get => Data[CardStart + 0xE8]; set => Data[CardStart + 0xE8] = value; }
     public byte AV_SPA { get => Data[CardStart + 0xE9]; set => Data[CardStart + 0xE9] = value; }
     public byte AV_SPD { get => Data[CardStart + 0xEA]; set => Data[CardStart + 0xEA] = value; }
+    public uint PID { get => ReadUInt32LittleEndian(Card[0xD4..]); set => WriteUInt32LittleEndian(Card[0xD4..], value); }
 
     // Meta Accessible Properties
     public int[] IVs

--- a/PKHeX.Core/MysteryGifts/WB7.cs
+++ b/PKHeX.Core/MysteryGifts/WB7.cs
@@ -468,13 +468,13 @@ public sealed class WB7(byte[] Data)
         _ => throw new ArgumentException(),
     };
 
-    private float GetHomeHeightAbsolute() => CardID switch
+    public float GetHomeHeightAbsolute() => CardID switch
     {
         9028 => (float)18.1490211,
         _ => throw new ArgumentException(),
     };
 
-    private float GetHomeWeightAbsolute() => CardID switch
+    public float GetHomeWeightAbsolute() => CardID switch
     {
         9028 => (float)77.09419,
         _ => throw new ArgumentException(),

--- a/PKHeX.Core/MysteryGifts/WB7.cs
+++ b/PKHeX.Core/MysteryGifts/WB7.cs
@@ -7,7 +7,8 @@ namespace PKHeX.Core;
 /// Generation 7 Mystery Gift Template File (LGP/E)
 /// </summary>
 public sealed class WB7(byte[] Data)
-    : DataMysteryGift(Data), ILangNick, IAwakened, IRelearn, IEncounterServerDate, INature, ILangNicknamedTemplate, IMetLevel, IRestrictVersion
+    : DataMysteryGift(Data), ILangNick, IAwakened, IRelearn, IEncounterServerDate, INature, ILangNicknamedTemplate,
+        IMetLevel, IRestrictVersion, IRibbonSetEvent3, IRibbonSetEvent4
 {
     public WB7() : this(new byte[Size]) { }
 
@@ -37,21 +38,21 @@ public sealed class WB7(byte[] Data)
     // General Card Properties
     public override int CardID
     {
-        get => ReadUInt16LittleEndian(Data.AsSpan(CardStart + 0));
-        set => WriteUInt16LittleEndian(Data.AsSpan(CardStart + 0), (ushort)value);
+        get => ReadUInt16LittleEndian(Card);
+        set => WriteUInt16LittleEndian(Card, (ushort)value);
     }
 
     public override string CardTitle
     {
         // Max len 36 char, followed by null terminator
-        get => StringConverter8.GetString(Data.AsSpan(CardStart + 2, 0x4A));
-        set => StringConverter8.SetString(Data.AsSpan(CardStart + 2, 0x4A), value, 36, StringConverterOption.ClearZero);
+        get => StringConverter8.GetString(Card.Slice(2, 0x4A));
+        set => StringConverter8.SetString(Card.Slice(2, 0x4A), value, 36, StringConverterOption.ClearZero);
     }
 
     private uint RawDate
     {
-        get => ReadUInt32LittleEndian(Data.AsSpan(CardStart + 0x4C));
-        set => WriteUInt32LittleEndian(Data.AsSpan(CardStart + 0x4C), value);
+        get => ReadUInt32LittleEndian(Card[0x4C..]);
+        set => WriteUInt32LittleEndian(Card[0x4C..], value);
     }
 
     private uint Year
@@ -107,29 +108,29 @@ public sealed class WB7(byte[] Data)
         }
     }
 
-    public int CardLocation { get => Data[CardStart + 0x50]; set => Data[CardStart + 0x50] = (byte)value; }
+    public int CardLocation { get => Card[0x50]; set => Card[0x50] = (byte)value; }
 
-    public int CardType { get => Data[CardStart + 0x51]; set => Data[CardStart + 0x51] = (byte)value; }
-    public byte CardFlags { get => Data[CardStart + 0x52]; set => Data[CardStart + 0x52] = value; }
+    public int CardType { get => Card[0x51]; set => Card[0x51] = (byte)value; }
+    public byte CardFlags { get => Card[0x52]; set => Card[0x52] = value; }
 
     public bool GiftRepeatable { get => (CardFlags & 1) == 0; set => CardFlags = (byte)((CardFlags & ~1) | (value ? 0 : 1)); }
     public override bool GiftUsed { get => (CardFlags & 2) == 2; set => CardFlags = (byte)((CardFlags & ~2) | (value ? 2 : 0)); }
     public bool GiftOncePerDay { get => (CardFlags & 4) == 4; set => CardFlags = (byte)((CardFlags & ~4) | (value ? 4 : 0)); }
 
-    public bool MultiObtain { get => Data[CardStart + 0x53] == 1; set => Data[CardStart + 0x53] = value ? (byte)1 : (byte)0; }
+    public bool MultiObtain { get => Card[0x53] == 1; set => Card[0x53] = value ? (byte)1 : (byte)0; }
 
     // Item Properties
     public override bool IsItem { get => CardType == 1; set { if (value) CardType = 1; } }
-    public override int ItemID { get => ReadUInt16LittleEndian(Data.AsSpan(CardStart + 0x68)); set => WriteUInt16LittleEndian(Data.AsSpan(CardStart + 0x68), (ushort)value); }
-    public int GetItem(int index) => ReadUInt16LittleEndian(Data.AsSpan(CardStart + 0x68 + (0x4 * index)));
-    public void SetItem(int index, ushort item) => WriteUInt16LittleEndian(Data.AsSpan(CardStart + 0x68 + (4 * index)), item);
-    public int GetQuantity(int index) => ReadUInt16LittleEndian(Data.AsSpan(CardStart + 0x6A + (0x4 * index)));
-    public void SetQuantity(int index, ushort quantity) => WriteUInt16LittleEndian(Data.AsSpan(CardStart + 0x6A + (4 * index)), quantity);
+    public int GetQuantity(int index) => ReadUInt16LittleEndian(Card[(0x6A + (0x4 * index))..]);
+    public void SetQuantity(int index, ushort quantity) => WriteUInt16LittleEndian(Card[(0x6A + (4 * index))..], quantity);
+    public override int ItemID { get => ReadUInt16LittleEndian(Card[0x68..]); set => WriteUInt16LittleEndian(Card[0x68..], (ushort)value); }
+    public int GetItem(int index) => ReadUInt16LittleEndian(Card[(0x68 + (0x4 * index))..]);
+    public void SetItem(int index, ushort item) => WriteUInt16LittleEndian(Card[(0x68 + (4 * index))..], item);
 
     public override int Quantity
     {
-        get => ReadUInt16LittleEndian(Data.AsSpan(CardStart + 0x6A));
-        set => WriteUInt16LittleEndian(Data.AsSpan(CardStart + 0x6A), (ushort)value);
+        get => ReadUInt16LittleEndian(Card[0x6A..]);
+        set => WriteUInt16LittleEndian(Card[0x6A..], (ushort)value);
     }
 
     // Pokémon Properties
@@ -145,99 +146,87 @@ public sealed class WB7(byte[] Data)
         _ => throw new ArgumentOutOfRangeException(),
     };
 
-    public override uint ID32
-    {
-        get => ReadUInt32LittleEndian(Data.AsSpan(CardStart + 0x68));
-        set => WriteUInt32LittleEndian(Data.AsSpan(CardStart + 0x68), value);
-    }
+    public override uint ID32 { get => ReadUInt32LittleEndian(Card[0x68..]); set => WriteUInt32LittleEndian(Card[0x68..], value); }
+    public override ushort TID16 { get => ReadUInt16LittleEndian(Card[0x68..]); set => WriteUInt16LittleEndian(Card[0x68..], value); }
+    public override ushort SID16 { get => ReadUInt16LittleEndian(Card[0x6A..]); set => WriteUInt16LittleEndian(Card[0x6A..], value); }
+    public int OriginGame { get => ReadInt32LittleEndian(Card[0x6C..]); set => WriteInt32LittleEndian(Card[0x6C..], value); }
+    public uint EncryptionConstant { get => ReadUInt32LittleEndian(Card[0x70..]); set => WriteUInt32LittleEndian(Card[0x70..], value); }
+    public override byte Ball { get => Card[0x76]; set => Card[0x76] = value; }
+    // held item: unused
+    public override int HeldItem { get => ReadUInt16LittleEndian(Card[0x78..]); set => WriteUInt16LittleEndian(Card[0x78..], (ushort)value); }
+    public ushort Move1 { get => ReadUInt16LittleEndian(Card[0x7A..]); set => WriteUInt16LittleEndian(Card[0x7A..], value); }
+    public ushort Move2 { get => ReadUInt16LittleEndian(Card[0x7C..]); set => WriteUInt16LittleEndian(Card[0x7C..], value); }
+    public ushort Move3 { get => ReadUInt16LittleEndian(Card[0x7E..]); set => WriteUInt16LittleEndian(Card[0x7E..], value); }
+    public ushort Move4 { get => ReadUInt16LittleEndian(Card[0x80..]); set => WriteUInt16LittleEndian(Card[0x80..], value); }
+    public override ushort Species { get => ReadUInt16LittleEndian(Card[0x82..]); set => WriteUInt16LittleEndian(Card[0x82..], value); }
+    public override byte Form { get => Card[0x84]; set => Card[0x84] = value; }
 
-    public override ushort TID16
-    {
-        get => ReadUInt16LittleEndian(Data.AsSpan(CardStart + 0x68));
-        set => WriteUInt16LittleEndian(Data.AsSpan(CardStart + 0x68), value);
-    }
-
-    public override ushort SID16 {
-        get => ReadUInt16LittleEndian(Data.AsSpan(CardStart + 0x6A));
-        set => WriteUInt16LittleEndian(Data.AsSpan(CardStart + 0x6A), value);
-    }
-
-    public int OriginGame
-    {
-        get => ReadInt32LittleEndian(Data.AsSpan(CardStart + 0x6C));
-        set => WriteInt32LittleEndian(Data.AsSpan(CardStart + 0x6C), value);
-    }
-
-    public uint EncryptionConstant {
-        get => ReadUInt32LittleEndian(Data.AsSpan(CardStart + 0x70));
-        set => WriteUInt32LittleEndian(Data.AsSpan(CardStart + 0x70), value);
-    }
-
-    public override byte Ball
-    {
-        get => Data[CardStart + 0x76];
-        set => Data[CardStart + 0x76] = value; }
-
-    public override int HeldItem // no references
-    {
-        get => ReadUInt16LittleEndian(Data.AsSpan(CardStart + 0x78));
-        set => WriteUInt16LittleEndian(Data.AsSpan(CardStart + 0x78), (ushort)value);
-    }
-
-    public ushort Move1 { get => ReadUInt16LittleEndian(Data.AsSpan(CardStart + 0x7A)); set => WriteUInt16LittleEndian(Data.AsSpan(CardStart + 0x7A), value); }
-    public ushort Move2 { get => ReadUInt16LittleEndian(Data.AsSpan(CardStart + 0x7C)); set => WriteUInt16LittleEndian(Data.AsSpan(CardStart + 0x7C), value); }
-    public ushort Move3 { get => ReadUInt16LittleEndian(Data.AsSpan(CardStart + 0x7E)); set => WriteUInt16LittleEndian(Data.AsSpan(CardStart + 0x7E), value); }
-    public ushort Move4 { get => ReadUInt16LittleEndian(Data.AsSpan(CardStart + 0x80)); set => WriteUInt16LittleEndian(Data.AsSpan(CardStart + 0x80), value); }
-    public override ushort Species { get => ReadUInt16LittleEndian(Data.AsSpan(CardStart + 0x82)); set => WriteUInt16LittleEndian(Data.AsSpan(CardStart + 0x82), value); }
-    public override byte Form { get => Data[CardStart + 0x84]; set => Data[CardStart + 0x84] = value; }
-
-    // public int Language { get => Data[CardStart + 0x85]; set => Data[CardStart + 0x85] = (byte)value; }
+    // public int Language { get => Card[0x85]; set => Card[0x85] = (byte)value; }
 
     // public string Nickname
     // {
-    //     get => Util.TrimFromZero(Encoding.Unicode.GetString(Data, CardStart + 0x86, 0x1A));
-    //     set => Encoding.Unicode.GetBytes(value.PadRight(12 + 1, '\0')).CopyTo(Data, CardStart + 0x86);
+    //     get => Util.TrimFromZero(Encoding.Unicode.GetString(Card.Slice(0x86, 0x1A));
+    //     set => Encoding.Unicode.GetBytes(value.PadRight(12 + 1, '\0')).CopyTo(Card.Slice(0x86);
     // }
 
-    public Nature Nature { get => (Nature)Data[CardStart + 0xA0]; set => Data[CardStart + 0xA0] = (byte)value; }
-    public override byte Gender { get => Data[CardStart + 0xA1]; set => Data[CardStart + 0xA1] = value; }
-    public override int AbilityType { get => IsHOMEGift ? Data[CardStart + 0xA2] : 3; set => Data[CardStart + 0xA2] = (byte)value; } // no references, always ability 0/1
-    public ShinyType6 PIDType { get => (ShinyType6)Data[CardStart + 0xA3]; set => Data[CardStart + 0xA3] = (byte)value; }
-    public override ushort EggLocation { get => ReadUInt16LittleEndian(Data.AsSpan(CardStart + 0xA4)); set => WriteUInt16LittleEndian(Data.AsSpan(CardStart + 0xA4), value); }
-    public override ushort Location  { get => ReadUInt16LittleEndian(Data.AsSpan(CardStart + 0xA6)); set => WriteUInt16LittleEndian(Data.AsSpan(CardStart + 0xA6), value); }
-    public byte MetLevel { get => Data[CardStart + 0xA8]; set => Data[CardStart + 0xA8] = value; }
+    public Nature Nature { get => (Nature)Card[0xA0]; set => Card[0xA0] = (byte)value; }
+    public override byte Gender { get => Card[0xA1]; set => Card[0xA1] = value; }
+    public override int AbilityType { get => IsHOMEGift ? Card[0xA2] : 3; set => Card[0xA2] = (byte)value; } // no references, always ability 0/1
+    public ShinyType6 PIDType { get => (ShinyType6)Card[0xA3]; set => Card[0xA3] = (byte)value; }
+    public override ushort EggLocation { get => ReadUInt16LittleEndian(Card[0xA4..]); set => WriteUInt16LittleEndian(Card[0xA4..], value); }
+    public override ushort Location  { get => ReadUInt16LittleEndian(Card[0xA6..]); set => WriteUInt16LittleEndian(Card[0xA6..], value); }
+    public byte MetLevel { get => Card[0xA8]; set => Card[0xA8] = value; }
 
-    public int IV_HP { get => Data[CardStart + 0xAF]; set => Data[CardStart + 0xAF] = (byte)value; }
-    public int IV_ATK { get => Data[CardStart + 0xB0]; set => Data[CardStart + 0xB0] = (byte)value; }
-    public int IV_DEF { get => Data[CardStart + 0xB1]; set => Data[CardStart + 0xB1] = (byte)value; }
-    public int IV_SPE { get => Data[CardStart + 0xB2]; set => Data[CardStart + 0xB2] = (byte)value; }
-    public int IV_SPA { get => Data[CardStart + 0xB3]; set => Data[CardStart + 0xB3] = (byte)value; }
-    public int IV_SPD { get => Data[CardStart + 0xB4]; set => Data[CardStart + 0xB4] = (byte)value; }
+    public int IV_HP { get => Card[0xAF]; set => Card[0xAF] = (byte)value; }
+    public int IV_ATK { get => Card[0xB0]; set => Card[0xB0] = (byte)value; }
+    public int IV_DEF { get => Card[0xB1]; set => Card[0xB1] = (byte)value; }
+    public int IV_SPE { get => Card[0xB2]; set => Card[0xB2] = (byte)value; }
+    public int IV_SPA { get => Card[0xB3]; set => Card[0xB3] = (byte)value; }
+    public int IV_SPD { get => Card[0xB4]; set => Card[0xB4] = (byte)value; }
 
-    public byte OTGender { get => Data[CardStart + 0xB5]; set => Data[CardStart + 0xB5] = value; }
+    public byte OTGender { get => Card[0xB5]; set => Card[0xB5] = value; }
 
     // public override string OriginalTrainerName
     // {
-    //     get => Util.TrimFromZero(Encoding.Unicode.GetString(Data, CardStart + 0xB6, 0x1A));
-    //     set => Encoding.Unicode.GetBytes(value.PadRight(value.Length + 1, '\0')).CopyTo(Data, CardStart + 0xB6);
+    //     get => Util.TrimFromZero(Encoding.Unicode.GetString(Card.Slice(0xB6, 0x1A));
+    //     set => Encoding.Unicode.GetBytes(value.PadRight(value.Length + 1, '\0')).CopyTo(Card.Slice(0xB6);
     // }
 
-    public override byte Level { get => Data[CardStart + 0xD0]; set => Data[CardStart + 0xD0] = value; }
-    public override bool IsEgg { get => Data[CardStart + 0xD1] == 1; set => Data[CardStart + 0xD1] = value ? (byte)1 : (byte)0; }
-    public ushort AdditionalItem { get => ReadUInt16LittleEndian(Data.AsSpan(CardStart + 0xD2)); set => WriteUInt16LittleEndian(Data.AsSpan(CardStart + 0xD2), value); }
+    public override byte Level { get => Card[0xD0]; set => Card[0xD0] = value; }
+    public override bool IsEgg { get => Card[0xD1] == 1; set => Card[0xD1] = value ? (byte)1 : (byte)0; }
+    public ushort AdditionalItem { get => ReadUInt16LittleEndian(Card[0xD2..]); set => WriteUInt16LittleEndian(Card[0xD2..], value); }
 
-    public ushort RelearnMove1 { get => ReadUInt16LittleEndian(Data.AsSpan(CardStart + 0xD8)); set => WriteUInt16LittleEndian(Data.AsSpan(CardStart + 0xD8), value); }
-    public ushort RelearnMove2 { get => ReadUInt16LittleEndian(Data.AsSpan(CardStart + 0xDA)); set => WriteUInt16LittleEndian(Data.AsSpan(CardStart + 0xDA), value); }
-    public ushort RelearnMove3 { get => ReadUInt16LittleEndian(Data.AsSpan(CardStart + 0xDC)); set => WriteUInt16LittleEndian(Data.AsSpan(CardStart + 0xDC), value); }
-    public ushort RelearnMove4 { get => ReadUInt16LittleEndian(Data.AsSpan(CardStart + 0xDE)); set => WriteUInt16LittleEndian(Data.AsSpan(CardStart + 0xDE), value); }
-
-    public byte AV_HP  { get => Data[CardStart + 0xE5]; set => Data[CardStart + 0xE5] = value; }
-    public byte AV_ATK { get => Data[CardStart + 0xE6]; set => Data[CardStart + 0xE6] = value; }
-    public byte AV_DEF { get => Data[CardStart + 0xE7]; set => Data[CardStart + 0xE7] = value; }
-    public byte AV_SPE { get => Data[CardStart + 0xE8]; set => Data[CardStart + 0xE8] = value; }
-    public byte AV_SPA { get => Data[CardStart + 0xE9]; set => Data[CardStart + 0xE9] = value; }
-    public byte AV_SPD { get => Data[CardStart + 0xEA]; set => Data[CardStart + 0xEA] = value; }
     public uint PID { get => ReadUInt32LittleEndian(Card[0xD4..]); set => WriteUInt32LittleEndian(Card[0xD4..], value); }
+    public ushort RelearnMove1 { get => ReadUInt16LittleEndian(Card[0xD8..]); set => WriteUInt16LittleEndian(Card[0xD8..], value); }
+    public ushort RelearnMove2 { get => ReadUInt16LittleEndian(Card[0xDA..]); set => WriteUInt16LittleEndian(Card[0xDA..], value); }
+    public ushort RelearnMove3 { get => ReadUInt16LittleEndian(Card[0xDC..]); set => WriteUInt16LittleEndian(Card[0xDC..], value); }
+    public ushort RelearnMove4 { get => ReadUInt16LittleEndian(Card[0xDE..]); set => WriteUInt16LittleEndian(Card[0xDE..], value); }
+
+    public byte AV_HP  { get => Card[0xE5]; set => Card[0xE5] = value; }
+    public byte AV_ATK { get => Card[0xE6]; set => Card[0xE6] = value; }
+    public byte AV_DEF { get => Card[0xE7]; set => Card[0xE7] = value; }
+    public byte AV_SPE { get => Card[0xE8]; set => Card[0xE8] = value; }
+    public byte AV_SPA { get => Card[0xE9]; set => Card[0xE9] = value; }
+    public byte AV_SPD { get => Card[0xEA]; set => Card[0xEA] = value; }
+    private byte RIB0 { get => Data[0x74]; set => Data[0x74] = value; }
+    private byte RIB1 { get => Data[0x75]; set => Data[0x75] = value; }
+
+    public bool RibbonChampionBattle { get => (RIB0 & (1 << 0)) == 1 << 0; set => RIB0 = (byte)((RIB0 & ~(1 << 0)) | (value ? 1 << 0 : 0)); }
+    public bool RibbonChampionRegional { get => (RIB0 & (1 << 1)) == 1 << 1; set => RIB0 = (byte)((RIB0 & ~(1 << 1)) | (value ? 1 << 1 : 0)); }
+    public bool RibbonChampionNational { get => (RIB0 & (1 << 2)) == 1 << 2; set => RIB0 = (byte)((RIB0 & ~(1 << 2)) | (value ? 1 << 2 : 0)); }
+    public bool RibbonCountry { get => (RIB0 & (1 << 3)) == 1 << 3; set => RIB0 = (byte)((RIB0 & ~(1 << 3)) | (value ? 1 << 3 : 0)); }
+    public bool RibbonNational { get => (RIB0 & (1 << 4)) == 1 << 4; set => RIB0 = (byte)((RIB0 & ~(1 << 4)) | (value ? 1 << 4 : 0)); }
+    public bool RibbonEarth { get => (RIB0 & (1 << 5)) == 1 << 5; set => RIB0 = (byte)((RIB0 & ~(1 << 5)) | (value ? 1 << 5 : 0)); }
+    public bool RibbonWorld { get => (RIB0 & (1 << 6)) == 1 << 6; set => RIB0 = (byte)((RIB0 & ~(1 << 6)) | (value ? 1 << 6 : 0)); }
+    public bool RibbonEvent { get => (RIB0 & (1 << 7)) == 1 << 7; set => RIB0 = (byte)((RIB0 & ~(1 << 7)) | (value ? 1 << 7 : 0)); }
+    public bool RibbonChampionWorld { get => (RIB1 & (1 << 0)) == 1 << 0; set => RIB1 = (byte)((RIB1 & ~(1 << 0)) | (value ? 1 << 0 : 0)); }
+    public bool RibbonBirthday { get => (RIB1 & (1 << 1)) == 1 << 1; set => RIB1 = (byte)((RIB1 & ~(1 << 1)) | (value ? 1 << 1 : 0)); }
+    public bool RibbonSpecial { get => (RIB1 & (1 << 2)) == 1 << 2; set => RIB1 = (byte)((RIB1 & ~(1 << 2)) | (value ? 1 << 2 : 0)); }
+    public bool RibbonSouvenir { get => (RIB1 & (1 << 3)) == 1 << 3; set => RIB1 = (byte)((RIB1 & ~(1 << 3)) | (value ? 1 << 3 : 0)); }
+    public bool RibbonWishing { get => (RIB1 & (1 << 4)) == 1 << 4; set => RIB1 = (byte)((RIB1 & ~(1 << 4)) | (value ? 1 << 4 : 0)); }
+    public bool RibbonClassic { get => (RIB1 & (1 << 5)) == 1 << 5; set => RIB1 = (byte)((RIB1 & ~(1 << 5)) | (value ? 1 << 5 : 0)); }
+    public bool RibbonPremier { get => (RIB1 & (1 << 6)) == 1 << 6; set => RIB1 = (byte)((RIB1 & ~(1 << 6)) | (value ? 1 << 6 : 0)); }
+    public bool RIB1_7 { get => (RIB1 & (1 << 7)) == 1 << 7; set => RIB1 = (byte)((RIB1 & ~(1 << 7)) | (value ? 1 << 7 : 0)); }
 
     // Meta Accessible Properties
     public int[] IVs
@@ -406,6 +395,8 @@ public sealed class WB7(byte[] Data)
 
             OriginalTrainerFriendship = pi.BaseFriendship,
             FatefulEncounter = true,
+
+            RibbonSouvenir = RibbonSouvenir, // HOME Meltan
         };
 
         if (hasOT)

--- a/PKHeX.Core/PKM/PB7.cs
+++ b/PKHeX.Core/PKM/PB7.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 using static System.Buffers.Binary.BinaryPrimitives;
 
@@ -6,6 +7,7 @@ namespace PKHeX.Core;
 
 /// <summary> Generation 7 <see cref="PKM"/> format used for <see cref="GameVersion.GG"/>. </summary>
 public sealed class PB7 : G6PKM, IHyperTrain, IAwakened, IScaledSizeValue, ICombatPower, IFavorite,
+    IRibbonSetEvent3, IRibbonSetEvent4, IRibbonSetCommon3, IRibbonSetCommon4, IRibbonSetCommon6, IRibbonSetMemory6, IRibbonSetCommon7, IRibbonSetRibbons,
     IFormArgument, IAppliedMarkings7, IFullnessEnjoyment
 {
     public override ReadOnlySpan<ushort> ExtraBytes =>
@@ -128,6 +130,73 @@ public sealed class PB7 : G6PKM, IHyperTrain, IAwakened, IScaledSizeValue, IComb
     public override int PokerusDays { get => PokerusState & 0xF; set => PokerusState = (byte)((PokerusState & ~0xF) | value); }
     public override int PokerusStrain { get => PokerusState >> 4; set => PokerusState = (byte)((PokerusState & 0xF) | (value << 4)); }
     public float HeightAbsolute { get => ReadSingleLittleEndian(Data.AsSpan(0x2C)); set => WriteSingleLittleEndian(Data.AsSpan(0x2C), value); }
+    private byte RIB0 { get => Data[0x30]; set => Data[0x30] = value; } // Ribbons are read as uints, but let's keep them per byte.
+    private byte RIB1 { get => Data[0x31]; set => Data[0x31] = value; }
+    private byte RIB2 { get => Data[0x32]; set => Data[0x32] = value; }
+    private byte RIB3 { get => Data[0x33]; set => Data[0x33] = value; }
+    private byte RIB4 { get => Data[0x34]; set => Data[0x34] = value; }
+    private byte RIB5 { get => Data[0x35]; set => Data[0x35] = value; }
+    private byte RIB6 { get => Data[0x36]; set => Data[0x36] = value; }
+    //private byte RIB7 { get => Data[0x37]; set => Data[0x37] = value; } // Unused
+    public bool RibbonChampionKalos         { get => (RIB0 & (1 << 0)) == 1 << 0; set => RIB0 = (byte)((RIB0 & ~(1 << 0)) | (value ? 1 << 0 : 0)); }
+    public bool RibbonChampionG3            { get => (RIB0 & (1 << 1)) == 1 << 1; set => RIB0 = (byte)((RIB0 & ~(1 << 1)) | (value ? 1 << 1 : 0)); }
+    public bool RibbonChampionSinnoh        { get => (RIB0 & (1 << 2)) == 1 << 2; set => RIB0 = (byte)((RIB0 & ~(1 << 2)) | (value ? 1 << 2 : 0)); }
+    public bool RibbonBestFriends           { get => (RIB0 & (1 << 3)) == 1 << 3; set => RIB0 = (byte)((RIB0 & ~(1 << 3)) | (value ? 1 << 3 : 0)); }
+    public bool RibbonTraining              { get => (RIB0 & (1 << 4)) == 1 << 4; set => RIB0 = (byte)((RIB0 & ~(1 << 4)) | (value ? 1 << 4 : 0)); }
+    public bool RibbonBattlerSkillful       { get => (RIB0 & (1 << 5)) == 1 << 5; set => RIB0 = (byte)((RIB0 & ~(1 << 5)) | (value ? 1 << 5 : 0)); }
+    public bool RibbonBattlerExpert         { get => (RIB0 & (1 << 6)) == 1 << 6; set => RIB0 = (byte)((RIB0 & ~(1 << 6)) | (value ? 1 << 6 : 0)); }
+    public bool RibbonEffort                { get => (RIB0 & (1 << 7)) == 1 << 7; set => RIB0 = (byte)((RIB0 & ~(1 << 7)) | (value ? 1 << 7 : 0)); }
+    public bool RibbonAlert                 { get => (RIB1 & (1 << 0)) == 1 << 0; set => RIB1 = (byte)((RIB1 & ~(1 << 0)) | (value ? 1 << 0 : 0)); }
+    public bool RibbonShock                 { get => (RIB1 & (1 << 1)) == 1 << 1; set => RIB1 = (byte)((RIB1 & ~(1 << 1)) | (value ? 1 << 1 : 0)); }
+    public bool RibbonDowncast              { get => (RIB1 & (1 << 2)) == 1 << 2; set => RIB1 = (byte)((RIB1 & ~(1 << 2)) | (value ? 1 << 2 : 0)); }
+    public bool RibbonCareless              { get => (RIB1 & (1 << 3)) == 1 << 3; set => RIB1 = (byte)((RIB1 & ~(1 << 3)) | (value ? 1 << 3 : 0)); }
+    public bool RibbonRelax                 { get => (RIB1 & (1 << 4)) == 1 << 4; set => RIB1 = (byte)((RIB1 & ~(1 << 4)) | (value ? 1 << 4 : 0)); }
+    public bool RibbonSnooze                { get => (RIB1 & (1 << 5)) == 1 << 5; set => RIB1 = (byte)((RIB1 & ~(1 << 5)) | (value ? 1 << 5 : 0)); }
+    public bool RibbonSmile                 { get => (RIB1 & (1 << 6)) == 1 << 6; set => RIB1 = (byte)((RIB1 & ~(1 << 6)) | (value ? 1 << 6 : 0)); }
+    public bool RibbonGorgeous              { get => (RIB1 & (1 << 7)) == 1 << 7; set => RIB1 = (byte)((RIB1 & ~(1 << 7)) | (value ? 1 << 7 : 0)); }
+    public bool RibbonRoyal                 { get => (RIB2 & (1 << 0)) == 1 << 0; set => RIB2 = (byte)((RIB2 & ~(1 << 0)) | (value ? 1 << 0 : 0)); }
+    public bool RibbonGorgeousRoyal         { get => (RIB2 & (1 << 1)) == 1 << 1; set => RIB2 = (byte)((RIB2 & ~(1 << 1)) | (value ? 1 << 1 : 0)); }
+    public bool RibbonArtist                { get => (RIB2 & (1 << 2)) == 1 << 2; set => RIB2 = (byte)((RIB2 & ~(1 << 2)) | (value ? 1 << 2 : 0)); }
+    public bool RibbonFootprint             { get => (RIB2 & (1 << 3)) == 1 << 3; set => RIB2 = (byte)((RIB2 & ~(1 << 3)) | (value ? 1 << 3 : 0)); }
+    public bool RibbonRecord                { get => (RIB2 & (1 << 4)) == 1 << 4; set => RIB2 = (byte)((RIB2 & ~(1 << 4)) | (value ? 1 << 4 : 0)); }
+    public bool RibbonLegend                { get => (RIB2 & (1 << 5)) == 1 << 5; set => RIB2 = (byte)((RIB2 & ~(1 << 5)) | (value ? 1 << 5 : 0)); }
+    public bool RibbonCountry               { get => (RIB2 & (1 << 6)) == 1 << 6; set => RIB2 = (byte)((RIB2 & ~(1 << 6)) | (value ? 1 << 6 : 0)); }
+    public bool RibbonNational              { get => (RIB2 & (1 << 7)) == 1 << 7; set => RIB2 = (byte)((RIB2 & ~(1 << 7)) | (value ? 1 << 7 : 0)); }
+    public bool RibbonEarth                 { get => (RIB3 & (1 << 0)) == 1 << 0; set => RIB3 = (byte)((RIB3 & ~(1 << 0)) | (value ? 1 << 0 : 0)); }
+    public bool RibbonWorld                 { get => (RIB3 & (1 << 1)) == 1 << 1; set => RIB3 = (byte)((RIB3 & ~(1 << 1)) | (value ? 1 << 1 : 0)); }
+    public bool RibbonClassic               { get => (RIB3 & (1 << 2)) == 1 << 2; set => RIB3 = (byte)((RIB3 & ~(1 << 2)) | (value ? 1 << 2 : 0)); }
+    public bool RibbonPremier               { get => (RIB3 & (1 << 3)) == 1 << 3; set => RIB3 = (byte)((RIB3 & ~(1 << 3)) | (value ? 1 << 3 : 0)); }
+    public bool RibbonEvent                 { get => (RIB3 & (1 << 4)) == 1 << 4; set => RIB3 = (byte)((RIB3 & ~(1 << 4)) | (value ? 1 << 4 : 0)); }
+    public bool RibbonBirthday              { get => (RIB3 & (1 << 5)) == 1 << 5; set => RIB3 = (byte)((RIB3 & ~(1 << 5)) | (value ? 1 << 5 : 0)); }
+    public bool RibbonSpecial               { get => (RIB3 & (1 << 6)) == 1 << 6; set => RIB3 = (byte)((RIB3 & ~(1 << 6)) | (value ? 1 << 6 : 0)); }
+    public bool RibbonSouvenir              { get => (RIB3 & (1 << 7)) == 1 << 7; set => RIB3 = (byte)((RIB3 & ~(1 << 7)) | (value ? 1 << 7 : 0)); }
+    public bool RibbonWishing               { get => (RIB4 & (1 << 0)) == 1 << 0; set => RIB4 = (byte)((RIB4 & ~(1 << 0)) | (value ? 1 << 0 : 0)); }
+    public bool RibbonChampionBattle        { get => (RIB4 & (1 << 1)) == 1 << 1; set => RIB4 = (byte)((RIB4 & ~(1 << 1)) | (value ? 1 << 1 : 0)); }
+    public bool RibbonChampionRegional      { get => (RIB4 & (1 << 2)) == 1 << 2; set => RIB4 = (byte)((RIB4 & ~(1 << 2)) | (value ? 1 << 2 : 0)); }
+    public bool RibbonChampionNational      { get => (RIB4 & (1 << 3)) == 1 << 3; set => RIB4 = (byte)((RIB4 & ~(1 << 3)) | (value ? 1 << 3 : 0)); }
+    public bool RibbonChampionWorld         { get => (RIB4 & (1 << 4)) == 1 << 4; set => RIB4 = (byte)((RIB4 & ~(1 << 4)) | (value ? 1 << 4 : 0)); }
+    public bool HasContestMemoryRibbon      { get => (RIB4 & (1 << 5)) == 1 << 5; set => RIB4 = (byte)((RIB4 & ~(1 << 5)) | (value ? 1 << 5 : 0)); }
+    public bool HasBattleMemoryRibbon       { get => (RIB4 & (1 << 6)) == 1 << 6; set => RIB4 = (byte)((RIB4 & ~(1 << 6)) | (value ? 1 << 6 : 0)); }
+    public bool RibbonChampionG6Hoenn       { get => (RIB4 & (1 << 7)) == 1 << 7; set => RIB4 = (byte)((RIB4 & ~(1 << 7)) | (value ? 1 << 7 : 0)); }
+    public bool RibbonContestStar           { get => (RIB5 & (1 << 0)) == 1 << 0; set => RIB5 = (byte)((RIB5 & ~(1 << 0)) | (value ? 1 << 0 : 0)); }
+    public bool RibbonMasterCoolness        { get => (RIB5 & (1 << 1)) == 1 << 1; set => RIB5 = (byte)((RIB5 & ~(1 << 1)) | (value ? 1 << 1 : 0)); }
+    public bool RibbonMasterBeauty          { get => (RIB5 & (1 << 2)) == 1 << 2; set => RIB5 = (byte)((RIB5 & ~(1 << 2)) | (value ? 1 << 2 : 0)); }
+    public bool RibbonMasterCuteness        { get => (RIB5 & (1 << 3)) == 1 << 3; set => RIB5 = (byte)((RIB5 & ~(1 << 3)) | (value ? 1 << 3 : 0)); }
+    public bool RibbonMasterCleverness      { get => (RIB5 & (1 << 4)) == 1 << 4; set => RIB5 = (byte)((RIB5 & ~(1 << 4)) | (value ? 1 << 4 : 0)); }
+    public bool RibbonMasterToughness       { get => (RIB5 & (1 << 5)) == 1 << 5; set => RIB5 = (byte)((RIB5 & ~(1 << 5)) | (value ? 1 << 5 : 0)); }
+    public bool RibbonChampionAlola         { get => (RIB5 & (1 << 6)) == 1 << 6; set => RIB5 = (byte)((RIB5 & ~(1 << 6)) | (value ? 1 << 6 : 0)); }
+    public bool RibbonBattleRoyale          { get => (RIB5 & (1 << 7)) == 1 << 7; set => RIB5 = (byte)((RIB5 & ~(1 << 7)) | (value ? 1 << 7 : 0)); }
+    public bool RibbonBattleTreeGreat       { get => (RIB6 & (1 << 0)) == 1 << 0; set => RIB6 = (byte)((RIB6 & ~(1 << 0)) | (value ? 1 << 0 : 0)); }
+    public bool RibbonBattleTreeMaster      { get => (RIB6 & (1 << 1)) == 1 << 1; set => RIB6 = (byte)((RIB6 & ~(1 << 1)) | (value ? 1 << 1 : 0)); }
+    public bool RIB6_2                      { get => (RIB6 & (1 << 2)) == 1 << 2; set => RIB6 = (byte)((RIB6 & ~(1 << 2)) | (value ? 1 << 2 : 0)); } // Unused
+    public bool RIB6_3                      { get => (RIB6 & (1 << 3)) == 1 << 3; set => RIB6 = (byte)((RIB6 & ~(1 << 3)) | (value ? 1 << 3 : 0)); } // Unused
+    public bool RIB6_4                      { get => (RIB6 & (1 << 4)) == 1 << 4; set => RIB6 = (byte)((RIB6 & ~(1 << 4)) | (value ? 1 << 4 : 0)); } // Unused
+    public bool RIB6_5                      { get => (RIB6 & (1 << 5)) == 1 << 5; set => RIB6 = (byte)((RIB6 & ~(1 << 5)) | (value ? 1 << 5 : 0)); } // Unused
+    public bool RIB6_6                      { get => (RIB6 & (1 << 6)) == 1 << 6; set => RIB6 = (byte)((RIB6 & ~(1 << 6)) | (value ? 1 << 6 : 0)); } // Unused
+    public bool RIB6_7                      { get => (RIB6 & (1 << 7)) == 1 << 7; set => RIB6 = (byte)((RIB6 & ~(1 << 7)) | (value ? 1 << 7 : 0)); } // Unused
+    public byte RibbonCountMemoryContest { get => Data[0x38]; set => Data[0x38] = value; }
+    public byte RibbonCountMemoryBattle  { get => Data[0x39]; set => Data[0x39] = value; }
+
     // 0x38 Unused
     // 0x39 Unused
     public byte HeightScalar { get => Data[0x3A]; set => Data[0x3A] = value; }
@@ -136,6 +205,8 @@ public sealed class PB7 : G6PKM, IHyperTrain, IAwakened, IScaledSizeValue, IComb
     public byte FormArgumentRemain { get => (byte)FormArgument; set => FormArgument = (FormArgument & ~0xFFu) | value; }
     public byte FormArgumentElapsed { get => (byte)(FormArgument >> 8); set => FormArgument = (FormArgument & ~0xFF00u) | (uint)(value << 8); }
     public byte FormArgumentMaximum { get => (byte)(FormArgument >> 16); set => FormArgument = (FormArgument & ~0xFF0000u) | (uint)(value << 16); }
+
+    public int RibbonCount => BitOperations.PopCount(ReadUInt64LittleEndian(Data.AsSpan(0x30)) & 0b00000000_00000011__11111111_11111111__11111111_11111111__11111111_11111111);
 
     #endregion
     #region Block B


### PR DESCRIPTION
The AbilityType for LGPE wondercards was hardcoded to 3, to ensure that the ability of generated entities was picked randomly (Any12). From what I’ve seen, the Meltan distributed via the HOME gift always has Ability 1. To make sure the first ability slot is always chosen during generation, the program needs to properly read the AbilityType from the wondercard. I’ve set the wondercard to contain AbilityType 0, so that 'OnlyFirst' is selected.

The handling for height, weight, and scale follows the same approach as the other classes.

Meltan is particularly tricky. The mystery gift stores the Souvenir Ribbon in the core data of the PH3. However, the WB7 and PB7 classes do not currently handle ribbons. It might be possible to utilize unused space within the WB7 and PB7 data, but the code flow would need to be reworked. I’m not sure how we should proceed to properly account for that ribbon.