### PR TITLE
Handle HOME Shiny Volcanion

### DIFF
--- a/PKHeX.Core/Legality/Encounters/Data/Live/EncounterServerDate.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Live/EncounterServerDate.cs
@@ -259,5 +259,6 @@ public static class EncounterServerDate
         {9031, new(2026, 04, 02)}, // Alpha Chikorita
         {9032, new(2026, 04, 02)}, // Alpha Tepig
         {9033, new(2026, 04, 02)}, // Alpha Totodile
+        {9034, new(2026, 04, 26)}, // Shiny Volcanion 
     };
 }

--- a/PKHeX.Core/MysteryGifts/WA9.cs
+++ b/PKHeX.Core/MysteryGifts/WA9.cs
@@ -102,7 +102,7 @@ public sealed class WA9(Memory<byte> raw) : DataMysteryGift(raw), ILangNick, INa
     private Shiny FixedShinyType() => GetShinyXor() switch
     {
         0 => Shiny.AlwaysSquare,
-        <= 15 => Shiny.AlwaysStar,
+        <= 15 => Shiny.Always,
         _ => Shiny.Never,
     };
 

--- a/PKHeX.Core/MysteryGifts/WA9.cs
+++ b/PKHeX.Core/MysteryGifts/WA9.cs
@@ -702,7 +702,7 @@ public sealed class WA9(Memory<byte> raw) : DataMysteryGift(raw), ILangNick, INa
         if (pk is IAlphaReadOnly a && a.IsAlpha != IsAlpha)
             return true;
 
-        if (IsHOMEGift)
+        if (IsHOMEGift && FlawlessIVCount > 0)
         {
             if (pk.FlawlessIVCount != FlawlessIVCount)
                 return false; // HOME ZA-starters have non-perfect IVs to 20, so IVs at 31 can't exceed the flawless count.

--- a/PKHeX.Core/MysteryGifts/WA9.cs
+++ b/PKHeX.Core/MysteryGifts/WA9.cs
@@ -108,10 +108,11 @@ public sealed class WA9(Memory<byte> raw) : DataMysteryGift(raw), ILangNick, INa
 
     private uint GetShinyXor()
     {
+        var id32 = IsOldIDFormat ? ID32Old : ID32;
         // Player owned anti-shiny fixed PID
-        if (ID32 == 0)
+        if (id32 == 0)
             return uint.MaxValue;
-        return ShinyUtil.GetShinyXor(PID, ID32);
+        return ShinyUtil.GetShinyXor(PID, id32);
     }
 
     // When applying the ID32, the game sets the DisplayTID7 directly, then sets PA9.DisplaySID7 as (wa9.DisplaySID7 - wa9.CardID)


### PR DESCRIPTION
Changes/additions in this PR:
- Since WA9 wondercards are forced to have [IsOldIDFormat = true](https://github.com/kwsch/PKHeX/blob/52ed9177e36c0f13089d20f070f8c2bd86255169/PKHeX.Core/MysteryGifts/WA9.cs#L121), update [GetShinyXor](https://github.com/kwsch/PKHeX/blob/52ed9177e36c0f13089d20f070f8c2bd86255169/PKHeX.Core/MysteryGifts/WA9.cs#L109) method to actually fetch the correct ID32.
- The actual Shiny XOR value for this wondercard is 12. Returning `Shiny.AlwaysStar` from the [FixedShinyType](https://github.com/kwsch/PKHeX/blob/52ed9177e36c0f13089d20f070f8c2bd86255169/PKHeX.Core/MysteryGifts/WA9.cs#L102) method causes [Shiny.IsValid](https://github.com/kwsch/PKHeX/blob/52ed9177e36c0f13089d20f070f8c2bd86255169/PKHeX.Core/Legality/Encounters/Templates/Enums/Shiny.cs#L43) to fail, as it enforces the check for XOR = 1. This PR relaxes the value to `Shiny.Always` rather than `Shiny.AlwaysStar`, allowing any Shiny XOR value instead of only XOR = 1. This is a workaround and only affects WA9 entities wich are both Shiny and with a fixed PID type (currently only Shiny Volcanion). More robust solutions would be more invasive. Previous HOME shiny gifts with fixed PID all used XOR = 1, so this issue did not occur.
- Volcanion has fixed IVs (no semi-random Flawless IVs/random IVs) so [these](https://github.com/kwsch/PKHeX/blob/52ed9177e36c0f13089d20f070f8c2bd86255169/PKHeX.Core/MysteryGifts/WA9.cs#L707) checks are removed for this instance.
- The gift was available to be redeemed on April 27 at around 6:00/7:00 am UTC. Depending on the timezone, this may appear as April 26.