### PR TITLE
Update the French readme file

### DIFF
--- a/.github/README-fr.md
+++ b/.github/README-fr.md
@@ -1,48 +1,48 @@
 PKHeX
 =====
-![License](https://img.shields.io/badge/License-GPLv3-blue.svg)
+![Licence](https://img.shields.io/badge/License-GPLv3-blue.svg)
 
-Éditeur de sauvegarde de la série de base Pokémon, programmé en [C#](https://fr.wikipedia.org/wiki/C_sharp).
+Éditeur de sauvegarde des jeux principaux de la série Pokémon, programmé en [C#](https://fr.wikipedia.org/wiki/C_sharp).
 
-Prend en charge les fichiers suivants:
-* Enregistrer les fichiers ("main", \*.sav, \*.dsv, \*.dat, \*.gci, \*.bin)
-* Fichiers de carte mémoire GameCube (\*.raw, \*.bin) contenant des sauvegardes de Pokémon GC.
+Les fichiers suivants sont pris en charge :
+* Fichiers de sauvegarde (« main », \*.sav, \*.dsv, \*.dat, \*.gci, \*.bin)
+* Fichiers de carte mémoire GameCube (\*.raw, \*.bin) contenant des sauvegardes de jeux Pokémon GameCube.
 * Fichiers d'entités Pokémon individuels (.pk\*, \*.ck3, \*.xk3, \*.pb7, \*.sk2, \*.bk4, \*.rk4)
-* Fichiers de cadeau mystère (\*.pgt, \*.pcd, \*.pgf, .wc\*) y compris la conversion en .pk\*
-* Importation d'entités GO Park (\*.gp1) incluant la conversion en .pb7
-* Importation d'équipes à partir de 3DS Battle Videos
-* Transfert d'une génération à l'autre, conversion des formats en cours de route.
+* Fichiers de Cadeau Mystère (\*.pgt, \*.pcd, \*.pgf, .wc\*), incluant la conversion en .pk\*
+* Importation d'entités GO Park (\*.gp1), incluant la conversion en .pb7
+* Importation d'équipes à partir de vidéos de combat 3DS déchiffrées
+* Transfert d'une génération à l'autre, avec une conversion du format au passage.
 
-Les données sont affichées dans une vue qui peut être modifiée et enregistrée. L'interface peut être traduite avec des fichiers de ressources/textes externes afin que différentes langues puissent être prises en charge.
+Les données sont affichées sur une interface graphique, permettant de faire des modifications et des sauvegardes. L'interface peut être traduite avec des fichiers de ressources/textes externes afin que différentes langues puissent être prises en charge.
 
-Les ensembles Pokémon Showdown et les QR codes peuvent être importés/exportés pour faciliter le partage.
+Les sets Pokémon Showdown! et les QR codes peuvent être importés/exportés pour faciliter le partage.
 
-PKHeX attend des fichiers de sauvegarde qui ne sont pas chiffrés avec des clés spécifiques à la console. Utilisez un gestionnaire de données enregistrées pour importer et exporter des données enregistrées à partir de la console ([Checkpoint](https://github.com/FlagBrew/Checkpoint) ou [JKSM](https://github.com/J-D-K/JKSM)).
+PKHeX demande des fichiers de sauvegarde qui ne sont pas chiffrés par des clés spécifiques aux consoles. Utilisez un gestionnaire de sauvegardes pour importer et exporter des sauvegardes depuis une console ([Checkpoint](https://github.com/FlagBrew/Checkpoint), save_manager, [JKSM](https://github.com/J-D-K/JKSM), ou SaveDataFiler).
 
-**Nous ne soutenons ni ne tolérons la tricherie aux dépens des autres. N'utilisez pas de Pokémon piratés de manière significative au combat ou dans des échanges avec ceux qui ne savent pas que des Pokémon piratés sont en cours d'utilisation.**
+**Nous ne soutenons ni ne tolérons la tricherie aux dépens des autres. N'utilisez pas de Pokémon piratés de manière significative en combat ou en échanges avec ceux qui ne savent pas que des Pokémon piratés sont utilisés.**
 
-## Captures d'écran
+## Capture d'écran
 
-![Main Window](https://i.imgur.com/CpUzqmY.png)
+![Fenêtre principale](https://i.imgur.com/CpUzqmY.png)
 
-## Construction
+## Compilation
 
-PKHeX est une application Windows Forms qui nécessite [.NET 10.0](https://dotnet.microsoft.com/download/dotnet/10.0).
+PKHeX est une application Windows Forms qui nécessite [.NET 10](https://dotnet.microsoft.com/download/dotnet/10.0).
 
-L'exécutable peut être construit avec n'importe quel compilateur prenant en charge C# 14.
+L'exécutable peut être compilé avec n'importe quel compilateur prenant en charge C# 14.
 
-### Construire les configurations
+### Configurations de la compilation
 
-Utilisez les configurations Debug ou Release lors de la construction. Il n'y a pas de code spécifique à la plate-forme à craindre!
+Utilisez la configuration Debug ou Release lors de la compilation. Aucun code spécifique à une plateforme n'est utilisée dans le programme, donc soyez sans crainte !
 
 ## Dépendances
 
-Le code de génération du QR code de PKHeX est extrait de [QRCoder](https://github.com/codebude/QRCoder), qui est [sous licence MIT](https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
+Le code de génération des QR codes de PKHeX est extrait de [QRCoder](https://github.com/codebude/QRCoder), qui est [sous licence MIT](https://github.com/codebude/QRCoder/blob/master/LICENSE.txt).
 
-La collection de sprites shiny de PKHeX est tirée de [pokesprite](https://github.com/msikma/pokesprite), qui est [sous licence MIT](https://github.com/msikma/pokesprite/blob/master/LICENSE).
+La collection de sprites chromatiques de PKHeX est tirée de [pokesprite](https://github.com/msikma/pokesprite), qui est [sous licence MIT](https://github.com/msikma/pokesprite/blob/master/LICENSE).
 
-PKHeX's Pokémon Legends: Arceus sprite collection is taken from the [National Pokédex - Icon Dex](https://www.deviantart.com/pikafan2000/art/National-Pokedex-Version-Delta-Icon-Dex-824897934) project and its abundance of collaborators and contributors.
+La collection de sprites Légendes Pokémon : Arceus de PKHeX est tirée du projet [National Pokédex - Icon Dex](https://www.deviantart.com/pikafan2000/art/National-Pokedex-Version-Delta-Icon-Dex-824897934), avec son abondance de collaborateurs et de contributeurs.
 
 ## IDE
 
-PKHeX peut être ouvert avec des IDE tels que [Visual Studio](https://visualstudio.microsoft.com/fr/downloads/) en ouvrant le fichier .sln ou .csproj.
+PKHeX peut être ouvert avec des IDEs tels que [Visual Studio](https://visualstudio.microsoft.com/fr/downloads/) en ouvrant le fichier .sln ou .csproj.


### PR DESCRIPTION
- Translate the Pokémon Legends: Arceus line that was not yet translated
- Translate terms that were left untranslated
- Add minor changes that were missing from the English readme (save_manager and SaveDataFiler as save editors, .NET 10 without the .0)
- Adjust the wording of the lines to be more correct and natural