### PR TITLE
Gen1: Handle KOR Gen2 -> Gen1 transfers

### DIFF
--- a/PKHeX.Core/PKM/PK1.cs
+++ b/PKHeX.Core/PKM/PK1.cs
@@ -12,7 +12,7 @@ public sealed class PK1 : GBPKML, IPersonalType
 
     public override int SIZE_STORED => Japanese ? PokeCrypto.SIZE_1JLIST : PokeCrypto.SIZE_1ULIST;
     public override int SIZE_PARTY => SIZE_STORED;
-    public override bool Korean => false;
+    public override bool Korean => !Japanese && StringConverter2KOR.IsHangul(OriginalTrainerTrash);
 
     public override EntityContext Context => EntityContext.Gen1;
 

--- a/PKHeX.Core/PKM/Strings/StringConverter1.cs
+++ b/PKHeX.Core/PKM/Strings/StringConverter1.cs
@@ -93,6 +93,9 @@ public static class StringConverter1
     /// <returns>Decoded string.</returns>
     public static string GetString(ReadOnlySpan<byte> data, bool jp)
     {
+        if (!jp && StringConverter2KOR.IsHangul(data))
+            return StringConverter2KOR.GetString(data);
+
         Span<char> result = stackalloc char[data.Length];
         int length = LoadString(data, result, jp);
         return new string(result[..length]);
@@ -105,6 +108,9 @@ public static class StringConverter1
     /// <returns>Character count loaded.</returns>
     public static int LoadString(ReadOnlySpan<byte> data, Span<char> result, bool jp)
     {
+        if (!jp && StringConverter2KOR.IsHangul(data))
+            return StringConverter2KOR.LoadString(data, result);
+
         if (data.Length == 0)
             return 0;
         if (data[0] == TradeOTCode) // In-game Trade
@@ -138,6 +144,9 @@ public static class StringConverter1
     public static int SetString(Span<byte> destBuffer, ReadOnlySpan<char> value, int maxLength, bool jp,
         StringConverterOption option = StringConverterOption.Clear50)
     {
+        if (!jp && StringConverter2KOR.IsHangul(value))
+            return StringConverter2KOR.SetString(destBuffer, value, maxLength, option);
+
         if (option is StringConverterOption.ClearZero)
             destBuffer.Clear();
         else if (option is StringConverterOption.Clear50)


### PR DESCRIPTION
Mirror the Korean detection logic in StringConverter2 that was added in #4800 in StringConverter1, so that Korean PK1 tradebacks to Gen1 via the Time Capsule are decoded properly.