### PR TITLE
Fix SAV1 fallback detection for Yellow version

### DIFF
--- a/PKHeX.Core/Saves/SAV1.cs
+++ b/PKHeX.Core/Saves/SAV1.cs
@@ -66,7 +66,8 @@ public sealed class SAV1 : SaveFile, ILangDeviantSave, IEventFlagArray, IEventWo
         if (versionOverride is not (GameVersion.RB or GameVersion.YW))
         {
             if (Starter != 0)
-                Version = Yellow ? GameVersion.YW : GameVersion.RB;
+                // Pikachu
+                Version = Starter == 0x54 ? GameVersion.YW : GameVersion.RB;
             else
                 Version = Data[Offsets.PikaFriendship] != 0 ? GameVersion.YW : GameVersion.RB;
         }
@@ -305,7 +306,6 @@ public sealed class SAV1 : SaveFile, ILangDeviantSave, IEventFlagArray, IEventWo
     public Span<byte> RivalTrash { get => Data.AsSpan(Offsets.Rival, StringLength); set { if (value.Length == StringLength) value.CopyTo(Data.AsSpan(Offsets.Rival)); } }
 
     public byte RivalStarter { get => Data[Offsets.Starter - 2]; set => Data[Offsets.Starter - 2] = value; }
-    public bool Yellow => Starter == 0x54; // Pikachu
     public byte Starter { get => Data[Offsets.Starter]; set => Data[Offsets.Starter] = value; }
 
     public ref byte WramD72E => ref Data[Offsets.Starter + 0x17]; // offset relative to player starter

--- a/PKHeX.Core/Saves/Util/SaveLanguage.cs
+++ b/PKHeX.Core/Saves/Util/SaveLanguage.cs
@@ -322,9 +322,8 @@ public static class SaveLanguage
     private static SaveLanguageResult GetFallback(SAV1 sav)
     {
         bool jp = sav.Japanese;
-        bool yw = sav.Yellow;
         var lang = jp ? Japanese : OverrideLanguageGen1;
-        var ver = yw ? YW : OverrideVersionGen1;
+        var ver = sav.Version == YW ? YW : OverrideVersionGen1;
         return (lang, ver);
     }
 


### PR DESCRIPTION
This PR fixes the issue which current version of PKHeX is changing the Gen1 sav version from YW to RB in the fallback detection when the starter is not defined yet.
There is a secondary heuristic with Pikachu friendship for this case, which was not being used.

Also, removed the unnecessary bool field Yellow from SAV1, as we already have perfectly fine detection for RB and Yellow, so SAV.Version is trustworthy for any possible case.
This aligns with how the fallback detection works for Gen2 Crystal version.