### PR TITLE
Fix JP Crystal save detection

### DIFF
--- a/PKHeX.Core/Saves/Util/SaveUtil.cs
+++ b/PKHeX.Core/Saves/Util/SaveUtil.cs
@@ -201,7 +201,7 @@ public static class SaveUtil
     private static bool IsG2GSJPN(ReadOnlySpan<byte> data) => HasListAt(data, 0x2D10, 0x283E, 30);
     private static bool IsG2GSKOR(ReadOnlySpan<byte> data) => HasListAt(data, 0x2DAE, 0x28CC, 20);
     private static bool IsG2CrystalINT(ReadOnlySpan<byte> data) => HasListAt(data, 0x2865, 0x2D10, 20);
-    private static bool IsG2CrystalJPN(ReadOnlySpan<byte> data) => HasListAt(data, 0x283E, 0x281A, 30);
+    private static bool IsG2CrystalJPN(ReadOnlySpan<byte> data) => HasListAt(data, 0x2D10, 0x281A, 30);
     private static bool HasListAt(ReadOnlySpan<byte> data, [ConstantExpected] int offset1, [ConstantExpected] int offset2, [ConstantExpected] byte maxCount) =>
         IsListValidG12(data, offset1, maxCount) && IsListValidG12(data, offset2, maxCount);
 


### PR DESCRIPTION
Loading Japanese Crystal save files broke in ff0f472, the [previous logic](https://github.com/kwsch/PKHeX/blob/f370c0cc39bd12124e12c562cfe46acb5cda59d5/PKHeX.Core/Saves/Util/SaveUtil.cs#L295) required offsets 0x2D10 for GSC and 0x281A for Crystal (0x283E is for GS).