### PR TITLE
PJCS Garchomp

### DIFF
--- a/PKHeX.Core/Legality/Encounters/Data/Live/EncounterServerDate.cs
+++ b/PKHeX.Core/Legality/Encounters/Data/Live/EncounterServerDate.cs
@@ -244,6 +244,7 @@ public static class EncounterServerDate
         {9024, new(2024, 10, 16)}, // Shiny Meloetta
         {9025, new(2024, 11, 01)}, // PokéCenter Birthday Tandemaus
         {9030, new(2025, 10, 31)}, // PokéCenter Fidough Birthday Gift
+        {9035, new(2026, 06, 05, +1)} // PJCS26 Garchomp
     };
 
     /// <summary>


### PR DESCRIPTION
The NFC distribution station was theoretically accessible as early as June 6 at 9:00am JST, with proofed redemptions beginning at around 10am JST.

Since JST is UTC+9, anyone could manually set their device timezone to as early as UTC-10 and redeem the gift with a met date of June 5. However, most users would be using the automatic timezone settings, which would default to June 6 as suggested start date.

The gift could be stored indefinitely before being redeemed, meaning there is effectively no end date.

Thanks to Anubis and 9Bitd0 for collecting and discussing redemption evidences and timing windows.