### PR TITLE
Add support for loading zipped saves

### DIFF
--- a/PKHeX.Core/Util/MessageStrings.cs
+++ b/PKHeX.Core/Util/MessageStrings.cs
@@ -1,6 +1,5 @@
 // ReSharper disable AutoPropertyCanBeMadeGetOnly.Global
 
-using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace PKHeX.Core;
@@ -85,6 +84,8 @@ public static class MessageStrings
     public static string MsgFileWriteProtected { get; set; } = "File's location is write protected:";
     public static string MsgFileWriteProtectedAdvice { get; set; } = "If the file is on a removable disk (SD card), please ensure the write protection switch is not set.";
     public static string MsgFileInUse { get; set; } = "Unable to load file. It could be in use by another program.";
+    public static string MsgFileZipArchiveNoEntries { get; set; } = "The zip archive has no entries.";
+    public static string MsgFileZipArchiveEntryReadFail { get; set; } = "Failed to read the expected number of bytes from the archive entry. This could mean your archive is corrupt. Try manually extracting the archive first.";
     public static string MsgFileUnsupported { get; set; } = "Attempted to load an unsupported file type/size. This could mean PKHeX doesn't support your save file or your save file is corrupt.";
     public static string MsgPKMUnsupported { get; set; } = "Attempted to load an unsupported file type/size. This could be caused by loading a different generation Pokemon file on an unsupported generation or your file is corrupt.";
 
@@ -126,6 +127,8 @@ public static class MessageStrings
     public static string MsgDatabaseAdvice { get; set; } = "Please dump all boxes from a save file, then ensure the '{0}' folder exists.";
     public static string MsgDatabaseExport { get; set; } = "Save to PKHeX's database?";
     public static string MsgDatabaseLoad { get; set; } = "Load from PKHeX's database?";
+
+    public static string MsgZipArchiveSelectEntryPrompt { get; set; } = "Select entry from ";
 
     #endregion
 

--- a/PKHeX.WinForms/Subforms/ZipArchiveEntrySelect.Designer.cs
+++ b/PKHeX.WinForms/Subforms/ZipArchiveEntrySelect.Designer.cs
@@ -1,0 +1,153 @@
+namespace PKHeX.WinForms
+{
+    partial class ZipArchiveEntrySelect
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            labelInstruction = new System.Windows.Forms.Label();
+            buttonCancel = new System.Windows.Forms.Button();
+            buttonSelect = new System.Windows.Forms.Button();
+            listViewArchiveEntries = new System.Windows.Forms.ListView();
+            columnHeaderFilename = new System.Windows.Forms.ColumnHeader();
+            columnHeaderSize = new System.Windows.Forms.ColumnHeader();
+            labelSelectedEntry = new System.Windows.Forms.Label();
+            textBoxSelectedEntry = new System.Windows.Forms.TextBox();
+            SuspendLayout();
+            // 
+            // labelInstruction
+            // 
+            labelInstruction.AutoEllipsis = true;
+            labelInstruction.AutoSize = true;
+            labelInstruction.Location = new System.Drawing.Point(12, 9);
+            labelInstruction.Name = "labelInstruction";
+            labelInstruction.Size = new System.Drawing.Size(126, 15);
+            labelInstruction.TabIndex = 0;
+            labelInstruction.Text = "<select entry prompt>";
+            // 
+            // buttonCancel
+            // 
+            buttonCancel.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right;
+            buttonCancel.Location = new System.Drawing.Point(397, 276);
+            buttonCancel.Name = "buttonCancel";
+            buttonCancel.Size = new System.Drawing.Size(75, 23);
+            buttonCancel.TabIndex = 1;
+            buttonCancel.Text = "&Cancel";
+            buttonCancel.UseVisualStyleBackColor = true;
+            buttonCancel.Click += ClickButtonCancel;
+            // 
+            // buttonSelect
+            // 
+            buttonSelect.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right;
+            buttonSelect.Enabled = false;
+            buttonSelect.Location = new System.Drawing.Point(316, 276);
+            buttonSelect.Name = "buttonSelect";
+            buttonSelect.Size = new System.Drawing.Size(75, 23);
+            buttonSelect.TabIndex = 1;
+            buttonSelect.Text = "&Select";
+            buttonSelect.UseVisualStyleBackColor = true;
+            buttonSelect.Click += ClickButtonSelect;
+            // 
+            // listViewArchiveEntries
+            // 
+            listViewArchiveEntries.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            listViewArchiveEntries.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] { columnHeaderFilename, columnHeaderSize });
+            listViewArchiveEntries.Location = new System.Drawing.Point(12, 27);
+            listViewArchiveEntries.MultiSelect = false;
+            listViewArchiveEntries.Name = "listViewArchiveEntries";
+            listViewArchiveEntries.Size = new System.Drawing.Size(460, 243);
+            listViewArchiveEntries.TabIndex = 2;
+            listViewArchiveEntries.UseCompatibleStateImageBehavior = false;
+            listViewArchiveEntries.View = System.Windows.Forms.View.Details;
+            listViewArchiveEntries.ItemSelectionChanged += ItemSelectionChangedListViewArchiveEntries;
+            listViewArchiveEntries.MouseDoubleClick += MouseDoubleClickListViewArchiveEntries;
+            // 
+            // columnHeaderFilename
+            // 
+            columnHeaderFilename.Text = "File name";
+            columnHeaderFilename.Width = 360;
+            // 
+            // columnHeaderSize
+            // 
+            columnHeaderSize.Text = "Size";
+            // 
+            // labelSelectedEntry
+            // 
+            labelSelectedEntry.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left;
+            labelSelectedEntry.AutoSize = true;
+            labelSelectedEntry.Location = new System.Drawing.Point(12, 280);
+            labelSelectedEntry.Name = "labelSelectedEntry";
+            labelSelectedEntry.Size = new System.Drawing.Size(84, 15);
+            labelSelectedEntry.TabIndex = 3;
+            labelSelectedEntry.Text = "Selected entry:";
+            // 
+            // textBoxSelectedEntry
+            // 
+            textBoxSelectedEntry.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right;
+            textBoxSelectedEntry.Location = new System.Drawing.Point(102, 276);
+            textBoxSelectedEntry.Name = "textBoxSelectedEntry";
+            textBoxSelectedEntry.ReadOnly = true;
+            textBoxSelectedEntry.Size = new System.Drawing.Size(208, 23);
+            textBoxSelectedEntry.TabIndex = 4;
+            // 
+            // ZipArchiveEntrySelect
+            // 
+            AcceptButton = buttonSelect;
+            AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            CancelButton = buttonCancel;
+            ClientSize = new System.Drawing.Size(484, 311);
+            Controls.Add(textBoxSelectedEntry);
+            Controls.Add(labelSelectedEntry);
+            Controls.Add(listViewArchiveEntries);
+            Controls.Add(buttonSelect);
+            Controls.Add(buttonCancel);
+            Controls.Add(labelInstruction);
+            MaximizeBox = false;
+            MinimizeBox = false;
+            MinimumSize = new System.Drawing.Size(500, 350);
+            Name = "ZipArchiveEntrySelect";
+            ShowIcon = false;
+            ShowInTaskbar = false;
+            StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            Text = "Opening Zip Archive...";
+            TopMost = true;
+            ResumeLayout(false);
+            PerformLayout();
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Label labelInstruction;
+        private System.Windows.Forms.Button buttonCancel;
+        private System.Windows.Forms.Button buttonSelect;
+        private System.Windows.Forms.ListView listViewArchiveEntries;
+        private System.Windows.Forms.ColumnHeader columnHeaderFilename;
+        private System.Windows.Forms.ColumnHeader columnHeaderSize;
+        private System.Windows.Forms.Label labelSelectedEntry;
+        private System.Windows.Forms.TextBox textBoxSelectedEntry;
+    }
+}

--- a/PKHeX.WinForms/Subforms/ZipArchiveEntrySelect.cs
+++ b/PKHeX.WinForms/Subforms/ZipArchiveEntrySelect.cs
@@ -1,0 +1,105 @@
+using PKHeX.Core;
+
+using System;
+using System.IO.Compression;
+using System.Linq;
+using System.Windows.Forms;
+
+namespace PKHeX.WinForms;
+
+public partial class ZipArchiveEntrySelect : Form
+{
+    public ZipArchiveEntry? SelectedEntry { get; private set; } = null;
+
+    public ZipArchiveEntrySelect(ZipArchive zip, string pathDisplay)
+    {
+        InitializeComponent();
+        labelInstruction.Text = MessageStrings.MsgZipArchiveSelectEntryPrompt + pathDisplay;
+        listViewArchiveEntries.Items.AddRange(CreateListViewItems(zip));
+
+        if (listViewArchiveEntries.Items.Count > 0)
+        {
+            listViewArchiveEntries.Items[0].Selected = true;
+        }
+    }
+
+    private void ClickButtonCancel(object sender, EventArgs e)
+    {
+        SelectedEntry = null;
+        DialogResult = DialogResult.Cancel;
+        Close();
+    }
+
+    private void ClickButtonSelect(object sender, EventArgs e)
+    {
+        DialogResult = DialogResult.OK;
+        Close();
+    }
+
+    private void ItemSelectionChangedListViewArchiveEntries(object sender, ListViewItemSelectionChangedEventArgs e)
+    {
+        SelectedEntry = e.Item?.Tag as ZipArchiveEntry ?? throw new InvalidCastException();
+        buttonSelect.Enabled = SelectedEntry != null;
+        textBoxSelectedEntry.Text = SelectedEntry?.FullName ?? string.Empty;
+    }
+
+    private void MouseDoubleClickListViewArchiveEntries(object sender, MouseEventArgs e)
+    {
+        ListViewHitTestInfo hit = listViewArchiveEntries.HitTest(e.Location);
+
+        if (hit.Item == null)
+            return;
+
+        SelectedEntry = hit.Item.Tag as ZipArchiveEntry ?? throw new InvalidCastException();
+        DialogResult = DialogResult.OK;
+        Close();
+    }
+
+    static private ListViewItem[] CreateListViewItems(ZipArchive zip)
+    {
+        return zip.Entries
+            .Where(e => e.Length > 0 && !string.IsNullOrWhiteSpace(e.Name))
+            .OrderBy(SaveFilenameOpionionatedSort)
+            .ThenByDescending(e => e.Length)
+            .ThenBy(e => e.FullName)
+            .Select(e =>
+            {
+                ListViewItem lvi = new(e.FullName);
+                lvi.Tag = e;
+                lvi.SubItems.Add(BytesToHumanReadable(e.Length));
+                return lvi;
+            })
+            .ToArray();
+
+        // a sort function that prefers common names of save files
+        static long SaveFilenameOpionionatedSort(ZipArchiveEntry e)
+        {
+            string name = e.Name.ToLowerInvariant();
+
+            if (name.EndsWith(".sav", StringComparison.OrdinalIgnoreCase))
+            {
+                return 0;
+            }
+
+            return name switch
+            {
+                "main" => 0,
+                "savedata.bin" => 0,
+                "sav.dat" => 0,
+                "backup" => 1,
+                "backup.bin" => 1,
+                _ => 999,
+            };
+        }
+    }
+
+    // via https://stackoverflow.com/a/62698159
+    private static string BytesToHumanReadable(long bytes)
+    {
+        var unit = 1024;
+        if (bytes < unit) { return $"{bytes} B"; }
+
+        var exp = (int)(Math.Log(bytes) / Math.Log(unit));
+        return $"{bytes / Math.Pow(unit, exp):F2} {("KMGTPE")[exp - 1]}B";
+    }
+}


### PR DESCRIPTION
When a user selects a zip file, they'll be prompted to select an entry from that zip file. That file is then extracted to a temporary location, and loaded like usual.

Some save file managers zip up save backups, and handling zip files like this slightly reduces the friction of interacting with saves like that, removing the need to extract files manually before they can be used with PKHeX.

There are some bits about this patch that I don't love: I looked at modifying the metadata associated with saves (e.g.: like how the path is stored with them while loaded,) in order to save more information about where the file came from. However, it would take me a bit of refactoring to pass that data along cleanly. Ideally it would know it came from an archive, so that the export process could properly open to that folder rather than the temp directory as it does currently. As well, being able to replace an entry in a zip file would further reduce the friction with file-zipping save utilities.

I'd be glad to take on such a thing, but wanted to submit this as-is to first get a read on if such a feature is even desired before I attempted any further additions that would need aforementioned refactoring.

Screenshot of the zip entry selection:
<img width="858" height="417" alt="image" src="https://github.com/user-attachments/assets/132a23b4-a542-4ae6-94b6-90e4182b68b3" />
