### PR TITLE
PBR: Fix SetStringUnicodeBR maxLength

### DIFF
--- a/PKHeX.Core/PKM/Strings/StringConverter4GC.cs
+++ b/PKHeX.Core/PKM/Strings/StringConverter4GC.cs
@@ -208,17 +208,17 @@ public static class StringConverter4GC
     public static int SetStringUnicodeBR(ReadOnlySpan<char> value, Span<byte> destBuffer, int maxLength = -1, StringConverterOption option = StringConverterOption.ClearZero)
     {
         if (maxLength < 0)
-            maxLength = destBuffer.Length - 2;
+            maxLength = (destBuffer.Length / 2) - 1;
         if (option is StringConverterOption.ClearZero)
             destBuffer.Clear();
 
         int count = 0;
-        for (int i = 0; i < value.Length && count < maxLength; i++)
+        for (int i = 0; i < value.Length && count < maxLength * 2; i++)
         {
             var c = value[i];
             if (c is LineBreak or Proportional or PokemonName)
             {
-                if (count + 2 >= maxLength)
+                if (count + 2 >= maxLength * 2)
                     break;
                 WriteUInt16BigEndian(destBuffer[count..], VariableChar);
                 count += 2;


### PR DESCRIPTION
The `maxLength` parameter of `SetString` methods are supposed to be the maximum length in terms of characters, not bytes;  `SetStringUnicodeBR`, which was added in #4540, incorrectly treated it as a byte count. This primarily affected `SAV4BR.SetOTName`, which caused it to truncate to 7 bytes instead of 7 characters.