### PR TITLE
implement missing `StreetName` property in SAV9ZA.cs

### DIFF
--- a/PKHeX.Core/Saves/SAV9ZA.cs
+++ b/PKHeX.Core/Saves/SAV9ZA.cs
@@ -262,4 +262,14 @@ public sealed class SAV9ZA : SaveFile, ISCBlockArray, ISaveFileRevision, IBoxDet
         get => Blocks.GetBlockValue<uint>(SaveBlockAccessor9ZA.KTicketPointsZARoyaleInfinite);
         set => Blocks.SetBlockValue(SaveBlockAccessor9ZA.KTicketPointsZARoyaleInfinite, value);
     }
+
+    public string StreetName
+    {
+        get => GetString(Blocks.GetBlock(SaveBlockAccessor9ZA.KStreetName).Data);
+        set
+        {
+            var b = Blocks.GetBlock(SaveBlockAccessor9ZA.KStreetName);
+            SetString(b.Data, value, b.Data.Length, StringConverterOption.None);
+        }
+    }
 }


### PR DESCRIPTION
---
name: This PR implements the `StreetName` property in SAV9ZA.cs
about: The block constants for `KStreetName` were already defined in SaveBlockAccessor9ZA.cs, but the property was not exposed in the SAV9ZA.cs class.
title: ''
labels: enhancement
assignees: ''
---