### PR TITLE
Exclude same gender rival in PokeGear callers for HGSS

### DIFF
--- a/PKHeX.Core/Saves/SAV4HGSS.cs
+++ b/PKHeX.Core/Saves/SAV4HGSS.cs
@@ -221,10 +221,25 @@ public sealed class SAV4HGSS : SAV4, IBoxDetailName, IBoxDetailWallpaper
 
     public void SetPokeGearRoloDex(ReadOnlySpan<PokegearNumber> value) => value.CopyTo(GetPokeGearRoloDex());
 
+    /// <summary>
+    /// Returns the opposite-gender player character rival, which should not appear as a phone contact.
+    /// </summary>
+    private PokegearNumber OppositeGenderRival => Gender == 0 ? PokegearNumber.Lyra : PokegearNumber.Ethan;
+
     public void PokeGearUnlockAllCallers()
     {
+        var excluded = OppositeGenderRival;
+        int index = 0;
         for (int i = 0; i < GearCallerCount; i++)
-            SetCallerAtIndex(i, (PokegearNumber)i);
+        {
+            var caller = (PokegearNumber)i;
+            if (caller == excluded)
+                continue;
+            SetCallerAtIndex(index++, caller);
+        }
+        // clear the trailing slot left over from skipping the opposite-gender rival
+        for (; index < GearCallerCount; index++)
+            SetCallerAtIndex(index, PokegearNumber.None);
     }
 
     public void PokeGearClearAllCallers(int start = 0)
@@ -250,11 +265,19 @@ public sealed class SAV4HGSS : SAV4, IBoxDetailName, IBoxDetailWallpaper
 
     public void PokeGearUnlockAllCallersNoTrainers()
     {
+        var excluded = OppositeGenderRival;
         var dex = GetPokeGearRoloDex();
-        NotTrainers.CopyTo(dex);
+
+        int index = 0;
+        foreach (var caller in NotTrainers)
+        {
+            if (caller == excluded)
+                continue;
+            dex[index++] = caller;
+        }
 
         // clear remaining callers
-        PokeGearClearAllCallers(NotTrainers.Length);
+        PokeGearClearAllCallers(index);
     }
 
     public Pokeathlon4 Pokeathlon => new(GeneralBuffer.Slice(0xD9D4, Pokeathlon4.SIZE)); // 0xB80

--- a/PKHeX.Core/Saves/SAV4HGSS.cs
+++ b/PKHeX.Core/Saves/SAV4HGSS.cs
@@ -222,13 +222,13 @@ public sealed class SAV4HGSS : SAV4, IBoxDetailName, IBoxDetailWallpaper
     public void SetPokeGearRoloDex(ReadOnlySpan<PokegearNumber> value) => value.CopyTo(GetPokeGearRoloDex());
 
     /// <summary>
-    /// Returns the opposite-gender player character rival, which should not appear as a phone contact.
+    /// Returns the player's own on-screen character (Ethan/Lyra), which should not appear as a phone contact.
     /// </summary>
-    private PokegearNumber OppositeGenderRival => Gender == 0 ? PokegearNumber.Lyra : PokegearNumber.Ethan;
+    private PokegearNumber PlayerCharacterRival => Gender == 0 ? PokegearNumber.Ethan : PokegearNumber.Lyra;
 
     public void PokeGearUnlockAllCallers()
     {
-        var excluded = OppositeGenderRival;
+        var excluded = PlayerCharacterRival;
         int index = 0;
         for (int i = 0; i < GearCallerCount; i++)
         {
@@ -265,7 +265,7 @@ public sealed class SAV4HGSS : SAV4, IBoxDetailName, IBoxDetailWallpaper
 
     public void PokeGearUnlockAllCallersNoTrainers()
     {
-        var excluded = OppositeGenderRival;
+        var excluded = PlayerCharacterRival;
         var dex = GetPokeGearRoloDex();
 
         int index = 0;

--- a/PKHeX.Core/Saves/SAV4HGSS.cs
+++ b/PKHeX.Core/Saves/SAV4HGSS.cs
@@ -259,7 +259,6 @@ public sealed class SAV4HGSS : SAV4, IBoxDetailName, IBoxDetailWallpaper
         PokegearNumber.Daycare_Man,
         PokegearNumber.Daycare_Lady,
         PokegearNumber.Bill,
-        PokegearNumber.Bike_Shop,
         PokegearNumber.Baoba,
     ];
 

--- a/PKHeX.Core/Saves/SAV4HGSS.cs
+++ b/PKHeX.Core/Saves/SAV4HGSS.cs
@@ -233,11 +233,11 @@ public sealed class SAV4HGSS : SAV4, IBoxDetailName, IBoxDetailWallpaper
         for (int i = 0; i < GearCallerCount; i++)
         {
             var caller = (PokegearNumber)i;
-            if (caller == excluded)
+            if (caller == excluded || caller == PokegearNumber.Bike_Shop)
                 continue;
             SetCallerAtIndex(index++, caller);
         }
-        // clear the trailing slot left over from skipping the opposite-gender rival
+        // clear the trailing slots left over from skipping the rival and bike shop
         for (; index < GearCallerCount; index++)
             SetCallerAtIndex(index, PokegearNumber.None);
     }

--- a/PKHeX.Core/Saves/SAV4HGSS.cs
+++ b/PKHeX.Core/Saves/SAV4HGSS.cs
@@ -229,17 +229,19 @@ public sealed class SAV4HGSS : SAV4, IBoxDetailName, IBoxDetailWallpaper
     public void PokeGearUnlockAllCallers()
     {
         var excluded = PlayerCharacterRival;
+        var dex = GetPokeGearRoloDex();
+
         int index = 0;
         for (int i = 0; i < GearCallerCount; i++)
         {
             var caller = (PokegearNumber)i;
             if (caller == excluded || caller == PokegearNumber.Bike_Shop)
                 continue;
-            SetCallerAtIndex(index++, caller);
+            dex[index++] = caller;
         }
-        // clear the trailing slots left over from skipping the rival and bike shop
-        for (; index < GearCallerCount; index++)
-            SetCallerAtIndex(index, PokegearNumber.None);
+
+        // clear remaining callers
+        PokeGearClearAllCallers(index);
     }
 
     public void PokeGearClearAllCallers(int start = 0)


### PR DESCRIPTION
Added functionality to exclude the same gender rival from PokeGear phone list.
Also removed Bike Shop since you can't legally get that number saved in the game.