### PR TITLE
Enhancement: Add timestamped backup rotation system

### DIFF
--- a/PKHeX.WinForms/Properties/PKHeXSettings.cs
+++ b/PKHeX.WinForms/Properties/PKHeXSettings.cs
@@ -114,6 +114,9 @@ public sealed class BackupSettings
     [LocalizedDescription("Tracks if the \"Create Backup\" prompt has been issued to the user.")]
     public bool BAKPrompt { get; set; }
 
+    [LocalizedDescription("Maximum number of backup files to keep per original file. Older backups are deleted when this limit is exceeded.")]
+    public int MaxBackupCount { get; set; } = 5;
+
     [LocalizedDescription("List of extra locations to look for Save Files.")]
     public List<string> OtherBackupPaths { get; set; } = [];
 


### PR DESCRIPTION
Enhances the backup system to maintain multiple timestamped backups instead of a single .bak file. This provides users with better recovery options and version history.

Changes:
- Create timestamped backups with format: filename.bak.yyyyMMdd_HHmmss
- Implement automatic rotation to keep only the most recent N backups (default: 5)
- Add MaxBackupCount setting to allow users to configure retention limit
- Apply rotation to both PKM files and save files
- Include fallback to simple .bak files if timestamped creation fails

This improvement gives users peace of mind when editing their Pokémon, knowing they have multiple recovery points available if needed.