### PR TITLE
Fix Zygarde form handling in ShowdownParsing

### DIFF
--- a/PKHeX.Core/Editing/BattleTemplate/Showdown/ShowdownParsing.cs
+++ b/PKHeX.Core/Editing/BattleTemplate/Showdown/ShowdownParsing.cs
@@ -148,7 +148,7 @@ public static class ShowdownParsing
             (int)Darmanitan when form is "Galar-Zen"    => "Galar Zen",
             (int)Minior     when form is not MiniorFormName => $"C-{form}",
             (int)Zygarde    when form is "Complete"     => form,
-            (int)Zygarde    when ability == 211         => $"{(string.IsNullOrWhiteSpace(form) ? "50%" : "10%")}-C",
+            (int)Zygarde    when ability == 211         => $"{(form.Contains("10%") ? "10%" : "50%")}-C",
             (int)Greninja   when ability == 210         => "Ash", // Battle Bond
             (int)Rockruff   when ability == 020         => "Dusk", // Rockruff-1
             (int)Maushold   when form is "Four"         => "Family of Four",


### PR DESCRIPTION
The logic for parsing Zygarde-50%-C and Zygarde-10%-C was inverted, causing 50%-C forms to be imported as 10%-C. Fixed by checking if the form string contains "10%" instead of checking if it's empty.