### PR TITLE
Update Switch badwords to v21.0.0

### DIFF
--- a/PKHeX.Core/Resources/text/badwords/badwords_switch.txt
+++ b/PKHeX.Core/Resources/text/badwords/badwords_switch.txt
@@ -482,6 +482,7 @@
 .*cunilingus.*
 .*cunni.*
 .*cunt.*
+.*cvlt.*
 .*cvoлoab.*
 .*cvoлoyb.*
 .*cwoлoab.*
@@ -870,6 +871,7 @@
 .*hatejew.*
 .*hatequeer.*
 .*hatetrans.*
+.*hawktuah.*
 .*haцnct.*
 .*haцuct.*
 .*hdolfaitler.*
@@ -4521,6 +4523,7 @@
 ^ダツプン$
 ^チンゲ$
 ^バカ$
+^ヒマンジ$
 ^リスカ$
 ^씨발$
 ^아날$


### PR DESCRIPTION
Confirmed that the new words are blocked on both Switch and Switch 2.

There are also new lists for the new Switch 2 language options (Polish/Thai), which are already being used by the system software. The test words `^bbwpol$` and `^bbwtha$` aren't filtered in Z-A though, even if the Switch 2 is set to those languages, so there's no point in including those lists at the moment.