### PR TITLE
Add Mainland China Melmetal gift

### DIFF
--- a/PKHeX.Core/MysteryGifts/WB7.cs
+++ b/PKHeX.Core/MysteryGifts/WB7.cs
@@ -318,7 +318,7 @@ public sealed class WB7(byte[] Data)
     /// <remarks>
     /// Gifts received can be locally traded to the international release, so there is no need to consider residence or transferability.
     /// </remarks>
-    public bool IsMainlandChinaGift => CardID is (1501 or 1503);
+    public bool IsMainlandChinaGift => CardID is (> 1500 and <= 1503);
 
     public int GetLanguage(int redeemLanguage)
     {


### PR DESCRIPTION
Melmetal WC is 1502, filling the gap between Meltan (1501) and Arbok (1503). The [original announcement](https://m.weibo.cn/status/5088320474580186) implied that there would be three gifts, so that should be all of them.