### PR TITLE
 Add WCS 2025 Toedscool & Luca Ceribelli's Farigiraf date

### DIFF
--- a/PKHeX.Core/Legality/Encounters/Data/Live/EncounterServerDate.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Live/EncounterServerDate.cs
@@ -226,6 +226,8 @@ public static class EncounterServerDate
         {9997, new(2025, 08, 21, 2025, 10, 01)}, // Shiny Chien-Pao
         {9998, new(2025, 09, 04, 2025, 10, 01)}, // Shiny Ting-Lu
         {9999, new(2025, 09, 18, 2025, 10, 01)}, // Shiny Chi-Yu
+        {0524, new(2025, 08, 14, 2025, 08, 30)}, // WCS 2025 Toedscool
+        {0525, new(2025, 08, 15, 2025, 08, 23)}, // WCS 2025 Luca Ceribelli's Farigiraf
 
         {9021, HOME3_ML}, // Hidden Ability Sprigatito
         {9022, HOME3_ML}, // Hidden Ability Fuecoco


### PR DESCRIPTION
 WCS 2025 Toedscool's date

Redemption card were handed out on the August 14th, 2025 PDT(UTC -7) and the earliest region (UTC -11) would be able to redeem it on the same date. Code redemption by August 29, 2025 2359 UTC, hence regions from (UTC +1) and onwards would still be able to it on the August 30th, 2025 


WCS 2025 Luca Ceribelli's Farigiraf date

Gift code were released on the August 15th, 2025. PDT(UTC -7) and the earliest region (UTC -11) would be able to redeem it on the same date. Code redemption by August 22, 2025. 2359 UTC, hence regions from (UTC +1) and onwards would still be able to it on the August 23rd, 2025
