### PR TITLE
 Add NAIC 2025 Wolfe's Incineroar date

### DIFF
--- a/PKHeX.Core/Legality/Encounters/Data/Live/EncounterServerDate.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Live/EncounterServerDate.cs
@@ -219,6 +219,7 @@ public static class EncounterServerDate
         {0066, new(2025, 04, 18, 2025, 08, 01)}, // Wei Chyr's Rillaboom
         {1019, new(2025, 04, 24, 2025, 07, 01)}, // Pokémon Town - KOR Ditto Project
         {1020, new(2025, 06, 06, 2025, 06, 10)}, // PTC 2025 홍주영's Porygon2
+        {0523, new(2025, 06, 13, 2025, 06, 21)}, // NAIC 2025 Wolfe's Incineroar
 
         {9021, HOME3_ML}, // Hidden Ability Sprigatito
         {9022, HOME3_ML}, // Hidden Ability Fuecoco


### PR DESCRIPTION
Serial code redemption begins on June 13, 2025, at 0955 PDT (UTC -7), and remained the same across the earliest time zone (UTC -11). Code must be redeemed by June 20, 2025 1659 PDT (UTC -7). The regions in (UTC +10) and later will still be able to redeem it on June 21, 2025.