### PR TITLE
Add a movement threshold for initiating drag & drop operations

### DIFF
--- a/PKHeX.Core/Editing/Program/Settings/AdvancedSettings.cs
+++ b/PKHeX.Core/Editing/Program/Settings/AdvancedSettings.cs
@@ -17,6 +17,9 @@ public sealed class AdvancedSettings
     [LocalizedDescription("Hide event variable names for that contain any of the comma-separated substrings below. Removes event values from the GUI that the user doesn't care to view.")]
     public string HideEvent8Contains { get; set; } = string.Empty;
 
+    [LocalizedDescription("Minimum distance threshold that mouse movement must exceed before a drag operation is started from a slot.")]
+    public int DragStartThreshold { get; set; } = 0;
+
     [Browsable(false)]
     public string[] GetExclusionList8() => Array.ConvertAll(HideEvent8Contains.Split(',', StringSplitOptions.RemoveEmptyEntries), z => z.Trim());
 }

--- a/PKHeX.WinForms/Controls/Slots/DragManager.cs
+++ b/PKHeX.WinForms/Controls/Slots/DragManager.cs
@@ -92,5 +92,5 @@ public sealed class DragManager : IDisposable
     /// <summary>
     /// Gets a value indicating whether a drag operation can be started.
     /// </summary>
-    public bool CanStartDrag => Info.IsLeftMouseDown && !Cursor.Position.Equals(MouseDownPosition);
+    public bool CanStartDrag => Info.IsLeftMouseDown && ((Math.Abs(Cursor.Position.X - MouseDownPosition.X) + Math.Abs(Cursor.Position.Y - MouseDownPosition.Y)) > Main.Settings.Advanced.DragStartThreshold);
 }

--- a/PKHeX.WinForms/Resources/text/lang_en.txt
+++ b/PKHeX.WinForms/Resources/text/lang_en.txt
@@ -270,6 +270,7 @@ LocalizedDescription.DatabasePath=Path to the PKM Database folder.
 LocalizedDescription.DefaultBoxExportNamer=Selected File namer to use for box exports for the GUI, if multiple are available.
 LocalizedDescription.DisableScalingDpi=Disables the GUI scaling based on Dpi on program startup, falling back to font scaling.
 LocalizedDescription.DisableWordFilterPastGen=Disables retroactive Word Filter checks for earlier formats.
+LocalizedDescription.DragStartThreshold=Minimum distance threshold that mouse movement must exceed before a drag operation is started from a slot.
 LocalizedDescription.EggRandomAnyType3=Allow Generation 3 bred eggs to have any PID/IV type by assuming they were RNG abused to be collisions instead of hacked.
 LocalizedDescription.EggRandomAnyType4=Allow Generation 4 bred eggs to have any PID/IV type by assuming they were RNG abused to be collisions instead of hacked.
 LocalizedDescription.Export=Settings for showing details when exporting a slot.


### PR DESCRIPTION
Adds a configurable threshold for a minimum distance the mouse must move from the click point before a drag operation begins when dragging a slot.
- Default threshold is `0` to match existing behaviour.
- Setting placed under the Advanced tab. While this is defined in `PKHeX.Core` rather than `PKHeX.WinForms` where it might make more sense there isn't really a good category there without creating a whole new one. And other seemingly UI specific settings are also found under `PKHeX.Core`
- Only modified the English translation.
- Does not change drag behaviour for the currently loaded Pokémon as that does not reference `CanStartDrag` but it doesn't have any action besides dragging associated with it anyway.

Should particularly help when clicking slots while holding modifier keys as currently even the slightest movement while clicking will start a drag operation and ignore any intention to load, save, or clear the clicked slot.  
Only when initiating a drag from the very edge of one slot onto the edge of an adjacent slot might this setting create an additional hindrance unless a nonsensically high value is chosen for the threshold. I've found even a setting as low as `2` is very reliable at preventing lost clicks and have set mine to `10` without it causing attempted drag operations to fail.