### PR TITLE
Fix PK2.ConvertToPK1

### DIFF
--- a/PKHeX.Core/PKM/PK2.cs
+++ b/PKHeX.Core/PKM/PK2.cs
@@ -114,8 +114,7 @@ public sealed class PK2 : GBPKML, ICaughtData2
     public PK1 ConvertToPK1()
     {
         PK1 pk1 = new(Japanese);
-        var dest = pk1.Data.Slice(0x7, 0x1A);
-        Data[1..].CopyTo(dest);
+        Data.Slice(1, 0x1A).CopyTo(pk1.Data[7..]);
         pk1.Species = Species; // This will take care of Typing :)
 
         var lvl = Stat_Level;


### PR DESCRIPTION
Fixes regression that broke PK2 to PK1 conversion in f370c0c, only 0x1A bytes are supposed to be copied per the [previous implementation](https://github.com/kwsch/PKHeX/blob/0674d72fae0928c25a200739cd80f30e888407da/PKHeX.Core/PKM/PK2.cs#L117) and the [reverse process](https://github.com/kwsch/PKHeX/blob/e5705b078aed7c7af21e76bff816a5ae5f13b060/PKHeX.Core/PKM/PK1.cs#L164).