### PR TITLE
 Add Poké Center Fidough & Audino Birthday Gift's date

### DIFF
--- a/PKHeX.Core/Legality/Encounters/Data/Live/EncounterServerDate.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Live/EncounterServerDate.cs
@@ -234,6 +234,7 @@ public static class EncounterServerDate
         {0524, new(2025, 08, 14, 2025, 08, 31)}, // WCS 2025 Toedscool
         {0525, new(2025, 08, 15, 2025, 08, 23)}, // WCS 2025 Luca Ceribelli's Farigiraf
         {1540, new(2025, 09, 25, 2025, 10, 25)}, // Shiny Miraidon / Koraidon Gift
+        {0070, new(2025, 10, 31, 2027, 02, 01)}, // Poké Center Fidough Birthday Gift
 
         {9021, HOME3_ML}, // Hidden Ability Sprigatito
         {9022, HOME3_ML}, // Hidden Ability Fuecoco
@@ -249,5 +250,6 @@ public static class EncounterServerDate
     {
         {1601, new(2025, 10, 14, 2026, 3, 1, +2)}, // Ralts holding Gardevoirite
         {0102, new(2025, 10, 23, 2026, 2, 1, +2)}, // Slowpoke Poké Center Gift
+        {0101, new(2025, 10, 31, 2027, 2, 1)}, // Poké Center Audino Birthday Gift
     };
 }


### PR DESCRIPTION
Serial code redemption starts on 1st Nov 2025, 1000 JST(UTC +9) hence UTC-2 regions and earlier would be able to redeem it on 31th Oct 2025. Code must be redeemed by 31th Jan 2027 2359 JST(UTC +9), regions from UTC +10 onwards would be able to redeem it on 1st Feb 2027
<img width="352" height="275" alt="Screenshot 2025-11-01 210700" src="https://github.com/user-attachments/assets/86aa515e-1586-42f3-a113-aa31b5ac3021" />
