### PR TITLE
 Add PJCS 2025 Ray Yamanaka's Amoonguss date

### DIFF
--- a/PKHeX.Core/Legality/Encounters/Data/Live/EncounterServerDate.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Live/EncounterServerDate.cs
@@ -221,6 +221,7 @@ public static class EncounterServerDate
         {1020, new(2025, 06, 06, 2025, 06, 10)}, // PTC 2025 홍주영's Porygon2
         {0523, new(2025, 06, 13, 2025, 06, 21)}, // NAIC 2025 Wolfe's Incineroar
         {0067, new(2025, 06, 20, 2025, 06, 23)}, // PJCS 2025 Hyuma Hara's Flutter Mane
+        {0068, new(2025, 06, 20, 2025, 10, 01)}, // PJCS 2025 Ray Yamanaka's Amoonguss
 
         {9021, HOME3_ML}, // Hidden Ability Sprigatito
         {9022, HOME3_ML}, // Hidden Ability Fuecoco


### PR DESCRIPTION
Mystery gift codes distributed via NFC scanning onsite at PJCS 2025 using Pokémon HOME and redeemed via Pokémon S/V on June 21, 2025 0900 JST(UTC +9), hence it is possible for regions from (UTC -1) and onwards to redeem it on June 20, 2025. Deadline for redemption by September 30, 2025 2359 JST(UTC +9), regions from (UTC +10) and onwards would be able to redeem it till October 1, 2025.
![Screenshot 2025-06-21 142513](https://github.com/user-attachments/assets/577a73ea-62fd-4bad-91aa-5f0ee8f73283)
