### PR TITLE
Fix dark mode and add design-time safety checks

### DIFF
--- a/PKHeX.WinForms/Controls/PKM Editor/PKMEditor.cs
+++ b/PKHeX.WinForms/Controls/PKM Editor/PKMEditor.cs
@@ -78,6 +78,23 @@ public sealed partial class PKMEditor : UserControl, IMainEditor
         TB_EXP.MouseWheel += WinFormsUtil.MouseWheelIncrement1;
         TB_Level.MouseWheel += WinFormsUtil.MouseWheelIncrement1;
         TB_Friendship.MouseWheel += WinFormsUtil.MouseWheelIncrement1;
+
+        Load += (_, _) =>
+        {
+            if (DesignMode || !Program.Settings.Startup.DarkMode)
+                return;
+
+            var darkBg = Color.FromArgb(30, 30, 30);
+            BackColor = Hidden_TC.BackColor = TC_Editor.BackColor = darkBg;
+            TC_Editor.ForeColor = Color.FromArgb(241, 241, 241);
+
+            foreach (TabPage page in Hidden_TC.TabPages)
+            {
+                page.UseVisualStyleBackColor = false;
+                page.BackColor = darkBg;
+                page.ForeColor = Color.FromArgb(241, 241, 241);
+            }
+        };
     }
 
     private sealed class ValidationRequiredSet(Control[] controls, Func<PKM, bool> shouldCheck, Func<Control, bool> isState)

--- a/PKHeX.WinForms/Controls/PKM Editor/StatEditor.cs
+++ b/PKHeX.WinForms/Controls/PKM Editor/StatEditor.cs
@@ -306,9 +306,15 @@ public partial class StatEditor : UserControl
     {
         var tb = MT_IVs[index];
         if (value)
+        {
             tb.BackColor = StatHyperTrained;
+            if (StatHyperTrained.GetBrightness() > 0.5f)
+                tb.ForeColor = Color.Black;
+        }
         else
+        {
             tb.ResetBackColor();
+        }
     }
 
     private void UpdateHPType(object sender, EventArgs e)
@@ -376,7 +382,9 @@ public partial class StatEditor : UserControl
     private void UpdateEVTotals()
     {
         var evtotal = Entity.EVTotal;
-        TB_EVTotal.BackColor = GetEVTotalColor(evtotal, TB_IVTotal.BackColor);
+        var color = GetEVTotalColor(evtotal, TB_IVTotal.BackColor);
+        TB_EVTotal.BackColor = color;
+        TB_EVTotal.ForeColor = color.GetBrightness() > 0.5f ? Color.Black : TB_EVTotal.ForeColor;
         TB_EVTotal.Text = evtotal.ToString();
         EVTip.SetToolTip(TB_EVTotal, $"Remaining: {510 - evtotal}");
     }
@@ -612,11 +620,21 @@ public partial class StatEditor : UserControl
         var max = ganbaru.GetMax(entity, i);
         var tb = MT_GVs[i];
         if (current > max)
+        {
             tb.BackColor = EVsInvalid;
+            if (EVsInvalid.GetBrightness() > 0.5f)
+                tb.ForeColor = Color.Black;
+        }
         else if (current == max)
+        {
             tb.BackColor = StatHyperTrained;
+            if (StatHyperTrained.GetBrightness() > 0.5f)
+                tb.ForeColor = Color.Black;
+        }
         else
+        {
             tb.ResetBackColor();
+        }
     }
 
     private void SetStatOrder(StatEditorStatOrder order)

--- a/PKHeX.WinForms/Controls/PKM Editor/VerticalTabControl.cs
+++ b/PKHeX.WinForms/Controls/PKM Editor/VerticalTabControl.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Windows.Forms;
@@ -78,8 +79,28 @@ public sealed class VerticalTabControlEntityEditor : VerticalTabControl
         var graphics = e.Graphics;
         if (e.State == DrawItemState.Selected)
         {
-            var settings = Main.Settings.Draw;
-            var (c1, c2) = (settings.VerticalSelectPrimary, settings.VerticalSelectSecondary);
+            Color c1 = Color.White;
+            Color c2 = Color.LightGray;
+
+            if (LicenseManager.UsageMode != LicenseUsageMode.Designtime)
+            {
+                try
+                {
+                    if (Main.Settings?.Draw is { } settings)
+                    {
+                        c1 = settings.VerticalSelectPrimary;
+                        c2 = settings.VerticalSelectSecondary;
+                    }
+
+                    if (IsDarkMode(BackColor))
+                    {
+                        if (c1.GetBrightness() > 0.6f) c1 = Color.FromArgb(62, 62, 66);
+                        if (c2.GetBrightness() > 0.6f) c2 = Color.FromArgb(45, 45, 48);
+                    }
+                }
+                catch { }
+            }
+
             using var brush = new LinearGradientBrush(bounds, c1, c2, 90f);
             graphics.FillRectangle(brush, bounds);
 
@@ -101,4 +122,6 @@ public sealed class VerticalTabControlEntityEditor : VerticalTabControl
         var tab = TabPages[index];
         graphics.DrawString(tab.Text, Font, text, bounds, flags);
     }
+
+    private static bool IsDarkMode(Color backColor) => backColor.GetBrightness() < 0.5f;
 }

--- a/PKHeX.WinForms/Controls/SAV Editor/BoxEditor.cs
+++ b/PKHeX.WinForms/Controls/SAV Editor/BoxEditor.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Drawing;
 using System.IO;
 using System.Windows.Forms;
 using PKHeX.Core;
@@ -25,6 +26,14 @@ public partial class BoxEditor : UserControl, ISlotViewer<PictureBox>
     public BoxEditor()
     {
         InitializeComponent();
+        Load += (_, _) =>
+        {
+            if (!DesignMode && Program.Settings.Startup.DarkMode)
+            {
+                var darkBg = Color.FromArgb(30, 30, 30);
+                BoxPokeGrid.BackColor = BackColor = darkBg;
+            }
+        };
     }
 
     internal bool InitializeGrid()
@@ -196,7 +205,12 @@ public partial class BoxEditor : UserControl, ISlotViewer<PictureBox>
     {
         Editor.Reload();
         int box = CurrentBox;
-        BoxPokeGrid.SetBackground(SAV.WallpaperImage(box));
+
+        if (DesignMode || !Program.Settings.Startup.DarkMode)
+            BoxPokeGrid.SetBackground(SAV.WallpaperImage(box));
+        else
+            BoxPokeGrid.SetBackground(null!);
+
         M?.Hover.Stop();
 
         int index = box * SAV.BoxSlotCount;

--- a/PKHeX.WinForms/Controls/SAV Editor/SAVEditor.cs
+++ b/PKHeX.WinForms/Controls/SAV Editor/SAVEditor.cs
@@ -78,10 +78,21 @@ public partial class SAVEditor : UserControl, ISlotViewer<PictureBox>, ISaveFile
         M = new SlotChangeManager(this) { Env = EditEnv };
         Box.Setup(M);
         SL_Party.Setup(M);
-
         SL_Extra.ViewIndex = -2;
         menu = new ContextMenuSAV { Manager = M };
         InitializeEvents();
+
+        if (!DesignMode && Program.Settings.Startup.DarkMode)
+        {
+            var darkBg = Color.FromArgb(30, 30, 30);
+            tabBoxMulti.BackColor = darkBg;
+            foreach (TabPage page in tabBoxMulti.TabPages)
+            {
+                page.UseVisualStyleBackColor = false;
+                page.BackColor = darkBg;
+                page.ForeColor = Color.FromArgb(241, 241, 241);
+            }
+        }
     }
 
     private void InitializeEvents()

--- a/PKHeX.WinForms/Program.cs
+++ b/PKHeX.WinForms/Program.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -29,6 +30,12 @@ internal static class Program
     public static bool HaX { get; private set; }
     static Program()
     {
+        if (LicenseManager.UsageMode == LicenseUsageMode.Designtime)
+        {
+            Settings = new PKHeXSettings();
+            return;
+        }
+
 #if !DEBUG
         Application.ThreadException += UIThreadException;
         Application.SetUnhandledExceptionMode(UnhandledExceptionMode.CatchException);


### PR DESCRIPTION
Improves dark mode appearance by dynamically adjusting text colors based on background brightness. Prevents Settings-related crashes during design-time by adding proper null checks.

Changes:
- Adjust foreground colors in StatEditor when background is bright
- Apply dark theming to tab controls and editor panels
- Suppress box wallpapers in dark mode for better contrast
- Add design-time checks to prevent null reference errors in Program.cs when editing in VS Designer