### PR TITLE
Fix `FormInfo.IsBattleOnlyForm` for Zygarde-Complete

### DIFF
--- a/PKHeX.Core/Legality/Tables/FormInfo.cs
+++ b/PKHeX.Core/Legality/Tables/FormInfo.cs
@@ -17,10 +17,10 @@ public static class FormInfo
     /// <returns>True if it can only exist in a battle, false if it can exist outside of battle.</returns>
     public static bool IsBattleOnlyForm(ushort species, byte form, byte format)
     {
-        if (BattleMegas.Contains(species))
-            return IsBattleMegaForm(species, form);
-        if (BattleForms.Contains(species))
-            return IsBattleForm(species, form);
+        if (BattleMegas.Contains(species) && IsBattleMegaForm(species, form))
+            return true;
+        if (BattleForms.Contains(species) && IsBattleForm(species, form))
+            return true;
         return false;
     }
 


### PR DESCRIPTION
Due to the early return, after #4667 the first check started erroneously returning false for Zygarde-Complete. The second if was changed for consistency only.