### PR TITLE
Unban Swampertite

### DIFF
--- a/PKHeX.Core/Items/ItemStorage9ZA.cs
+++ b/PKHeX.Core/Items/ItemStorage9ZA.cs
@@ -121,7 +121,6 @@ public sealed class ItemStorage9ZA : IItemStorage
         0016, // Cherish Ball
 
         0664, // Blazikenite
-        0752, // Swampertite
 
         2640, // Garchompite Z
     ];


### PR DESCRIPTION
The Swampertite is now available since the Season 6 release that occurred on Thursday.
Not sure if it was forgotten intentionally or not, so I thought about making a pull request for it as to not have it be forgotten.