### PR TITLE
Implement Gen 4 groups and group-derived values

### DIFF
--- a/PKHeX.Core/Saves/SAV4.cs
+++ b/PKHeX.Core/Saves/SAV4.cs
@@ -243,6 +243,8 @@ public abstract class SAV4 : SaveFile, IEventFlag37, IDaycareStorage, IDaycareRa
     protected int OFS_Record = int.MinValue;
     public Record4 Records => new(this, Data.AsMemory(OFS_Record, Record4.GetSize(this)));
 
+    protected int OFS_Groups = int.MinValue;
+    
     // Storage
     public override int PartyCount
     {
@@ -637,6 +639,27 @@ public abstract class SAV4 : SaveFile, IEventFlag37, IDaycareStorage, IDaycareRa
             while (SwarmIndex != value)
                 ++SwarmSeed;
         }
+    }
+
+    /// <remarks>
+    /// The game stores an array of 6 groups:
+    /// [0] is the group created by the player (empty if the player has never created one)
+    /// [1] is the group the player is currently in (controls swarms, Great Marsh, Feebas etc.) Unnamed default group if the player has never joined one
+    /// [2] through [5] are groups created by other players, imported via record mixing. These are joinable via the group NPC
+    /// </remarks>
+    public Group4 GroupPlayer => GetGroup(0);
+    public Group4 GroupActive => GetGroup(1);
+    public Group4 GroupOther1 => GetGroup(2);
+    public Group4 GroupOther2 => GetGroup(3);
+    public Group4 GroupOther3 => GetGroup(4);
+    public Group4 GroupOther4 => GetGroup(5);
+
+    private Group4 GetGroup(int index)
+    {
+        const int size = Group4.SIZE;
+        var ofs = OFS_Groups + (index * size);
+        var mem = GeneralBuffer.Slice(ofs, size);
+        return new Group4(mem);
     }
 
     public abstract int BP { get; set; }

--- a/PKHeX.Core/Saves/SAV4.cs
+++ b/PKHeX.Core/Saves/SAV4.cs
@@ -663,6 +663,7 @@ public abstract class SAV4 : SaveFile, IEventFlag37, IDaycareStorage, IDaycareRa
     }
 
     public abstract int BP { get; set; }
+    public abstract uint BattleTowerSeed { get; set; }
     public abstract BattleFrontierFacility4 MaxFacility { get; }
 
     public abstract MysteryBlock4 Mystery { get; }

--- a/PKHeX.Core/Saves/SAV4.cs
+++ b/PKHeX.Core/Saves/SAV4.cs
@@ -641,6 +641,8 @@ public abstract class SAV4 : SaveFile, IEventFlag37, IDaycareStorage, IDaycareRa
         }
     }
 
+    public int Lottery { get => GetWork(60); set => SetWork(60, (ushort)value); }
+
     /// <remarks>
     /// The game stores an array of 6 groups:
     /// [0] is the group created by the player (empty if the player has never created one)

--- a/PKHeX.Core/Saves/SAV4DP.cs
+++ b/PKHeX.Core/Saves/SAV4DP.cs
@@ -66,6 +66,7 @@ public sealed class SAV4DP : SAV4Sinnoh
         OFS_HONEY = 0x72E4;
         OFS_UG_Stats = 0x3A2C;
         OFS_UG_Items = 0x42B0;
+        OFS_Groups = 0x5374;
 
         PoketchStart = 0x114C;
         Seal = 0x6178;

--- a/PKHeX.Core/Saves/SAV4DP.cs
+++ b/PKHeX.Core/Saves/SAV4DP.cs
@@ -131,6 +131,7 @@ public sealed class SAV4DP : SAV4Sinnoh
     public override uint SwarmSeed { get => ReadUInt32LittleEndian(General[0x72D4..]); set => WriteUInt32LittleEndian(General[0x72D4..], value); }
     public override uint SwarmMaxCountModulo => 28;
     public override int BP { get => ReadUInt16LittleEndian(General[0x65F8..]); set => WriteUInt16LittleEndian(General[0x65F8..], (ushort)value); }
+    public override uint BattleTowerSeed { get => ReadUInt32LittleEndian(General[0x65FC..]); set => WriteUInt32LittleEndian(General[0x65FC..], value); }
 
     protected override ReadOnlySpan<ushort> TreeSpecies =>
     [

--- a/PKHeX.Core/Saves/SAV4DP.cs
+++ b/PKHeX.Core/Saves/SAV4DP.cs
@@ -126,8 +126,8 @@ public sealed class SAV4DP : SAV4Sinnoh
     public override int Y2 { get => ReadUInt16LittleEndian(General[0x25FE..]); set => WriteUInt16LittleEndian(General[0x25FE..], (ushort)value); }
     public override int Z { get => ReadUInt16LittleEndian(General[0x2602..]); set => WriteUInt16LittleEndian(General[0x2602..], (ushort)value); }
 
-    public override uint SafariSeed { get => ReadUInt32LittleEndian(General[0x53C4..]); set => WriteUInt32LittleEndian(General[0x53C4..], value); }
-    public override uint SwarmSeed { get => ReadUInt32LittleEndian(General[0x53C8..]); set => WriteUInt32LittleEndian(General[0x53C8..], value); }
+    public override uint SafariSeed { get => ReadUInt32LittleEndian(General[0x72D0..]); set => WriteUInt32LittleEndian(General[0x72D0..], value); }
+    public override uint SwarmSeed { get => ReadUInt32LittleEndian(General[0x72D4..]); set => WriteUInt32LittleEndian(General[0x72D4..], value); }
     public override uint SwarmMaxCountModulo => 28;
     public override int BP { get => ReadUInt16LittleEndian(General[0x65F8..]); set => WriteUInt16LittleEndian(General[0x65F8..], (ushort)value); }
 

--- a/PKHeX.Core/Saves/SAV4HGSS.cs
+++ b/PKHeX.Core/Saves/SAV4HGSS.cs
@@ -328,7 +328,9 @@ public sealed class SAV4HGSS : SAV4, IBoxDetailName, IBoxDetailWallpaper
     // Swarm
     public override uint SwarmSeed { get => ReadUInt32LittleEndian(General[0x68A8..]); set => WriteUInt32LittleEndian(General[0x68A8..], value); }
     public override uint SwarmMaxCountModulo => 20;
+
     public override int BP { get => ReadUInt16LittleEndian(General[0x5BB8..]); set => WriteUInt16LittleEndian(General[0x5BB8..], (ushort)value); }
+    public override uint BattleTowerSeed { get => ReadUInt32LittleEndian(General[0x5BBC..]); set => WriteUInt32LittleEndian(General[0x5BBC..], value); }
 
     // Roamers
     public Roamer4 RoamerRaikou => GetRoamer(0);

--- a/PKHeX.Core/Saves/SAV4HGSS.cs
+++ b/PKHeX.Core/Saves/SAV4HGSS.cs
@@ -77,6 +77,7 @@ public sealed class SAV4HGSS : SAV4, IBoxDetailName, IBoxDetailWallpaper
         FashionCase = 0x3F64;
         OFS_Record = 0x4B3C;
         OFS_Chatter = 0x4E74;
+        OFS_Groups = 0x440C;
         Geonet = 0x8D44;
         WondercardFlags = 0x9D3C;
         Seal = 0x4E20;

--- a/PKHeX.Core/Saves/SAV4Pt.cs
+++ b/PKHeX.Core/Saves/SAV4Pt.cs
@@ -167,8 +167,8 @@ public sealed class SAV4Pt : SAV4Sinnoh
     public override int Y2 { get => ReadUInt16LittleEndian(General[0x2882..]); set => WriteUInt16LittleEndian(General[0x2882..], (ushort)value); }
     public override int Z  { get => ReadUInt16LittleEndian(General[0x2886..]); set => WriteUInt16LittleEndian(General[0x2886..], (ushort)value); }
 
-    public override uint SafariSeed { get => ReadUInt32LittleEndian(General[0x5660..]); set => WriteUInt32LittleEndian(General[0x5660..], value); }
-    public override uint SwarmSeed { get => ReadUInt32LittleEndian(General[0x5664..]); set => WriteUInt32LittleEndian(General[0x5664..], value); }
+    public override uint SafariSeed { get => ReadUInt32LittleEndian(General[0x7F24..]); set => WriteUInt32LittleEndian(General[0x7F24..], value); }
+    public override uint SwarmSeed { get => ReadUInt32LittleEndian(General[0x7F28..]); set => WriteUInt32LittleEndian(General[0x7F28..], value); }
     public override uint SwarmMaxCountModulo => 22;
     public override int BP { get => ReadUInt16LittleEndian(General[0x7234..]); set => WriteUInt16LittleEndian(General[0x7234..], (ushort)value); }
 

--- a/PKHeX.Core/Saves/SAV4Pt.cs
+++ b/PKHeX.Core/Saves/SAV4Pt.cs
@@ -173,6 +173,7 @@ public sealed class SAV4Pt : SAV4Sinnoh
     public override uint SwarmSeed { get => ReadUInt32LittleEndian(General[0x7F28..]); set => WriteUInt32LittleEndian(General[0x7F28..], value); }
     public override uint SwarmMaxCountModulo => 22;
     public override int BP { get => ReadUInt16LittleEndian(General[0x7234..]); set => WriteUInt16LittleEndian(General[0x7234..], (ushort)value); }
+    public override uint BattleTowerSeed { get => ReadUInt32LittleEndian(General[0x7238..]); set => WriteUInt32LittleEndian(General[0x7238..], value); }
 
     protected override ReadOnlySpan<ushort> TreeSpecies =>
     [

--- a/PKHeX.Core/Saves/SAV4Pt.cs
+++ b/PKHeX.Core/Saves/SAV4Pt.cs
@@ -73,6 +73,8 @@ public sealed class SAV4Pt : SAV4Sinnoh
 
         OFS_UG_Stats = 0x3CB4;
         OFS_UG_Items = 0x4538;
+        
+        OFS_Groups = 0x5610;
 
         PoketchStart = 0x1160;
 

--- a/PKHeX.Core/Saves/Substructures/Gen4/Group4.cs
+++ b/PKHeX.Core/Saves/Substructures/Gen4/Group4.cs
@@ -18,26 +18,29 @@ public sealed class Group4(Memory<byte> Raw)
     // u32 origin seed (used as identifier)
     // u32 current seed
 
-    public readonly Memory<byte> Raw = Raw;
     private Span<byte> Data => Raw.Span;
 
-    private Span<byte> NameTrash => Data.Slice(0x00, 16);
-    public string Name
+    private Span<byte> GroupNameTrash => Data.Slice(0x00, 16);
+    public string GroupName
     {
-        get => StringConverter4.GetString(NameTrash);
-        set => StringConverter4.SetString(NameTrash, value, 7, LeaderLang, StringConverterOption.None);
+        get => StringConverter4.GetString(GroupNameTrash);
+        set => StringConverter4.SetString(GroupNameTrash, value, 7, LeaderLanguage, StringConverterOption.None);
     }
 
     private Span<byte> LeaderTrash => Data.Slice(0x10, 16);
-    public string Leader
+    public string LeaderName
     {
         get => StringConverter4.GetString(LeaderTrash);
-        set => StringConverter4.SetString(LeaderTrash, value, 7, LeaderLang, StringConverterOption.None);
+        set => StringConverter4.SetString(LeaderTrash, value, 7, LeaderLanguage, StringConverterOption.None);
     }
     
     public byte LeaderGender { get => Data[0x20]; set => Data[0x20] = value; }
-    public byte LeaderLang   { get => Data[0x21]; set => Data[0x21] = value; }
+    public byte LeaderLanguage { get => Data[0x21]; set => Data[0x21] = value; }
+
+    // 0x22,0x23 unused alignment
 
     public uint Id   { get => ReadUInt32LittleEndian(Data[0x24..]); set => WriteUInt32LittleEndian(Data[0x24..], value); }
     public uint Seed { get => ReadUInt32LittleEndian(Data[0x28..]); set => WriteUInt32LittleEndian(Data[0x28..], value); }
+
+    public override string ToString() => $"{Seed:X8} {GroupName} {LeaderName} {Id:X8}";
 }

--- a/PKHeX.Core/Saves/Substructures/Gen4/Group4.cs
+++ b/PKHeX.Core/Saves/Substructures/Gen4/Group4.cs
@@ -1,0 +1,43 @@
+using System;
+using System.ComponentModel;
+using static System.Buffers.Binary.BinaryPrimitives;
+
+namespace PKHeX.Core;
+
+[TypeConverter(typeof(ExpandableObjectConverter))]
+public sealed class Group4(Memory<byte> Raw)
+{
+    public const int SIZE = 0x2C;
+
+    // Structure:
+    // wchar[8] group name
+    // wchar[8] creator name
+    // u8 creator gender
+    // u8 creator lang
+    // u16 alignment
+    // u32 origin seed (used as identifier)
+    // u32 current seed
+
+    public readonly Memory<byte> Raw = Raw;
+    private Span<byte> Data => Raw.Span;
+
+    private Span<byte> NameTrash => Data.Slice(0x00, 16);
+    public string Name
+    {
+        get => StringConverter4.GetString(NameTrash);
+        set => StringConverter4.SetString(NameTrash, value, 7, CreatorLang, StringConverterOption.None);
+    }
+
+    private Span<byte> CreatorTrash => Data.Slice(0x10, 16);
+    public string Creator
+    {
+        get => StringConverter4.GetString(CreatorTrash);
+        set => StringConverter4.SetString(CreatorTrash, value, 7, CreatorLang, StringConverterOption.None);
+    }
+    
+    public byte CreatorGender { get => Data[0x20]; set => Data[0x20] = value; }
+    public byte CreatorLang   { get => Data[0x21]; set => Data[0x21] = value; }
+
+    public uint Id   { get => ReadUInt32LittleEndian(Data[0x24..]); set => WriteUInt32LittleEndian(Data[0x24..], value); }
+    public uint Seed { get => ReadUInt32LittleEndian(Data[0x28..]); set => WriteUInt32LittleEndian(Data[0x28..], value); }
+}

--- a/PKHeX.Core/Saves/Substructures/Gen4/Group4.cs
+++ b/PKHeX.Core/Saves/Substructures/Gen4/Group4.cs
@@ -11,9 +11,9 @@ public sealed class Group4(Memory<byte> Raw)
 
     // Structure:
     // wchar[8] group name
-    // wchar[8] creator name
-    // u8 creator gender
-    // u8 creator lang
+    // wchar[8] leader name
+    // u8 leader gender
+    // u8 leader lang
     // u16 alignment
     // u32 origin seed (used as identifier)
     // u32 current seed
@@ -25,18 +25,18 @@ public sealed class Group4(Memory<byte> Raw)
     public string Name
     {
         get => StringConverter4.GetString(NameTrash);
-        set => StringConverter4.SetString(NameTrash, value, 7, CreatorLang, StringConverterOption.None);
+        set => StringConverter4.SetString(NameTrash, value, 7, LeaderLang, StringConverterOption.None);
     }
 
-    private Span<byte> CreatorTrash => Data.Slice(0x10, 16);
-    public string Creator
+    private Span<byte> LeaderTrash => Data.Slice(0x10, 16);
+    public string Leader
     {
-        get => StringConverter4.GetString(CreatorTrash);
-        set => StringConverter4.SetString(CreatorTrash, value, 7, CreatorLang, StringConverterOption.None);
+        get => StringConverter4.GetString(LeaderTrash);
+        set => StringConverter4.SetString(LeaderTrash, value, 7, LeaderLang, StringConverterOption.None);
     }
     
-    public byte CreatorGender { get => Data[0x20]; set => Data[0x20] = value; }
-    public byte CreatorLang   { get => Data[0x21]; set => Data[0x21] = value; }
+    public byte LeaderGender { get => Data[0x20]; set => Data[0x20] = value; }
+    public byte LeaderLang   { get => Data[0x21]; set => Data[0x21] = value; }
 
     public uint Id   { get => ReadUInt32LittleEndian(Data[0x24..]); set => WriteUInt32LittleEndian(Data[0x24..], value); }
     public uint Seed { get => ReadUInt32LittleEndian(Data[0x28..]); set => WriteUInt32LittleEndian(Data[0x28..], value); }


### PR DESCRIPTION
Added a `Group4` class that mimics the Gen 4 games' group structure and allows editing groups in the block data window. Documented its locations and structure. This behavior is identical across all of the Gen 4 games.

When a new day is processed, group-derived data is recalculated:
- Group seeds are first updated to `(groupSeed * 0x6C078965) + 0x1` (ARNG)
- The active group seed is copied, unaltered, to the safari seed (DP: 0x72D0, Pt: 0x7F24, HGSS: 0x68A4) and the swarm seed (DP: 0x72D4, Pt: 0x7F28, HGSS: 0x68A8)
- The lotto number is calculated as `((groupSeed * 0x41C64E6D) + 0x3039) >> 16` and written to an event work address (DP: 0xE14, PT: 0xE24, HGSS: 0xE5C)
- A Battle Tower seed, which determines opponents in the Battle *Tower* only, is calculated as `(groupSeed * 0x5D588B65) + 0x1` and written to the Battle Frontier region adjacent to the BP count (DP: 0x65FC, Pt: 0x7238, HGSS: 0x5BBC). Only the Tower uses a group-derived value for opponent generation.

Other group-derived values are calculated from the active group seed on-the-fly without using an intermediate, day-lagged location. I did not implement these:
- Feebas tiles
- Luck of slot machines

The locations for swarm seed and safari seed for DP and Pt were incorrect, reading instead from the active group ID and active group seed. The active group seed is typically the same as the swarm seed, but editing it will not alter the swarming Pokemon. HGSS had the correct location. Also possibly of note, HGSS also stores and updates the safari seed identically to DPPt at location 0x68A4, but this is never read from in-game.