### PR TITLE
 Add Shiny Miraidon / Koraidon Gift's date

### DIFF
--- a/PKHeX.Core/Legality/Encounters/Data/Live/EncounterServerDate.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Live/EncounterServerDate.cs
@@ -228,6 +228,7 @@ public static class EncounterServerDate
         {1548, new(2025, 09, 18, 2025, 10, 01)}, // Shiny Chi-Yu
         {0524, new(2025, 08, 14, 2025, 08, 31)}, // WCS 2025 Toedscool
         {0525, new(2025, 08, 15, 2025, 08, 23)}, // WCS 2025 Luca Ceribelli's Farigiraf
+        {1540, new(2025, 09, 25, 2025, 10, 24)}, // Shiny Miraidon / Koraidon Gift
 
         {9021, HOME3_ML}, // Hidden Ability Sprigatito
         {9022, HOME3_ML}, // Hidden Ability Fuecoco


### PR DESCRIPTION
The earliest serial code distribution would be possible at EB Games outlets located in New Zealand, Wellington (UTC +13) on Sept 26, 2025 0900. Hence region in the (UTC <= +3) would be able to redeem it on Sept 25, 2025.  Code must be redeemed by Oct 23, 2025 2359 (UTC +9), this would allow regions in the UTC +10 onwards to redeem the code on Oct 24, 2025
