### PR TITLE
Add Zygarde to `FormInfo.BattleMegas`

### DIFF
--- a/PKHeX.Core/Legality/Tables/FormInfo.cs
+++ b/PKHeX.Core/Legality/Tables/FormInfo.cs
@@ -282,6 +282,7 @@ public static class FormInfo
         (int)Barbaracle,
         (int)Dragalge,
         (int)Hawlucha,
+        (int)Zygarde,
         (int)Drampa,
         (int)Falinks,
 


### PR DESCRIPTION
`IsBattleMegaForm` already checks for Mega Zygarde, but since it's only called if the species is in `BattleMegas`, both `IsBattleOnlyForm` and `IsMegaForm` currently return false for Mega Zygarde