### PR TITLE
Fix Alpha encounter matching prioritizing pre-evolutions over evolved…

### DIFF
--- a/PKHeX.Core/Legality/Encounters/Templates/Gen9a/EncounterSlot9a.cs
+++ b/PKHeX.Core/Legality/Encounters/Templates/Gen9a/EncounterSlot9a.cs
@@ -123,6 +123,10 @@ public sealed record EncounterSlot9a(EncounterArea9a Parent, ushort Species, byt
         if (!IsMatchCorrelation(pk))
             return EncounterMatchRating.DeferredErrors;
 
+        // Prefer encounters where the species matches exactly over evolution line matches
+        if (pk.Species != Species)
+            return EncounterMatchRating.PartialMatch;
+
         return EncounterMatchRating.Match;
     }
 


### PR DESCRIPTION
… forms

## Issue
When generating Alpha Pokemon from the encounter database, the encounter matcher could incorrectly match evolved Pokemon to their pre-evolution's Alpha encounter when both encounters had overlapping level ranges.

For example, at level 43:
- Alpha Snover encounter: Level 42-43 (AlphaMove: Water Pulse)
- Alpha Abomasnow encounter: Level 43-45 (AlphaMove: Earth Power)

An Abomasnow generated at level 43 would incorrectly match to the Snover encounter, causing validation to fail with "Expected to have mastered the move Water Pulse when encountered as an alpha" even though Abomasnow's AlphaMove is Earth Power and the Pokemon was correctly generated.

## Solution
Modified EncounterSlot9a.GetMatchRating() to return PartialMatch for evolution line matches (where pk.Species != encounter.Species) and Match only for exact species matches. This ensures the encounter finder prefers exact species matches over pre-evolution encounters when both are valid.

## Testing
Verified that Alpha Abomasnow generated at level 43 now correctly matches to the Abomasnow encounter (species 460) instead of the Snover encounter (species 459) and passes all legality checks.

Fixes validation errors for any Alpha Pokemon where both the base and evolved forms have overlapping Alpha encounters.