### PR TITLE
Gen2: Adjust Korean string detection logic

### DIFF
--- a/PKHeX.Core/PKM/PK2.cs
+++ b/PKHeX.Core/PKM/PK2.cs
@@ -12,7 +12,7 @@ public sealed class PK2 : GBPKML, ICaughtData2
 
     public override int SIZE_STORED => Japanese ? PokeCrypto.SIZE_2JLIST : PokeCrypto.SIZE_2ULIST;
     public override int SIZE_PARTY => SIZE_STORED;
-    public override bool Korean => !Japanese && OriginalTrainerTrash[0] <= 0xB;
+    public override bool Korean => !Japanese && StringConverter2KOR.IsHangul(OriginalTrainerTrash);
 
     public override EntityContext Context => EntityContext.Gen2;
 
@@ -208,7 +208,7 @@ public sealed class PK2 : GBPKML, ICaughtData2
         else if (IsNicknamedBank)
         {
             pk7.IsNicknamed = true;
-            pk7.Nickname = Korean ? Nickname : StringConverter12Transporter.GetString(NicknameTrash, Japanese);
+            pk7.Nickname = StringConverter2KOR.IsHangul(NicknameTrash) ? Nickname : StringConverter12Transporter.GetString(NicknameTrash, Japanese);
         }
 
         // Dizzy Punch cannot be transferred
@@ -228,7 +228,7 @@ public sealed class PK2 : GBPKML, ICaughtData2
     {
         if (OriginalTrainerTrash[0] == StringConverter1.TradeOTCode) // In-game Trade
             return StringConverter12Transporter.GetTradeNameGen1(lang);
-        if (Korean)
+        if (StringConverter2KOR.IsHangul(OriginalTrainerTrash))
             return OriginalTrainerName;
         return StringConverter12Transporter.GetString(OriginalTrainerTrash, Japanese);
     }
@@ -269,29 +269,15 @@ public sealed class PK2 : GBPKML, ICaughtData2
     };
 
     public override string GetString(ReadOnlySpan<byte> data)
-    {
-        if (Korean)
-            return StringConverter2KOR.GetString(data);
-        return StringConverter2.GetString(data, Language);
-    }
-
+        => StringConverter2.GetString(data, Language);
     public override int LoadString(ReadOnlySpan<byte> data, Span<char> destBuffer)
-    {
-        if (Korean)
-            return StringConverter2KOR.LoadString(data, destBuffer);
-        return StringConverter2.LoadString(data, destBuffer, Language);
-    }
-
+        => StringConverter2.LoadString(data, destBuffer, Language);
     public override int SetString(Span<byte> destBuffer, ReadOnlySpan<char> value, int maxLength, StringConverterOption option)
-    {
-        if (Korean)
-            return StringConverter2KOR.SetString(destBuffer, value, maxLength, option);
-        return StringConverter2.SetString(destBuffer, value, maxLength, Language, option);
-    }
+        => StringConverter2.SetString(destBuffer, value, maxLength, Language, option);
     public override int GetStringTerminatorIndex(ReadOnlySpan<byte> data)
-        => Korean ? StringConverter2KOR.GetTerminatorIndex(data) : TrashBytesGB.GetTerminatorIndex(data);
+        => (!Japanese && StringConverter2KOR.IsHangul(data)) ? StringConverter2KOR.GetTerminatorIndex(data) : TrashBytesGB.GetTerminatorIndex(data);
     public override int GetStringLength(ReadOnlySpan<byte> data)
-        => Korean ? StringConverter2KOR.GetStringLength(data) : TrashBytesGB.GetStringLength(data);
+        => (!Japanese && StringConverter2KOR.IsHangul(data)) ? StringConverter2KOR.GetStringLength(data) : TrashBytesGB.GetStringLength(data);
     public override int GetBytesPerChar() => 1;
 
     /// <summary>

--- a/PKHeX.Core/PKM/Strings/StringConverter2.cs
+++ b/PKHeX.Core/PKM/Strings/StringConverter2.cs
@@ -43,6 +43,9 @@ public static class StringConverter2
     /// <returns>Decoded string.</returns>
     public static string GetString(ReadOnlySpan<byte> data, int language)
     {
+        if (language == (int)LanguageID.Korean || (language != (int)LanguageID.Japanese && StringConverter2KOR.IsHangul(data)))
+            return StringConverter2KOR.GetString(data);
+
         Span<char> result = stackalloc char[data.Length];
         int length = LoadString(data, result, language);
         return new string(result[..length]);
@@ -55,6 +58,9 @@ public static class StringConverter2
     /// <returns>Character count loaded.</returns>
     public static int LoadString(ReadOnlySpan<byte> data, Span<char> result, int language)
     {
+        if (language == (int)LanguageID.Korean || (language != (int)LanguageID.Japanese && StringConverter2KOR.IsHangul(data)))
+            return StringConverter2KOR.LoadString(data, result);
+
         if (data.Length == 0)
             return 0;
         if (data[0] == TradeOTCode) // In-game Trade
@@ -96,6 +102,9 @@ public static class StringConverter2
     public static int SetString(Span<byte> destBuffer, ReadOnlySpan<char> value, int maxLength, int language,
         StringConverterOption option = StringConverterOption.Clear50)
     {
+        if (language == (int)LanguageID.Korean || (language != (int)LanguageID.Japanese && StringConverter2KOR.IsHangul(value)))
+            return StringConverter2KOR.SetString(destBuffer, value, maxLength, option);
+
         ConditionBuffer(destBuffer, option);
         if (value.Length == 0)
             return 0;

--- a/PKHeX.Core/PKM/Strings/StringConverter2KOR.cs
+++ b/PKHeX.Core/PKM/Strings/StringConverter2KOR.cs
@@ -13,7 +13,7 @@ public static class StringConverter2KOR
     public const char LineBreak = StringConverter2.LineBreak;
 
     /// <summary>
-    /// Checks if any of the characters inside <see cref="str"/> are from the special Korean codepoint pages.
+    /// Checks if all of the characters inside <see cref="str"/> are from the special Korean codepoint pages.
     /// </summary>
     public static bool GetIsKorean(ReadOnlySpan<char> str)
     {
@@ -24,6 +24,16 @@ public static class StringConverter2KOR
         }
         return true;
     }
+
+    /// <summary>
+    /// Checks if the encoded data appears to consist of Korean characters.
+    /// </summary>
+    public static bool IsHangul(ReadOnlySpan<byte> data) => data.Length > 0 && data[0] <= 0xB;
+
+    /// <summary>
+    /// Checks if the string appears to consist of Korean characters.
+    /// </summary>
+    public static bool IsHangul(ReadOnlySpan<char> str) => str.Length > 0 && str[0] is (>= (char)0xAC00 and <= (char)0xD7AF) or (>= (char)0x3130 and <= (char)0x318F) or '　';
 
     /// <summary>
     /// Converts Generation 2 Korean encoded data into a string.

--- a/PKHeX.Core/Saves/SAV2.cs
+++ b/PKHeX.Core/Saves/SAV2.cs
@@ -778,25 +778,11 @@ public sealed class SAV2 : SaveFile, ILangDeviantSave, IEventFlagArray, IEventWo
     }
 
     public override string GetString(ReadOnlySpan<byte> data)
-    {
-        if (Korean)
-            return StringConverter2KOR.GetString(data);
-        return StringConverter2.GetString(data, Language);
-    }
-
+        => StringConverter2.GetString(data, Language);
     public override int LoadString(ReadOnlySpan<byte> data, Span<char> text)
-    {
-        if (Korean)
-            return StringConverter2KOR.LoadString(data, text);
-        return StringConverter2.LoadString(data, text, Language);
-    }
-
+        => StringConverter2.LoadString(data, text, Language);
     public override int SetString(Span<byte> destBuffer, ReadOnlySpan<char> value, int maxLength, StringConverterOption option)
-    {
-        if (Korean)
-            return StringConverter2KOR.SetString(destBuffer, value, maxLength, option);
-        return StringConverter2.SetString(destBuffer, value, maxLength, Language, option);
-    }
+        => StringConverter2.SetString(destBuffer, value, maxLength, Language, option);
 
     public bool IsGBMobileAvailable => Japanese && Version == GameVersion.C;
     public bool IsGBMobileEnabled => Japanese && Enum.IsDefined(GBMobileCable);


### PR DESCRIPTION
Currently, a PK2 can be converted from Korean to English by setting its nickname/OT to English strings. However, the reverse fails since PK2.Korean is still false when SetString is called, so the Western character table is used to encode the Korean text, returning an empty string.

This PR removes the dependency in PK2.SetString on PK2.Korean by extracting the Korean string detection logic into StringConverter2/StringConverter2KOR to check the actual string being read/written in GetString/LoadString/SetString. If the first byte is 0x00 to 0x0B or the first char is a Korean hangul character or a fullwidth space, it is treated as Korean. Note that the existing GetIsKorean method doesn't work for this check, since Nidoran and Porygon2 have non-Korean characters in their species names and characters like `()!?` can be entered in Western names but not Korean names (despite being in the Korean tables).