### PR TITLE
Add accessors for PBR save language

### DIFF
--- a/PKHeX.Core/Game/Enums/LanguageBR.cs
+++ b/PKHeX.Core/Game/Enums/LanguageBR.cs
@@ -1,0 +1,65 @@
+namespace PKHeX.Core;
+
+/// <summary>
+/// <see cref="GameVersion.BATREV"/> Game Language IDs
+/// </summary>
+public enum LanguageBR : byte
+{
+    /// <summary>
+    /// Japanese (日本語) or English (UK/AU)
+    /// </summary>
+    /// <remarks>Language value is only used by PAL, and is ignored/left as 0 by NTSC-J/NTSC-U.</remarks>
+    JapaneseOrEnglish = 0,
+
+    /// <summary>
+    /// German (Deutsch)
+    /// </summary>
+    German = 1,
+
+    /// <summary>
+    /// Spanish (Español)
+    /// </summary>
+    Spanish = 2,
+
+    /// <summary>
+    /// French (Français)
+    /// </summary>
+    French = 3,
+
+    /// <summary>
+    /// Italian (Italiano)
+    /// </summary>
+    Italian = 4,
+}
+
+/// <summary>
+/// Extension to convert between <see cref="LanguageBR"/> and <see cref="LanguageID"/>.
+/// </summary>
+public static class LanguageBRRemap
+{
+    /// <summary>
+    /// Converts <see cref="LanguageBR"/> to <see cref="LanguageID"/>.
+    /// </summary>
+    public static LanguageID ToLanguageID(this LanguageBR lang) => lang switch
+    {
+        LanguageBR.JapaneseOrEnglish => LanguageID.English,
+        LanguageBR.German => LanguageID.German,
+        LanguageBR.Spanish => LanguageID.Spanish,
+        LanguageBR.French => LanguageID.French,
+        LanguageBR.Italian => LanguageID.Italian,
+        _ => LanguageID.English,
+    };
+
+    /// <summary>
+    /// Converts <see cref="LanguageID"/> to <see cref="LanguageBR"/>.
+    /// </summary>
+    public static LanguageBR ToLanguageBR(this LanguageID lang) => lang switch
+    {
+        LanguageID.Japanese or LanguageID.English => LanguageBR.JapaneseOrEnglish,
+        LanguageID.German => LanguageBR.German,
+        LanguageID.Spanish => LanguageBR.Spanish,
+        LanguageID.French => LanguageBR.French,
+        LanguageID.Italian => LanguageBR.Italian,
+        _ => LanguageBR.JapaneseOrEnglish,
+    };
+}

--- a/PKHeX.Core/Saves/SAV4BR.cs
+++ b/PKHeX.Core/Saves/SAV4BR.cs
@@ -113,7 +113,6 @@ public sealed class SAV4BR : SaveFile, IBoxDetailName
     public override int MaxStringLengthTrainer => 7;
     public override int MaxStringLengthNickname => 10;
     public override int MaxMoney => 999999;
-    public override int Language => (int)LanguageID.English; // prevent KOR from inhabiting
 
     public override int BoxCount => 18;
 
@@ -160,6 +159,17 @@ public sealed class SAV4BR : SaveFile, IBoxDetailName
 
     // Trainer Info
     public override GameVersion Version { get => GameVersion.BATREV; set { } }
+
+    public bool Japanese { get => !FlagUtil.GetFlag(Data, 0x57, 0); set => FlagUtil.SetFlag(Data, 0x57, 0, !value); }
+    public LanguageBR BRLanguage { get => (LanguageBR)Data[(_currentSlot * SIZE_SLOT) + 0x384]; set => Data[(_currentSlot * SIZE_SLOT) + 0x384] = (byte)(value); }
+    public override int Language
+    {
+        get => (int)(BRLanguage == LanguageBR.JapaneseOrEnglish && Japanese ? LanguageID.Japanese : BRLanguage.ToLanguageID());
+        set {
+            Japanese = value == (int)LanguageID.Japanese;
+            BRLanguage = ((LanguageID)value).ToLanguageBR();
+        }
+    }
 
     private string GetOTName(int slot)
     {

--- a/PKHeX.Core/Saves/SAV4BR.cs
+++ b/PKHeX.Core/Saves/SAV4BR.cs
@@ -33,9 +33,12 @@ public sealed class SAV4BR : SaveFile, IBoxDetailName
 
         // Detect active save
         var first  = ReadUInt32BigEndian(Data.AsSpan(0x00004C));
-        var second = ReadUInt32BigEndian(Data.AsSpan(0x1C004C));
-        SaveCount = Math.Max(second, first);
-        if (second > first)
+        var second = ReadUInt32BigEndian(Data.AsSpan(SIZE_HALF + 0x00004C));
+        var firstValid  = IsChecksumValid(Data, 0x0000000);
+        var secondValid = IsChecksumValid(Data, SIZE_HALF);
+        var preferSecond = secondValid && (!firstValid || second > first);
+        SaveCount = preferSecond ? second : first;
+        if (preferSecond)
         {
             // swap halves
             byte[] tempData = new byte[SIZE_HALF];
@@ -137,19 +140,22 @@ public sealed class SAV4BR : SaveFile, IBoxDetailName
     {
         SetChecksum(Data, 0x0000000, 0x0000100, 0x000008);
         SetChecksum(Data, 0x0000000, SIZE_HALF, SIZE_HALF - 0x80);
-        SetChecksum(Data, SIZE_HALF, 0x0000100, SIZE_HALF + 0x000008);
-        SetChecksum(Data, SIZE_HALF, SIZE_HALF, SIZE_HALF + SIZE_HALF - 0x80);
+
+        // Don't update the checksum for the second half.
+        // We swap the active half to the first half on open, and the second half can be invalid data.
+        // SetChecksum(Data, SIZE_HALF, 0x0000100, SIZE_HALF + 0x000008);
+        // SetChecksum(Data, SIZE_HALF, SIZE_HALF, SIZE_HALF + SIZE_HALF - 0x80);
     }
 
     public override bool ChecksumsValid => IsChecksumsValid(Data);
     public override string ChecksumInfo => $"Checksums valid: {ChecksumsValid}.";
 
-    public static bool IsChecksumsValid(Span<byte> sav)
+    public static bool IsChecksumsValid(Span<byte> sav) => IsChecksumValid(sav, 0x0000000) || IsChecksumValid(sav, SIZE_HALF);
+
+    private static bool IsChecksumValid(Span<byte> sav, int offset)
     {
-        return VerifyChecksum(sav, 0x0000000, 0x0000100, 0x000008)
-               && VerifyChecksum(sav, 0x0000000, SIZE_HALF, SIZE_HALF - 0x80)
-               && VerifyChecksum(sav, SIZE_HALF, 0x0000100, SIZE_HALF + 0x000008)
-               && VerifyChecksum(sav, SIZE_HALF, SIZE_HALF, SIZE_HALF + SIZE_HALF - 0x80);
+        return VerifyChecksum(sav, offset, 0x0000100, offset + 0x000008)
+               && VerifyChecksum(sav, offset, SIZE_HALF, offset + SIZE_HALF - 0x80);
     }
 
     // Trainer Info


### PR DESCRIPTION
### Add accessors for PBR save language
For the PAL region, PBR appears to use a byte value to specify which language that save slot should be locked to. These values are English (0), German (1), Spanish (2), French (3), and Italian (4). NTSC-J/NTSC-U appear to ignore this value and leave it as zero.

For Japanese, there is an additional bit flag in the save file that needs to not be set for  the game to show the save data. NTSC-U/PAL have this flag set when creating a new save file, but they still read and display Japanese save files without the flag set normally.

### Allow PBR saves with at least one valid half
When a save file is first created, it appears that PBR does not properly initialize the memory used for the save file, so whatever was in memory before is included in the second half of the save file. Previously, these saves would not be recognized since the checksum failed for that half. Now, only the checksum for at least one half needs to match, and the checksum for the inactive half is no longer fixed on save (since that might cause a potentially invalid half to now pass the checksum).