### PR TITLE
Add Mirage Island editing for RS/E saves

### DIFF
--- a/PKHeX.Core/Saves/Blocks/Gen3/SaveBlock3LargeE.cs
+++ b/PKHeX.Core/Saves/Blocks/Gen3/SaveBlock3LargeE.cs
@@ -1,10 +1,11 @@
+using PKHeX.Core.Saves.Substructures.Gen3;
 using System;
 using System.Collections.Generic;
 using static System.Buffers.Binary.BinaryPrimitives;
 
 namespace PKHeX.Core;
 
-public sealed record SaveBlock3LargeE(Memory<byte> Raw) : ISaveBlock3LargeExpansion, ISaveBlock3LargeHoenn, IRecordStatStorage<RecID3Emerald, uint>
+public sealed record SaveBlock3LargeE(Memory<byte> Raw) : ISaveBlock3LargeExpansion, ISaveBlock3LargeHoenn, IRecordStatStorage<RecID3Emerald, uint>, ISaveBlock3MirageIsland
 {
     public Span<byte> Data => Raw.Span;
     public ushort X { get => ReadUInt16LittleEndian(Data); set => WriteUInt16LittleEndian(Data, value); }
@@ -201,4 +202,16 @@ public sealed record SaveBlock3LargeE(Memory<byte> Raw) : ISaveBlock3LargeExpans
     public byte WaldaIconID { get => Data[Walda + 0x14]; set => Data[Walda + 0x14] = value; }
     public byte WaldaPatternID { get => Data[Walda + 0x15]; set => Data[Walda + 0x15] = value; }
     public bool WaldaUnlocked { get => Data[Walda + 0x16] != 0; set => Data[Walda + 0x16] = (byte)(value ? 1 : 0); }
+
+    // Mirage Island value
+    private const int OFS_MirageIslandValue = 0x13E4;
+
+    /// <summary>
+    /// Mirage Island match value. The game compares this against the low 16 bits of party Pokémon PIDs.
+    /// </summary>
+    public ushort MirageIslandValue
+    {
+        get => ReadUInt16LittleEndian(Data[OFS_MirageIslandValue..]);
+        set => WriteUInt16LittleEndian(Data[OFS_MirageIslandValue..], value);
+    }
 }

--- a/PKHeX.Core/Saves/Blocks/Gen3/SaveBlock3LargeRS.cs
+++ b/PKHeX.Core/Saves/Blocks/Gen3/SaveBlock3LargeRS.cs
@@ -1,10 +1,11 @@
+using PKHeX.Core.Saves.Substructures.Gen3;
 using System;
 using System.Collections.Generic;
 using static System.Buffers.Binary.BinaryPrimitives;
 
 namespace PKHeX.Core;
 
-public sealed record SaveBlock3LargeRS(Memory<byte> Raw) : ISaveBlock3LargeHoenn, IRecordStatStorage<RecID3RuSa, uint>
+public sealed record SaveBlock3LargeRS(Memory<byte> Raw) : ISaveBlock3LargeHoenn, IRecordStatStorage<RecID3RuSa, uint>, ISaveBlock3MirageIsland
 {
     public Span<byte> Data => Raw.Span;
     public ushort X { get => ReadUInt16LittleEndian(Data); set => WriteUInt16LittleEndian(Data, value); }
@@ -169,4 +170,16 @@ public sealed record SaveBlock3LargeRS(Memory<byte> Raw) : ISaveBlock3LargeHoenn
     }
 
     public int SeenOffset3 => 0x3A8C;
+
+    // Mirage Island value
+    private const int OFS_MirageIslandValue = 0x1388;
+
+    /// <summary>
+    /// Mirage Island match value. The game compares this against the low 16 bits of party Pokemon PIDs.
+    /// </summary>
+    public ushort MirageIslandValue
+    {
+        get => ReadUInt16LittleEndian(Data[OFS_MirageIslandValue..]);
+        set => WriteUInt16LittleEndian(Data[OFS_MirageIslandValue..], value);
+    }
 }

--- a/PKHeX.Core/Saves/SAV3.cs
+++ b/PKHeX.Core/Saves/SAV3.cs
@@ -1,3 +1,4 @@
+using PKHeX.Core.Saves.Substructures.Gen3;
 using System;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
@@ -754,6 +755,47 @@ public abstract class SAV3 : SaveFile, ILangDeviantSave, IEventFlag37, IBoxDetai
     {
         get => GetFlag(ExternalEventFlags + 2, 0);
         set => SetFlag(ExternalEventFlags + 2, 0, value);
+    }
+    #endregion
+
+    #region MirageIsland
+    public bool HasMirageIsland => LargeBlock is ISaveBlock3MirageIsland;
+
+    public ushort MirageIslandValue
+    {
+        get
+        {
+            if (LargeBlock is not ISaveBlock3MirageIsland m)
+                throw new InvalidOperationException("This save does not support Mirage Island.");
+            return m.MirageIslandValue;
+        }
+        set
+        {
+            if (LargeBlock is not ISaveBlock3MirageIsland m)
+                throw new InvalidOperationException("This save does not support Mirage Island.");
+            m.MirageIslandValue = value;
+        }
+    }
+
+    /// <summary>
+    /// Sets the Mirage Island match value from the PID of the first party slot.
+    /// Returns false if the save does not support Mirage Island, or if the first party slot is empty or invalid.
+    /// </summary>
+    public bool TrySetMirageIslandFromFirstPartySlot()
+    {
+        if (LargeBlock is not ISaveBlock3MirageIsland m)
+            return false;
+
+        if (LargeBlock.PartyCount == 0)
+            return false;
+
+        var slot = LargeBlock.PartyBuffer[..PokeCrypto.SIZE_3PARTY];
+        if (!IsPKMPresent(slot))
+            return false;
+
+        var pk = new PK3(slot.ToArray());
+        m.MirageIslandValue = (ushort)(pk.PID & 0xFFFF);
+        return true;
     }
     #endregion
 }

--- a/PKHeX.Core/Saves/Substructures/Gen3/ISaveBlock3MirageIsland.cs
+++ b/PKHeX.Core/Saves/Substructures/Gen3/ISaveBlock3MirageIsland.cs
@@ -1,0 +1,10 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace PKHeX.Core.Saves.Substructures.Gen3;
+
+public interface ISaveBlock3MirageIsland
+{
+    ushort MirageIslandValue { get; set; }
+}

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen3/SAV_Misc3.Designer.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen3/SAV_Misc3.Designer.cs
@@ -30,6 +30,14 @@ namespace PKHeX.WinForms
         /// </summary>
         private void InitializeComponent()
         {
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle1 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle2 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle3 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle4 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle5 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle6 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle7 = new System.Windows.Forms.DataGridViewCellStyle();
+            System.Windows.Forms.DataGridViewCellStyle dataGridViewCellStyle8 = new System.Windows.Forms.DataGridViewCellStyle();
             B_Save = new System.Windows.Forms.Button();
             B_Cancel = new System.Windows.Forms.Button();
             TC_Misc = new System.Windows.Forms.TabControl();
@@ -163,6 +171,8 @@ namespace PKHeX.WinForms
             TB_SID = new System.Windows.Forms.MaskedTextBox();
             NUD_Painting = new System.Windows.Forms.NumericUpDown();
             CHK_EnablePaint = new System.Windows.Forms.CheckBox();
+            TAB_MirageIsland = new System.Windows.Forms.TabPage();
+            B_MirageIsland = new System.Windows.Forms.Button();
             TC_Misc.SuspendLayout();
             TAB_Main.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)NUD_BPEarned).BeginInit();
@@ -209,6 +219,7 @@ namespace PKHeX.WinForms
             GB_Painting.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)NUD_Caption).BeginInit();
             ((System.ComponentModel.ISupportInitialize)NUD_Painting).BeginInit();
+            TAB_MirageIsland.SuspendLayout();
             SuspendLayout();
             // 
             // B_Save
@@ -246,6 +257,7 @@ namespace PKHeX.WinForms
             TC_Misc.Controls.Add(Tab_Pokeblocks);
             TC_Misc.Controls.Add(Tab_Decorations);
             TC_Misc.Controls.Add(Tab_Paintings);
+            TC_Misc.Controls.Add(TAB_MirageIsland);
             TC_Misc.Location = new System.Drawing.Point(14, 14);
             TC_Misc.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             TC_Misc.Multiline = true;
@@ -498,7 +510,7 @@ namespace PKHeX.WinForms
             L_JMaxPlayers.Location = new System.Drawing.Point(10, 113);
             L_JMaxPlayers.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             L_JMaxPlayers.Name = "L_JMaxPlayers";
-            L_JMaxPlayers.Size = new System.Drawing.Size(73, 15);
+            L_JMaxPlayers.Size = new System.Drawing.Size(72, 15);
             L_JMaxPlayers.TabIndex = 7;
             L_JMaxPlayers.Text = "Max Players:";
             // 
@@ -939,7 +951,7 @@ namespace PKHeX.WinForms
             L_Stat3.Location = new System.Drawing.Point(3, 201);
             L_Stat3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             L_Stat3.Name = "L_Stat3";
-            L_Stat3.Size = new System.Drawing.Size(35, 15);
+            L_Stat3.Size = new System.Drawing.Size(36, 15);
             L_Stat3.TabIndex = 13;
             L_Stat3.Text = "Trade";
             // 
@@ -959,7 +971,7 @@ namespace PKHeX.WinForms
             L_Stat1.Location = new System.Drawing.Point(3, 149);
             L_Stat1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             L_Stat1.Name = "L_Stat1";
-            L_Stat1.Size = new System.Drawing.Size(35, 15);
+            L_Stat1.Size = new System.Drawing.Size(36, 15);
             L_Stat1.TabIndex = 8;
             L_Stat1.Text = "Trade";
             // 
@@ -1283,6 +1295,8 @@ namespace PKHeX.WinForms
             DGV_Desk.AllowUserToDeleteRows = false;
             DGV_Desk.AllowUserToResizeColumns = false;
             DGV_Desk.AllowUserToResizeRows = false;
+            dataGridViewCellStyle1.BackColor = System.Drawing.SystemColors.ControlLight;
+            DGV_Desk.AlternatingRowsDefaultCellStyle = dataGridViewCellStyle1;
             DGV_Desk.CellBorderStyle = System.Windows.Forms.DataGridViewCellBorderStyle.None;
             DGV_Desk.ColumnHeadersBorderStyle = System.Windows.Forms.DataGridViewHeaderBorderStyle.Single;
             DGV_Desk.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
@@ -1324,6 +1338,8 @@ namespace PKHeX.WinForms
             DGV_Chair.AllowUserToDeleteRows = false;
             DGV_Chair.AllowUserToResizeColumns = false;
             DGV_Chair.AllowUserToResizeRows = false;
+            dataGridViewCellStyle2.BackColor = System.Drawing.SystemColors.ControlLight;
+            DGV_Chair.AlternatingRowsDefaultCellStyle = dataGridViewCellStyle2;
             DGV_Chair.CellBorderStyle = System.Windows.Forms.DataGridViewCellBorderStyle.None;
             DGV_Chair.ColumnHeadersBorderStyle = System.Windows.Forms.DataGridViewHeaderBorderStyle.Single;
             DGV_Chair.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
@@ -1365,6 +1381,8 @@ namespace PKHeX.WinForms
             DGV_Plant.AllowUserToDeleteRows = false;
             DGV_Plant.AllowUserToResizeColumns = false;
             DGV_Plant.AllowUserToResizeRows = false;
+            dataGridViewCellStyle3.BackColor = System.Drawing.SystemColors.ControlLight;
+            DGV_Plant.AlternatingRowsDefaultCellStyle = dataGridViewCellStyle3;
             DGV_Plant.CellBorderStyle = System.Windows.Forms.DataGridViewCellBorderStyle.None;
             DGV_Plant.ColumnHeadersBorderStyle = System.Windows.Forms.DataGridViewHeaderBorderStyle.Single;
             DGV_Plant.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
@@ -1406,6 +1424,8 @@ namespace PKHeX.WinForms
             DGV_Ornament.AllowUserToDeleteRows = false;
             DGV_Ornament.AllowUserToResizeColumns = false;
             DGV_Ornament.AllowUserToResizeRows = false;
+            dataGridViewCellStyle4.BackColor = System.Drawing.SystemColors.ControlLight;
+            DGV_Ornament.AlternatingRowsDefaultCellStyle = dataGridViewCellStyle4;
             DGV_Ornament.CellBorderStyle = System.Windows.Forms.DataGridViewCellBorderStyle.None;
             DGV_Ornament.ColumnHeadersBorderStyle = System.Windows.Forms.DataGridViewHeaderBorderStyle.Single;
             DGV_Ornament.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
@@ -1447,6 +1467,8 @@ namespace PKHeX.WinForms
             DGV_Mat.AllowUserToDeleteRows = false;
             DGV_Mat.AllowUserToResizeColumns = false;
             DGV_Mat.AllowUserToResizeRows = false;
+            dataGridViewCellStyle5.BackColor = System.Drawing.SystemColors.ControlLight;
+            DGV_Mat.AlternatingRowsDefaultCellStyle = dataGridViewCellStyle5;
             DGV_Mat.CellBorderStyle = System.Windows.Forms.DataGridViewCellBorderStyle.None;
             DGV_Mat.ColumnHeadersBorderStyle = System.Windows.Forms.DataGridViewHeaderBorderStyle.Single;
             DGV_Mat.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
@@ -1488,6 +1510,8 @@ namespace PKHeX.WinForms
             DGV_Poster.AllowUserToDeleteRows = false;
             DGV_Poster.AllowUserToResizeColumns = false;
             DGV_Poster.AllowUserToResizeRows = false;
+            dataGridViewCellStyle6.BackColor = System.Drawing.SystemColors.ControlLight;
+            DGV_Poster.AlternatingRowsDefaultCellStyle = dataGridViewCellStyle6;
             DGV_Poster.CellBorderStyle = System.Windows.Forms.DataGridViewCellBorderStyle.None;
             DGV_Poster.ColumnHeadersBorderStyle = System.Windows.Forms.DataGridViewHeaderBorderStyle.Single;
             DGV_Poster.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
@@ -1529,6 +1553,8 @@ namespace PKHeX.WinForms
             DGV_Doll.AllowUserToDeleteRows = false;
             DGV_Doll.AllowUserToResizeColumns = false;
             DGV_Doll.AllowUserToResizeRows = false;
+            dataGridViewCellStyle7.BackColor = System.Drawing.SystemColors.ControlLight;
+            DGV_Doll.AlternatingRowsDefaultCellStyle = dataGridViewCellStyle7;
             DGV_Doll.CellBorderStyle = System.Windows.Forms.DataGridViewCellBorderStyle.None;
             DGV_Doll.ColumnHeadersBorderStyle = System.Windows.Forms.DataGridViewHeaderBorderStyle.Single;
             DGV_Doll.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
@@ -1570,6 +1596,8 @@ namespace PKHeX.WinForms
             DGV_Cushion.AllowUserToDeleteRows = false;
             DGV_Cushion.AllowUserToResizeColumns = false;
             DGV_Cushion.AllowUserToResizeRows = false;
+            dataGridViewCellStyle8.BackColor = System.Drawing.SystemColors.ControlLight;
+            DGV_Cushion.AlternatingRowsDefaultCellStyle = dataGridViewCellStyle8;
             DGV_Cushion.CellBorderStyle = System.Windows.Forms.DataGridViewCellBorderStyle.None;
             DGV_Cushion.ColumnHeadersBorderStyle = System.Windows.Forms.DataGridViewHeaderBorderStyle.Single;
             DGV_Cushion.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
@@ -1784,6 +1812,27 @@ namespace PKHeX.WinForms
             CHK_EnablePaint.UseVisualStyleBackColor = true;
             CHK_EnablePaint.CheckedChanged += CHK_EnablePaint_CheckedChanged;
             // 
+            // TAB_MirageIsland
+            // 
+            TAB_MirageIsland.Controls.Add(B_MirageIsland);
+            TAB_MirageIsland.Location = new System.Drawing.Point(4, 44);
+            TAB_MirageIsland.Name = "TAB_MirageIsland";
+            TAB_MirageIsland.Padding = new System.Windows.Forms.Padding(3);
+            TAB_MirageIsland.Size = new System.Drawing.Size(357, 234);
+            TAB_MirageIsland.TabIndex = 8;
+            TAB_MirageIsland.Text = "Mirage Island";
+            TAB_MirageIsland.UseVisualStyleBackColor = true;
+            // 
+            // B_MirageIsland
+            // 
+            B_MirageIsland.Location = new System.Drawing.Point(86, 74);
+            B_MirageIsland.Name = "B_MirageIsland";
+            B_MirageIsland.Size = new System.Drawing.Size(140, 47);
+            B_MirageIsland.TabIndex = 0;
+            B_MirageIsland.Text = "Match First Party PID";
+            B_MirageIsland.UseVisualStyleBackColor = true;
+            B_MirageIsland.Click += SetMirageIsland;
+            // 
             // SAV_Misc3
             // 
             AutoScaleMode = System.Windows.Forms.AutoScaleMode.Inherit;
@@ -1853,6 +1902,7 @@ namespace PKHeX.WinForms
             GB_Painting.PerformLayout();
             ((System.ComponentModel.ISupportInitialize)NUD_Caption).EndInit();
             ((System.ComponentModel.ISupportInitialize)NUD_Painting).EndInit();
+            TAB_MirageIsland.ResumeLayout(false);
             ResumeLayout(false);
         }
 
@@ -1990,5 +2040,7 @@ namespace PKHeX.WinForms
         private System.Windows.Forms.Label L_Mode;
         private System.Windows.Forms.Label L_Facility;
         private System.Windows.Forms.Label L_Continue;
+        private System.Windows.Forms.TabPage TAB_MirageIsland;
+        private System.Windows.Forms.Button B_MirageIsland;
     }
 }

--- a/PKHeX.WinForms/Subforms/Save Editors/Gen3/SAV_Misc3.cs
+++ b/PKHeX.WinForms/Subforms/Save Editors/Gen3/SAV_Misc3.cs
@@ -53,6 +53,9 @@ public partial class SAV_Misc3 : Form
             TC_Misc.Controls.Remove(TAB_BF);
         }
 
+        if (!SAV.HasMirageIsland)
+            TC_Misc.Controls.Remove(TAB_MirageIsland);
+
         if (SAV is SAV3FRLG frlg)
         {
             TB_RivalName.Text = frlg.RivalName;
@@ -72,7 +75,9 @@ public partial class SAV_Misc3 : Form
             }
         }
         else
-        { TB_RivalName.Visible = L_TrainerName.Visible = GB_TCM.Visible = false; }
+        {
+            TB_RivalName.Visible = L_TrainerName.Visible = GB_TCM.Visible = false;
+        }
 
         NUD_Coins.Value = Math.Min(NUD_Coins.Maximum, SAV.Coin);
     }
@@ -247,6 +252,25 @@ public partial class SAV_Misc3 : Form
         SAV.SetEventFlag(0x1AF, CHK_InitialBirth.Checked);
         SAV.SetEventFlag(0x1B0, CHK_InitialFaraway.Checked);
         SAV.SetEventFlag(0x1DB, CHK_InitialNavel.Checked);
+    }
+    #endregion
+
+    #region Mirage Island
+    private void SetMirageIsland(object sender, EventArgs e)
+    {
+        if (!SAV.HasMirageIsland)
+        {
+            WinFormsUtil.Alert("This save does not support Mirage Island.");
+            return;
+        }
+
+        if (!SAV.TrySetMirageIslandFromFirstPartySlot())
+        {
+            WinFormsUtil.Alert("The first party slot is empty or invalid.");
+            return;
+        }
+
+        WinFormsUtil.Alert($"Mirage Island value set to 0x{SAV.MirageIslandValue:X4}.");
     }
     #endregion
 
@@ -762,4 +786,5 @@ public partial class SAV_Misc3 : Form
             TB_SID.Text = sid.ToString();
     }
     #endregion
+
 }

--- a/Tests/PKHeX.Core.Tests/Saves/Gen3/MirageIslandTests.cs
+++ b/Tests/PKHeX.Core.Tests/Saves/Gen3/MirageIslandTests.cs
@@ -1,0 +1,93 @@
+using PKHeX.Core;
+using Xunit;
+
+namespace PKHeX.Core.Tests.Saves.Gen3;
+
+public class MirageIslandTests
+{
+    [Fact]
+    public void SaveBlock3LargeE_MirageIslandValue_ReadWrite()
+    {
+        var block = new SaveBlock3LargeE(new byte[0x3D88]);
+
+        block.MirageIslandValue = 0xAA80;
+
+        Assert.Equal((ushort)0xAA80, block.MirageIslandValue);
+    }
+
+    [Fact]
+    public void SaveBlock3LargeRS_MirageIslandValue_ReadWrite()
+    {
+        var block = new SaveBlock3LargeRS(new byte[0x3B4C]);
+
+        block.MirageIslandValue = 0xAA80;
+
+        Assert.Equal((ushort)0xAA80, block.MirageIslandValue);
+    }
+
+    [Fact]
+    public void SAV3E_TrySetMirageIslandFromFirstPartySlot_ReturnsFalse_WhenPartyIsEmpty()
+    {
+        var sav = new SAV3E();
+
+        sav.LargeBlock.PartyCount = 0;
+
+        Assert.False(sav.TrySetMirageIslandFromFirstPartySlot());
+    }
+
+    [Fact]
+    public void SAV3RS_TrySetMirageIslandFromFirstPartySlot_ReturnsFalse_WhenPartyIsEmpty()
+    {
+        var sav = new SAV3RS();
+
+        sav.LargeBlock.PartyCount = 0;
+
+        Assert.False(sav.TrySetMirageIslandFromFirstPartySlot());
+    }
+
+    [Fact]
+    public void SAV3E_TrySetMirageIslandFromFirstPartySlot_SetsLow16BitsOfPID()
+    {
+        var sav = new SAV3E();
+        var pk = CreateTestPK3(0x4603AA80);
+
+        SetFirstPartySlot(sav, pk);
+
+        var result = sav.TrySetMirageIslandFromFirstPartySlot();
+
+        Assert.True(result);
+        Assert.Equal((ushort)0xAA80, sav.MirageIslandValue);
+    }
+
+    [Fact]
+    public void SAV3RS_TrySetMirageIslandFromFirstPartySlot_SetsLow16BitsOfPID()
+    {
+        var sav = new SAV3RS();
+        var pk = CreateTestPK3(0x4603AA80);
+
+        SetFirstPartySlot(sav, pk);
+
+        var result = sav.TrySetMirageIslandFromFirstPartySlot();
+
+        Assert.True(result);
+        Assert.Equal((ushort)0xAA80, sav.MirageIslandValue);
+    }
+
+    private static PK3 CreateTestPK3(uint pid)
+    {
+        var pk = new PK3
+        {
+            Species = (ushort)Species.Treecko,
+            PID = pid,
+        };
+
+        pk.RefreshChecksum();
+        return pk;
+    }
+
+    private static void SetFirstPartySlot(SAV3 sav, PK3 pk)
+    {
+        sav.LargeBlock.PartyCount = 1;
+        pk.Data.CopyTo(sav.LargeBlock.PartyBuffer[..sav.SIZE_PARTY]);
+    }
+}


### PR DESCRIPTION
## Motivation
While hunting shiny Latios through Mirage Island, I found it inconvenient to rely on AR codes or external plugins just to control the Mirage Island match value. This change adds native support for that workflow directly in PKHeX for Gen 3 Hoenn saves.

## How it works
When triggered from the Misc Editor, the save reads the PID of the first party Pokémon and stores its low 16 bits as the Mirage Island match value. This mirrors the in-game comparison used by Ruby, Sapphire, and Emerald saves.

## Changes
- add `ISaveBlock3MirageIsland` for shared Gen 3 Hoenn save support
- add Mirage Island value accessors to `SaveBlock3LargeE` and `SaveBlock3LargeRS`
- add shared Mirage Island helpers to `SAV3`
- add a Misc Editor UI action to set the Mirage Island match value from the first party Pokémon PID
- hide the Mirage Island UI for saves that do not support it, such as FR/LG
- add core tests for:
  - RS/E Mirage Island value read/write
  - empty party handling
  - setting the value from the low 16 bits of the first party Pokémon PID

## Testing
- added core tests for `SaveBlock3LargeE` Mirage Island value read/write
- added core tests for `SaveBlock3LargeRS` Mirage Island value read/write
- added core tests verifying `TrySetMirageIslandFromFirstPartySlot()` returns `false` when the party is empty
- added core tests verifying `TrySetMirageIslandFromFirstPartySlot()` stores the low 16 bits of the first party Pokémon PID for both Emerald and RS
- ran `dotnet test PKHeX.sln`

## Images
### Tests
<img width="1049" height="289" alt="Tests" src="https://github.com/user-attachments/assets/21f5b055-53ce-4121-bec4-13e53a42a0f8" />

### Mirage Island appears
<img width="544" height="399" alt="mirageisland" src="https://github.com/user-attachments/assets/b73e1f36-da1d-46d7-b6b1-9df9b95b5c05" />

### Tab is not showing in LG/RF save file.
<img width="625" height="431" alt="MirageLGFR" src="https://github.com/user-attachments/assets/ca62110c-1eca-4287-8801-975abe8f6b98" />

### Tab in R/S/E save files.
<img width="389" height="373" alt="MirageRSE" src="https://github.com/user-attachments/assets/dc7e5022-5f1f-4cd8-83e8-20e8833b2aeb" />
