### PR TITLE
Reset clothing when changing gender in ZA

### DIFF
--- a/PKHeX.Core/Saves/Substructures/Gen9/ZA/PlayerFashion9a.cs
+++ b/PKHeX.Core/Saves/Substructures/Gen9/ZA/PlayerFashion9a.cs
@@ -49,4 +49,23 @@ public sealed class PlayerFashion9a(SAV9ZA sav, SCBlock block) : SaveBlock<SAV9Z
     [TypeConverter(typeof(TypeConverterU64))] public ulong Eyes      { get => ReadUInt64LittleEndian(Data[0x50..]); set => WriteUInt64LittleEndian(Data[0x50..], value); }
     [TypeConverter(typeof(TypeConverterU64))] public ulong LowerBody { get => ReadUInt64LittleEndian(Data[0x58..]); set => WriteUInt64LittleEndian(Data[0x58..], value); }
     [TypeConverter(typeof(TypeConverterU64))] public ulong UpperBody { get => ReadUInt64LittleEndian(Data[0x60..]); set => WriteUInt64LittleEndian(Data[0x60..], value); }
+
+    /// <summary>
+    /// Resets the clothing choices to default values.
+    /// </summary>
+    public void Reset()
+    {
+        if (SAV.Gender == 0) // male
+        {
+            Clothing  = 0x5BD86B952ACADA3A;
+            LowerBody = 0x9CC9B53A365377A8; // Skinny Jeans Set
+            UpperBody = 0xA261E0196A33613B; // V-Neck T-Shirt
+        }
+        else // female
+        {
+            Clothing  = 0x81769EA06D93234B;
+            LowerBody = 0xDE5A305C2753196D; // Wide-Leg Pants Set
+            UpperBody = 0xA61E77465A086A14; // Off-Shoulder Shirt
+        }
+    }
 }

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen9/SAV_Trainer9a.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen9/SAV_Trainer9a.cs
@@ -165,7 +165,11 @@ public sealed partial class SAV_Trainer9a : Form
 
     private void SaveTrainerInfo()
     {
-        SAV.Gender = (byte)CB_Gender.SelectedIndex;
+        if (SAV.Gender != (byte)CB_Gender.SelectedIndex)
+        {
+            SAV.Gender = (byte)CB_Gender.SelectedIndex;
+            SAV.PlayerFashion.Reset();
+        }
 
         SAV.Money = Util.ToUInt32(MT_Money.Text);
         SAV.Language = WinFormsUtil.GetIndex(CB_Language);


### PR DESCRIPTION
Minimal support for editing the player's gender in ZA while allowing the game to load properly. Since most of the fashion items/customization options are shared, only Clothing/LowerBody/UpperBody need to be changed in PlayerFashion9a, so they're reset to their initial values in a new save file, preserving the other values.