### PR TITLE
Add fallback for unspecified IV criteria in SetPINGA

### DIFF
--- a/PKHeX.Core/Legality/Encounters/Templates/Gen3/XD/EncounterSlot3XD.cs
+++ b/PKHeX.Core/Legality/Encounters/Templates/Gen3/XD/EncounterSlot3XD.cs
@@ -63,7 +63,7 @@ public sealed record EncounterSlot3XD(EncounterArea3XD Parent, ushort Species, b
         if (criteria.IsSpecifiedIVsAll() && !MethodPokeSpot.TrySetIVs(pk, criteria, LevelMin, LevelMax))
             MethodPokeSpot.SetRandomIVs(pk, criteria, LevelMin, LevelMax);
         else
-            MethodPokeSpot.SetRandomIVs(pk,EncounterCriteria.Unrestricted, LevelMin, LevelMax);
+            MethodPokeSpot.SetRandomIVs(pk, EncounterCriteria.Unrestricted, LevelMin, LevelMax);
     }
 
     #endregion

--- a/PKHeX.Core/Legality/Encounters/Templates/Gen3/XD/EncounterSlot3XD.cs
+++ b/PKHeX.Core/Legality/Encounters/Templates/Gen3/XD/EncounterSlot3XD.cs
@@ -62,6 +62,8 @@ public sealed record EncounterSlot3XD(EncounterArea3XD Parent, ushort Species, b
         MethodPokeSpot.SetRandomPID(pk, criteria, pi.Gender, SlotNumber);
         if (criteria.IsSpecifiedIVsAll() && !MethodPokeSpot.TrySetIVs(pk, criteria, LevelMin, LevelMax))
             MethodPokeSpot.SetRandomIVs(pk, criteria, LevelMin, LevelMax);
+        else
+            MethodPokeSpot.SetRandomIVs(pk,EncounterCriteria.Unrestricted, LevelMin, LevelMax);
     }
 
     #endregion


### PR DESCRIPTION
Added an else clause in SetPINGA method of EncounterSlot3XD.cs to call SetRandomIVs with unrestricted criteria when specified IV criteria are not met.