### PR TITLE
Add current version ribbon suggestion

### DIFF
--- a/PKHeX.Core/Editing/Bulk/Suggestion/BatchModifications.cs
+++ b/PKHeX.Core/Editing/Bulk/Suggestion/BatchModifications.cs
@@ -72,13 +72,15 @@ internal static class BatchModifications
     /// <summary>
     /// Sets suggested ribbon data for the Entity.
     /// </summary>
-    /// <remarks>If None, removes all ribbons possible.</remarks>
+    /// <remarks>None removes ribbons, All sets ribbons from all visited generations, otherwise sets ribbons for current version only.</remarks>
     public static ModifyResult SetSuggestedRibbons(BatchInfo info, ReadOnlySpan<char> value)
     {
         if (IsNone(value))
             RibbonApplicator.RemoveAllValidRibbons(info.Legality);
-        else // All
+        else if (IsAll(value))
             RibbonApplicator.SetAllValidRibbons(info.Legality);
+        else
+            RibbonApplicator.SetCurrentVersionValidRibbons(info.Legality);
         return ModifyResult.Modified;
     }
 


### PR DESCRIPTION
Adds Ribbons=$suggest to set only ribbons valid for the current game version.

Changes:
- Add SetCurrentVersionValidRibbons to RibbonApplicator
- Update BatchModifications to support three modes:
  * $suggest - current version ribbons only
  * $suggestAll - all visited generation ribbons
  * $suggestNone - remove all ribbons

Implementation creates a single-generation EvolutionHistory and reuses existing ribbon logic to determine valid ribbons for that version.