### PR TITLE
Standardize IGenerateSeed32 API for gen9 raid encounters

### DIFF
--- a/PKHeX.Core/Legality/Encounters/Templates/Gen9/EncounterDist9.cs
+++ b/PKHeX.Core/Legality/Encounters/Templates/Gen9/EncounterDist9.cs
@@ -6,7 +6,8 @@ using static System.Buffers.Binary.BinaryPrimitives;
 namespace PKHeX.Core;
 
 public sealed record EncounterDist9
-    : IEncounterable, IEncounterMatch, IEncounterConvertible<PK9>, ITeraRaid9, IMoveset, IFlawlessIVCount, IFixedGender, IFixedNature
+    : IEncounterable, IEncounterMatch, IEncounterConvertible<PK9>, IGenerateSeed32,
+    ITeraRaid9, IMoveset, IFlawlessIVCount, IFixedGender, IFixedNature
 {
     public byte Generation => 9;
     ushort ILocation.Location => Location;
@@ -242,7 +243,7 @@ public sealed record EncounterDist9
     {
         int language = (int)Language.GetSafeLanguage(Generation, (LanguageID)tr.Language);
         var version = this.GetCompatibleVersion(tr.Version);
-        var pi = PersonalTable.SV[Species, Form];
+        var pi = GetPersonal();
         var pk = new PK9
         {
             Language = language,
@@ -269,18 +270,32 @@ public sealed record EncounterDist9
         return pk;
     }
 
+    private PersonalInfo9SV GetPersonal() => PersonalTable.SV[Species, Form];
+
     private void SetPINGA(PK9 pk, EncounterCriteria criteria, PersonalInfo9SV pi)
     {
-        const byte rollCount = 1;
-        const byte undefinedSize = 0;
-        var param = new GenerateParam9(Species, pi.Gender, FlawlessIVCount, rollCount,
-            undefinedSize, undefinedSize, ScaleType, Scale,
-            Ability, Shiny, Nature, IVs: IVs);
-
+        var param = GetParam(pi);
         var init = Util.Rand.Rand64();
         var success = this.TryApply32(pk, init, param, criteria);
         if (!success && !this.TryApply32(pk, init, param, criteria.WithoutIVs()))
             this.TryApply32(pk, init, param, EncounterCriteria.Unrestricted);
+    }
+
+    private GenerateParam9 GetParam(PersonalInfo9SV pi)
+    {
+        const byte rollCount = 1;
+        const byte undefinedSize = 0;
+        return new GenerateParam9(Species, pi.Gender, FlawlessIVCount, rollCount,
+            undefinedSize, undefinedSize, ScaleType, Scale,
+            Ability, Shiny, Nature, IVs: IVs);
+    }
+
+    public bool GenerateSeed32(PKM pk, uint seed)
+    {
+        var pk9 = (PK9)pk;
+        var param = GetParam(GetPersonal());
+        Encounter9RNG.GenerateData(pk9, param, EncounterCriteria.Unrestricted, seed);
+        return true;
     }
     #endregion
 

--- a/PKHeX.Core/Legality/Encounters/Templates/Gen9/EncounterDist9.cs
+++ b/PKHeX.Core/Legality/Encounters/Templates/Gen9/EncounterDist9.cs
@@ -5,9 +5,7 @@ using static System.Buffers.Binary.BinaryPrimitives;
 
 namespace PKHeX.Core;
 
-public sealed record EncounterDist9
-    : IEncounterable, IEncounterMatch, IEncounterConvertible<PK9>, IGenerateSeed32,
-    ITeraRaid9, IMoveset, IFlawlessIVCount, IFixedGender, IFixedNature
+public sealed record EncounterDist9 : ITeraRaid9, IFixedNature
 {
     public byte Generation => 9;
     ushort ILocation.Location => Location;
@@ -236,8 +234,6 @@ public sealed record EncounterDist9
     };
 
     #region Generating
-    PKM IEncounterConvertible.ConvertToPKM(ITrainerInfo tr, EncounterCriteria criteria) => ConvertToPKM(tr, criteria);
-    PKM IEncounterConvertible.ConvertToPKM(ITrainerInfo tr) => ConvertToPKM(tr);
     public PK9 ConvertToPKM(ITrainerInfo tr) => ConvertToPKM(tr, EncounterCriteria.Unrestricted);
     public PK9 ConvertToPKM(ITrainerInfo tr, EncounterCriteria criteria)
     {

--- a/PKHeX.Core/Legality/Encounters/Templates/Gen9/EncounterMight9.cs
+++ b/PKHeX.Core/Legality/Encounters/Templates/Gen9/EncounterMight9.cs
@@ -3,9 +3,7 @@ using static System.Buffers.Binary.BinaryPrimitives;
 
 namespace PKHeX.Core;
 
-public sealed record EncounterMight9
-    : IEncounterable, IEncounterMatch, IEncounterConvertible<PK9>, IGenerateSeed32,
-    ITeraRaid9, IMoveset, IFlawlessIVCount, IFixedGender, IFixedNature
+public sealed record EncounterMight9 : ITeraRaid9, IFixedNature
 {
     public byte Generation => 9;
     ushort ILocation.Location => Location;
@@ -250,8 +248,6 @@ public sealed record EncounterMight9
     };
 
     #region Generating
-    PKM IEncounterConvertible.ConvertToPKM(ITrainerInfo tr, EncounterCriteria criteria) => ConvertToPKM(tr, criteria);
-    PKM IEncounterConvertible.ConvertToPKM(ITrainerInfo tr) => ConvertToPKM(tr);
     public PK9 ConvertToPKM(ITrainerInfo tr) => ConvertToPKM(tr, EncounterCriteria.Unrestricted);
     public PK9 ConvertToPKM(ITrainerInfo tr, EncounterCriteria criteria)
     {

--- a/PKHeX.Core/Legality/Encounters/Templates/Gen9/EncounterMight9.cs
+++ b/PKHeX.Core/Legality/Encounters/Templates/Gen9/EncounterMight9.cs
@@ -4,7 +4,8 @@ using static System.Buffers.Binary.BinaryPrimitives;
 namespace PKHeX.Core;
 
 public sealed record EncounterMight9
-    : IEncounterable, IEncounterMatch, IEncounterConvertible<PK9>, ITeraRaid9, IMoveset, IFlawlessIVCount, IFixedGender, IFixedNature
+    : IEncounterable, IEncounterMatch, IEncounterConvertible<PK9>, IGenerateSeed32,
+    ITeraRaid9, IMoveset, IFlawlessIVCount, IFixedGender, IFixedNature
 {
     public byte Generation => 9;
     ushort ILocation.Location => Location;
@@ -285,19 +286,33 @@ public sealed record EncounterMight9
         return pk;
     }
 
+    private PersonalInfo9SV GetPersonal() => PersonalTable.SV[Species, Form];
+
     private void SetPINGA(PK9 pk, EncounterCriteria criteria, PersonalInfo9SV pi)
     {
-        const byte rollCount = 1;
-        const byte undefinedSize = 0;
-        byte gender = GetGender(pi);
-        var param = new GenerateParam9(Species, gender, FlawlessIVCount, rollCount,
-            undefinedSize, undefinedSize, ScaleType, Scale,
-            Ability, Shiny, Nature, IVs);
-
+        var param = GetParam(pi);
         var init = Util.Rand.Rand64();
         var success = this.TryApply32(pk, init, param, criteria);
         if (!success && !this.TryApply32(pk, init, param, criteria.WithoutIVs()))
             this.TryApply32(pk, init, param, EncounterCriteria.Unrestricted);
+    }
+
+    private GenerateParam9 GetParam(PersonalInfo9SV pi)
+    {
+        const byte rollCount = 1;
+        const byte undefinedSize = 0;
+        byte gender = GetGender(pi);
+        return new GenerateParam9(Species, gender, FlawlessIVCount, rollCount,
+            undefinedSize, undefinedSize, ScaleType, Scale,
+            Ability, Shiny, Nature, IVs);
+    }
+
+    public bool GenerateSeed32(PKM pk, uint seed)
+    {
+        var pk9 = (PK9)pk;
+        var param = GetParam(GetPersonal());
+        Encounter9RNG.GenerateData(pk9, param, EncounterCriteria.Unrestricted, seed);
+        return true;
     }
     #endregion
 

--- a/PKHeX.Core/Legality/Encounters/Templates/Gen9/EncounterTera9.cs
+++ b/PKHeX.Core/Legality/Encounters/Templates/Gen9/EncounterTera9.cs
@@ -7,9 +7,7 @@ namespace PKHeX.Core;
 /// <summary>
 /// Generation 9 Tera Raid Encounter
 /// </summary>
-public sealed record EncounterTera9
-    : IEncounterable, IEncounterMatch, IEncounterConvertible<PK9>, IGenerateSeed32,
-        ITeraRaid9, IMoveset, IFlawlessIVCount, IFixedGender, IEncounterFormRandom
+public sealed record EncounterTera9 : ITeraRaid9, IEncounterFormRandom
 {
     public byte Generation => 9;
     public EntityContext Context => EntityContext.Gen9;
@@ -173,8 +171,6 @@ public sealed record EncounterTera9
     };
 
     #region Generating
-    PKM IEncounterConvertible.ConvertToPKM(ITrainerInfo tr, EncounterCriteria criteria) => ConvertToPKM(tr, criteria);
-    PKM IEncounterConvertible.ConvertToPKM(ITrainerInfo tr) => ConvertToPKM(tr);
     public PK9 ConvertToPKM(ITrainerInfo tr) => ConvertToPKM(tr, EncounterCriteria.Unrestricted);
     public PK9 ConvertToPKM(ITrainerInfo tr, EncounterCriteria criteria)
     {

--- a/PKHeX.Core/Legality/Encounters/Templates/Gen9/ITeraRaid9.cs
+++ b/PKHeX.Core/Legality/Encounters/Templates/Gen9/ITeraRaid9.cs
@@ -3,7 +3,7 @@ namespace PKHeX.Core;
 /// <summary>
 /// Properties shared for all Tera Crystal raids.
 /// </summary>
-public interface ITeraRaid9 : IGemType
+public interface ITeraRaid9 : IEncounterable, IEncounterMatch, IGemType, IGenerateSeed32, IMoveset, IFixedGender, IFlawlessIVCount, IEncounterConvertible<PK9>
 {
     /// <summary>
     /// Is a BCAT raid.
@@ -29,4 +29,9 @@ public interface ITeraRaid9 : IGemType
     /// Checks if the provided <see cref="seed"/> will pick this object by random choice.
     /// </summary>
     bool CanBeEncountered(uint seed);
+
+    PKM IEncounterConvertible.ConvertToPKM(ITrainerInfo tr, EncounterCriteria criteria) => ConvertToPKM(tr, criteria);
+    PKM IEncounterConvertible.ConvertToPKM(ITrainerInfo tr) => ConvertToPKM(tr);
+    new PK9 ConvertToPKM(ITrainerInfo tr);
+    new PK9 ConvertToPKM(ITrainerInfo tr, EncounterCriteria criteria);
 }


### PR DESCRIPTION
Implement the IGenerateSeed32 interface for both the EncounterDist9 and EncounterMight9 templates, following the implementation patterns already present in EncounterTera9.