### PR TITLE
 Add LAIC 2026 Federico Camporesi's Whimiscott date

### DIFF
--- a/PKHeX.Core/Legality/Encounters/Data/Live/EncounterServerDate.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Live/EncounterServerDate.cs
@@ -235,6 +235,7 @@ public static class EncounterServerDate
         {0525, new(2025, 08, 15, 2025, 08, 23)}, // WCS 2025 Luca Ceribelli's Farigiraf
         {1540, new(2025, 09, 25, 2025, 10, 25)}, // Shiny Miraidon / Koraidon Gift
         {0070, new(2025, 10, 31, 2027, 02, 01)}, // Poké Center Fidough Birthday Gift
+        {0526, new(2025, 11, 21, 2025, 12, 01)}, // LAIC 2026 Federico Camporesi’s Whimsicott
 
         {9021, HOME3_ML}, // Hidden Ability Sprigatito
         {9022, HOME3_ML}, // Hidden Ability Fuecoco


### PR DESCRIPTION
The serial code was broadcasted live on 21 November 2025 at 04:00 PST (UTC -8), allowing the earliest regions to redeem the code on the same date. The serial code expired on 30 November 2025 at 15:59 PST (UTC -8). Regions in UTC +1 and later were able to redeem the code until 1 December 2025.

