### PR TITLE
 Add EUIC 2026 Yuma Kinugawa's Hisuian Typhlosion date

### DIFF
--- a/PKHeX.Core/Legality/Encounters/Data/Live/EncounterServerDate.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Live/EncounterServerDate.cs
@@ -236,6 +236,7 @@ public static class EncounterServerDate
         {1540, new(2025, 09, 25, 2025, 10, 25)}, // Shiny Miraidon / Koraidon Gift
         {0070, new(2025, 10, 31, 2027, 02, 01)}, // PokéCenter Fidough Birthday Gift
         {0526, new(2025, 11, 21, 2025, 12, 01)}, // LAIC 2026 Federico Camporesi’s Whimsicott
+        {0527, new(2026, 02, 12, 2026, 02, 21)}, // EUIC 2026 Yuma Kinugawa's Hisuian Typhlosion 
 
         {9021, HOME3_ML}, // Hidden Ability Sprigatito
         {9022, HOME3_ML}, // Hidden Ability Fuecoco


### PR DESCRIPTION
The serial code was broadcast live on 13 February 2026 at 01:00 PST (UTC−8). Regions in UTC −10 and earlier could redeem as early as 12 February 2026. The code expires on 20 February 2026 at 15:59 PST (UTC−8), regions in UTC +1 and later could still redeem it on 21 February 2026.