### PR TITLE
Add Korean Ditto Serial Code Distribution Event

### DIFF
--- a/PKHeX.Core/Legality/Encounters/Data/Live/EncounterServerDate.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Live/EncounterServerDate.cs
@@ -217,6 +217,7 @@ public static class EncounterServerDate
         {0514, new(2025, 02, 05, 2025, 07, 01, +2)}, // Pokémon Day 2025 Flying Tera Type Eevee
         {0519, new(2025, 02, 20, 2025, 03, 01)}, // Marco's Jumpluff
         {0066, new(2025, 04, 18, 2025, 08, 01)}, // Wei Chyr's Rillaboom
+        {1019, new(2025, 04, 24, 2025, 07, 01)}, // Pokémon Town - KOR Ditto Project
 
         {9021, HOME3_ML}, // Hidden Ability Sprigatito
         {9022, HOME3_ML}, // Hidden Ability Fuecoco


### PR DESCRIPTION
Submitting the date based on:
* Hard copy serial code issued at Pokémon Town 2025 with LOTTE event in Korea starting on April 25, 2025 at 10:00 AM (GMT+9) (operating hours beginning at 10:00 AM). Countries in UTC-11 would be able to redeem it on April 24, 2025 at 2:00 PM at the earliest.
* Event takes place at two locations:
  - Lotte World Adventure: April 25 - May 18, 2025
  - Jamsil Lotte World 2nd Floor (ZARA building): May 1 - May 6, 2025
* Serial code expiry date is June 30, 2025 at 23:59 (GMT+9) or July 1, 2025 in UTC+11