### PR TITLE
PBR: Fix box names, add play time

### DIFF
--- a/PKHeX.Core/Saves/SAV4BR.cs
+++ b/PKHeX.Core/Saves/SAV4BR.cs
@@ -27,6 +27,12 @@ public sealed class SAV4BR : SaveFile, IBoxDetailName
         InitializeData(data);
     }
 
+    public SAV4BR(byte[] data, int currentSlot) : base(data)
+    {
+        InitializeData(data);
+        CurrentSlot = currentSlot;
+    }
+
     private void InitializeData(ReadOnlySpan<byte> data)
     {
         Data = DecryptPBRSaveData(data);
@@ -74,7 +80,7 @@ public sealed class SAV4BR : SaveFile, IBoxDetailName
     }
 
     // Configuration
-    protected override SAV4BR CloneInternal() => new(GetFinalData());
+    protected override SAV4BR CloneInternal() => new(GetFinalData(), CurrentSlot);
 
     public readonly IReadOnlyList<string> SaveNames = new string[SAVE_COUNT];
 

--- a/PKHeX.Core/Saves/SAV4BR.cs
+++ b/PKHeX.Core/Saves/SAV4BR.cs
@@ -223,7 +223,7 @@ public sealed class SAV4BR : SaveFile, IBoxDetailName
         }
     }
 
-    // Save file does not have Box Name / Wallpaper info
+    // Save file does not have Wallpaper info
     private int BoxName = -1;
     private const int BoxNameLength = 0x28;
 
@@ -239,8 +239,6 @@ public sealed class SAV4BR : SaveFile, IBoxDetailName
             return BoxDetailNameExtensions.GetDefaultBoxNameCaps(box);
 
         var span = GetBoxNameSpan(box);
-        if (ReadUInt16BigEndian(span) == 0)
-            return BoxDetailNameExtensions.GetDefaultBoxNameCaps(box);
         return GetString(span);
     }
 
@@ -250,9 +248,6 @@ public sealed class SAV4BR : SaveFile, IBoxDetailName
             return;
 
         var span = GetBoxNameSpan(box);
-        if (ReadUInt16BigEndian(span) == 0)
-            return;
-
         SetString(span, value, BoxNameLength / 2, StringConverterOption.ClearZero);
     }
 

--- a/PKHeX.Core/Saves/SAV4BR.cs
+++ b/PKHeX.Core/Saves/SAV4BR.cs
@@ -178,6 +178,30 @@ public sealed class SAV4BR : SaveFile, IBoxDetailName
         }
     }
 
+    private TimeSpan PlayedSpan
+    {
+        get => TimeSpan.FromSeconds(ReadDoubleBigEndian(Data.AsSpan((0x388 + (_currentSlot * SIZE_SLOT)), 16)));
+        set => WriteDoubleBigEndian(Data.AsSpan((0x388 + (_currentSlot * SIZE_SLOT)), 16), value.TotalSeconds);
+    }
+
+    public override int PlayedHours
+    {
+        get => (ushort)PlayedSpan.TotalHours;
+        set { var time = PlayedSpan; PlayedSpan = time - TimeSpan.FromHours(time.TotalHours) + TimeSpan.FromHours(value); }
+    }
+
+    public override int PlayedMinutes
+    {
+        get => (byte)PlayedSpan.Minutes;
+        set { var time = PlayedSpan; PlayedSpan = time - TimeSpan.FromMinutes(time.Minutes) + TimeSpan.FromMinutes(value); }
+    }
+
+    public override int PlayedSeconds
+    {
+        get => (byte)PlayedSpan.Seconds;
+        set { var time = PlayedSpan; PlayedSpan = time - TimeSpan.FromSeconds(time.Seconds) + TimeSpan.FromSeconds(value); }
+    }
+
     private string GetOTName(int slot)
     {
         var ofs = 0x390 + (SIZE_SLOT * slot);


### PR DESCRIPTION
- Previously, zeroed-out box names couldn't be edited. These checks are removed so that they can be read/written directly like they would be in any other game.
- Certain editors like SAV_BoxLayout clone the save file before editing it, but Clone did not preserve the currently selected save slot, meaning only slot 0 could be edited. Cloning now passes the selected slot as a parameter to the constructor.
- Play time uses the same structure as Western XD, a double with total seconds.