### PR TITLE
 Add PTC 2025 홍주영's Porygon2's date

### DIFF
--- a/PKHeX.Core/Legality/Encounters/Data/Live/EncounterServerDate.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Live/EncounterServerDate.cs
@@ -218,6 +218,7 @@ public static class EncounterServerDate
         {0519, new(2025, 02, 20, 2025, 03, 01)}, // Marco's Jumpluff
         {0066, new(2025, 04, 18, 2025, 08, 01)}, // Wei Chyr's Rillaboom
         {1019, new(2025, 04, 24, 2025, 07, 01)}, // Pokémon Town - KOR Ditto Project
+        {1020, new(2025, 06, 06, 2025, 06, 10)}, // PTC 2025 홍주영's Porygon2
 
         {9021, HOME3_ML}, // Hidden Ability Sprigatito
         {9022, HOME3_ML}, // Hidden Ability Fuecoco


### PR DESCRIPTION
Serial code redemption starts on 7th Jun 2025, 1545 KST(UTC +9) hence UTC-8 regions onwards would be able to redeem it on 6th June 2025. Code must be redeemed by 9th Jun 2025 2359 KST(UTC +9), regions from UTC +10 onwards would be able to redeem it on 10th Jun 2025 