### PR TITLE
Ignore case for valid file names in zips

### DIFF
--- a/PKHeX.Core/Saves/Util/Recognition/ZipReader.cs
+++ b/PKHeX.Core/Saves/Util/Recognition/ZipReader.cs
@@ -11,7 +11,7 @@ public sealed class ZipReader : ISaveReader
 {
     public bool IsRecognized(long dataLength) => dataLength > 4;
 
-    private static bool IsValidFileName(string name) => name is "main" or "SaveData.bin";
+    private static bool IsValidFileName(string name) => name.ToLowerInvariant() is "main" or "savedata.bin";
 
     public SaveFile? ReadSaveFile(Memory<byte> data, string? path = null)
     {


### PR DESCRIPTION
Loved what you did in 83beeaa5d0c345469164092f781b1d71c5c89e70!

This patch is just a tiny change to `IsValidFileName()` to ignore case, because for whatever reason, LGP/LGE save filenames are all lowercase, unlike the gen 8 games. Those just happened to be what I'm working with at the moment.

Cheers!